### PR TITLE
feat: Surface validation errors at the field level when configuring an agent

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -216,6 +216,7 @@ Organized by feature area:
 - **RunDetail/** — RunHeader, StepTimeline, FilterBar, MetadataGrid, CapabilitySnapshotCard, ThoughtBlock, ThinkingBlock, ToolBlock, CompleteBlock, ErrorBlock, FeedbackBlock, ApprovalActions, FeedbackActions
 - **MCPPage/** — ServerCard, ToolList, ToolRow, MCPStatsBar, HealthIndicator, AddServerModal, DeleteServerModal
 - **admin/** — EncryptionKeyNotice (persistent warning banner on the Models page about encryption key backup requirements)
+- **form/** — FieldError (inline message under a field), ErrorBanner (top-of-form bulleted summary with scroll-to-field). Shared primitives for surfacing validation/save errors.
 - **Shared** — Button, Modal, ModalFooter, EmptyState, ErrorBoundary, QueryBoundary, CopyBlock, CollapsibleJSON, SkeletonBlock, PageHeader, ApprovalBanner, ConnectionBanner, TriggerRunModal
 
 ### Hooks (`src/hooks/`)

--- a/frontend/src/api/fetch.ts
+++ b/frontend/src/api/fetch.ts
@@ -1,12 +1,19 @@
+export interface ApiErrorIssue {
+  field?: string
+  message: string
+}
+
 export class ApiError extends Error {
   status: number
   detail?: string
+  issues?: ApiErrorIssue[]
 
-  constructor(status: number, message: string, detail?: string) {
+  constructor(status: number, message: string, detail?: string, issues?: ApiErrorIssue[]) {
     super(message)
     this.name = 'ApiError'
     this.status = status
     this.detail = detail
+    this.issues = issues
   }
 }
 
@@ -14,16 +21,29 @@ interface BaseRequestOptions {
   skipAuthRedirect?: boolean
 }
 
-function parseApiErrorBody(body: unknown): { error: string; detail?: string } | null {
+function parseApiErrorBody(
+  body: unknown,
+): { error: string; detail?: string; issues?: ApiErrorIssue[] } | null {
   if (
     typeof body === 'object' &&
     body !== null &&
     typeof (body as Record<string, unknown>).error === 'string'
   ) {
     const b = body as Record<string, unknown>
+    let issues: ApiErrorIssue[] | undefined
+    if (Array.isArray(b.issues)) {
+      const parsed = b.issues.filter(
+        (item): item is ApiErrorIssue =>
+          typeof item === 'object' &&
+          item !== null &&
+          typeof (item as Record<string, unknown>).message === 'string',
+      )
+      if (parsed.length > 0) issues = parsed
+    }
     return {
       error: b.error as string,
       detail: typeof b.detail === 'string' ? b.detail : undefined,
+      issues,
     }
   }
   return null
@@ -49,17 +69,19 @@ async function baseRequest(
     }
     let message = response.statusText
     let detail: string | undefined
+    let issues: ApiErrorIssue[] | undefined
     try {
       const body = await response.json()
       const parsed = parseApiErrorBody(body)
       if (parsed) {
         message = parsed.error
         detail = parsed.detail
+        issues = parsed.issues
       }
     } catch {
       // JSON parse failed, fall back to statusText already set above
     }
-    throw new ApiError(response.status, message, detail)
+    throw new ApiError(response.status, message, detail, issues)
   }
 
   return response

--- a/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.tsx
@@ -4,18 +4,22 @@ import { useMcpServers } from '@/hooks/queries/servers';
 import { queryKeys } from '@/hooks/queryKeys';
 import { apiFetch } from '@/api/fetch';
 import type { ApiMcpTool } from '@/api/types';
-import type { AssignedTool, CapabilitiesFormState } from './types';
+import type { AssignedTool, CapabilitiesFormState, SectionIssues, FormIssue } from './types';
 import shared from './FormSections.module.css';
 import styles from './CapabilitiesSection.module.css';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface CapabilitiesSectionProps {
   value: CapabilitiesFormState;
   onChange: (next: CapabilitiesFormState) => void;
+  errors?: SectionIssues;
 }
 
 type RegistryEntry = { tool: ApiMcpTool; serverName: string };
 
-export function CapabilitiesSection({ value, onChange }: CapabilitiesSectionProps) {
+export function CapabilitiesSection({ value, onChange, errors = [] }: CapabilitiesSectionProps) {
+  const capabilityRootErrors = errors.filter(e => e.field === 'capabilities').map(e => e.message);
+  const feedbackTimeoutErrors = errors.filter(e => e.field === 'capabilities.feedback.timeout').map(e => e.message);
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
 
@@ -104,21 +108,27 @@ export function CapabilitiesSection({ value, onChange }: CapabilitiesSectionProp
     <div className={shared.section}>
       <div className={shared.heading}>Capabilities</div>
 
+      <FieldError messages={capabilityRootErrors} />
       {value.tools.length === 0 ? (
         <div className={styles.emptyState}>
           No tools added yet. Add tools from the registry below.
         </div>
       ) : (
         <div className={styles.toolList}>
-          {value.tools.map(tool => (
-            <AssignedToolRow
-              key={tool.toolId}
-              tool={tool}
-              onRemove={handleRemove}
-              onToggleApproval={handleToggleApproval}
-              onTimeoutChange={handleTimeoutChange}
-            />
-          ))}
+          {value.tools.map((tool, i) => {
+            const rowIssues = errors.filter(e => e.field.startsWith(`capabilities.tools[${i}].`));
+            return (
+              <AssignedToolRow
+                key={tool.toolId}
+                tool={tool}
+                rowIndex={i}
+                rowIssues={rowIssues}
+                onRemove={handleRemove}
+                onToggleApproval={handleToggleApproval}
+                onTimeoutChange={handleTimeoutChange}
+              />
+            );
+          })}
         </div>
       )}
 
@@ -156,7 +166,7 @@ export function CapabilitiesSection({ value, onChange }: CapabilitiesSectionProp
         </div>
         {value.feedback.enabled && (
           <div className={styles.feedbackFields}>
-            <div className={styles.feedbackRow}>
+            <div className={styles.feedbackRow} data-field="capabilities.feedback.timeout">
               <span className={styles.feedbackLabel}>Timeout</span>
               <input
                 className={styles.feedbackInput}
@@ -166,6 +176,7 @@ export function CapabilitiesSection({ value, onChange }: CapabilitiesSectionProp
                 onChange={e => handleFeedbackTimeoutChange(e.target.value)}
               />
             </div>
+            <FieldError messages={feedbackTimeoutErrors} />
             <div className={styles.feedbackRow}>
               <span className={styles.feedbackLabel}>On timeout</span>
               <span className={styles.feedbackLabel}>fail</span>
@@ -179,18 +190,23 @@ export function CapabilitiesSection({ value, onChange }: CapabilitiesSectionProp
 
 interface AssignedToolRowProps {
   tool: AssignedTool;
+  rowIndex: number;
+  rowIssues: FormIssue[];
   onRemove: (toolId: string) => void;
   onToggleApproval: (toolId: string) => void;
   onTimeoutChange: (toolId: string, timeout: string) => void;
 }
 
-function AssignedToolRow({ tool, onRemove, onToggleApproval, onTimeoutChange }: AssignedToolRowProps) {
+function AssignedToolRow({ tool, rowIndex, rowIssues, onRemove, onToggleApproval, onTimeoutChange }: AssignedToolRowProps) {
   const displayName = `${tool.serverName}.${tool.name}`;
+  const toolErrors = rowIssues.filter(e => e.field === `capabilities.tools[${rowIndex}].tool`).map(e => e.message);
+  const timeoutErrors = rowIssues.filter(e => e.field === `capabilities.tools[${rowIndex}].timeout`).map(e => e.message);
 
   return (
-    <div className={styles.toolRow}>
+    <div className={styles.toolRow} data-field={`capabilities.tools[${rowIndex}].tool`}>
       <span className={styles.toolName}>{displayName}</span>
       <span className={styles.toolDesc}>{tool.description}</span>
+      <FieldError messages={toolErrors} />
       <div className={styles.approvalToggle}>
         <span className={styles.approvalLabel}>approval</span>
         <button
@@ -215,6 +231,7 @@ function AssignedToolRow({ tool, onRemove, onToggleApproval, onTimeoutChange }: 
           />
         )}
       </div>
+      <FieldError messages={timeoutErrors} />
       <button
         className={styles.removeButton}
         onClick={() => onRemove(tool.toolId)}

--- a/frontend/src/components/AgentEditor/FormMode/ConcurrencySection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/ConcurrencySection.tsx
@@ -1,11 +1,13 @@
 import { Check } from 'lucide-react';
 import shared from './FormSections.module.css';
 import styles from './ConcurrencySection.module.css';
-import type { ConcurrencyFormState, ConcurrencyValue } from './types';
+import type { ConcurrencyFormState, ConcurrencyValue, SectionIssues } from './types';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface ConcurrencySectionProps {
   value: ConcurrencyFormState;
   onChange: (next: ConcurrencyFormState) => void;
+  errors?: SectionIssues;
 }
 
 const CONCURRENCY_OPTIONS: { value: ConcurrencyValue; label: string; desc: string }[] = [
@@ -15,7 +17,10 @@ const CONCURRENCY_OPTIONS: { value: ConcurrencyValue; label: string; desc: strin
   { value: 'replace',  label: 'Replace',  desc: 'Cancel current, start fresh' },
 ];
 
-export function ConcurrencySection({ value, onChange }: ConcurrencySectionProps) {
+export function ConcurrencySection({ value, onChange, errors = [] }: ConcurrencySectionProps) {
+  const concurrencyErrors = errors.filter(e => e.field === 'agent.concurrency').map(e => e.message);
+  const queueDepthErrors = errors.filter(e => e.field === 'agent.queue_depth').map(e => e.message);
+
   function handleQueueDepthChange(e: React.ChangeEvent<HTMLInputElement>) {
     // Clamp to non-negative integers. Backend rejects negatives (validator.go:200)
     // and 0 means "use default" (model.DefaultQueueDepth).
@@ -27,7 +32,7 @@ export function ConcurrencySection({ value, onChange }: ConcurrencySectionProps)
     <div className={shared.section}>
       <div className={shared.heading}>Concurrency</div>
 
-      <div className={styles.cards}>
+      <div className={styles.cards} data-field="agent.concurrency">
         {CONCURRENCY_OPTIONS.map((option) => {
           const isActive = value.concurrency === option.value;
           return (
@@ -50,9 +55,10 @@ export function ConcurrencySection({ value, onChange }: ConcurrencySectionProps)
           );
         })}
       </div>
+      <FieldError messages={concurrencyErrors} />
 
       {value.concurrency === 'queue' && (
-        <div className={styles.queueDepthRow}>
+        <div className={styles.queueDepthRow} data-field="agent.queue_depth">
           <label className={styles.queueDepthLabel} htmlFor="queue-depth-input">
             Queue depth
           </label>
@@ -65,6 +71,7 @@ export function ConcurrencySection({ value, onChange }: ConcurrencySectionProps)
             value={value.queueDepth || ''}
             onChange={handleQueueDepthChange}
           />
+          <FieldError messages={queueDepthErrors} />
         </div>
       )}
     </div>

--- a/frontend/src/components/AgentEditor/FormMode/ModelSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/ModelSection.tsx
@@ -1,17 +1,22 @@
 import { useEffect } from 'react';
 import shared from './FormSections.module.css';
 import styles from './ModelSection.module.css';
-import type { ModelFormState } from './types';
+import type { ModelFormState, SectionIssues } from './types';
 import { useModels } from '@/hooks/queries/users';
 import { usePublicConfig } from '@/hooks/queries/config';
 import { formatProviderName } from '@/utils/format';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface ModelSectionProps {
   value: ModelFormState;
   onChange: (next: ModelFormState) => void;
+  errors?: SectionIssues;
 }
 
-export function ModelSection({ value, onChange }: ModelSectionProps) {
+export function ModelSection({ value, onChange, errors = [] }: ModelSectionProps) {
+  const providerErrors = errors.filter(e => e.field === 'model.provider').map(e => e.message);
+  const nameErrors = errors.filter(e => e.field === 'model.name').map(e => e.message);
+  const modelErrors = [...providerErrors, ...nameErrors];
   const { data: providers, isLoading, isError } = useModels();
   const { data: publicConfig } = usePublicConfig();
 
@@ -64,29 +69,33 @@ export function ModelSection({ value, onChange }: ModelSectionProps) {
   return (
     <div className={shared.section}>
       <div className={shared.heading}>Model</div>
-      <select
-        className={styles.select}
-        value={selected}
-        onChange={handleChange}
-        disabled={isLoading || isError || providers?.length === 0}
-      >
-        {isLoading && <option value={selected}>Loading models…</option>}
-        {isError && <option value={selected}>Failed to load models</option>}
-        {providers?.length === 0 && <option value="">No models enabled — go to Admin → Models</option>}
-        {/* Placeholder shown when no model has been chosen yet (new policy, no system default) */}
-        {isEmpty && !isLoading && !isError && (providers?.length ?? 0) > 0 && (
-          <option value="">Select a model…</option>
-        )}
-        {providers?.map((group) => (
-          <optgroup key={group.provider} label={formatProviderName(group.provider)}>
-            {group.models.map((m) => (
-              <option key={`${group.provider}:${m.name}`} value={`${group.provider}:${m.name}`}>
-                {m.display_name}
-              </option>
-            ))}
-          </optgroup>
-        ))}
-      </select>
+      <div data-field="model.provider">
+        <select
+          className={styles.select}
+          value={selected}
+          onChange={handleChange}
+          disabled={isLoading || isError || providers?.length === 0}
+          aria-invalid={modelErrors.length > 0 || undefined}
+        >
+          {isLoading && <option value={selected}>Loading models…</option>}
+          {isError && <option value={selected}>Failed to load models</option>}
+          {providers?.length === 0 && <option value="">No models enabled — go to Admin → Models</option>}
+          {/* Placeholder shown when no model has been chosen yet (new policy, no system default) */}
+          {isEmpty && !isLoading && !isError && (providers?.length ?? 0) > 0 && (
+            <option value="">Select a model…</option>
+          )}
+          {providers?.map((group) => (
+            <optgroup key={group.provider} label={formatProviderName(group.provider)}>
+              {group.models.map((m) => (
+                <option key={`${group.provider}:${m.name}`} value={`${group.provider}:${m.name}`}>
+                  {m.display_name}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+        <FieldError messages={modelErrors} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/AgentEditor/FormMode/PolicyIdentitySection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/PolicyIdentitySection.tsx
@@ -1,27 +1,34 @@
 import shared from './FormSections.module.css';
-import type { IdentityFormState } from './types';
+import type { IdentityFormState, SectionIssues } from './types';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface PolicyIdentitySectionProps {
   value: IdentityFormState;
   onChange: (next: IdentityFormState) => void;
   existingFolders?: string[];
+  errors?: SectionIssues;
 }
 
-export function PolicyIdentitySection({ value, onChange, existingFolders = [] }: PolicyIdentitySectionProps) {
+export function PolicyIdentitySection({ value, onChange, existingFolders = [], errors = [] }: PolicyIdentitySectionProps) {
   const datalistId = 'policy-folder-suggestions';
+  const nameErrors = errors.filter(e => e.field === 'name').map(e => e.message);
+  const nameInvalid = nameErrors.length > 0;
 
   return (
     <div className={shared.section}>
       <div className={shared.heading}>Identity</div>
 
-      <div className={shared.field}>
+      <div className={shared.field} data-field="name">
         <label className={shared.label}>Name</label>
         <input
           className={`${shared.input} ${shared.inputMono}`}
           type="text"
           value={value.name}
+          aria-invalid={nameInvalid || undefined}
+          aria-describedby={nameInvalid ? 'field-name-error' : undefined}
           onChange={(e) => onChange({ ...value, name: e.target.value })}
         />
+        <FieldError id="field-name-error" messages={nameErrors} />
       </div>
 
       <div className={shared.field}>

--- a/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.tsx
@@ -1,13 +1,18 @@
 import shared from './FormSections.module.css';
 import styles from './RunLimitsSection.module.css';
-import type { RunLimitsFormState } from './types';
+import type { RunLimitsFormState, SectionIssues } from './types';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface RunLimitsSectionProps {
   value: RunLimitsFormState;
   onChange: (next: RunLimitsFormState) => void;
+  errors?: SectionIssues;
 }
 
-export function RunLimitsSection({ value, onChange }: RunLimitsSectionProps) {
+export function RunLimitsSection({ value, onChange, errors = [] }: RunLimitsSectionProps) {
+  const tokensErrors = errors.filter(e => e.field === 'agent.limits.max_tokens_per_run').map(e => e.message);
+  const toolCallsErrors = errors.filter(e => e.field === 'agent.limits.max_tool_calls_per_run').map(e => e.message);
+
   function handleTokensChange(e: React.ChangeEvent<HTMLInputElement>) {
     const parsed = parseInt(e.target.value, 10);
     if (isNaN(parsed) || parsed <= 0) return;
@@ -25,26 +30,30 @@ export function RunLimitsSection({ value, onChange }: RunLimitsSectionProps) {
       <div className={shared.heading}>Run Limits</div>
 
       <div className={styles.fieldRow}>
-        <div className={shared.field}>
+        <div className={shared.field} data-field="agent.limits.max_tokens_per_run">
           <label className={shared.label}>Max tokens per run</label>
           <input
             className={shared.input}
             type="number"
             min="1"
             value={value.max_tokens_per_run}
+            aria-invalid={tokensErrors.length > 0 || undefined}
             onChange={handleTokensChange}
           />
+          <FieldError messages={tokensErrors} />
         </div>
 
-        <div className={shared.field}>
+        <div className={shared.field} data-field="agent.limits.max_tool_calls_per_run">
           <label className={shared.label}>Max tool calls per run</label>
           <input
             className={shared.input}
             type="number"
             min="1"
             value={value.max_tool_calls_per_run}
+            aria-invalid={toolCallsErrors.length > 0 || undefined}
             onChange={handleToolCallsChange}
           />
+          <FieldError messages={toolCallsErrors} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/AgentEditor/FormMode/TaskInstructionsSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/TaskInstructionsSection.tsx
@@ -1,25 +1,31 @@
 import shared from './FormSections.module.css';
 import styles from './TaskInstructionsSection.module.css';
-import type { TaskInstructionsFormState } from './types';
+import type { TaskInstructionsFormState, SectionIssues } from './types';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface TaskInstructionsSectionProps {
   value: TaskInstructionsFormState;
   onChange: (next: TaskInstructionsFormState) => void;
+  errors?: SectionIssues;
 }
 
-export function TaskInstructionsSection({ value, onChange }: TaskInstructionsSectionProps) {
+export function TaskInstructionsSection({ value, onChange, errors = [] }: TaskInstructionsSectionProps) {
+  const taskErrors = errors.filter(e => e.field === 'agent.task').map(e => e.message);
+
   return (
     <div className={shared.section}>
       <div className={shared.heading}>Task Instructions</div>
 
-      <div className={shared.field}>
+      <div className={shared.field} data-field="agent.task">
         <label className={shared.label}>Task</label>
         <textarea
           className={styles.textarea}
           value={value.task}
           placeholder="Describe what the agent should do…"
+          aria-invalid={taskErrors.length > 0 || undefined}
           onChange={(e) => onChange({ ...value, task: e.target.value })}
         />
+        <FieldError messages={taskErrors} />
       </div>
       <div className={styles.hint}>
         The trigger payload (webhook body, poll result) is delivered as the agent's first message.

--- a/frontend/src/components/AgentEditor/FormMode/TriggerSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/TriggerSection.tsx
@@ -1,6 +1,6 @@
 import shared from './FormSections.module.css';
 import styles from './TriggerSection.module.css';
-import type { TriggerFormState, ManualTriggerState, ScheduledTriggerState, PollTriggerState } from './types';
+import type { TriggerFormState, ManualTriggerState, ScheduledTriggerState, PollTriggerState, SectionIssues } from './types';
 import { TriggerCard } from './triggers/TriggerCard';
 import { WebhookConfig } from './triggers/WebhookConfig';
 import { ScheduledConfig } from './triggers/ScheduledConfig';
@@ -10,6 +10,7 @@ export interface TriggerSectionProps {
   value: TriggerFormState;
   onChange: (next: TriggerFormState) => void;
   policyId?: string;
+  errors?: SectionIssues;
 }
 
 const DEFAULT_MANUAL: ManualTriggerState = { type: 'manual' };
@@ -21,7 +22,7 @@ const DEFAULT_POLL: PollTriggerState = {
   checks: [{ tool: '', input: '', path: '', comparator: 'equals', value: '' }],
 };
 
-export function TriggerSection({ value, onChange, policyId }: TriggerSectionProps) {
+export function TriggerSection({ value, onChange, policyId, errors = [] }: TriggerSectionProps) {
   function handleTypeSelect(type: TriggerFormState['type']) {
     if (type === 'webhook') onChange({ type: 'webhook', auth: 'hmac' });
     else if (type === 'manual') onChange(DEFAULT_MANUAL);
@@ -52,8 +53,8 @@ export function TriggerSection({ value, onChange, policyId }: TriggerSectionProp
             onChange={(next) => onChange(next)}
           />
         )}
-        {value.type === 'scheduled' && <ScheduledConfig value={value} onChange={onChange} />}
-        {value.type === 'poll' && <PollConfig value={value} onChange={onChange} />}
+        {value.type === 'scheduled' && <ScheduledConfig value={value} onChange={onChange} errors={errors} />}
+        {value.type === 'poll' && <PollConfig value={value} onChange={onChange} errors={errors} />}
         {value.type === 'manual' && null}
       </div>
     </div>

--- a/frontend/src/components/AgentEditor/FormMode/triggers/PollConfig.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/triggers/PollConfig.tsx
@@ -1,10 +1,12 @@
 import shared from '../FormSections.module.css';
 import styles from '../TriggerSection.module.css';
-import type { PollCheckState, PollTriggerState, TriggerFormState } from '../types';
+import type { PollCheckState, PollTriggerState, TriggerFormState, SectionIssues } from '../types';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface PollConfigProps {
   value: PollTriggerState;
   onChange: (next: TriggerFormState) => void;
+  errors?: SectionIssues;
 }
 
 const COMPARATOR_LABELS: Record<PollCheckState['comparator'], string> = {
@@ -15,7 +17,8 @@ const COMPARATOR_LABELS: Record<PollCheckState['comparator'], string> = {
   contains: 'contains',
 };
 
-export function PollConfig({ value, onChange }: PollConfigProps) {
+export function PollConfig({ value, onChange, errors = [] }: PollConfigProps) {
+  const intervalErrors = errors.filter(e => e.field === 'trigger.interval').map(e => e.message);
   function updateInterval(interval: string) {
     onChange({ ...value, interval });
   }
@@ -43,7 +46,7 @@ export function PollConfig({ value, onChange }: PollConfigProps) {
 
   return (
     <div className={styles.pollConfig}>
-      <div className={shared.field}>
+      <div className={shared.field} data-field="trigger.interval">
         <label className={shared.label}>Interval</label>
         <input
           className={`${shared.input} ${shared.inputMono}`}
@@ -52,6 +55,7 @@ export function PollConfig({ value, onChange }: PollConfigProps) {
           placeholder="5m"
           onChange={(e) => updateInterval(e.target.value)}
         />
+        <FieldError messages={intervalErrors} />
       </div>
 
       <div className={shared.field}>
@@ -75,80 +79,88 @@ export function PollConfig({ value, onChange }: PollConfigProps) {
       </div>
 
       <div className={styles.checksContainer}>
-        {value.checks.map((check, i) => (
-          <div key={i} className={styles.checkGroup}>
-            <div className={styles.checkHeader}>
-              <span className={styles.checkNumber}>Check {i + 1}</span>
-              {value.checks.length > 1 && (
-                <button
-                  className={styles.copyButton}
-                  type="button"
-                  onClick={() => removeCheck(i)}
-                >
-                  Remove
-                </button>
-              )}
-            </div>
-
-            <div className={shared.field}>
-              <label className={shared.label}>Tool</label>
-              <input
-                className={`${shared.input} ${shared.inputMono}`}
-                type="text"
-                value={check.tool}
-                placeholder="server.tool_name"
-                onChange={(e) => updateCheck(i, { ...check, tool: e.target.value })}
-              />
-            </div>
-
-            <div className={shared.field}>
-              <label className={shared.label}>Input (JSON, optional)</label>
-              <textarea
-                className={styles.textarea}
-                value={check.input}
-                placeholder={'{"key": "value"}'}
-                onChange={(e) => updateCheck(i, { ...check, input: e.target.value })}
-              />
-            </div>
-
-            <div className={shared.field}>
-              <label className={shared.label}>JSONPath</label>
-              <input
-                className={`${shared.input} ${shared.inputMono}`}
-                type="text"
-                value={check.path}
-                placeholder="$.field.path"
-                onChange={(e) => updateCheck(i, { ...check, path: e.target.value })}
-              />
-            </div>
-
-            <div className={styles.fieldRow}>
-              <div className={shared.field}>
-                <label className={shared.label}>Comparator</label>
-                <select
-                  className={styles.select}
-                  value={check.comparator}
-                  onChange={(e) => updateCheck(i, { ...check, comparator: e.target.value as PollCheckState['comparator'] })}
-                >
-                  {(Object.keys(COMPARATOR_LABELS) as PollCheckState['comparator'][]).map((comp) => (
-                    <option key={comp} value={comp}>{COMPARATOR_LABELS[comp]}</option>
-                  ))}
-                </select>
+        {value.checks.map((check, i) => {
+          const toolErrors = errors.filter(e => e.field === `trigger.checks[${i}].tool`).map(e => e.message);
+          const pathErrors = errors.filter(e => e.field === `trigger.checks[${i}].path`).map(e => e.message);
+          const comparatorErrors = errors.filter(e => e.field === `trigger.checks[${i}].comparator`).map(e => e.message);
+          return (
+            <div key={i} className={styles.checkGroup}>
+              <div className={styles.checkHeader}>
+                <span className={styles.checkNumber}>Check {i + 1}</span>
+                {value.checks.length > 1 && (
+                  <button
+                    className={styles.copyButton}
+                    type="button"
+                    onClick={() => removeCheck(i)}
+                  >
+                    Remove
+                  </button>
+                )}
               </div>
 
-              <div className={shared.field}>
-                <label className={shared.label}>Value</label>
+              <div className={shared.field} data-field={`trigger.checks[${i}].tool`}>
+                <label className={shared.label}>Tool</label>
                 <input
                   className={`${shared.input} ${shared.inputMono}`}
                   type="text"
-                  value={check.value}
-                  placeholder="expected value"
-                  onChange={(e) => updateCheck(i, { ...check, value: e.target.value })}
+                  value={check.tool}
+                  placeholder="server.tool_name"
+                  onChange={(e) => updateCheck(i, { ...check, tool: e.target.value })}
+                />
+                <FieldError messages={toolErrors} />
+              </div>
+
+              <div className={shared.field}>
+                <label className={shared.label}>Input (JSON, optional)</label>
+                <textarea
+                  className={styles.textarea}
+                  value={check.input}
+                  placeholder={'{"key": "value"}'}
+                  onChange={(e) => updateCheck(i, { ...check, input: e.target.value })}
                 />
               </div>
+
+              <div className={shared.field} data-field={`trigger.checks[${i}].path`}>
+                <label className={shared.label}>JSONPath</label>
+                <input
+                  className={`${shared.input} ${shared.inputMono}`}
+                  type="text"
+                  value={check.path}
+                  placeholder="$.field.path"
+                  onChange={(e) => updateCheck(i, { ...check, path: e.target.value })}
+                />
+                <FieldError messages={pathErrors} />
+              </div>
+
+              <div className={styles.fieldRow}>
+                <div className={shared.field} data-field={`trigger.checks[${i}].comparator`}>
+                  <label className={shared.label}>Comparator</label>
+                  <select
+                    className={styles.select}
+                    value={check.comparator}
+                    onChange={(e) => updateCheck(i, { ...check, comparator: e.target.value as PollCheckState['comparator'] })}
+                  >
+                    {(Object.keys(COMPARATOR_LABELS) as PollCheckState['comparator'][]).map((comp) => (
+                      <option key={comp} value={comp}>{COMPARATOR_LABELS[comp]}</option>
+                    ))}
+                  </select>
+                  <FieldError messages={comparatorErrors} />
+                </div>
+
+                <div className={shared.field}>
+                  <label className={shared.label}>Value</label>
+                  <input
+                    className={`${shared.input} ${shared.inputMono}`}
+                    type="text"
+                    value={check.value}
+                    placeholder="expected value"
+                    onChange={(e) => updateCheck(i, { ...check, value: e.target.value })}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       <button

--- a/frontend/src/components/AgentEditor/FormMode/triggers/ScheduledConfig.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/triggers/ScheduledConfig.tsx
@@ -1,13 +1,16 @@
 import shared from '../FormSections.module.css';
 import styles from '../TriggerSection.module.css';
-import type { ScheduledTriggerState, TriggerFormState } from '../types';
+import type { ScheduledTriggerState, TriggerFormState, SectionIssues } from '../types';
+import { FieldError } from '@/components/form/FieldError';
 
 export interface ScheduledConfigProps {
   value: ScheduledTriggerState;
   onChange: (next: TriggerFormState) => void;
+  errors?: SectionIssues;
 }
 
-export function ScheduledConfig({ value, onChange }: ScheduledConfigProps) {
+export function ScheduledConfig({ value, onChange, errors = [] }: ScheduledConfigProps) {
+  const fireAtErrors = errors.filter(e => e.field === 'trigger.fire_at').map(e => e.message);
   function addEntry() {
     // Default to one hour from now, formatted as a datetime-local value (no seconds).
     const soon = new Date(Date.now() + 60 * 60 * 1000);
@@ -41,7 +44,7 @@ export function ScheduledConfig({ value, onChange }: ScheduledConfigProps) {
   }
 
   return (
-    <div className={shared.field}>
+    <div className={shared.field} data-field="trigger.fire_at">
       <label className={shared.label}>Fire at (UTC)</label>
       {value.fireAt.map((ts, i) => (
         <div key={i} className={styles.fieldRow}>
@@ -67,6 +70,7 @@ export function ScheduledConfig({ value, onChange }: ScheduledConfigProps) {
       >
         + Add time
       </button>
+      <FieldError messages={fireAtErrors} />
     </div>
   );
 }

--- a/frontend/src/components/AgentEditor/FormMode/types.ts
+++ b/frontend/src/components/AgentEditor/FormMode/types.ts
@@ -84,3 +84,11 @@ export interface ModelFormState {
   provider: string;
   model: string;
 }
+
+// FormIssue is defined in validateFormState.ts (single source of truth).
+// It is re-exported here so section components only need to import from './types'.
+// SectionIssues is the array form: a flat list of issues pre-filtered to a
+// specific form section.
+import type { FormIssue } from '@/components/AgentEditor/validateFormState';
+export type { FormIssue };
+export type SectionIssues = FormIssue[];

--- a/frontend/src/components/AgentEditor/validateFormState.test.ts
+++ b/frontend/src/components/AgentEditor/validateFormState.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest'
+import { validateFormState, parseGoDuration, type FormIssue } from './validateFormState'
+import { defaultFormState } from './agentEditorUtils'
+import type { FormState } from './agentEditorUtils'
+
+// valid() returns a copy of the default form state pre-populated with all
+// required fields so individual tests can override just the field under test.
+function valid(): FormState {
+  const base = defaultFormState()
+  return {
+    ...base,
+    identity: { name: 'test-agent', description: '', folder: '' },
+    trigger: { type: 'webhook', auth: 'hmac' },
+    capabilities: {
+      tools: [
+        {
+          toolId: 'srv.do_thing',
+          serverId: 'srv',
+          serverName: 'srv',
+          name: 'do_thing',
+          description: '',
+          approvalRequired: false,
+          approvalTimeout: '',
+        },
+      ],
+      feedback: { enabled: false, timeout: '', onTimeout: 'fail' },
+    },
+    task: { task: 'Do something useful.' },
+    model: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+    limits: { max_tokens_per_run: 20000, max_tool_calls_per_run: 50 },
+    concurrency: { concurrency: 'skip', queueDepth: 0 },
+  }
+}
+
+function findIssue(issues: FormIssue[], field: string, msgSubstr: string): boolean {
+  return issues.some(iss => iss.field === field && iss.message.includes(msgSubstr))
+}
+
+// ---- parseGoDuration ----
+
+describe('parseGoDuration', () => {
+  it('parses minutes', () => {
+    expect(parseGoDuration('5m')).toBe(5 * 60 * 1000)
+  })
+  it('parses hours', () => {
+    expect(parseGoDuration('1h')).toBe(60 * 60 * 1000)
+  })
+  it('parses combined h+m', () => {
+    expect(parseGoDuration('1h30m')).toBe(90 * 60 * 1000)
+  })
+  it('parses seconds', () => {
+    expect(parseGoDuration('30s')).toBe(30 * 1000)
+  })
+  it('returns null for empty string', () => {
+    expect(parseGoDuration('')).toBeNull()
+  })
+  it('returns null for invalid input', () => {
+    expect(parseGoDuration('bad')).toBeNull()
+  })
+})
+
+// ---- validateFormState ----
+
+describe('validateFormState — valid baseline', () => {
+  it('returns no issues for a fully valid form', () => {
+    expect(validateFormState(valid())).toHaveLength(0)
+  })
+})
+
+describe('validateFormState — name', () => {
+  it('reports missing name', () => {
+    const s = valid()
+    s.identity = { ...s.identity, name: '' }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'name', 'name is required')).toBe(true)
+  })
+  it('reports whitespace-only name', () => {
+    const s = valid()
+    s.identity = { ...s.identity, name: '   ' }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'name', 'name is required')).toBe(true)
+  })
+})
+
+describe('validateFormState — trigger.fire_at', () => {
+  it('reports missing fire_at for scheduled trigger', () => {
+    const s = valid()
+    s.trigger = { type: 'scheduled', fireAt: [] }
+    const issues = validateFormState(s)
+    // scheduled with empty fireAt AND empty capabilities triggers two issues;
+    // we only care that the fire_at one is present.
+    expect(findIssue(issues, 'trigger.fire_at', 'required')).toBe(true)
+  })
+  it('no fire_at error when timestamps are provided', () => {
+    const s = valid()
+    s.trigger = { type: 'scheduled', fireAt: ['2030-01-01T00:00:00Z'] }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'trigger.fire_at', 'required')).toBe(false)
+  })
+})
+
+describe('validateFormState — trigger.interval', () => {
+  it('reports missing interval for poll trigger', () => {
+    const s = valid()
+    s.trigger = { type: 'poll', interval: '', match: 'all', checks: [{ tool: 'srv.t', input: '', path: '$.x', comparator: 'equals', value: 'ok' }] }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'trigger.interval', 'required')).toBe(true)
+  })
+  it('reports interval < 1m', () => {
+    const s = valid()
+    s.trigger = { type: 'poll', interval: '30s', match: 'all', checks: [{ tool: 'srv.t', input: '', path: '$.x', comparator: 'equals', value: 'ok' }] }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'trigger.interval', 'at least 1m')).toBe(true)
+  })
+  it('no interval error for valid duration', () => {
+    const s = valid()
+    s.trigger = { type: 'poll', interval: '5m', match: 'all', checks: [{ tool: 'srv.t', input: '', path: '$.x', comparator: 'equals', value: 'ok' }] }
+    expect(findIssue(validateFormState(s), 'trigger.interval', 'required')).toBe(false)
+  })
+})
+
+describe('validateFormState — trigger.checks', () => {
+  it('reports missing tool in poll check', () => {
+    const s = valid()
+    s.trigger = { type: 'poll', interval: '5m', match: 'all', checks: [{ tool: '', input: '', path: '$.x', comparator: 'equals', value: 'ok' }] }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'trigger.checks[0].tool', 'required')).toBe(true)
+  })
+  it('reports bad dot-notation in poll check tool', () => {
+    const s = valid()
+    s.trigger = { type: 'poll', interval: '5m', match: 'all', checks: [{ tool: 'nodot', input: '', path: '$.x', comparator: 'equals', value: 'ok' }] }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'trigger.checks[0].tool', 'dot notation')).toBe(true)
+  })
+  it('reports missing path in poll check', () => {
+    const s = valid()
+    s.trigger = { type: 'poll', interval: '5m', match: 'all', checks: [{ tool: 'srv.t', input: '', path: '', comparator: 'equals', value: 'ok' }] }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'trigger.checks[0].path', 'required')).toBe(true)
+  })
+  it('reports invalid comparator in poll check', () => {
+    const s = valid()
+    s.trigger = {
+      type: 'poll', interval: '5m', match: 'all',
+      checks: [{ tool: 'srv.t', input: '', path: '$.x', comparator: 'banana' as never, value: 'ok' }],
+    }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'trigger.checks[0].comparator', 'comparator')).toBe(true)
+  })
+})
+
+describe('validateFormState — capabilities', () => {
+  it('reports missing capability when tools and feedback both absent', () => {
+    const s = valid()
+    s.capabilities = { tools: [], feedback: { enabled: false, timeout: '', onTimeout: 'fail' } }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'capabilities', 'at least one capability')).toBe(true)
+  })
+  it('no capability error when feedback is enabled', () => {
+    const s = valid()
+    s.capabilities = { tools: [], feedback: { enabled: true, timeout: '', onTimeout: 'fail' } }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'capabilities', 'at least one capability')).toBe(false)
+  })
+  it('reports duplicate tool', () => {
+    const s = valid()
+    s.capabilities.tools = [
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: false, approvalTimeout: '' },
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: false, approvalTimeout: '' },
+    ]
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'capabilities.tools[1].tool', 'duplicate')).toBe(true)
+  })
+  it('reports invalid approval timeout', () => {
+    const s = valid()
+    s.capabilities.tools = [
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: true, approvalTimeout: 'badtime' },
+    ]
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'capabilities.tools[0].timeout', 'not a valid duration')).toBe(true)
+  })
+  it('reports invalid feedback timeout', () => {
+    const s = valid()
+    s.capabilities.feedback = { enabled: true, timeout: 'badtime', onTimeout: 'fail' }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'capabilities.feedback.timeout', 'not a valid duration')).toBe(true)
+  })
+})
+
+describe('validateFormState — agent.task', () => {
+  it('reports empty task', () => {
+    const s = valid()
+    s.task = { task: '' }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.task', 'required')).toBe(true)
+  })
+})
+
+describe('validateFormState — model', () => {
+  it('reports missing provider', () => {
+    const s = valid()
+    s.model = { provider: '', model: 'claude-sonnet-4-6' }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'model.provider', 'required')).toBe(true)
+  })
+  it('reports missing model name', () => {
+    const s = valid()
+    s.model = { provider: 'anthropic', model: '' }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'model.name', 'required')).toBe(true)
+  })
+})
+
+describe('validateFormState — agent.limits', () => {
+  it('reports non-positive max_tokens_per_run', () => {
+    const s = valid()
+    s.limits = { max_tokens_per_run: 0, max_tool_calls_per_run: 50 }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.limits.max_tokens_per_run', 'must be positive')).toBe(true)
+  })
+  it('reports non-positive max_tool_calls_per_run', () => {
+    const s = valid()
+    s.limits = { max_tokens_per_run: 1000, max_tool_calls_per_run: 0 }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.limits.max_tool_calls_per_run', 'must be positive')).toBe(true)
+  })
+})
+
+describe('validateFormState — agent.concurrency', () => {
+  it('reports invalid concurrency mode', () => {
+    const s = valid()
+    s.concurrency = { concurrency: 'invalid' as never, queueDepth: 0 }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.concurrency', 'invalid')).toBe(true)
+  })
+  it('reports negative queue depth', () => {
+    const s = valid()
+    s.concurrency = { concurrency: 'queue', queueDepth: -1 }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.queue_depth', 'must not be negative')).toBe(true)
+  })
+})
+
+describe('validateFormState — replace + approval cross-field rule', () => {
+  it('reports replace + approval conflict', () => {
+    const s = valid()
+    s.concurrency = { concurrency: 'replace', queueDepth: 0 }
+    s.capabilities.tools = [
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: true, approvalTimeout: '' },
+    ]
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.concurrency', '"replace" is not valid')).toBe(true)
+  })
+  it('no replace+approval error when no tool has approval required', () => {
+    const s = valid()
+    s.concurrency = { concurrency: 'replace', queueDepth: 0 }
+    s.capabilities.tools = [
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: false, approvalTimeout: '' },
+    ]
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.concurrency', '"replace"')).toBe(false)
+  })
+})

--- a/frontend/src/components/AgentEditor/validateFormState.ts
+++ b/frontend/src/components/AgentEditor/validateFormState.ts
@@ -1,0 +1,203 @@
+import type { FormState } from './agentEditorUtils'
+import type { PollTriggerState, ScheduledTriggerState } from './FormMode/types'
+
+export interface FormIssue {
+  field: string
+  message: string
+}
+
+// parseGoDuration parses a Go duration string (e.g. "5m", "1h30m") and returns
+// the total duration in milliseconds, or null if the string is not parseable.
+// Supports: ms, s, m, h — the units used in Gleipnir policy YAML.
+export function parseGoDuration(s: string): number | null {
+  if (!s || s.trim() === '') return null
+  // All groups are optional, so the regex matches "" — guard against that with match[0] === ''.
+  const pattern = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?(?:(\d+)ms)?$/
+  const match = s.trim().match(pattern)
+  if (!match || match[0] === '') return null
+  const [, h, m, sec, ms] = match
+  const total =
+    (parseInt(h ?? '0') * 3600 +
+      parseInt(m ?? '0') * 60 +
+      parseInt(sec ?? '0')) *
+      1000 +
+    parseInt(ms ?? '0')
+  return total
+}
+
+// isValidToolRef checks that the string uses dot-notation (server.tool).
+function isValidToolRef(ref: string): boolean {
+  const parts = ref.split('.')
+  return parts.length >= 2 && parts[0] !== '' && parts.slice(1).join('.') !== ''
+}
+
+const VALID_CONCURRENCY = ['skip', 'queue', 'parallel', 'replace'] as const
+const VALID_COMPARATORS = ['equals', 'not_equals', 'greater_than', 'less_than', 'contains'] as const
+
+/**
+ * Validates a FormState against the rules mirrored from internal/policy/validator.go.
+ * Field paths are identical to the backend so server issues and client issues
+ * collapse on the same field in the ErrorBanner.
+ *
+ * Rules NOT replicated here (backend-only fallback):
+ * - claude-code legacy provider (form constrains provider via a select)
+ * - trigger.auth enum (form constrains via radio buttons)
+ * - capabilities.tools[i].approval enum (form is a boolean toggle)
+ * - capabilities.feedback.on_timeout enum (form hard-codes "fail")
+ */
+export function validateFormState(state: FormState): FormIssue[] {
+  const issues: FormIssue[] = []
+
+  function add(field: string, message: string) {
+    issues.push({ field, message })
+  }
+
+  // --- Identity ---
+  if (state.identity.name.trim() === '') {
+    add('name', 'name is required')
+  }
+
+  // --- Trigger ---
+  const trigger = state.trigger
+  if (trigger.type === 'scheduled') {
+    const scheduled = trigger as ScheduledTriggerState
+    if (scheduled.fireAt.length === 0) {
+      add(
+        'trigger.fire_at',
+        'trigger.fire_at is required for scheduled triggers and must contain at least one timestamp',
+      )
+    }
+  }
+
+  if (trigger.type === 'poll') {
+    const poll = trigger as PollTriggerState
+    const intervalMs = parseGoDuration(poll.interval)
+    if (intervalMs === null || intervalMs <= 0) {
+      add(
+        'trigger.interval',
+        'trigger.interval is required for poll triggers and must be a positive duration (e.g. "5m", "1h")',
+      )
+    } else if (intervalMs < 60 * 1000) {
+      add('trigger.interval', 'trigger.interval must be at least 1m to prevent excessive polling')
+    }
+
+    if (poll.checks.length === 0) {
+      add('trigger.checks', 'trigger.checks is required for poll triggers and must contain at least one check')
+    }
+
+    for (let i = 0; i < poll.checks.length; i++) {
+      const c = poll.checks[i]
+      if (c.tool === '') {
+        add(`trigger.checks[${i}].tool`, `trigger.checks[${i}].tool is required`)
+      } else if (!isValidToolRef(c.tool)) {
+        add(
+          `trigger.checks[${i}].tool`,
+          `trigger.checks[${i}].tool "${c.tool}" must use dot notation (server_name.tool_name)`,
+        )
+      }
+      if (c.path === '') {
+        add(`trigger.checks[${i}].path`, `trigger.checks[${i}].path is required`)
+      }
+      if (!VALID_COMPARATORS.includes(c.comparator as typeof VALID_COMPARATORS[number])) {
+        add(
+          `trigger.checks[${i}].comparator`,
+          `trigger.checks[${i}] must specify exactly one comparator (equals, not_equals, greater_than, less_than, contains)`,
+        )
+      }
+    }
+  }
+
+  // --- Capabilities ---
+  const { tools, feedback } = state.capabilities
+  if (tools.length === 0 && !feedback.enabled) {
+    add('capabilities', 'at least one capability is required (tool or feedback)')
+  }
+
+  const seen = new Set<string>()
+  for (let i = 0; i < tools.length; i++) {
+    const t = tools[i]
+    const toolRef = `${t.serverName}.${t.name}`
+    if (toolRef === '.' || t.serverName === '' || t.name === '') {
+      add(`capabilities.tools[${i}].tool`, `capabilities.tools[${i}].tool is required`)
+    } else if (!isValidToolRef(toolRef)) {
+      add(
+        `capabilities.tools[${i}].tool`,
+        `capabilities.tools[${i}].tool "${toolRef}" must use dot notation (server_name.tool_name)`,
+      )
+    } else if (seen.has(toolRef)) {
+      add(
+        `capabilities.tools[${i}].tool`,
+        `capabilities.tools[${i}].tool "${toolRef}" is a duplicate`,
+      )
+    }
+    seen.add(toolRef)
+
+    if (t.approvalRequired && t.approvalTimeout !== '') {
+      if (parseGoDuration(t.approvalTimeout) === null) {
+        add(
+          `capabilities.tools[${i}].timeout`,
+          `capabilities.tools[${i}].timeout "${t.approvalTimeout}" is not a valid duration`,
+        )
+      }
+    }
+  }
+
+  if (feedback.enabled && feedback.timeout !== '') {
+    if (parseGoDuration(feedback.timeout) === null) {
+      add(
+        'capabilities.feedback.timeout',
+        `capabilities.feedback.timeout "${feedback.timeout}" is not a valid duration`,
+      )
+    }
+  }
+
+  // --- Task ---
+  if (state.task.task.trim() === '') {
+    add('agent.task', 'agent.task is required')
+  }
+
+  // --- Model ---
+  if (state.model.provider === '') {
+    add(
+      'model.provider',
+      'model.provider is required (set a default in Admin → Models or specify model.provider in policy YAML)',
+    )
+  }
+  if (state.model.model === '') {
+    add(
+      'model.name',
+      'model.name is required (set a default in Admin → Models or specify model.name in policy YAML)',
+    )
+  }
+
+  // --- Run Limits ---
+  if (state.limits.max_tokens_per_run <= 0) {
+    add('agent.limits.max_tokens_per_run', 'agent.limits.max_tokens_per_run must be positive')
+  }
+  if (state.limits.max_tool_calls_per_run <= 0) {
+    add('agent.limits.max_tool_calls_per_run', 'agent.limits.max_tool_calls_per_run must be positive')
+  }
+
+  // --- Concurrency ---
+  if (!VALID_CONCURRENCY.includes(state.concurrency.concurrency)) {
+    add(
+      'agent.concurrency',
+      `agent.concurrency "${state.concurrency.concurrency}" is invalid; must be skip, queue, parallel, or replace`,
+    )
+  }
+  if (state.concurrency.queueDepth < 0) {
+    add('agent.queue_depth', 'agent.queue_depth must not be negative')
+  }
+
+  // Cross-validation: replace is incompatible with approval-required tools.
+  if (state.concurrency.concurrency === 'replace') {
+    if (tools.some(t => t.approvalRequired)) {
+      add(
+        'agent.concurrency',
+        'agent.concurrency "replace" is not valid when any tool has approval: required',
+      )
+    }
+  }
+
+  return issues
+}

--- a/frontend/src/components/MCPPage/AddServerModal/AddServerModal.tsx
+++ b/frontend/src/components/MCPPage/AddServerModal/AddServerModal.tsx
@@ -4,6 +4,7 @@ import { ModalFooter } from '@/components/ModalFooter'
 import { Button } from '@/components/Button/Button'
 import { useTestMcpConnection } from '@/hooks/mutations/servers'
 import type { ApiError } from '@/api/fetch'
+import { ErrorBanner } from '@/components/form/ErrorBanner'
 import styles from './AddServerModal.module.css'
 import formStyles from '@/styles/forms.module.css'
 import alertStyles from '@/styles/alerts.module.css'
@@ -118,11 +119,16 @@ export function AddServerModal({ onClose, onSubmit, isPending, error, discoveryW
             </div>
           )}
         </div>
-        {error && (
-          <div className={alertStyles.alertError} role="alert">
-            {error.message}
-          </div>
-        )}
+        <ErrorBanner
+          issues={
+            error
+              ? (error.issues ??
+                  (error.detail
+                    ? [{ message: error.detail }]
+                    : [{ message: error.message }]))
+              : []
+          }
+        />
         {discoveryWarning && (
           <div className={alertStyles.alertWarning} role="status">
             Server registered, but tool discovery failed: {discoveryWarning}. You can retry with the Discover button.

--- a/frontend/src/components/Settings/ChangePasswordSection.tsx
+++ b/frontend/src/components/Settings/ChangePasswordSection.tsx
@@ -3,6 +3,7 @@ import { Lock } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { useChangePassword } from '@/hooks/useSettings'
 import type { ApiError } from '@/api/fetch'
+import { ErrorBanner } from '@/components/form/ErrorBanner'
 import styles from './Settings.module.css'
 
 export function ChangePasswordSection() {
@@ -100,11 +101,18 @@ export function ChangePasswordSection() {
               />
             </div>
 
-            {(clientError ?? serverError) && (
-              <div className={styles.errorMsg}>
-                {clientError ?? serverError?.message}
-              </div>
-            )}
+            <ErrorBanner
+              issues={
+                clientError
+                  ? [{ message: clientError }]
+                  : serverError
+                    ? (serverError.issues ??
+                        (serverError.detail
+                          ? [{ message: serverError.detail }]
+                          : [{ message: serverError.message }]))
+                    : []
+              }
+            />
 
             {success && (
               <div className={styles.successMsg}>

--- a/frontend/src/components/UsersPage/CreateUserModal/CreateUserModal.tsx
+++ b/frontend/src/components/UsersPage/CreateUserModal/CreateUserModal.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from 'react'
 import { Modal } from '@/components/Modal'
 import { ModalFooter } from '@/components/ModalFooter'
 import type { ApiError } from '@/api/fetch'
-import alertStyles from '@/styles/alerts.module.css'
+import { ErrorBanner } from '@/components/form/ErrorBanner'
 import styles from './CreateUserModal.module.css'
 
 const ALL_ROLES = ['admin', 'operator', 'approver', 'auditor'] as const
@@ -95,11 +95,13 @@ export function CreateUserModal({ onClose, onSubmit, isPending, error }: Props) 
           </div>
         </div>
 
-        {error && (
-          <div className={alertStyles.alertError} role="alert">
-            {error.message}
-          </div>
-        )}
+        <ErrorBanner
+          issues={
+            error
+              ? (error.issues ?? (error.detail ? [{ message: error.detail }] : [{ message: error.message }]))
+              : []
+          }
+        />
       </form>
     </Modal>
   )

--- a/frontend/src/components/admin/OpenAICompatProviderModal.tsx
+++ b/frontend/src/components/admin/OpenAICompatProviderModal.tsx
@@ -6,9 +6,10 @@ import {
   useUpdateOpenAICompatProvider,
 } from '@/hooks/mutations/openaiCompatProviders'
 import type { ApiOpenAICompatProvider, ApiOpenAICompatProviderUpsert } from '@/api/types'
+import { ApiError } from '@/api/fetch'
+import { ErrorBanner } from '@/components/form/ErrorBanner'
 import styles from './OpenAICompatProviderModal.module.css'
 import formStyles from '@/styles/forms.module.css'
-import alertStyles from '@/styles/alerts.module.css'
 
 interface Props {
   mode: 'create' | 'edit'
@@ -22,7 +23,7 @@ export function OpenAICompatProviderModal({ mode, provider, onClose }: Props) {
   const [baseUrl, setBaseUrl] = useState(mode === 'edit' ? (provider?.base_url ?? '') : '')
   // Never pre-fill the API key — the masked value from the server is not a valid key.
   const [apiKey, setApiKey] = useState('')
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<ApiError | null>(null)
 
   const createMut = useCreateOpenAICompatProvider()
   const updateMut = useUpdateOpenAICompatProvider()
@@ -58,7 +59,7 @@ export function OpenAICompatProviderModal({ mode, provider, onClose }: Props) {
       createMut.mutate(body, {
         onSuccess: onClose,
         onError: (err) =>
-          setError(err instanceof Error ? err.message : 'Save failed, please try again'),
+          setError(err instanceof ApiError ? err : new ApiError(0, err instanceof Error ? err.message : 'Save failed, please try again')),
       })
     } else {
       updateMut.mutate(
@@ -66,7 +67,7 @@ export function OpenAICompatProviderModal({ mode, provider, onClose }: Props) {
         {
           onSuccess: onClose,
           onError: (err) =>
-            setError(err instanceof Error ? err.message : 'Save failed, please try again'),
+            setError(err instanceof ApiError ? err : new ApiError(0, err instanceof Error ? err.message : 'Save failed, please try again')),
         },
       )
     }
@@ -150,11 +151,16 @@ export function OpenAICompatProviderModal({ mode, provider, onClose }: Props) {
           </span>
         </div>
 
-        {error && (
-          <div className={alertStyles.alertError} role="alert">
-            {error}
-          </div>
-        )}
+        <ErrorBanner
+          issues={
+            error
+              ? (error.issues ??
+                  (error.detail
+                    ? [{ message: error.detail }]
+                    : [{ message: error.message }]))
+              : []
+          }
+        />
       </form>
     </Modal>
   )

--- a/frontend/src/components/form/ErrorBanner/ErrorBanner.module.css
+++ b/frontend/src/components/form/ErrorBanner/ErrorBanner.module.css
@@ -1,0 +1,59 @@
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(in srgb, var(--color-red) 10%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-red) 25%, transparent);
+  color: var(--color-red);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.bannerContent {
+  flex: 1;
+}
+
+.bannerTitle {
+  font-weight: 500;
+  margin-bottom: var(--space-2);
+}
+
+.issueList {
+  margin: 0;
+  padding-left: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.issueItem {
+  list-style-type: disc;
+}
+
+.issueButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  font-size: inherit;
+  text-align: left;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.issueButton:hover {
+  opacity: 0.8;
+}
+
+.dismissButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  line-height: 1;
+  font-size: var(--text-base);
+  flex-shrink: 0;
+}

--- a/frontend/src/components/form/ErrorBanner/ErrorBanner.stories.tsx
+++ b/frontend/src/components/form/ErrorBanner/ErrorBanner.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ErrorBanner } from './ErrorBanner'
+
+const meta: Meta<typeof ErrorBanner> = {
+  title: 'Form/ErrorBanner',
+  component: ErrorBanner,
+}
+
+export default meta
+
+type Story = StoryObj<typeof ErrorBanner>
+
+export const NoIssues: Story = {
+  args: {
+    issues: [],
+  },
+}
+
+export const OneIssue: Story = {
+  args: {
+    issues: [{ field: 'name', message: 'Name is required' }],
+    onIssueClick: (field) => console.log('clicked', field),
+  },
+}
+
+export const ManyIssues: Story = {
+  args: {
+    issues: [
+      { field: 'name', message: 'Name is required' },
+      { field: 'agent.task', message: 'Task is required' },
+      { field: 'model.provider', message: 'Provider is required' },
+      { field: 'capabilities.tools[0].tool', message: 'Tool must use dot notation' },
+      { field: 'agent.concurrency', message: '"replace" is not valid when any tool has approval: required' },
+    ],
+    onIssueClick: (field) => console.log('clicked', field),
+    onDismiss: () => console.log('dismissed'),
+  },
+}
+
+export const ServerOnlyIssues: Story = {
+  args: {
+    issues: [
+      { message: 'Server returned an unexpected error' },
+      { message: 'Rate limit exceeded; please wait before retrying' },
+    ],
+  },
+}
+
+export const WithDismiss: Story = {
+  args: {
+    issues: [{ field: 'model.provider', message: 'Provider is required' }],
+    onDismiss: () => console.log('dismissed'),
+    onIssueClick: (field) => console.log('clicked', field),
+  },
+}

--- a/frontend/src/components/form/ErrorBanner/ErrorBanner.test.tsx
+++ b/frontend/src/components/form/ErrorBanner/ErrorBanner.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ErrorBanner } from './ErrorBanner'
+
+describe('ErrorBanner', () => {
+  it('returns null when issues is empty', () => {
+    const { container } = render(<ErrorBanner issues={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a bulleted list when issues are provided', () => {
+    render(
+      <ErrorBanner
+        issues={[
+          { field: 'name', message: 'Name is required' },
+          { field: 'agent.task', message: 'Task is required' },
+        ]}
+      />,
+    )
+    expect(screen.getByText('Name is required')).toBeInTheDocument()
+    expect(screen.getByText('Task is required')).toBeInTheDocument()
+  })
+
+  it('renders issue with field as a clickable button', () => {
+    const onClick = vi.fn()
+    render(
+      <ErrorBanner
+        issues={[{ field: 'name', message: 'Name is required' }]}
+        onIssueClick={onClick}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Name is required' })
+    fireEvent.click(btn)
+    expect(onClick).toHaveBeenCalledWith('name')
+  })
+
+  it('renders issue without field as plain text (no button)', () => {
+    const onClick = vi.fn()
+    render(
+      <ErrorBanner
+        issues={[{ message: 'Server error' }]}
+        onIssueClick={onClick}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: 'Server error' })).toBeNull()
+    expect(screen.getByText('Server error')).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(
+      <ErrorBanner
+        issues={[{ message: 'Error' }]}
+        onDismiss={onDismiss}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render a dismiss button when onDismiss is not provided', () => {
+    render(<ErrorBanner issues={[{ message: 'Error' }]} />)
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
+  })
+
+  it('renders multiple issues with the same field as separate bullets', () => {
+    render(
+      <ErrorBanner
+        issues={[
+          { field: 'capabilities.tools[0].tool', message: 'Bad dot notation' },
+          { field: 'capabilities.tools[0].tool', message: 'Duplicate tool' },
+        ]}
+      />,
+    )
+    expect(screen.getByText('Bad dot notation')).toBeInTheDocument()
+    expect(screen.getByText('Duplicate tool')).toBeInTheDocument()
+  })
+
+  it('renders with role=alert', () => {
+    render(<ErrorBanner issues={[{ message: 'Error' }]} />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('uses the custom title when provided', () => {
+    render(
+      <ErrorBanner
+        title="Please fix these issues"
+        issues={[{ message: 'Error' }]}
+      />,
+    )
+    expect(screen.getByText('Please fix these issues')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/form/ErrorBanner/ErrorBanner.tsx
+++ b/frontend/src/components/form/ErrorBanner/ErrorBanner.tsx
@@ -1,0 +1,61 @@
+import styles from './ErrorBanner.module.css'
+
+export interface BannerIssue {
+  field?: string
+  message: string
+}
+
+export interface ErrorBannerProps {
+  /** Title shown above the issue list. Defaults to "Fix the following before saving". */
+  title?: string
+  /** Issues to display. Returns null when empty. */
+  issues: BannerIssue[]
+  /** Called when the dismiss (×) button is clicked. Omit to hide the button. */
+  onDismiss?: () => void
+  /** Called with the field path when a clickable issue bullet is clicked. */
+  onIssueClick?: (field: string) => void
+}
+
+/**
+ * A top-of-form error banner that lists validation issues. Issues with a
+ * `field` render as a button so the user can click to jump to the offending
+ * input. Returns null when there are no issues.
+ */
+export function ErrorBanner({ title = 'Fix the following before saving', issues, onDismiss, onIssueClick }: ErrorBannerProps) {
+  if (issues.length === 0) return null
+
+  return (
+    <div className={styles.banner} role="alert">
+      <div className={styles.bannerContent}>
+        <div className={styles.bannerTitle}>{title}</div>
+        <ul className={styles.issueList}>
+          {issues.map((issue, i) => (
+            <li key={i} className={styles.issueItem}>
+              {issue.field && onIssueClick ? (
+                <button
+                  type="button"
+                  className={styles.issueButton}
+                  onClick={() => onIssueClick(issue.field!)}
+                >
+                  {issue.message}
+                </button>
+              ) : (
+                <span>{issue.message}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          className={styles.dismissButton}
+          onClick={onDismiss}
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/form/ErrorBanner/index.ts
+++ b/frontend/src/components/form/ErrorBanner/index.ts
@@ -1,0 +1,2 @@
+export { ErrorBanner } from './ErrorBanner'
+export type { ErrorBannerProps, BannerIssue } from './ErrorBanner'

--- a/frontend/src/components/form/FieldError/FieldError.module.css
+++ b/frontend/src/components/form/FieldError/FieldError.module.css
@@ -1,0 +1,15 @@
+.fieldError {
+  color: var(--color-red);
+  font-size: var(--text-xs);
+  margin-top: var(--space-1);
+  line-height: 1.4;
+}
+
+.fieldErrorList {
+  margin: var(--space-1) 0 0;
+  padding-left: var(--space-4);
+}
+
+.fieldErrorList li {
+  margin-top: var(--space-1);
+}

--- a/frontend/src/components/form/FieldError/FieldError.stories.tsx
+++ b/frontend/src/components/form/FieldError/FieldError.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FieldError } from './FieldError'
+
+const meta: Meta<typeof FieldError> = {
+  title: 'Form/FieldError',
+  component: FieldError,
+}
+
+export default meta
+
+type Story = StoryObj<typeof FieldError>
+
+export const Empty: Story = {
+  args: {
+    messages: [],
+  },
+}
+
+export const Single: Story = {
+  args: {
+    id: 'field-name-error',
+    messages: 'Name is required',
+  },
+}
+
+export const Multi: Story = {
+  args: {
+    id: 'field-tool-error',
+    messages: [
+      'Tool must use dot notation (server.tool_name)',
+      'Tool name is a duplicate',
+    ],
+  },
+}

--- a/frontend/src/components/form/FieldError/FieldError.test.tsx
+++ b/frontend/src/components/form/FieldError/FieldError.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FieldError } from './FieldError'
+
+describe('FieldError', () => {
+  it('renders nothing when messages is empty array', () => {
+    const { container } = render(<FieldError messages={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when messages is undefined', () => {
+    const { container } = render(<FieldError />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when messages is an empty string', () => {
+    const { container } = render(<FieldError messages="" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders role=alert for a single message string', () => {
+    render(<FieldError messages="Name is required" />)
+    const el = screen.getByRole('alert')
+    expect(el).toBeInTheDocument()
+    expect(el).toHaveTextContent('Name is required')
+  })
+
+  it('renders role=alert for a single-element array', () => {
+    render(<FieldError messages={['Name is required']} />)
+    const el = screen.getByRole('alert')
+    expect(el).toBeInTheDocument()
+    expect(el).toHaveTextContent('Name is required')
+  })
+
+  it('renders multiple messages as a list with role=alert', () => {
+    render(<FieldError messages={['Error one', 'Error two']} />)
+    const el = screen.getByRole('alert')
+    expect(el.tagName).toBe('UL')
+    expect(screen.getByText('Error one')).toBeInTheDocument()
+    expect(screen.getByText('Error two')).toBeInTheDocument()
+  })
+
+  it('forwards the id prop to the root element', () => {
+    render(<FieldError id="my-error" messages="oops" />)
+    expect(screen.getByRole('alert')).toHaveAttribute('id', 'my-error')
+  })
+
+  it('filters out empty strings from the messages array', () => {
+    const { container } = render(<FieldError messages={['', '']} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/components/form/FieldError/FieldError.tsx
+++ b/frontend/src/components/form/FieldError/FieldError.tsx
@@ -1,0 +1,41 @@
+import styles from './FieldError.module.css'
+
+export interface FieldErrorProps {
+  /** DOM id — lets the field set aria-describedby to this element. */
+  id?: string
+  /** One or more error messages. A single string is treated as one message. */
+  messages?: string | string[]
+}
+
+/**
+ * Renders a small inline error message beneath a form field. Returns null
+ * when there are no messages to show. Use `id` + `aria-describedby` on the
+ * associated input to wire up the accessibility relationship.
+ */
+export function FieldError({ id, messages }: FieldErrorProps) {
+  const list = messages === undefined || messages === null
+    ? []
+    : Array.isArray(messages)
+      ? messages.filter(m => m.length > 0)
+      : messages.length > 0
+        ? [messages]
+        : []
+
+  if (list.length === 0) return null
+
+  if (list.length === 1) {
+    return (
+      <div id={id} role="alert" className={styles.fieldError}>
+        {list[0]}
+      </div>
+    )
+  }
+
+  return (
+    <ul id={id} role="alert" className={`${styles.fieldError} ${styles.fieldErrorList}`}>
+      {list.map((msg, i) => (
+        <li key={i}>{msg}</li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/components/form/FieldError/index.ts
+++ b/frontend/src/components/form/FieldError/index.ts
@@ -1,0 +1,2 @@
+export { FieldError } from './FieldError'
+export type { FieldErrorProps } from './FieldError'

--- a/frontend/src/components/form/index.ts
+++ b/frontend/src/components/form/index.ts
@@ -1,0 +1,4 @@
+export { FieldError } from './FieldError'
+export type { FieldErrorProps } from './FieldError'
+export { ErrorBanner } from './ErrorBanner'
+export type { ErrorBannerProps, BannerIssue } from './ErrorBanner'

--- a/frontend/src/pages/AdminSystemPage.tsx
+++ b/frontend/src/pages/AdminSystemPage.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useAdminSettings, useSystemInfo } from '@/hooks/queries/admin'
 import { useUpdateAdminSettings } from '@/hooks/mutations/admin'
+import { ErrorBanner } from '@/components/form/ErrorBanner'
 import cardStyles from '@/components/Settings/Settings.module.css'
 import styles from './AdminSystemPage.module.css'
 
@@ -73,9 +74,9 @@ function PublicURLSection() {
             Save
           </button>
           {saved && <span className={cardStyles.successMsg}>Saved</span>}
-          {updateSettings.isError && (
-            <span className={cardStyles.errorMsg}>Failed to save settings</span>
-          )}
+          <ErrorBanner
+            issues={updateSettings.isError ? [{ message: 'Failed to save settings' }] : []}
+          />
         </div>
       </div>
     </section>
@@ -171,9 +172,9 @@ function RunLimitsSection() {
             Save
           </button>
           {saved && <span className={cardStyles.successMsg}>Saved</span>}
-          {updateSettings.isError && (
-            <span className={cardStyles.errorMsg}>Failed to save settings</span>
-          )}
+          <ErrorBanner
+            issues={updateSettings.isError ? [{ message: 'Failed to save settings' }] : []}
+          />
         </div>
       </div>
     </section>

--- a/frontend/src/pages/AgentEditorPage.module.css
+++ b/frontend/src/pages/AgentEditorPage.module.css
@@ -30,33 +30,6 @@
   width: 100%;
 }
 
-.errorBanner {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  background: color-mix(in srgb, var(--color-red) 10%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--color-red) 25%, transparent);
-  color: var(--color-red);
-  font-size: var(--text-sm);
-  line-height: 1.5;
-}
-
-.errorBannerMessage {
-  flex: 1;
-}
-
-.errorBannerClose {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: inherit;
-  padding: 0;
-  line-height: 1;
-  font-size: var(--text-base);
-  flex-shrink: 0;
-}
-
 .loadingState,
 .errorState {
   flex: 1;

--- a/frontend/src/pages/AgentEditorPage.test.tsx
+++ b/frontend/src/pages/AgentEditorPage.test.tsx
@@ -39,6 +39,24 @@ agent:
   concurrency: skip
 `
 
+// VALID_YAML has all required fields so validateFormState returns no issues.
+const VALID_YAML = `name: my-agent
+trigger:
+  type: webhook
+model:
+  provider: anthropic
+  name: claude-opus-4-5
+capabilities:
+  tools:
+    - tool: filesystem.read_file
+agent:
+  task: Do the thing.
+  limits:
+    max_tokens_per_run: 10000
+    max_tool_calls_per_run: 50
+  concurrency: skip
+`
+
 const MANUAL_YAML = `name: manual-policy
 trigger:
   type: manual
@@ -248,14 +266,15 @@ describe('AgentEditorUtils — YAML ↔ form round-trip (pure functions)', () =>
 
 describe('AgentEditorPage — dirty state and save', () => {
   it('editing the name field sets isDirty; saving clears it', async () => {
-    // Use an existing-policy route so save does not navigate away
+    // Use an existing-policy route so save does not navigate away.
+    // VALID_YAML passes all client-side validation so the save button works.
     vi.mocked(usePolicy).mockReturnValue({
       data: {
         id: 'existing-id',
-        name: 'existing-policy',
+        name: 'my-agent',
         trigger_type: 'webhook',
         folder: '',
-        yaml: WEBHOOK_YAML,
+        yaml: VALID_YAML,
         created_at: '',
         updated_at: '',
       },
@@ -279,8 +298,8 @@ describe('AgentEditorPage — dirty state and save', () => {
 
     const mutateAsync = vi.fn().mockResolvedValue({
       id: 'existing-id',
-      name: 'existing-policy',
-      yaml: WEBHOOK_YAML,
+      name: 'my-agent',
+      yaml: VALID_YAML,
       trigger_type: 'webhook',
       folder: '',
       created_at: '',
@@ -352,7 +371,20 @@ describe('AgentEditorPage — dirty state and save', () => {
 describe('AgentEditorPage — Ctrl+S always triggers save', () => {
   it('calls mutateAsync on Ctrl+S even when the form has not been changed', async () => {
     const { mutateAsync } = mockHooksDefault()
-    renderEditor()
+    // Load a valid policy so client-side validation passes.
+    vi.mocked(usePolicy).mockReturnValue({
+      data: {
+        id: 'valid-id',
+        name: 'my-agent',
+        trigger_type: 'webhook',
+        folder: '',
+        yaml: VALID_YAML,
+        created_at: '',
+        updated_at: '',
+      },
+      status: 'success',
+    } as ReturnType<typeof usePolicy>)
+    renderEditor('/agents/valid-id')
 
     // Ctrl+S fires handleSave unconditionally (does not check canSave/isDirty)
     fireEvent.keyDown(window, { key: 's', ctrlKey: true })
@@ -366,13 +398,30 @@ describe('AgentEditorPage — Ctrl+S always triggers save', () => {
 })
 
 describe('AgentEditorPage — Cmd+S / Ctrl+S fires save', () => {
-  it('fires mutateAsync on Cmd+S when form is dirty', async () => {
+  function renderValidEditor() {
     const { mutateAsync } = mockHooksDefault()
-    renderEditor()
+    vi.mocked(usePolicy).mockReturnValue({
+      data: {
+        id: 'valid-id',
+        name: 'my-agent',
+        trigger_type: 'webhook',
+        folder: '',
+        yaml: VALID_YAML,
+        created_at: '',
+        updated_at: '',
+      },
+      status: 'success',
+    } as ReturnType<typeof usePolicy>)
+    renderEditor('/agents/valid-id')
+    return { mutateAsync }
+  }
+
+  it('fires mutateAsync on Cmd+S when form is dirty', async () => {
+    const { mutateAsync } = renderValidEditor()
 
     // Make form dirty — Name is first textbox (label lacks htmlFor)
     const nameInput = screen.getAllByRole('textbox')[0]
-    await userEvent.type(nameInput, 'test')
+    await userEvent.type(nameInput, '-edited')
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled()
@@ -387,11 +436,10 @@ describe('AgentEditorPage — Cmd+S / Ctrl+S fires save', () => {
   })
 
   it('fires mutateAsync on Ctrl+S when form is dirty', async () => {
-    const { mutateAsync } = mockHooksDefault()
-    renderEditor()
+    const { mutateAsync } = renderValidEditor()
 
     const nameInput = screen.getAllByRole('textbox')[0]
-    await userEvent.type(nameInput, 'test')
+    await userEvent.type(nameInput, '-edited')
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled()
@@ -568,6 +616,126 @@ describe('AgentEditorPage — Run now button', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Run "manual-policy"/)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('AgentEditorPage — client-side validation', () => {
+  it('shows banner and inline error for empty name, does not call the API', async () => {
+    const { mutateAsync } = mockHooksDefault()
+    // Load a valid policy, then clear the name so the single "name is required"
+    // issue fires (and not a cascade of other missing-field issues).
+    vi.mocked(usePolicy).mockReturnValue({
+      data: {
+        id: 'valid-id',
+        name: 'my-agent',
+        trigger_type: 'webhook',
+        folder: '',
+        yaml: VALID_YAML,
+        created_at: '',
+        updated_at: '',
+      },
+      status: 'success',
+    } as ReturnType<typeof usePolicy>)
+    renderEditor('/agents/valid-id')
+
+    // Clear the name field
+    const nameInput = screen.getAllByRole('textbox')[0]
+    await userEvent.clear(nameInput)
+
+    // Attempt save via keyboard shortcut
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true })
+
+    await waitFor(() => {
+      // Both the ErrorBanner and the inline FieldError have role="alert"
+      const alerts = screen.getAllByRole('alert')
+      expect(alerts.length).toBeGreaterThan(0)
+      expect(screen.getAllByText(/name is required/i).length).toBeGreaterThan(0)
+    })
+
+    // mutateAsync must not have been called (API not hit)
+    expect(mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('clears banner and calls the API when the form is valid', async () => {
+    const { mutateAsync } = mockHooksDefault()
+    // Load a valid policy — all fields are set, no client errors expected.
+    vi.mocked(usePolicy).mockReturnValue({
+      data: {
+        id: 'valid-id',
+        name: 'my-agent',
+        trigger_type: 'webhook',
+        folder: '',
+        yaml: VALID_YAML,
+        created_at: '',
+        updated_at: '',
+      },
+      status: 'success',
+    } as ReturnType<typeof usePolicy>)
+    renderEditor('/agents/valid-id')
+
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true })
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('AgentEditorPage — server validation errors', () => {
+  function loadValidPolicy() {
+    vi.mocked(usePolicy).mockReturnValue({
+      data: {
+        id: 'valid-id',
+        name: 'my-agent',
+        trigger_type: 'webhook',
+        folder: '',
+        yaml: VALID_YAML,
+        created_at: '',
+        updated_at: '',
+      },
+      status: 'success',
+    } as ReturnType<typeof usePolicy>)
+  }
+
+  it('shows banner with server issue when server returns issues[]', async () => {
+    mockHooksDefault()
+    loadValidPolicy()
+    const serverIssues = [{ field: 'model.provider', message: 'model.provider is required' }]
+    vi.mocked(useSavePolicy).mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(
+        new ApiError(400, 'policy validation failed', 'model.provider is required', serverIssues),
+      ),
+      isPending: false,
+    } as unknown as ReturnType<typeof useSavePolicy>)
+
+    renderEditor('/agents/valid-id')
+
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true })
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThan(0)
+      expect(screen.getAllByText(/model\.provider is required/).length).toBeGreaterThan(0)
+    })
+  })
+
+  it('shows detail string in banner when server returns legacy response (no issues[])', async () => {
+    mockHooksDefault()
+    loadValidPolicy()
+    vi.mocked(useSavePolicy).mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(
+        new ApiError(400, 'policy validation failed', 'policy already exists'),
+      ),
+      isPending: false,
+    } as unknown as ReturnType<typeof useSavePolicy>)
+
+    renderEditor('/agents/valid-id')
+
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true })
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThan(0)
+      expect(screen.getByText(/policy already exists/)).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/AgentEditorPage.tsx
+++ b/frontend/src/pages/AgentEditorPage.tsx
@@ -11,13 +11,43 @@ import { RunLimitsSection } from '@/components/AgentEditor/FormMode/RunLimitsSec
 import { ConcurrencySection } from '@/components/AgentEditor/FormMode/ConcurrencySection'
 import { ModelSection } from '@/components/AgentEditor/FormMode/ModelSection'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { ErrorBanner } from '@/components/form/ErrorBanner'
 import { usePolicy, usePolicies } from '@/hooks/queries/policies'
 import { useSavePolicy, useDeletePolicy, usePausePolicy, useResumePolicy } from '@/hooks/mutations/policies'
 import { ApiError } from '@/api/fetch'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import NotFoundPage from '@/pages/NotFoundPage'
 import { defaultFormState, FormState, formStateToYaml, yamlToFormState } from '@/components/AgentEditor/agentEditorUtils'
+import { validateFormState, type FormIssue } from '@/components/AgentEditor/validateFormState'
 import styles from './AgentEditorPage.module.css'
+
+// splitIssuesBySection partitions a flat FormIssue list into buckets by the
+// canonical field prefix. Each section receives only the issues that belong to
+// it so it can render inline FieldError components without global state.
+function splitIssuesBySection(issues: FormIssue[]) {
+  return {
+    identity: issues.filter(iss => iss.field === 'name'),
+    trigger: issues.filter(iss => iss.field.startsWith('trigger.')),
+    capabilities: issues.filter(iss => iss.field.startsWith('capabilities')),
+    task: issues.filter(iss => iss.field === 'agent.task'),
+    model: issues.filter(iss => iss.field.startsWith('model.')),
+    limits: issues.filter(iss => iss.field.startsWith('agent.limits.')),
+    // Explicit field names rather than startsWith('agent.') because agent.task
+    // and agent.limits.* belong to separate sections.
+    concurrency: issues.filter(iss => iss.field === 'agent.concurrency' || iss.field === 'agent.queue_depth'),
+  }
+}
+
+// scrollToField scrolls the first element with data-field="<field>" into view
+// and focuses the first focusable child inside it.
+function scrollToField(field: string) {
+  const el = document.querySelector<HTMLElement>(`[data-field="${CSS.escape(field)}"]`)
+  if (!el) return
+  // scrollIntoView is not available in all environments (e.g. jsdom in tests).
+  el.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+  const focusable = el.querySelector<HTMLElement>('input, textarea, select, button')
+  focusable?.focus({ preventScroll: true })
+}
 
 export function AgentEditorPage() {
   const { id } = useParams<{ id?: string }>()
@@ -36,7 +66,11 @@ export function AgentEditorPage() {
 
   const [isDirty, setIsDirty] = useState(false)
   const [formState, setFormState] = useState<FormState>(() => defaultFormState())
-  const [saveError, setSaveError] = useState<string | null>(null)
+  // issues holds the current set of validation errors (either from client-side
+  // validation or from the server). detailMsg holds a non-structured error
+  // message (e.g. "already exists") when the server does not return issues[].
+  const [issues, setIssues] = useState<FormIssue[]>([])
+  const [detailMsg, setDetailMsg] = useState<string | null>(null)
   const [savedPolicyId, setSavedPolicyId] = useState<string | undefined>(id)
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
   const [deleteError, setDeleteError] = useState<ApiError | null>(null)
@@ -62,7 +96,19 @@ export function AgentEditorPage() {
   }
 
   async function handleSave() {
-    setSaveError(null)
+    // Client-side validation runs first. If it finds issues, short-circuit:
+    // display inline errors + banner and scroll to the first offending field.
+    const clientIssues = validateFormState(formState)
+    if (clientIssues.length > 0) {
+      setIssues(clientIssues)
+      setDetailMsg(null)
+      scrollToField(clientIssues[0].field)
+      return
+    }
+
+    setIssues([])
+    setDetailMsg(null)
+
     const yaml = formStateToYaml(formState)
     try {
       const result = await savePolicy.mutateAsync({ id, yaml })
@@ -73,7 +119,20 @@ export function AgentEditorPage() {
       }
     } catch (e) {
       const err = e as ApiError
-      setSaveError(err?.detail ?? err?.message ?? 'Save failed. Please try again.')
+      if (err?.issues?.length) {
+        // Server returned structured issues — render them like client-side issues.
+        const serverIssues: FormIssue[] = err.issues.map(iss => ({
+          field: iss.field ?? '',
+          message: iss.message,
+        }))
+        setIssues(serverIssues)
+        setDetailMsg(null)
+        scrollToField(serverIssues[0].field)
+      } else {
+        // Legacy or non-validation error — fall back to the single-bullet banner.
+        setDetailMsg(err?.detail ?? err?.message ?? 'Save failed. Please try again.')
+        setIssues([])
+      }
     }
   }
 
@@ -154,6 +213,16 @@ export function AgentEditorPage() {
     )
   }
 
+  const sectionIssues = splitIssuesBySection(issues)
+
+  // Build the banner issue list: if we have structured issues use them;
+  // otherwise fall back to the single detail message.
+  const bannerIssues = issues.length > 0
+    ? issues
+    : detailMsg
+      ? [{ message: detailMsg }]
+      : []
+
   return (
     <div className={styles.page}>
       <EditorTopBar
@@ -191,42 +260,48 @@ export function AgentEditorPage() {
       )}
       <ErrorBoundary>
         <div className={styles.content}>
-          {saveError && (
-            <div className={styles.errorBanner}>
-              <span className={styles.errorBannerMessage}>{saveError}</span>
-              <button className={styles.errorBannerClose} onClick={() => setSaveError(null)}>×</button>
-            </div>
-          )}
+          <ErrorBanner
+            issues={bannerIssues}
+            onDismiss={() => { setIssues([]); setDetailMsg(null) }}
+            onIssueClick={scrollToField}
+          />
           <div className={styles.formPane}>
             <PolicyIdentitySection
               value={formState.identity}
               onChange={v => handleFormChange({ identity: v })}
               existingFolders={existingFolders}
+              errors={sectionIssues.identity}
             />
             <TriggerSection
               value={formState.trigger}
               onChange={v => handleFormChange({ trigger: v })}
               policyId={savedPolicyId}
+              errors={sectionIssues.trigger}
             />
             <CapabilitiesSection
               value={formState.capabilities}
               onChange={v => handleFormChange({ capabilities: v })}
+              errors={sectionIssues.capabilities}
             />
             <TaskInstructionsSection
               value={formState.task}
               onChange={v => handleFormChange({ task: v })}
+              errors={sectionIssues.task}
             />
             <ModelSection
               value={formState.model}
               onChange={v => handleFormChange({ model: v })}
+              errors={sectionIssues.model}
             />
             <RunLimitsSection
               value={formState.limits}
               onChange={v => handleFormChange({ limits: v })}
+              errors={sectionIssues.limits}
             />
             <ConcurrencySection
               value={formState.concurrency}
               onChange={v => handleFormChange({ concurrency: v })}
+              errors={sectionIssues.concurrency}
             />
           </div>
         </div>

--- a/internal/api/policy_handler.go
+++ b/internal/api/policy_handler.go
@@ -314,7 +314,14 @@ func (h *PolicyHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		var ve *policy.ValidationError
 		if errors.As(err, &ve) {
-			httputil.WriteError(w, http.StatusBadRequest, "policy validation failed", strings.Join(ve.Errors, "; "))
+			messages := make([]string, 0, len(ve.Errors))
+			issues := make([]httputil.ErrorIssue, 0, len(ve.Errors))
+			for _, iss := range ve.Errors {
+				messages = append(messages, iss.Message)
+				issues = append(issues, httputil.ErrorIssue{Field: iss.Field, Message: iss.Message})
+			}
+			httputil.WriteValidationError(w, http.StatusBadRequest,
+				"policy validation failed", strings.Join(messages, "; "), issues)
 			return
 		}
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to create policy", err.Error())
@@ -348,7 +355,14 @@ func (h *PolicyHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 		var ve *policy.ValidationError
 		if errors.As(err, &ve) {
-			httputil.WriteError(w, http.StatusBadRequest, "policy validation failed", strings.Join(ve.Errors, "; "))
+			messages := make([]string, 0, len(ve.Errors))
+			issues := make([]httputil.ErrorIssue, 0, len(ve.Errors))
+			for _, iss := range ve.Errors {
+				messages = append(messages, iss.Message)
+				issues = append(issues, httputil.ErrorIssue{Field: iss.Field, Message: iss.Message})
+			}
+			httputil.WriteValidationError(w, http.StatusBadRequest,
+				"policy validation failed", strings.Join(messages, "; "), issues)
 			return
 		}
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to update policy", err.Error())

--- a/internal/api/policy_handler_test.go
+++ b/internal/api/policy_handler_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1554,4 +1555,197 @@ func TestPolicyHandler_NilNotifiersDoNotPanic(t *testing.T) {
 	resp.Body.Close()
 
 	// If we reach here without panicking, the test passes.
+}
+
+// TestPolicyValidationErrorShape asserts that the API returns the structured
+// `issues` array alongside the legacy `detail` string when policy validation
+// fails. This covers five distinct field families so the handler's mapping from
+// policy.Issue to httputil.ErrorIssue is exercised end-to-end.
+func TestPolicyValidationErrorShape(t *testing.T) {
+	// responseEnvelope captures the fields we want to assert on.
+	type issueJSON struct {
+		Field   string `json:"field"`
+		Message string `json:"message"`
+	}
+	type envelope struct {
+		Error  string      `json:"error"`
+		Detail string      `json:"detail"`
+		Issues []issueJSON `json:"issues"`
+	}
+
+	mustDecodeEnvelope := func(t *testing.T, body []byte) envelope {
+		t.Helper()
+		var env envelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			t.Fatalf("decode envelope: %v", err)
+		}
+		return env
+	}
+
+	findIssue := func(issues []issueJSON, field, messageSubstr string) bool {
+		for _, iss := range issues {
+			if iss.Field == field && strings.Contains(iss.Message, messageSubstr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// assertValidationEnvelope POSTs yaml and checks the structured response.
+	assertValidationEnvelope := func(t *testing.T, yaml string, wantIssues []issueJSON) {
+		t.Helper()
+		store := newPolicyHandlerStore(t)
+		srv := httptest.NewServer(newPolicyRouter(store))
+		t.Cleanup(srv.Close)
+
+		resp, err := http.Post(srv.URL+"/policies", "text/plain", strings.NewReader(yaml))
+		if err != nil {
+			t.Fatalf("POST /policies: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", resp.StatusCode)
+		}
+
+		var rawBody []byte
+		rawBody, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+
+		env := mustDecodeEnvelope(t, rawBody)
+
+		if env.Error != "policy validation failed" {
+			t.Errorf("error = %q, want %q", env.Error, "policy validation failed")
+		}
+		if env.Detail == "" {
+			t.Errorf("detail must not be empty (legacy shape preserved)")
+		}
+		if len(env.Issues) == 0 {
+			t.Errorf("issues must not be empty, got: %s", rawBody)
+		}
+
+		for _, want := range wantIssues {
+			if !findIssue(env.Issues, want.Field, want.Message) {
+				t.Errorf("missing issue {field=%q, message~=%q} in %v", want.Field, want.Message, env.Issues)
+			}
+		}
+	}
+
+	t.Run("missing name", func(t *testing.T) {
+		yaml := `
+trigger:
+  type: webhook
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do something
+  limits:
+    max_tokens_per_run: 1000
+    max_tool_calls_per_run: 10
+  concurrency: skip
+`
+		assertValidationEnvelope(t, yaml, []issueJSON{
+			{Field: "name", Message: "name is required"},
+		})
+	})
+
+	t.Run("missing tool dot-notation", func(t *testing.T) {
+		yaml := `
+name: test
+trigger:
+  type: webhook
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+capabilities:
+  tools:
+    - tool: nodot
+agent:
+  task: do something
+  limits:
+    max_tokens_per_run: 1000
+    max_tool_calls_per_run: 10
+  concurrency: skip
+`
+		assertValidationEnvelope(t, yaml, []issueJSON{
+			{Field: "capabilities.tools[0].tool", Message: "dot notation"},
+		})
+	})
+
+	t.Run("invalid concurrency mode", func(t *testing.T) {
+		yaml := `
+name: test
+trigger:
+  type: webhook
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do something
+  limits:
+    max_tokens_per_run: 1000
+    max_tool_calls_per_run: 10
+  concurrency: blorp
+`
+		assertValidationEnvelope(t, yaml, []issueJSON{
+			{Field: "agent.concurrency", Message: "invalid"},
+		})
+	})
+
+	t.Run("negative max_tokens_per_run", func(t *testing.T) {
+		yaml := `
+name: test
+trigger:
+  type: webhook
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do something
+  limits:
+    max_tokens_per_run: -1
+    max_tool_calls_per_run: 10
+  concurrency: skip
+`
+		assertValidationEnvelope(t, yaml, []issueJSON{
+			{Field: "agent.limits.max_tokens_per_run", Message: "must be positive"},
+		})
+	})
+
+	t.Run("replace plus approval conflict", func(t *testing.T) {
+		yaml := `
+name: test
+trigger:
+  type: webhook
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+capabilities:
+  tools:
+    - tool: srv.tool
+      approval: required
+      on_timeout: reject
+agent:
+  task: do something
+  limits:
+    max_tokens_per_run: 1000
+    max_tool_calls_per_run: 10
+  concurrency: replace
+`
+		assertValidationEnvelope(t, yaml, []issueJSON{
+			{Field: "agent.concurrency", Message: "replace"},
+		})
+	})
 }

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -6,6 +6,7 @@
 //
 //	{"data": T}                          for success
 //	{"error": "...", "detail": "..."}    for failure
+//	{"error": "...", "detail": "...", "issues": [...]} for validation failures
 package httputil
 
 import (
@@ -19,8 +20,18 @@ type successEnvelope struct {
 }
 
 type errorEnvelope struct {
-	Error  string `json:"error"`
-	Detail string `json:"detail,omitempty"`
+	Error  string       `json:"error"`
+	Detail string       `json:"detail,omitempty"`
+	Issues []ErrorIssue `json:"issues,omitempty"`
+}
+
+// ErrorIssue is a structured validation failure with an optional field path.
+// It is included in the API error envelope when validation fails so clients
+// can map errors back to specific form fields. Field is omitted when the error
+// is cross-cutting (not specific to a single input).
+type ErrorIssue struct {
+	Field   string `json:"field,omitempty"`
+	Message string `json:"message"`
 }
 
 // WriteJSON writes a JSON response body wrapped in {"data": data} with the
@@ -35,11 +46,25 @@ func WriteJSON(w http.ResponseWriter, status int, data any) {
 
 // WriteError writes a JSON error response with {"error": msg, "detail": detail}
 // and the given HTTP status code. detail is omitted from the response when empty.
+// Use WriteValidationError when structured field issues are available.
 func WriteError(w http.ResponseWriter, status int, msg, detail string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(errorEnvelope{Error: msg, Detail: detail}); err != nil {
 		slog.Error("failed to encode JSON error response", "err", err)
+	}
+}
+
+// WriteValidationError writes a structured validation error response that
+// includes both the legacy detail string (for old clients) and a typed issues
+// array (for new clients that surface per-field errors). The issues slice is
+// omitted from the JSON when nil or empty.
+func WriteValidationError(w http.ResponseWriter, status int, msg, detail string, issues []ErrorIssue) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	env := errorEnvelope{Error: msg, Detail: detail, Issues: issues}
+	if err := json.NewEncoder(w).Encode(env); err != nil {
+		slog.Error("failed to encode JSON validation error response", "err", err)
 	}
 }
 

--- a/internal/policy/service.go
+++ b/internal/policy/service.go
@@ -107,7 +107,7 @@ func NewService(store *db.Store, lookup ToolLookup, modelValidator ModelValidato
 // MCP registry (non-blocking warnings), and stores the policy.
 func (s *Service) Create(ctx context.Context, rawYAML string) (*SaveResult, error) {
 	if err := CheckLegacyWebhookSecret(rawYAML); err != nil {
-		return nil, &ValidationError{Errors: []string{err.Error()}}
+		return nil, &ValidationError{Errors: []Issue{{Field: "trigger.webhook_secret", Message: err.Error()}}}
 	}
 	provider, modelName := s.resolveDefaults(ctx)
 	parsed, err := Parse(rawYAML, provider, modelName)
@@ -118,7 +118,7 @@ func (s *Service) Create(ctx context.Context, rawYAML string) (*SaveResult, erro
 		return nil, err
 	}
 	if err := s.validateProviderOptions(parsed); err != nil {
-		return nil, &ValidationError{Errors: []string{err.Error()}}
+		return nil, &ValidationError{Errors: []Issue{{Field: "model", Message: err.Error()}}}
 	}
 	// Collect warnings before any blocking checks so model validation failures
 	// can be appended without returning an error.
@@ -141,7 +141,10 @@ func (s *Service) Create(ctx context.Context, rawYAML string) (*SaveResult, erro
 			}
 		}
 		if !hasFuture {
-			return nil, &ValidationError{Errors: []string{"trigger.fire_at: all timestamps are in the past; scheduled policy must have at least one future fire time"}}
+			return nil, &ValidationError{Errors: []Issue{{
+				Field:   "trigger.fire_at",
+				Message: "all timestamps are in the past; scheduled policy must have at least one future fire time",
+			}}}
 		}
 	}
 
@@ -171,7 +174,7 @@ func (s *Service) Create(ctx context.Context, rawYAML string) (*SaveResult, erro
 // replaces the stored YAML for the given policy ID.
 func (s *Service) Update(ctx context.Context, policyID string, rawYAML string) (*SaveResult, error) {
 	if err := CheckLegacyWebhookSecret(rawYAML); err != nil {
-		return nil, &ValidationError{Errors: []string{err.Error()}}
+		return nil, &ValidationError{Errors: []Issue{{Field: "trigger.webhook_secret", Message: err.Error()}}}
 	}
 	provider, modelName := s.resolveDefaults(ctx)
 	parsed, err := Parse(rawYAML, provider, modelName)
@@ -182,7 +185,7 @@ func (s *Service) Update(ctx context.Context, policyID string, rawYAML string) (
 		return nil, err
 	}
 	if err := s.validateProviderOptions(parsed); err != nil {
-		return nil, &ValidationError{Errors: []string{err.Error()}}
+		return nil, &ValidationError{Errors: []Issue{{Field: "model", Message: err.Error()}}}
 	}
 
 	var warnings []string

--- a/internal/policy/service_test.go
+++ b/internal/policy/service_test.go
@@ -449,13 +449,13 @@ func TestCreate_NoModelInYAMLAndNoSystemDefault(t *testing.T) {
 	}
 	found := false
 	for _, e := range ve.Errors {
-		if strings.Contains(e, "model.provider is required") {
+		if e.Field == "model.provider" && strings.Contains(e.Message, "model.provider is required") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected error containing 'model.provider is required', got %v", ve.Errors)
+		t.Errorf("expected error with field 'model.provider' containing 'model.provider is required', got %v", ve.Error())
 	}
 }
 

--- a/internal/policy/validator.go
+++ b/internal/policy/validator.go
@@ -9,49 +9,76 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Issue pairs a canonical field path with its error message. Field is empty for
+// cross-cutting errors that don't map to a single input.
+type Issue struct {
+	Field   string
+	Message string
+}
+
 // ValidationError collects all validation failures for a policy. It is
 // returned by Validate when one or more fields are invalid.
 type ValidationError struct {
-	Errors []string
+	Errors []Issue
 }
 
+// Error returns a semicolon-joined string suitable for logs and legacy callers
+// that only read the error message. Each issue is rendered as "field: message"
+// when a field is set, or just "message" for cross-cutting issues.
 func (e *ValidationError) Error() string {
-	return fmt.Sprintf("policy validation failed: %v", e.Errors)
+	parts := make([]string, 0, len(e.Errors))
+	for _, iss := range e.Errors {
+		if iss.Field != "" {
+			parts = append(parts, iss.Field+": "+iss.Message)
+		} else {
+			parts = append(parts, iss.Message)
+		}
+	}
+	return "policy validation failed: " + strings.Join(parts, "; ")
 }
 
 // Validate checks a ParsedPolicy for required fields, valid enum values,
 // and internal consistency (e.g. replace concurrency incompatible with
 // approval-required tools). Returns nil if valid.
 func Validate(p *model.ParsedPolicy) error {
-	var errs []string
+	var issues []Issue
 
-	if p.Name == "" {
-		errs = append(errs, "name is required")
+	// add appends a tagged Issue. field may be empty for cross-cutting messages.
+	add := func(field, format string, args ...any) {
+		issues = append(issues, Issue{Field: field, Message: fmt.Sprintf(format, args...)})
 	}
 
-	errs = append(errs, validateTrigger(p.Trigger)...)
-	errs = append(errs, validateCapabilities(p.Capabilities)...)
-	errs = append(errs, validateAgent(p.Agent, p.Capabilities)...)
+	if p.Name == "" {
+		add("name", "name is required")
+	}
 
-	if len(errs) > 0 {
-		return &ValidationError{Errors: errs}
+	issues = append(issues, validateTrigger(p.Trigger)...)
+	issues = append(issues, validateCapabilities(p.Capabilities)...)
+	issues = append(issues, validateAgent(p.Agent, p.Capabilities)...)
+
+	if len(issues) > 0 {
+		return &ValidationError{Errors: issues}
 	}
 	return nil
 }
 
 // validateTrigger checks the trigger type enum and type-specific required fields.
-func validateTrigger(t model.TriggerConfig) []string {
-	var errs []string
+func validateTrigger(t model.TriggerConfig) []Issue {
+	var issues []Issue
+
+	add := func(field, format string, args ...any) {
+		issues = append(issues, Issue{Field: field, Message: fmt.Sprintf(format, args...)})
+	}
 
 	if !t.Type.Valid() {
-		errs = append(errs, fmt.Sprintf("trigger.type %q is invalid; must be webhook, manual, scheduled, or poll", t.Type))
-		return errs // can't validate type-specific fields without a valid type
+		add("trigger.type", "trigger.type %q is invalid; must be webhook, manual, scheduled, or poll", t.Type)
+		return issues // can't validate type-specific fields without a valid type
 	}
 
 	switch t.Type {
 	case model.TriggerTypeWebhook:
 		if t.WebhookAuth != "" && !t.WebhookAuth.Valid() {
-			errs = append(errs, fmt.Sprintf("trigger.auth %q is invalid; must be hmac, bearer, or none", t.WebhookAuth))
+			add("trigger.auth", "trigger.auth %q is invalid; must be hmac, bearer, or none", t.WebhookAuth)
 		}
 
 	case model.TriggerTypeManual:
@@ -59,7 +86,7 @@ func validateTrigger(t model.TriggerConfig) []string {
 
 	case model.TriggerTypeScheduled:
 		if len(t.FireAt) == 0 {
-			errs = append(errs, "trigger.fire_at is required for scheduled triggers and must contain at least one timestamp")
+			add("trigger.fire_at", "trigger.fire_at is required for scheduled triggers and must contain at least one timestamp")
 		}
 		// Validate each individual timestamp can be parsed (parser skips bad entries,
 		// so an entry count mismatch signals parse failures).
@@ -68,103 +95,110 @@ func validateTrigger(t model.TriggerConfig) []string {
 
 	case model.TriggerTypePoll:
 		if t.Interval <= 0 {
-			errs = append(errs, "trigger.interval is required for poll triggers and must be a positive duration (e.g. \"5m\", \"1h\")")
+			add("trigger.interval", "trigger.interval is required for poll triggers and must be a positive duration (e.g. \"5m\", \"1h\")")
 		} else if t.Interval < time.Minute {
-			errs = append(errs, "trigger.interval must be at least 1m to prevent excessive polling")
+			add("trigger.interval", "trigger.interval must be at least 1m to prevent excessive polling")
 		}
 
 		if t.Match != "" && !t.Match.Valid() {
-			errs = append(errs, fmt.Sprintf("trigger.match %q is invalid; must be all or any", t.Match))
+			add("trigger.match", "trigger.match %q is invalid; must be all or any", t.Match)
 		}
 
 		if len(t.Checks) == 0 {
-			errs = append(errs, "trigger.checks is required for poll triggers and must contain at least one check")
+			add("trigger.checks", "trigger.checks is required for poll triggers and must contain at least one check")
 		}
 
 		for i, c := range t.Checks {
 			if c.Tool == "" {
-				errs = append(errs, fmt.Sprintf("trigger.checks[%d].tool is required", i))
+				add(fmt.Sprintf("trigger.checks[%d].tool", i), "trigger.checks[%d].tool is required", i)
 			} else if !isValidToolRef(c.Tool) {
-				errs = append(errs, fmt.Sprintf("trigger.checks[%d].tool %q must use dot notation (server_name.tool_name)", i, c.Tool))
+				add(fmt.Sprintf("trigger.checks[%d].tool", i), "trigger.checks[%d].tool %q must use dot notation (server_name.tool_name)", i, c.Tool)
 			}
 			if c.Path == "" {
-				errs = append(errs, fmt.Sprintf("trigger.checks[%d].path is required", i))
+				add(fmt.Sprintf("trigger.checks[%d].path", i), "trigger.checks[%d].path is required", i)
 			}
 			if c.Comparator == "" {
-				errs = append(errs, fmt.Sprintf("trigger.checks[%d] must specify exactly one comparator (equals, not_equals, greater_than, less_than, contains)", i))
+				add(fmt.Sprintf("trigger.checks[%d].comparator", i), "trigger.checks[%d] must specify exactly one comparator (equals, not_equals, greater_than, less_than, contains)", i)
 			} else if !c.Comparator.Valid() {
-				errs = append(errs, fmt.Sprintf("trigger.checks[%d].comparator %q is invalid; must be equals, not_equals, greater_than, less_than, or contains", i, c.Comparator))
+				add(fmt.Sprintf("trigger.checks[%d].comparator", i), "trigger.checks[%d].comparator %q is invalid; must be equals, not_equals, greater_than, less_than, or contains", i, c.Comparator)
 			}
 		}
 	}
 
-	return errs
+	return issues
 }
 
 // validateCapabilities checks that at least one capability is present (tool or
 // feedback), tool references use valid dot notation, there are no duplicates,
 // and approval/timeout and feedback fields are well-formed.
-func validateCapabilities(c model.CapabilitiesConfig) []string {
-	var errs []string
+func validateCapabilities(c model.CapabilitiesConfig) []Issue {
+	var issues []Issue
+
+	add := func(field, format string, args ...any) {
+		issues = append(issues, Issue{Field: field, Message: fmt.Sprintf(format, args...)})
+	}
 
 	if len(c.Tools) == 0 && !c.Feedback.Enabled {
-		errs = append(errs, "at least one capability is required (tool or feedback)")
+		add("capabilities", "at least one capability is required (tool or feedback)")
 	}
 
 	seen := make(map[string]bool)
 
 	for i, t := range c.Tools {
 		if t.Tool == "" {
-			errs = append(errs, fmt.Sprintf("capabilities.tools[%d].tool is required", i))
+			add(fmt.Sprintf("capabilities.tools[%d].tool", i), "capabilities.tools[%d].tool is required", i)
 			continue
 		}
 		if !isValidToolRef(t.Tool) {
-			errs = append(errs, fmt.Sprintf("capabilities.tools[%d].tool %q must use dot notation (server_name.tool_name)", i, t.Tool))
+			add(fmt.Sprintf("capabilities.tools[%d].tool", i), "capabilities.tools[%d].tool %q must use dot notation (server_name.tool_name)", i, t.Tool)
 		}
 		if seen[t.Tool] {
-			errs = append(errs, fmt.Sprintf("capabilities.tools[%d].tool %q is a duplicate", i, t.Tool))
+			add(fmt.Sprintf("capabilities.tools[%d].tool", i), "capabilities.tools[%d].tool %q is a duplicate", i, t.Tool)
 		}
 		seen[t.Tool] = true
 
 		if !t.Approval.Valid() {
-			errs = append(errs, fmt.Sprintf("capabilities.tools[%d].approval %q is invalid; must be none or required", i, t.Approval))
+			add(fmt.Sprintf("capabilities.tools[%d].approval", i), "capabilities.tools[%d].approval %q is invalid; must be none or required", i, t.Approval)
 		}
 
 		if t.Approval == model.ApprovalModeRequired {
 			if t.Timeout != "" {
 				if _, err := time.ParseDuration(t.Timeout); err != nil {
-					errs = append(errs, fmt.Sprintf("capabilities.tools[%d].timeout %q is not a valid duration: %v", i, t.Timeout, err))
+					add(fmt.Sprintf("capabilities.tools[%d].timeout", i), "capabilities.tools[%d].timeout %q is not a valid duration: %v", i, t.Timeout, err)
 				}
 			}
 			if !t.OnTimeout.Valid() {
-				errs = append(errs, fmt.Sprintf("capabilities.tools[%d].on_timeout %q is invalid; must be reject", i, t.OnTimeout))
+				add(fmt.Sprintf("capabilities.tools[%d].on_timeout", i), "capabilities.tools[%d].on_timeout %q is invalid; must be reject", i, t.OnTimeout)
 			}
 		}
 	}
 
-	errs = append(errs, validateFeedback(c.Feedback)...)
+	issues = append(issues, validateFeedback(c.Feedback)...)
 
-	return errs
+	return issues
 }
 
 // validateFeedback checks the feedback config block for valid duration and
 // on_timeout values. Fields are only validated when feedback is enabled; the
 // parser already clears timeout/on_timeout when disabled so there is nothing
 // to validate in the disabled case.
-func validateFeedback(f model.FeedbackConfig) []string {
+func validateFeedback(f model.FeedbackConfig) []Issue {
 	if !f.Enabled {
 		return nil
 	}
-	var errs []string
+	var issues []Issue
+	add := func(field, format string, args ...any) {
+		issues = append(issues, Issue{Field: field, Message: fmt.Sprintf(format, args...)})
+	}
 	if f.Timeout != "" {
 		if _, err := time.ParseDuration(f.Timeout); err != nil {
-			errs = append(errs, fmt.Sprintf("capabilities.feedback.timeout %q is not a valid duration", f.Timeout))
+			add("capabilities.feedback.timeout", "capabilities.feedback.timeout %q is not a valid duration", f.Timeout)
 		}
 	}
 	if f.OnTimeout != "" && !f.OnTimeout.Valid() {
-		errs = append(errs, fmt.Sprintf("capabilities.feedback.on_timeout %q is invalid; must be fail", f.OnTimeout))
+		add("capabilities.feedback.on_timeout", "capabilities.feedback.on_timeout %q is invalid; must be fail", f.OnTimeout)
 	}
-	return errs
+	return issues
 }
 
 // validateAgent checks agent config and cross-validates against capabilities.
@@ -173,40 +207,44 @@ func validateFeedback(f model.FeedbackConfig) []string {
 // Required-field validation for model.provider and model.name is done here;
 // model-option range validation (e.g. valid temperature, max_tokens bounds)
 // is done at the service layer via OptionsValidator.
-func validateAgent(a model.AgentConfig, c model.CapabilitiesConfig) []string {
-	var errs []string
+func validateAgent(a model.AgentConfig, c model.CapabilitiesConfig) []Issue {
+	var issues []Issue
+
+	add := func(field, format string, args ...any) {
+		issues = append(issues, Issue{Field: field, Message: fmt.Sprintf(format, args...)})
+	}
 
 	if a.Task == "" {
-		errs = append(errs, "agent.task is required")
+		add("agent.task", "agent.task is required")
 	}
 
 	if a.ModelConfig.Provider == "" {
-		errs = append(errs, "model.provider is required (set a default in Admin → Models or specify model.provider in policy YAML)")
+		add("model.provider", "model.provider is required (set a default in Admin → Models or specify model.provider in policy YAML)")
 	}
 	if a.ModelConfig.Name == "" {
-		errs = append(errs, "model.name is required (set a default in Admin → Models or specify model.name in policy YAML)")
+		add("model.name", "model.name is required (set a default in Admin → Models or specify model.name in policy YAML)")
 	}
 
 	// "claude-code" was a subprocess runner removed in issue #611. Policies that
 	// still declare this provider must fail with an actionable error rather than
 	// silently misbehaving at run time.
 	if a.ModelConfig.Provider == "claude-code" {
-		errs = append(errs, `model.provider "claude-code" is no longer supported; remove the policy or switch to an llm provider (anthropic, google, openai, openaicompat)`)
+		add("model.provider", `model.provider "claude-code" is no longer supported; remove the policy or switch to an llm provider (anthropic, google, openai, openaicompat)`)
 	}
 
 	if a.Limits.MaxTokensPerRun <= 0 {
-		errs = append(errs, "agent.limits.max_tokens_per_run must be positive")
+		add("agent.limits.max_tokens_per_run", "agent.limits.max_tokens_per_run must be positive")
 	}
 	if a.Limits.MaxToolCallsPerRun <= 0 {
-		errs = append(errs, "agent.limits.max_tool_calls_per_run must be positive")
+		add("agent.limits.max_tool_calls_per_run", "agent.limits.max_tool_calls_per_run must be positive")
 	}
 
 	if !a.Concurrency.Valid() {
-		errs = append(errs, fmt.Sprintf("agent.concurrency %q is invalid; must be skip, queue, parallel, or replace", a.Concurrency))
+		add("agent.concurrency", "agent.concurrency %q is invalid; must be skip, queue, parallel, or replace", a.Concurrency)
 	}
 
 	if a.QueueDepth < 0 {
-		errs = append(errs, "agent.queue_depth must not be negative")
+		add("agent.queue_depth", "agent.queue_depth must not be negative")
 	}
 
 	// Note: cross-validating queue_depth against concurrency mode is impractical
@@ -217,13 +255,13 @@ func validateAgent(a model.AgentConfig, c model.CapabilitiesConfig) []string {
 	if a.Concurrency == model.ConcurrencyReplace {
 		for _, t := range c.Tools {
 			if t.Approval == model.ApprovalModeRequired {
-				errs = append(errs, "agent.concurrency \"replace\" is not valid when any tool has approval: required")
+				add("agent.concurrency", "agent.concurrency \"replace\" is not valid when any tool has approval: required")
 				break
 			}
 		}
 	}
 
-	return errs
+	return issues
 }
 
 // CheckLegacyWebhookSecret parses rawYAML and returns an error if the trigger

--- a/internal/policy/validator_test.go
+++ b/internal/policy/validator_test.go
@@ -449,8 +449,8 @@ func TestValidate_ModelRequired(t *testing.T) {
 						t.Fatalf("unexpected error type %T: %v", err, err)
 					}
 					for _, e := range ve.Errors {
-						if strings.Contains(e, "model.") {
-							t.Errorf("unexpected model error: %q", e)
+						if strings.Contains(e.Field, "model.") || strings.Contains(e.Message, "model.") {
+							t.Errorf("unexpected model error: field=%q message=%q", e.Field, e.Message)
 						}
 					}
 				}
@@ -465,15 +465,8 @@ func TestValidate_ModelRequired(t *testing.T) {
 				t.Fatalf("expected *ValidationError, got %T: %v", err, err)
 			}
 			for _, want := range tt.wantErrs {
-				found := false
-				for _, e := range ve.Errors {
-					if strings.Contains(e, want) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected error containing %q in %v", want, ve.Errors)
+				if !containsIssue(ve.Errors, "", want) {
+					t.Errorf("expected error containing %q in %v", want, ve.Error())
 				}
 			}
 		})
@@ -533,6 +526,21 @@ agent:
 	})
 }
 
+// containsIssue returns true when issues contains an entry whose Field matches
+// fieldSubstr AND whose Message contains messageSubstr. Pass "" for fieldSubstr
+// to skip the field check.
+func containsIssue(issues []Issue, fieldSubstr, messageSubstr string) bool {
+	for _, iss := range issues {
+		if fieldSubstr != "" && !strings.Contains(iss.Field, fieldSubstr) {
+			continue
+		}
+		if strings.Contains(iss.Message, messageSubstr) {
+			return true
+		}
+	}
+	return false
+}
+
 func assertValidationContains(t *testing.T, p *model.ParsedPolicy, substr string) {
 	t.Helper()
 	err := Validate(p)
@@ -543,10 +551,219 @@ func assertValidationContains(t *testing.T, p *model.ParsedPolicy, substr string
 	if !ok {
 		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
 	}
+	// Check both the combined Error() string and individual Issue messages/fields
+	// so tests can match on field paths or on message substrings.
+	if strings.Contains(ve.Error(), substr) {
+		return
+	}
 	for _, e := range ve.Errors {
-		if strings.Contains(e, substr) {
+		if strings.Contains(e.Message, substr) || strings.Contains(e.Field, substr) {
 			return
 		}
 	}
 	t.Errorf("expected error containing %q in %v", substr, ve.Errors)
+}
+
+// assertIssueField asserts that Validate(p) returns a ValidationError
+// containing an Issue with the given field path and a message containing
+// messageSubstr. This locks down both the tagged field and the human text.
+func assertIssueField(t *testing.T, p *model.ParsedPolicy, field, messageSubstr string) {
+	t.Helper()
+	err := Validate(p)
+	if err == nil {
+		t.Fatalf("expected validation error for field %q, got nil", field)
+	}
+	ve, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+	if !containsIssue(ve.Errors, field, messageSubstr) {
+		t.Errorf("expected issue with field=%q message~=%q in %v", field, messageSubstr, ve.Error())
+	}
+}
+
+// TestValidate_IssueFields verifies that each validator rule tags its output
+// with the canonical field path exposed to the frontend. One representative
+// case per field family suffices — the full rule logic is covered by the
+// existing single-message tests above.
+func TestValidate_IssueFields(t *testing.T) {
+	t.Run("name field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Name = ""
+		assertIssueField(t, p, "name", "name is required")
+	})
+
+	t.Run("trigger.type field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.Type = "bad"
+		assertIssueField(t, p, "trigger.type", "invalid")
+	})
+
+	t.Run("trigger.auth field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.WebhookAuth = "invalidmode"
+		assertIssueField(t, p, "trigger.auth", "invalid")
+	})
+
+	t.Run("trigger.fire_at field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.Type = model.TriggerTypeScheduled
+		p.Trigger.FireAt = nil
+		assertIssueField(t, p, "trigger.fire_at", "required")
+	})
+
+	t.Run("trigger.interval field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.Type = model.TriggerTypePoll
+		p.Trigger.Checks = []model.PollCheck{validPollCheck()}
+		// Interval is zero (not set)
+		assertIssueField(t, p, "trigger.interval", "required")
+	})
+
+	t.Run("trigger.match field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.Type = model.TriggerTypePoll
+		p.Trigger.Interval = 5 * time.Minute
+		p.Trigger.Match = "xor"
+		p.Trigger.Checks = []model.PollCheck{validPollCheck()}
+		assertIssueField(t, p, "trigger.match", "invalid")
+	})
+
+	t.Run("trigger.checks[0].tool field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.Type = model.TriggerTypePoll
+		p.Trigger.Interval = 5 * time.Minute
+		c := validPollCheck()
+		c.Tool = ""
+		p.Trigger.Checks = []model.PollCheck{c}
+		assertIssueField(t, p, "trigger.checks[0].tool", "required")
+	})
+
+	t.Run("trigger.checks[0].path field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.Type = model.TriggerTypePoll
+		p.Trigger.Interval = 5 * time.Minute
+		c := validPollCheck()
+		c.Path = ""
+		p.Trigger.Checks = []model.PollCheck{c}
+		assertIssueField(t, p, "trigger.checks[0].path", "required")
+	})
+
+	t.Run("trigger.checks[0].comparator field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Trigger.Type = model.TriggerTypePoll
+		p.Trigger.Interval = 5 * time.Minute
+		c := validPollCheck()
+		c.Comparator = ""
+		p.Trigger.Checks = []model.PollCheck{c}
+		assertIssueField(t, p, "trigger.checks[0].comparator", "comparator")
+	})
+
+	t.Run("capabilities root field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Capabilities.Tools = nil
+		p.Capabilities.Feedback = model.FeedbackConfig{Enabled: false}
+		assertIssueField(t, p, "capabilities", "at least one capability")
+	})
+
+	t.Run("capabilities.tools[0].tool field is tagged for empty ref", func(t *testing.T) {
+		p := validPolicy()
+		p.Capabilities.Tools = []model.ToolCapability{{Tool: "", Approval: model.ApprovalModeNone}}
+		assertIssueField(t, p, "capabilities.tools[0].tool", "required")
+	})
+
+	t.Run("capabilities.tools[1].tool field is tagged for duplicate", func(t *testing.T) {
+		p := validPolicy()
+		p.Capabilities.Tools = []model.ToolCapability{
+			{Tool: "s.t", Approval: model.ApprovalModeNone},
+			{Tool: "s.t", Approval: model.ApprovalModeNone},
+		}
+		assertIssueField(t, p, "capabilities.tools[1].tool", "duplicate")
+	})
+
+	t.Run("capabilities.tools[0].timeout field is tagged for bad duration", func(t *testing.T) {
+		p := validPolicy()
+		p.Capabilities.Tools = []model.ToolCapability{
+			{Tool: "s.t", Approval: model.ApprovalModeRequired, Timeout: "bad", OnTimeout: model.OnTimeoutReject},
+		}
+		assertIssueField(t, p, "capabilities.tools[0].timeout", "not a valid duration")
+	})
+
+	t.Run("capabilities.feedback.timeout field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Capabilities.Feedback = model.FeedbackConfig{
+			Enabled:   true,
+			Timeout:   "bad-duration",
+			OnTimeout: model.FeedbackOnTimeoutFail,
+		}
+		assertIssueField(t, p, "capabilities.feedback.timeout", "not a valid duration")
+	})
+
+	t.Run("agent.task field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.Task = ""
+		assertIssueField(t, p, "agent.task", "required")
+	})
+
+	t.Run("model.provider field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.ModelConfig.Provider = ""
+		assertIssueField(t, p, "model.provider", "required")
+	})
+
+	t.Run("model.name field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.ModelConfig.Name = ""
+		assertIssueField(t, p, "model.name", "required")
+	})
+
+	t.Run("agent.limits.max_tokens_per_run field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.Limits.MaxTokensPerRun = -1
+		assertIssueField(t, p, "agent.limits.max_tokens_per_run", "must be positive")
+	})
+
+	t.Run("agent.limits.max_tool_calls_per_run field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.Limits.MaxToolCallsPerRun = 0
+		assertIssueField(t, p, "agent.limits.max_tool_calls_per_run", "must be positive")
+	})
+
+	t.Run("agent.concurrency field is tagged for invalid value", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.Concurrency = "invalid"
+		assertIssueField(t, p, "agent.concurrency", "invalid")
+	})
+
+	t.Run("agent.queue_depth field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.QueueDepth = -1
+		assertIssueField(t, p, "agent.queue_depth", "must not be negative")
+	})
+
+	t.Run("agent.concurrency replace+approval cross-field is tagged", func(t *testing.T) {
+		p := validPolicy()
+		p.Agent.Concurrency = model.ConcurrencyReplace
+		p.Capabilities.Tools = []model.ToolCapability{
+			{Tool: "s.t", Approval: model.ApprovalModeRequired, OnTimeout: model.OnTimeoutReject},
+		}
+		assertIssueField(t, p, "agent.concurrency", "replace")
+	})
+
+	t.Run("Error() string retains legacy format", func(t *testing.T) {
+		p := validPolicy()
+		p.Name = ""
+		err := Validate(p)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		// Legacy callers expect "policy validation failed: ..." shape.
+		if !strings.HasPrefix(err.Error(), "policy validation failed: ") {
+			t.Errorf("Error() = %q, want prefix %q", err.Error(), "policy validation failed: ")
+		}
+		// The field path must appear in Error() so grep-based log tools still work.
+		if !strings.Contains(err.Error(), "name") {
+			t.Errorf("Error() = %q, missing field path %q", err.Error(), "name")
+		}
+	})
 }


### PR DESCRIPTION
Closes #3

## Summary

Operators saving an invalid agent currently see a single red banner containing every validation error joined with `"; "`. This PR surfaces errors **where the problem is**:

- A **client-side validator** mirrors the backend rules so most issues are caught inline before Save is ever clicked.
- Validation failures render as **inline `FieldError` messages under each field** plus an **`ErrorBanner` with a bulleted summary**; clicking a bullet scrolls + focuses the offending input.
- The backend response gained an additive `issues: [{field, message}]` array (alongside the legacy `detail` string) so anything that slips past the client still maps back to a field.
- Five other forms (user create, password change, admin system, OpenAI-compat provider, MCP server) migrate to the new `ErrorBanner` for consistency — no new validation rules invented for those, just the banner swap.

## Review cycles

Two cycles. Architect plan passed after one adversarial revision (reviewer surfaced missing `internal/policy/service.go` + `service_test.go` edits). Code review flagged minor cleanup (dead-branch filter, duplicate FormIssue type, unused helper) which cycle 2 addressed. The second-cycle review flagged a blocking issue about a test field value, but verification of the actual code path (`validator.go:222` fires before `service.go:121`) showed the test was correct as-written and tests pass. Proceeded per the "max 2 cycles" rule.

## Docs

- `frontend/CLAUDE.md` updated with the new `components/form/` entry.

## Test plan

- [x] `go test ./...` passes
- [x] `npm run build` passes (TypeScript clean)
- [x] `npx vitest run` passes (991/991)
- [ ] Manual: open Agent editor → click Save on empty form → verify banner + inline errors + scroll-to-first-field
- [ ] Manual: submit form with only model missing → verify server's `issues` response renders the same way
- [ ] Manual: tools list with two bad tool names at indexes 0 and 2 → both rows show inline errors, banner lists both

## Architecture plan

<details>
<summary>Full implementation plan (25 files across 5 phases)</summary>

See `.dev-loop/plan.md` on the branch for the full plan. High-level phases:

1. **Backend error shape** — retype `ValidationError.Errors` to `[]Issue` with canonical field paths; add `WriteValidationError` helper.
2. **Frontend API type** — `ApiError.issues`; parse from body; pass through constructor.
3. **Reusable primitives** — `FieldError`, `ErrorBanner` under `components/form/` with CSS Modules, Storybook, Vitest.
4. **Client-side validator** — `validateFormState.ts` mirroring Go rules for form-exposed fields; wired into `AgentEditorPage` + all 7 sections via `data-field` attributes.
5. **Form migrations** — 5 other forms adopt `ErrorBanner` (no new validation rules).

</details>

🤖 Generated by the agentic dev loop (Claude Code).