### PR TITLE
docs: document GLEIPNIR_ENCRYPTION_KEY importance, backup requirements, and loss consequences

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,15 @@
 # Generate a key:
 #   openssl rand -hex 32
 #
-# WARNING: Rotating or losing this key invalidates every encrypted value in the
-# database (provider API keys, webhook secrets). Keep a secure backup.
+# WARNING: Losing GLEIPNIR_ENCRYPTION_KEY makes all encrypted data (provider
+# API keys, webhook secrets) permanently unrecoverable. There is no recovery
+# path — the ciphertext cannot be decrypted without the original key.
+#
+# Back it up securely (password manager or secrets vault) the moment you
+# generate it, before starting the stack for the first time.
+#
+# Rotating the key is NOT supported in v1.0 — see docs/user/operations.md for
+# the manual workaround if rotation is required.
 GLEIPNIR_ENCRYPTION_KEY=
 
 # SQLite database file path inside the container.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Any tool can be marked as requiring approval. When the agent tries to use one, t
 
 4. Complete the first-run setup: create the admin user, then add your Anthropic API key on the `/admin/models` page.
 
+### Back up your encryption key
+
+`GLEIPNIR_ENCRYPTION_KEY` is a mandatory AES-256 key that encrypts every provider API key and webhook secret stored in the database. Losing it makes those credentials permanently unrecoverable — there is no fallback decryption path. Store it in a password manager or secrets vault immediately after generating it. See [Operations — Backing up the encryption key](docs/user/operations.md#backing-up-the-encryption-key).
+
 ## Your first policy
 
 Once the stack is running and you're logged in, here's how to wire up your first agent:
@@ -51,7 +55,7 @@ For fully worked examples against specific services, follow one of the [playbook
 ## More reading
 
 - [Playbooks](docs/playbooks/) — copy-pasteable setups for the use cases above.
-- [User docs](docs/user/) — backups, logs, troubleshooting.
+- [User docs](docs/user/) — encryption key, backups, logs, troubleshooting.
 - [Developer docs](docs/developer/) — architecture, building, contributing.
 - [Security notes](SECURITY.md)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - "${GLEIPNIR_PORT:-3000}:8080"
     environment:
       - GLEIPNIR_DB_PATH=${GLEIPNIR_DB_PATH:-/data/gleipnir.db}
+      # REQUIRED. Encrypts provider API keys and webhook secrets at rest.
+      # Losing this value makes all encrypted data permanently unrecoverable.
+      # Back it up (password manager / secrets vault). Rotation not supported in v1.0.
       - GLEIPNIR_ENCRYPTION_KEY=${GLEIPNIR_ENCRYPTION_KEY}
     volumes:
       - gleipnir_data:/data

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -32,6 +32,7 @@ npm run storybook        # Storybook on port 6006
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `GLEIPNIR_ENCRYPTION_KEY` | *(required)* | Required. 64-char hex (32-byte AES-256) key that encrypts provider API keys and webhook secrets. Losing it is permanent — see [docs/user/operations.md](../user/operations.md). |
 | `GLEIPNIR_DB_PATH` | `/data/gleipnir.db` | SQLite file path |
 | `GLEIPNIR_LISTEN_ADDR` | `:8080` | HTTP listen address |
 | `GLEIPNIR_LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |

--- a/docs/user/operations.md
+++ b/docs/user/operations.md
@@ -2,6 +2,43 @@
 
 Day-to-day operational tasks for a running Gleipnir instance.
 
+## Backing up the encryption key
+
+`GLEIPNIR_ENCRYPTION_KEY` is a 32-byte AES-256 master key (stored as 64 hex characters) used to encrypt provider API keys and webhook secrets in the database.
+
+**Losing `GLEIPNIR_ENCRYPTION_KEY` makes all encrypted data in the database permanently unrecoverable. Back it up securely (e.g. a password manager or secrets vault).**
+
+Back it up immediately upon generation, before starting the stack for the first time. Store it in a location separate from your database backups — a single compromise should not expose both the data and the key that unlocks it.
+
+## Rotating the encryption key (v1.0 known limitation)
+
+Key rotation is not supported in v1.0. There is no re-encryption routine — replacing the key invalidates every ciphertext already in the database. Proper re-encryption support is planned for a future release.
+
+If you must rotate the key now, follow this manual workaround:
+
+1. **Copy out all secrets via the admin UI.** Note each provider API key and webhook secret before proceeding. Once the key is replaced these values will be unreadable.
+2. **Stop the stack:**
+   ```bash
+   docker compose stop
+   ```
+3. **Generate a new key and update `.env`:**
+   ```bash
+   openssl rand -hex 32
+   # Paste the output into GLEIPNIR_ENCRYPTION_KEY in your .env file.
+   ```
+4. **Clear the encrypted rows and columns.** The old ciphertext is now unreadable, so delete it rather than leaving stale data:
+   ```bash
+   docker compose exec api sqlite3 /data/gleipnir.db \
+     "DELETE FROM system_settings WHERE key LIKE '%_api_key';
+      DELETE FROM openai_compat_providers;
+      UPDATE policies SET webhook_secret_encrypted = NULL;"
+   ```
+5. **Restart the stack and re-enter credentials:**
+   ```bash
+   docker compose up -d
+   ```
+   Re-enter each provider API key at `/admin/models`. Rotate each webhook secret via `POST /api/v1/policies/:id/webhook/rotate` or through the admin UI.
+
 ## Backing up the database
 
 The SQLite database lives at the path set by `GLEIPNIR_DB_PATH` (default: `/data/gleipnir.db`) inside the `gleipnir_data` Docker volume.

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -4,4 +4,8 @@ Common issues will be added here as they come up. If you hit something not liste
 
 ## Known issues
 
-_None recorded yet._
+### Lost encryption key
+
+If `GLEIPNIR_ENCRYPTION_KEY` is lost, there is no recovery path. The AES-256-GCM ciphertext stored in the database cannot be decrypted without the original key — every provider API key and webhook secret stored before the key was lost is permanently gone.
+
+To get the instance working again, follow the key rotation workaround in [Operations — Rotating the encryption key](operations.md#rotating-the-encryption-key-v10-known-limitation). This requires re-entering all provider API keys and rotating all webhook secrets from scratch.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -215,6 +215,7 @@ Organized by feature area:
 - **AgentList/** — agent list with folder grouping
 - **RunDetail/** — RunHeader, StepTimeline, FilterBar, MetadataGrid, CapabilitySnapshotCard, ThoughtBlock, ThinkingBlock, ToolBlock, CompleteBlock, ErrorBlock, FeedbackBlock, ApprovalActions, FeedbackActions
 - **MCPPage/** — ServerCard, ToolList, ToolRow, MCPStatsBar, HealthIndicator, AddServerModal, DeleteServerModal
+- **admin/** — EncryptionKeyNotice (persistent warning banner on the Models page about encryption key backup requirements)
 - **Shared** — Button, Modal, ModalFooter, EmptyState, ErrorBoundary, QueryBoundary, CopyBlock, CollapsibleJSON, SkeletonBlock, PageHeader, ApprovalBanner, ConnectionBanner, TriggerRunModal
 
 ### Hooks (`src/hooks/`)
@@ -223,7 +224,7 @@ Organized by feature area:
 
 ### Storybook
 
-45 story files covering components, dashboard widgets, form sections, and hook demonstrations. Stories use MSW for API mocking and have their own `.stories.module.css` for layout scaffolding where needed.
+46 story files covering components, dashboard widgets, form sections, and hook demonstrations. Stories use MSW for API mocking and have their own `.stories.module.css` for layout scaffolding where needed.
 
 ## Key architectural decisions
 

--- a/frontend/src/components/admin/EncryptionKeyNotice.module.css
+++ b/frontend/src/components/admin/EncryptionKeyNotice.module.css
@@ -1,0 +1,24 @@
+.banner {
+  composes: alertWarning from '../../styles/alerts.module.css';
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+}
+
+.body {
+  margin-top: var(--space-2);
+}
+
+.footnote {
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  opacity: 0.75;
+}

--- a/frontend/src/components/admin/EncryptionKeyNotice.stories.tsx
+++ b/frontend/src/components/admin/EncryptionKeyNotice.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import '@/tokens.css'
+import { EncryptionKeyNotice } from './EncryptionKeyNotice'
+
+const meta: Meta<typeof EncryptionKeyNotice> = {
+  title: 'Admin/EncryptionKeyNotice',
+  component: EncryptionKeyNotice,
+}
+
+export default meta
+type Story = StoryObj<typeof EncryptionKeyNotice>
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 720, padding: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/frontend/src/components/admin/EncryptionKeyNotice.tsx
+++ b/frontend/src/components/admin/EncryptionKeyNotice.tsx
@@ -1,0 +1,29 @@
+import { ShieldAlert } from 'lucide-react'
+import styles from './EncryptionKeyNotice.module.css'
+
+/**
+ * Persistent warning banner reminding operators that GLEIPNIR_ENCRYPTION_KEY
+ * protects every credential stored in the database. Placed above the API Keys
+ * section on the admin Models page so it's in view while handling credentials.
+ *
+ * Non-dismissible by design (acceptance criterion: persistent notice).
+ */
+export function EncryptionKeyNotice() {
+  return (
+    <div className={styles.banner}>
+      <div className={styles.titleRow}>
+        <ShieldAlert size={16} strokeWidth={1.5} />
+        <span className={styles.title}>Encryption key protects stored credentials</span>
+      </div>
+      <p className={styles.body}>
+        Provider API keys and webhook secrets are encrypted with the server's{' '}
+        <code>GLEIPNIR_ENCRYPTION_KEY</code>. If that key is lost, every credential stored in
+        the database becomes permanently unrecoverable. Back it up in a password manager or
+        secrets vault.
+      </p>
+      <p className={styles.footnote}>
+        Key rotation is not supported in v1.0 — see Operations docs.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/AdminModelsPage.tsx
+++ b/frontend/src/pages/AdminModelsPage.tsx
@@ -8,6 +8,7 @@ import type { ApiProviderStatus, ApiAllModelEntry } from '@/api/types'
 import { useSetProviderKey } from '@/hooks/mutations/admin'
 import { useUpdateAdminSettings, useSetModelEnabled } from '@/hooks/mutations/admin'
 import { OpenAICompatProvidersSection } from '@/components/admin/OpenAICompatProvidersSection'
+import { EncryptionKeyNotice } from '@/components/admin/EncryptionKeyNotice'
 import { useOpenAICompatProviders } from '@/hooks/queries/openaiCompatProviders'
 import { formatProviderName } from '@/utils/format'
 import cardStyles from '@/components/Settings/Settings.module.css'
@@ -344,6 +345,7 @@ export default function AdminModelsPage() {
   return (
     <div className={styles.page}>
       <PageHeader title="Models" />
+      <EncryptionKeyNotice />
       <ApiKeysSection />
       <OpenAICompatProvidersSection />
       <SystemDefaultSection />


### PR DESCRIPTION
Closes #1

## Summary

- Added explicit loss/unrecoverability warnings to `.env.example`, `docker-compose.yml`, `README.md`, `docs/user/operations.md`, and `docs/developer/building.md`
- New `## Backing up the encryption key` section leads `operations.md` with the exact required wording; key rotation workaround documents the correct SQL (`DELETE`, not `UPDATE SET value=''`)
- Added "Lost encryption key" entry to `troubleshooting.md`
- New `EncryptionKeyNotice` banner component on the admin Models page — persistent, non-dismissible, `alertWarning`-styled, placed above the API keys section
- `frontend/CLAUDE.md` updated: `admin/` component subsection added, story count updated

## Architecture plan

<details>
<summary>Implementation plan summary</summary>

Documentation-first change that raises the visibility of the master encryption key. No backend behavior changes.

Files changed:
1. `.env.example` — strengthened existing WARNING block (not replaced)
2. `docker-compose.yml` — inline 3-line comment above GLEIPNIR_ENCRYPTION_KEY
3. `docs/user/operations.md` — two new sections: backup guidance (required wording verbatim) and v1.0 rotation workaround with correct DELETE SQL
4. `docs/user/troubleshooting.md` — "Lost encryption key" Known Issues entry
5. `README.md` — callout after Quick Start list, "More reading" updated
6. `docs/developer/building.md` — GLEIPNIR_ENCRYPTION_KEY env-var table row
7. `frontend/src/components/admin/EncryptionKeyNotice.tsx` — bare alertWarning banner (no card wrapper)
8. `frontend/src/components/admin/EncryptionKeyNotice.module.css` — single `.banner` class composing alertWarning
9. `frontend/src/components/admin/EncryptionKeyNotice.stories.tsx` — Storybook story
10. `frontend/src/pages/AdminModelsPage.tsx` — renders EncryptionKeyNotice above ApiKeysSection
11. `frontend/CLAUDE.md` — admin/ component subsection, story count

Plan review: REVISE then APPROVE (2 blocking issues fixed — wrong SQL and CSS padding conflict)
</details>

## Review cycles

1 review cycle — APPROVED on first pass after plan revision.

## CLAUDE.md updates

`frontend/CLAUDE.md` updated: added `admin/` component subsection, updated story count from 45 to 46.

---

*Generated by the agentic development pipeline (architect → plan-reviewer → architect revision → developer → code-reviewer)*