### PR TITLE
refactor: opaque ProviderState on llm.ThinkingBlock

### DIFF
--- a/docs/ADR_Tracker.md
+++ b/docs/ADR_Tracker.md
@@ -856,6 +856,40 @@ for the interface; it never imports provider SDKs directly.
 - Capability snapshot (ADR-018) records tools in MCP-native `ToolDefinition` format
 - Adding a new provider requires: implementing `LLMClient`, adding a `ProviderHints` field, registering in the registry — no BoundAgent changes
 
+**Amendment (2026-04):** `ThinkingBlock` now uses opaque `ProviderState json.RawMessage` instead
+of named provider-specific fields (`Signature`, `RedactedData`, `EncryptedContent`, `ID`). Each
+provider package that has round-trip state defines its own unexported state struct and
+marshal/unmarshal helpers; the shared interface carries only `Provider`, `Text`, `Redacted`, and
+`ProviderState`.
+
+Rationale: named fields created a lowest-common-denominator leak that grew with each new provider.
+Opaque bytes scale to additional providers without touching the shared interface.
+
+Per-provider adoption (not mandated uniformly):
+- `internal/llm/anthropic`: defines `anthropicThinkingState{Signature, RedactedData}`. Round-trips
+  via signature (non-redacted) or redacted-data (redacted blocks).
+- `internal/llm/openai`: defines `openaiThinkingState{ID, EncryptedContent}`. Round-trips via the
+  Responses API reasoning item ID and encrypted content.
+- `internal/llm/google`: has no `ThinkingBlock` round-trip state today (its thought signature lives
+  on `ToolCallBlock.ProviderMetadata["google.thought_signature"]`, out of scope). No state struct;
+  its `ThinkingBlock` constructions compile unchanged.
+- `internal/llm/openaicompat`: drops thinking blocks entirely. No state struct.
+
+What does NOT change:
+- `ProviderHints any` — typed-per-provider; request-time config where caller ergonomics favor a
+  typed interface over opaque bytes.
+- `ToolCallBlock.ProviderMetadata map[string][]byte` — already opaque bytes; map shape lets
+  independent keys coexist (Google uses one key).
+
+Cross-provider semantics: a block whose `Provider` does not match the current provider (empty or
+mismatched) is silently skipped (Debug log). Empty `ProviderState` (nil or len 0) is also skipped
+— treated as text-only with no round-trip data. Malformed `ProviderState` JSON returns an error
+and the agent fails the run with a wrapped message — do not silently drop continuity.
+
+Destructive migration: no DB schema change (`ThinkingBlock` provider-specific fields were never
+persisted — the audit writer records only `{text, redacted}`). Fresh installs only for in-flight
+conversations.
+
 ---
 
 ## ADR-028: Tool Risk Classification Model

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -2570,9 +2570,13 @@ func TestRun_ThinkingBlocksIncludedInHistory(t *testing.T) {
 
 	tools := []mcp.ResolvedTool{toolForRun(mcpSrv.URL, "my-server", "read_data")}
 
-	// First response: tool call with a ThinkingBlock carrying a Signature.
+	// First response: tool call with a ThinkingBlock carrying provider state.
 	firstResp := &llm.MessageResponse{
-		Thinking:   []llm.ThinkingBlock{{Text: "I need to call the tool", Signature: "sig_turn1"}},
+		Thinking: []llm.ThinkingBlock{{
+			Provider:      "anthropic",
+			Text:          "I need to call the tool",
+			ProviderState: json.RawMessage(`{"signature":"sig_turn1"}`),
+		}},
 		ToolCalls:  []llm.ToolCallBlock{{ID: "tc-1", Name: "my-server.read_data", Input: json.RawMessage(`{}`)}},
 		StopReason: llm.StopReasonToolUse,
 		Usage:      llm.TokenUsage{InputTokens: 10, OutputTokens: 5},
@@ -2628,8 +2632,14 @@ func TestRun_ThinkingBlocksIncludedInHistory(t *testing.T) {
 	if !ok {
 		t.Fatalf("first content block type = %T, want llm.ThinkingBlock", assistantTurn.Content[0])
 	}
-	if tb.Signature != "sig_turn1" {
-		t.Errorf("ThinkingBlock.Signature = %q, want sig_turn1", tb.Signature)
+	var state struct {
+		Signature string `json:"signature"`
+	}
+	if err := json.Unmarshal(tb.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ThinkingBlock.ProviderState: %v", err)
+	}
+	if state.Signature != "sig_turn1" {
+		t.Errorf("state.Signature = %q, want sig_turn1", state.Signature)
 	}
 	if tb.Text != "I need to call the tool" {
 		t.Errorf("ThinkingBlock.Text = %q, want 'I need to call the tool'", tb.Text)

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -84,7 +84,11 @@ func (c *AnthropicClient) CreateMessage(ctx context.Context, req llm.MessageRequ
 		err = fmt.Errorf("anthropic: building tools: %w", buildErr)
 		return
 	}
-	messages := buildMessages(req.History, nameMap.OriginalToSanitized)
+	messages, buildErr := buildMessages(req.History, nameMap.OriginalToSanitized)
+	if buildErr != nil {
+		err = fmt.Errorf("anthropic: %w", buildErr)
+		return
+	}
 
 	params := anthropic.MessageNewParams{
 		Model:     anthropic.Model(req.Model),
@@ -105,7 +109,11 @@ func (c *AnthropicClient) CreateMessage(ctx context.Context, req llm.MessageRequ
 		return
 	}
 
-	resp = translateResponse(sdkResp, nameMap.SanitizedToOriginal)
+	resp, err = translateResponse(sdkResp, nameMap.SanitizedToOriginal)
+	if err != nil {
+		err = fmt.Errorf("anthropic: translateResponse: %w", err)
+		return
+	}
 	return
 }
 
@@ -137,7 +145,10 @@ func (c *AnthropicClient) StreamMessage(ctx context.Context, req llm.MessageRequ
 	if err != nil {
 		return nil, fmt.Errorf("anthropic: building tools: %w", err)
 	}
-	messages := buildMessages(req.History, nameMap.OriginalToSanitized)
+	messages, err := buildMessages(req.History, nameMap.OriginalToSanitized)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: %w", err)
+	}
 
 	params := anthropic.MessageNewParams{
 		Model:     anthropic.Model(req.Model),
@@ -314,7 +325,7 @@ func buildSystemBlocks(req llm.MessageRequest, hints *AnthropicHints) []anthropi
 // Anthropic MessageParams. originalToSanitized maps original MCP tool names
 // to their sanitized wire-format names; when non-nil, ToolCallBlock names are
 // looked up in the map so the API receives valid tool names. See issue #413.
-func buildMessages(history []llm.ConversationTurn, originalToSanitized map[string]string) []anthropic.MessageParam {
+func buildMessages(history []llm.ConversationTurn, originalToSanitized map[string]string) ([]anthropic.MessageParam, error) {
 	msgs := make([]anthropic.MessageParam, 0, len(history))
 	for _, turn := range history {
 		blocks := make([]anthropic.ContentBlockParamUnion, 0, len(turn.Content))
@@ -338,14 +349,22 @@ func buildMessages(history []llm.ConversationTurn, originalToSanitized map[strin
 			case llm.ToolResultBlock:
 				blocks = append(blocks, anthropic.NewToolResultBlock(b.ToolCallID, b.Content, b.IsError))
 			case llm.ThinkingBlock:
-				if b.Redacted {
-					blocks = append(blocks, anthropic.NewRedactedThinkingBlock(b.RedactedData))
-				} else if b.Signature != "" {
-					blocks = append(blocks, anthropic.NewThinkingBlock(b.Signature, b.Text))
+				if b.Provider != "" && b.Provider != "anthropic" {
+					slog.Debug("buildMessages: skipping ThinkingBlock from non-Anthropic provider",
+						"block_provider", b.Provider)
+					continue
+				}
+				state, err := unmarshalThinkingState(b.ProviderState)
+				if err != nil {
+					return nil, fmt.Errorf("anthropic: buildMessages: %w", err)
+				}
+				if b.Redacted && state.RedactedData != "" {
+					blocks = append(blocks, anthropic.NewRedactedThinkingBlock(state.RedactedData))
+				} else if !b.Redacted && state.Signature != "" {
+					blocks = append(blocks, anthropic.NewThinkingBlock(state.Signature, b.Text))
 				} else {
-					// Empty signature means this block came from a non-Anthropic provider.
-					// Anthropic's API requires a non-empty signature, so skip it.
-					slog.Debug("buildMessages: skipping ThinkingBlock with empty signature (non-Anthropic source)")
+					// Empty state means no round-trip data — skip (no Signature or RedactedData to echo).
+					slog.Debug("buildMessages: skipping ThinkingBlock with empty provider state")
 				}
 			default:
 				slog.Warn("buildMessages: skipping unknown content block type", "type", fmt.Sprintf("%T", cb))
@@ -358,7 +377,7 @@ func buildMessages(history []llm.ConversationTurn, originalToSanitized map[strin
 			msgs = append(msgs, anthropic.NewUserMessage(blocks...))
 		}
 	}
-	return msgs
+	return msgs, nil
 }
 
 // buildTools translates the provider-neutral tool definitions into the
@@ -449,7 +468,7 @@ func buildToolInputSchema(schema json.RawMessage) (anthropic.ToolInputSchemaPara
 // provider-neutral MessageResponse. sanitizedToOriginal is the name map
 // returned by buildTools; it is used to reverse-map sanitized tool names
 // in ToolUseBlock responses back to the original MCP names.
-func translateResponse(resp *anthropic.Message, sanitizedToOriginal map[string]string) *llm.MessageResponse {
+func translateResponse(resp *anthropic.Message, sanitizedToOriginal map[string]string) (*llm.MessageResponse, error) {
 	var result llm.MessageResponse
 
 	for _, block := range resp.Content {
@@ -470,20 +489,28 @@ func translateResponse(resp *anthropic.Message, sanitizedToOriginal map[string]s
 				Input: b.Input,
 			})
 		case anthropic.ThinkingBlock:
+			raw, err := marshalThinkingState(anthropicThinkingState{Signature: b.Signature})
+			if err != nil {
+				return nil, fmt.Errorf("anthropic: translateResponse: %w", err)
+			}
 			result.Thinking = append(result.Thinking, llm.ThinkingBlock{
-				Provider:  "anthropic",
-				Text:      b.Thinking,
-				Redacted:  false,
-				Signature: b.Signature,
+				Provider:      "anthropic",
+				Text:          b.Thinking,
+				Redacted:      false,
+				ProviderState: raw,
 			})
 		case anthropic.RedactedThinkingBlock:
 			// Text is set to "[redacted]" for audit display only — it is never
 			// sent back to the API. Only RedactedData is echoed on subsequent requests.
+			raw, err := marshalThinkingState(anthropicThinkingState{RedactedData: b.Data})
+			if err != nil {
+				return nil, fmt.Errorf("anthropic: translateResponse: %w", err)
+			}
 			result.Thinking = append(result.Thinking, llm.ThinkingBlock{
-				Provider:     "anthropic",
-				Text:         "[redacted]",
-				Redacted:     true,
-				RedactedData: b.Data,
+				Provider:      "anthropic",
+				Text:          "[redacted]",
+				Redacted:      true,
+				ProviderState: raw,
 			})
 		default:
 			slog.Warn("translateResponse: skipping unhandled content block type", "type", fmt.Sprintf("%T", b))
@@ -509,7 +536,7 @@ func translateResponse(resp *anthropic.Message, sanitizedToOriginal map[string]s
 		OutputTokens: int(resp.Usage.OutputTokens),
 	}
 
-	return &result
+	return &result, nil
 }
 
 // wrapSDKError translates Anthropic SDK errors into descriptive errors with

--- a/internal/llm/anthropic/client_test.go
+++ b/internal/llm/anthropic/client_test.go
@@ -152,7 +152,10 @@ func TestBuildMessages_TextBlocks(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			msgs := buildMessages(tc.history, nil)
+			msgs, err := buildMessages(tc.history, nil)
+			if err != nil {
+				t.Fatalf("buildMessages: %v", err)
+			}
 			if len(msgs) != 1 {
 				t.Fatalf("got %d messages, want 1", len(msgs))
 			}
@@ -193,7 +196,10 @@ func TestBuildMessages_ToolCallBlocks(t *testing.T) {
 			history := []llm.ConversationTurn{
 				{Role: llm.RoleAssistant, Content: []llm.ContentBlock{tc.block}},
 			}
-			msgs := buildMessages(history, nil)
+			msgs, err := buildMessages(history, nil)
+			if err != nil {
+				t.Fatalf("buildMessages: %v", err)
+			}
 			if len(msgs) != 1 || len(msgs[0].Content) != 1 {
 				t.Fatal("expected 1 message with 1 content block")
 			}
@@ -234,7 +240,10 @@ func TestBuildMessages_ToolResultBlocks(t *testing.T) {
 			history := []llm.ConversationTurn{
 				{Role: llm.RoleUser, Content: []llm.ContentBlock{tc.block}},
 			}
-			msgs := buildMessages(history, nil)
+			msgs, err := buildMessages(history, nil)
+			if err != nil {
+				t.Fatalf("buildMessages: %v", err)
+			}
 			if len(msgs) != 1 || len(msgs[0].Content) != 1 {
 				t.Fatal("expected 1 message with 1 content block")
 			}
@@ -300,7 +309,10 @@ func TestBuildTools(t *testing.T) {
 func TestBuildMessages_EmptyHistory(t *testing.T) {
 	// nil and empty slices must not panic and must return an empty slice.
 	for _, history := range [][]llm.ConversationTurn{nil, {}} {
-		msgs := buildMessages(history, nil)
+		msgs, err := buildMessages(history, nil)
+		if err != nil {
+			t.Fatalf("buildMessages: %v", err)
+		}
 		if len(msgs) != 0 {
 			t.Errorf("buildMessages(%v) = %d messages, want 0", history, len(msgs))
 		}
@@ -496,7 +508,10 @@ func TestTranslateStopReason(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(string(tc.sdkReason), func(t *testing.T) {
 			msg := &sdkanthropic.Message{StopReason: tc.sdkReason}
-			got := translateResponse(msg, nil)
+			got, err := translateResponse(msg, nil)
+			if err != nil {
+				t.Fatalf("translateResponse: %v", err)
+			}
 			if got.StopReason != tc.want {
 				t.Errorf("StopReason = %v, want %v", got.StopReason, tc.want)
 			}
@@ -1169,7 +1184,10 @@ func TestBuildMessages_UsesNameMap(t *testing.T) {
 					},
 				},
 			}
-			msgs := buildMessages(history, tc.nameMap)
+			msgs, err := buildMessages(history, tc.nameMap)
+			if err != nil {
+				t.Fatalf("buildMessages: %v", err)
+			}
 			if len(msgs) != 1 || len(msgs[0].Content) != 1 {
 				t.Fatal("expected 1 message with 1 content block")
 			}
@@ -1249,7 +1267,10 @@ func TestToolNameRoundTrip(t *testing.T) {
 	}
 
 	// 5. Rebuild messages for the next API call using the forward map.
-	msgs := buildMessages(history, names.OriginalToSanitized)
+	msgs, err := buildMessages(history, names.OriginalToSanitized)
+	if err != nil {
+		t.Fatalf("buildMessages: %v", err)
+	}
 	if len(msgs) != 1 || len(msgs[0].Content) != 1 {
 		t.Fatal("expected 1 message with 1 content block")
 	}
@@ -1296,8 +1317,14 @@ func TestBuildMessages_IgnoresProviderMetadata(t *testing.T) {
 		{Role: llm.RoleAssistant, Content: []llm.ContentBlock{withoutMeta}},
 	}
 
-	msgsWith := buildMessages(histWith, nil)
-	msgsWithout := buildMessages(histWithout, nil)
+	msgsWith, err := buildMessages(histWith, nil)
+	if err != nil {
+		t.Fatalf("buildMessages (with): %v", err)
+	}
+	msgsWithout, err := buildMessages(histWithout, nil)
+	if err != nil {
+		t.Fatalf("buildMessages (without): %v", err)
+	}
 
 	if len(msgsWith) != 1 || len(msgsWithout) != 1 {
 		t.Fatal("expected 1 message for each history")
@@ -1333,8 +1360,12 @@ func TestTranslateResponse_ThinkingBlock_CapturesSignature(t *testing.T) {
 		t.Fatalf("Thinking len = %d, want 1", len(resp.Thinking))
 	}
 	tb := resp.Thinking[0]
-	if tb.Signature != "sig_abc" {
-		t.Errorf("Signature = %q, want %q", tb.Signature, "sig_abc")
+	var state anthropicThinkingState
+	if err := json.Unmarshal(tb.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.Signature != "sig_abc" {
+		t.Errorf("state.Signature = %q, want %q", state.Signature, "sig_abc")
 	}
 	if tb.Text != "let me think" {
 		t.Errorf("Text = %q, want %q", tb.Text, "let me think")
@@ -1361,8 +1392,12 @@ func TestTranslateResponse_RedactedThinkingBlock_CapturesData(t *testing.T) {
 		t.Fatalf("Thinking len = %d, want 1", len(resp.Thinking))
 	}
 	tb := resp.Thinking[0]
-	if tb.RedactedData != "opaque_data_xyz" {
-		t.Errorf("RedactedData = %q, want %q", tb.RedactedData, "opaque_data_xyz")
+	var state anthropicThinkingState
+	if err := json.Unmarshal(tb.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.RedactedData != "opaque_data_xyz" {
+		t.Errorf("state.RedactedData = %q, want %q", state.RedactedData, "opaque_data_xyz")
 	}
 	if tb.Text != "[redacted]" {
 		t.Errorf("Text = %q, want [redacted]", tb.Text)
@@ -1373,16 +1408,21 @@ func TestTranslateResponse_RedactedThinkingBlock_CapturesData(t *testing.T) {
 }
 
 func TestBuildMessages_ThinkingBlockRoundTrip(t *testing.T) {
+	state := anthropicThinkingState{Signature: "sig123"}
+	raw, _ := marshalThinkingState(state)
 	history := []llm.ConversationTurn{
 		{
 			Role: llm.RoleAssistant,
 			Content: []llm.ContentBlock{
-				llm.ThinkingBlock{Text: "reasoning", Signature: "sig123"},
+				llm.ThinkingBlock{Provider: "anthropic", Text: "reasoning", ProviderState: raw},
 				llm.TextBlock{Text: "answer"},
 			},
 		},
 	}
-	msgs := buildMessages(history, nil)
+	msgs, err := buildMessages(history, nil)
+	if err != nil {
+		t.Fatalf("buildMessages: %v", err)
+	}
 	if len(msgs) != 1 {
 		t.Fatalf("msgs len = %d, want 1", len(msgs))
 	}
@@ -1390,11 +1430,11 @@ func TestBuildMessages_ThinkingBlockRoundTrip(t *testing.T) {
 		t.Fatalf("content blocks = %d, want 2", len(msgs[0].Content))
 	}
 
-	raw, err := json.Marshal(msgs[0].Content[0])
+	wireRaw, err := json.Marshal(msgs[0].Content[0])
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	s := string(raw)
+	s := string(wireRaw)
 	if !strings.Contains(s, `"type":"thinking"`) {
 		t.Errorf("expected type=thinking in %s", s)
 	}
@@ -1407,24 +1447,29 @@ func TestBuildMessages_ThinkingBlockRoundTrip(t *testing.T) {
 }
 
 func TestBuildMessages_RedactedThinkingBlockRoundTrip(t *testing.T) {
+	state := anthropicThinkingState{RedactedData: "xyz_data"}
+	raw, _ := marshalThinkingState(state)
 	history := []llm.ConversationTurn{
 		{
 			Role: llm.RoleAssistant,
 			Content: []llm.ContentBlock{
-				llm.ThinkingBlock{Text: "[redacted]", Redacted: true, RedactedData: "xyz_data"},
+				llm.ThinkingBlock{Provider: "anthropic", Text: "[redacted]", Redacted: true, ProviderState: raw},
 			},
 		},
 	}
-	msgs := buildMessages(history, nil)
+	msgs, err := buildMessages(history, nil)
+	if err != nil {
+		t.Fatalf("buildMessages: %v", err)
+	}
 	if len(msgs) != 1 || len(msgs[0].Content) != 1 {
 		t.Fatalf("expected 1 message with 1 content block")
 	}
 
-	raw, err := json.Marshal(msgs[0].Content[0])
+	wireRaw, err := json.Marshal(msgs[0].Content[0])
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	s := string(raw)
+	s := string(wireRaw)
 	if !strings.Contains(s, `"type":"redacted_thinking"`) {
 		t.Errorf("expected type=redacted_thinking in %s", s)
 	}
@@ -1437,28 +1482,86 @@ func TestBuildMessages_RedactedThinkingBlockRoundTrip(t *testing.T) {
 	}
 }
 
-func TestBuildMessages_ThinkingBlockNoSignature_Skipped(t *testing.T) {
-	// A ThinkingBlock with an empty Signature (from a non-Anthropic provider)
-	// must be silently skipped — Anthropic requires a non-empty signature.
+func TestBuildMessages_ThinkingBlockEmptyProviderState_Skipped(t *testing.T) {
+	// A ThinkingBlock with nil ProviderState has no round-trip data and must
+	// be silently skipped — Anthropic requires a non-empty signature.
 	history := []llm.ConversationTurn{
 		{
 			Role: llm.RoleAssistant,
 			Content: []llm.ContentBlock{
-				llm.ThinkingBlock{Text: "reasoning", Signature: ""},
+				llm.ThinkingBlock{Provider: "anthropic", Text: "reasoning", ProviderState: nil},
 				llm.TextBlock{Text: "answer"},
 			},
 		},
 	}
-	msgs := buildMessages(history, nil)
+	msgs, err := buildMessages(history, nil)
+	if err != nil {
+		t.Fatalf("buildMessages: %v", err)
+	}
 	if len(msgs) != 1 {
 		t.Fatalf("msgs len = %d, want 1", len(msgs))
 	}
 	// Only the TextBlock should remain; the ThinkingBlock is dropped.
 	if len(msgs[0].Content) != 1 {
-		t.Fatalf("content blocks = %d, want 1 (ThinkingBlock with empty signature should be skipped)", len(msgs[0].Content))
+		t.Fatalf("content blocks = %d, want 1 (ThinkingBlock with empty ProviderState should be skipped)", len(msgs[0].Content))
 	}
 	if msgs[0].Content[0].OfText == nil {
 		t.Error("expected remaining block to be a text block")
+	}
+}
+
+func TestBuildMessages_ThinkingBlockCrossProviderSkipped(t *testing.T) {
+	// A ThinkingBlock from a different provider (e.g. OpenAI) must be silently
+	// skipped; Anthropic cannot round-trip another provider's opaque state.
+	history := []llm.ConversationTurn{
+		{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentBlock{
+				llm.ThinkingBlock{
+					Provider:      "openai",
+					Text:          "reasoning",
+					ProviderState: json.RawMessage(`{"id":"rs_1"}`),
+				},
+				llm.TextBlock{Text: "answer"},
+			},
+		},
+	}
+	msgs, err := buildMessages(history, nil)
+	if err != nil {
+		t.Fatalf("buildMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("msgs len = %d, want 1", len(msgs))
+	}
+	// Only the TextBlock should remain; the cross-provider ThinkingBlock is dropped.
+	if len(msgs[0].Content) != 1 {
+		t.Fatalf("content blocks = %d, want 1 (cross-provider ThinkingBlock should be skipped)", len(msgs[0].Content))
+	}
+	if msgs[0].Content[0].OfText == nil {
+		t.Error("expected remaining block to be a text block")
+	}
+}
+
+func TestBuildMessages_ThinkingBlockMalformedProviderState_Error(t *testing.T) {
+	// A ThinkingBlock with malformed ProviderState JSON must return an error.
+	history := []llm.ConversationTurn{
+		{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentBlock{
+				llm.ThinkingBlock{
+					Provider:      "anthropic",
+					Text:          "reasoning",
+					ProviderState: json.RawMessage([]byte("{not json")),
+				},
+			},
+		},
+	}
+	_, err := buildMessages(history, nil)
+	if err == nil {
+		t.Fatal("expected error for malformed ProviderState, got nil")
+	}
+	if !strings.Contains(err.Error(), "unmarshal thinking state") {
+		t.Errorf("error message %q does not contain 'unmarshal thinking state'", err.Error())
 	}
 }
 

--- a/internal/llm/anthropic/state.go
+++ b/internal/llm/anthropic/state.go
@@ -1,0 +1,38 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// anthropicThinkingState holds the round-trip state for a single Anthropic
+// thinking block. It is serialized into ThinkingBlock.ProviderState and
+// deserialized when building subsequent API requests.
+type anthropicThinkingState struct {
+	Signature    string `json:"signature,omitempty"`
+	RedactedData string `json:"redacted_data,omitempty"`
+}
+
+// marshalThinkingState encodes s into a JSON RawMessage for storage in
+// ThinkingBlock.ProviderState. Returns an error wrapping any json.Marshal failure.
+func marshalThinkingState(s anthropicThinkingState) (json.RawMessage, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: marshal thinking state: %w", err)
+	}
+	return json.RawMessage(b), nil
+}
+
+// unmarshalThinkingState decodes b into an anthropicThinkingState. When b is nil
+// or empty, it returns a zero struct and nil error (pass-through: no round-trip
+// state). Any json.Unmarshal failure is wrapped and returned.
+func unmarshalThinkingState(b json.RawMessage) (anthropicThinkingState, error) {
+	if len(b) == 0 {
+		return anthropicThinkingState{}, nil
+	}
+	var s anthropicThinkingState
+	if err := json.Unmarshal(b, &s); err != nil {
+		return anthropicThinkingState{}, fmt.Errorf("anthropic: unmarshal thinking state: %w", err)
+	}
+	return s, nil
+}

--- a/internal/llm/anthropic/stream.go
+++ b/internal/llm/anthropic/stream.go
@@ -126,22 +126,30 @@ func consumeStream(
 				// Text deltas were already emitted incrementally; nothing to flush.
 
 			case "thinking":
-				thinking := &llm.ThinkingBlock{
-					Provider:  "anthropic",
-					Text:      pb.thinkingText.String(),
-					Redacted:  false,
-					Signature: pb.signature,
+				raw, err := marshalThinkingState(anthropicThinkingState{Signature: pb.signature})
+				if err != nil {
+					out <- llm.MessageChunk{Err: fmt.Errorf("anthropic: marshal thinking state: %w", err)}
+					return
 				}
-				out <- llm.MessageChunk{Thinking: thinking}
+				out <- llm.MessageChunk{Thinking: &llm.ThinkingBlock{
+					Provider:      "anthropic",
+					Text:          pb.thinkingText.String(),
+					Redacted:      false,
+					ProviderState: raw,
+				}}
 
 			case "redacted_thinking":
-				thinking := &llm.ThinkingBlock{
-					Provider:     "anthropic",
-					Text:         "[redacted]",
-					Redacted:     true,
-					RedactedData: pb.redactedData,
+				raw, err := marshalThinkingState(anthropicThinkingState{RedactedData: pb.redactedData})
+				if err != nil {
+					out <- llm.MessageChunk{Err: fmt.Errorf("anthropic: marshal thinking state: %w", err)}
+					return
 				}
-				out <- llm.MessageChunk{Thinking: thinking}
+				out <- llm.MessageChunk{Thinking: &llm.ThinkingBlock{
+					Provider:      "anthropic",
+					Text:          "[redacted]",
+					Redacted:      true,
+					ProviderState: raw,
+				}}
 
 			case "tool_use":
 				originalName := pb.toolName

--- a/internal/llm/anthropic/stream_test.go
+++ b/internal/llm/anthropic/stream_test.go
@@ -266,8 +266,12 @@ func TestConsumeStream_ThinkingWithSignature(t *testing.T) {
 	if thinking.Text != "I think deeply" {
 		t.Errorf("Thinking.Text = %q, want %q", thinking.Text, "I think deeply")
 	}
-	if thinking.Signature != "sig-abc" {
-		t.Errorf("Thinking.Signature = %q, want %q", thinking.Signature, "sig-abc")
+	var state anthropicThinkingState
+	if err := json.Unmarshal(thinking.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.Signature != "sig-abc" {
+		t.Errorf("state.Signature = %q, want %q", state.Signature, "sig-abc")
 	}
 	if thinking.Redacted {
 		t.Error("Thinking.Redacted = true, want false")
@@ -306,8 +310,12 @@ func TestConsumeStream_RedactedThinking(t *testing.T) {
 	if !thinking.Redacted {
 		t.Error("Thinking.Redacted = false, want true")
 	}
-	if thinking.RedactedData != "redacted-blob" {
-		t.Errorf("Thinking.RedactedData = %q, want %q", thinking.RedactedData, "redacted-blob")
+	var state anthropicThinkingState
+	if err := json.Unmarshal(thinking.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.RedactedData != "redacted-blob" {
+		t.Errorf("state.RedactedData = %q, want %q", state.RedactedData, "redacted-blob")
 	}
 }
 

--- a/internal/llm/interface.go
+++ b/internal/llm/interface.go
@@ -62,32 +62,24 @@ type TokenUsage struct {
 
 // ThinkingBlock is an internal reasoning block returned by the model.
 // ThinkingBlock is included in conversation history for providers that require it
-// for multi-turn continuity (Anthropic via Signature, OpenAI via EncryptedContent).
+// for multi-turn continuity (Anthropic via signature, OpenAI via encrypted content).
 // Providers that don't need it (Google, OpenAI-compat) silently skip it during
 // message translation.
+//
+// Provider is the discriminator: request builders silently skip blocks whose Provider
+// does not match the current provider (empty or mismatched). ProviderState is opaque,
+// provider-owned JSON; each provider package defines an unexported state struct and its
+// own marshal/unmarshal helpers — no shared schema. Empty ProviderState (nil or len 0)
+// means text-only with no round-trip state; request builders skip the round-trip (same
+// semantics as empty Signature/EncryptedContent in the old shape). Malformed
+// ProviderState JSON is returned as an error — do not silently drop continuity.
+//
+// ADR-026 (amended): opaque provider-owned state
 type ThinkingBlock struct {
-	// Provider identifies which provider produced this block ("anthropic", "google",
-	// "openai", etc.). It determines which of the provider-specific opaque fields
-	// below are populated.
-	Provider string
-
-	Text     string
-	Redacted bool
-
-	// Signature carries the Anthropic-issued signature for a non-redacted thinking
-	// block. Required to round-trip it in subsequent Anthropic requests.
-	Signature string
-
-	// RedactedData carries the opaque data for an Anthropic redacted thinking
-	// block. This is never displayed — it is only echoed back to the API.
-	RedactedData string
-
-	// EncryptedContent carries the OpenAI encrypted reasoning content. Required
-	// to round-trip it in subsequent OpenAI Responses API requests.
-	EncryptedContent string
-
-	// ID is the OpenAI reasoning item ID. Required when echoing back to the API.
-	ID string
+	Provider      string
+	Text          string
+	Redacted      bool
+	ProviderState json.RawMessage
 }
 
 // TextBlock is a plain text content block from the model's response.

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -63,7 +63,11 @@ func (c *Client) CreateMessage(ctx context.Context, req llm.MessageRequest) (res
 		return
 	}
 
-	params := c.buildParams(req, hints, tools, names)
+	params, buildErr := c.buildParams(req, hints, tools, names)
+	if buildErr != nil {
+		err = fmt.Errorf("openai: %w", buildErr)
+		return
+	}
 
 	sdkResp, sdkErr := c.sdk.Responses.New(ctx, params)
 	if sdkErr != nil {
@@ -99,7 +103,10 @@ func (c *Client) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-c
 		return nil, fmt.Errorf("openai: building tools: %w", err)
 	}
 
-	params := c.buildParams(req, hints, tools, names)
+	params, err := c.buildParams(req, hints, tools, names)
+	if err != nil {
+		return nil, fmt.Errorf("openai: %w", err)
+	}
 
 	stream := c.sdk.Responses.NewStreaming(ctx, params)
 
@@ -115,7 +122,7 @@ func (c *Client) buildParams(
 	hints *OpenAIHints,
 	tools []responses.ToolUnionParam,
 	names llm.ToolNameMapping,
-) responses.ResponseNewParams {
+) (responses.ResponseNewParams, error) {
 	params := responses.ResponseNewParams{
 		Model: shared.ResponsesModel(req.Model),
 		Tools: tools,
@@ -128,7 +135,10 @@ func (c *Client) buildParams(
 		params.Include = []responses.ResponseIncludable{responses.ResponseIncludableReasoningEncryptedContent}
 	}
 
-	input := buildInput(req, names)
+	input, err := buildInput(req, names)
+	if err != nil {
+		return responses.ResponseNewParams{}, fmt.Errorf("openai: buildParams: %w", err)
+	}
 	if len(input) > 0 {
 		params.Input = responses.ResponseNewParamsInputUnion{
 			OfInputItemList: input,
@@ -161,7 +171,7 @@ func (c *Client) buildParams(
 		params.MaxOutputTokens = openaisdk.Int(maxOut)
 	}
 
-	return params
+	return params, nil
 }
 
 // ValidateOptions validates provider-specific options from the policy YAML.

--- a/internal/llm/openai/state.go
+++ b/internal/llm/openai/state.go
@@ -1,0 +1,38 @@
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// openaiThinkingState holds the round-trip state for a single OpenAI reasoning
+// item. It is serialized into ThinkingBlock.ProviderState and deserialized when
+// building subsequent Responses API requests.
+type openaiThinkingState struct {
+	ID               string `json:"id,omitempty"`
+	EncryptedContent string `json:"encrypted_content,omitempty"`
+}
+
+// marshalThinkingState encodes s into a JSON RawMessage for storage in
+// ThinkingBlock.ProviderState. Returns an error wrapping any json.Marshal failure.
+func marshalThinkingState(s openaiThinkingState) (json.RawMessage, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("openai: marshal thinking state: %w", err)
+	}
+	return json.RawMessage(b), nil
+}
+
+// unmarshalThinkingState decodes b into an openaiThinkingState. When b is nil
+// or empty, it returns a zero struct and nil error (pass-through: no round-trip
+// state). Any json.Unmarshal failure is wrapped and returned.
+func unmarshalThinkingState(b json.RawMessage) (openaiThinkingState, error) {
+	if len(b) == 0 {
+		return openaiThinkingState{}, nil
+	}
+	var s openaiThinkingState
+	if err := json.Unmarshal(b, &s); err != nil {
+		return openaiThinkingState{}, fmt.Errorf("openai: unmarshal thinking state: %w", err)
+	}
+	return s, nil
+}

--- a/internal/llm/openai/stream.go
+++ b/internal/llm/openai/stream.go
@@ -91,11 +91,15 @@ func consumeStream(
 				}
 				summaryText := strings.Join(parts, "\n")
 				if ri.EncryptedContent != "" || summaryText != "" {
+					raw, err := marshalThinkingState(openaiThinkingState{ID: ri.ID, EncryptedContent: ri.EncryptedContent})
+					if err != nil {
+						out <- llm.MessageChunk{Err: fmt.Errorf("openai: marshal thinking state: %w", err)}
+						return
+					}
 					out <- llm.MessageChunk{Thinking: &llm.ThinkingBlock{
-						Provider:         "openai",
-						ID:               ri.ID,
-						Text:             summaryText,
-						EncryptedContent: ri.EncryptedContent,
+						Provider:      "openai",
+						Text:          summaryText,
+						ProviderState: raw,
 					}}
 				}
 			}

--- a/internal/llm/openai/stream_test.go
+++ b/internal/llm/openai/stream_test.go
@@ -299,14 +299,18 @@ func TestConsumeStream_ReasoningItemEmitted(t *testing.T) {
 	if thinkChunk == nil {
 		t.Fatal("expected a thinking chunk from reasoning item")
 	}
-	if thinkChunk.ID != "rs_001" {
-		t.Errorf("ID = %q, want rs_001", thinkChunk.ID)
+	var state openaiThinkingState
+	if err := json.Unmarshal(thinkChunk.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.ID != "rs_001" {
+		t.Errorf("state.ID = %q, want rs_001", state.ID)
 	}
 	if thinkChunk.Text != "I should reason about this" {
 		t.Errorf("Text = %q, want 'I should reason about this'", thinkChunk.Text)
 	}
-	if thinkChunk.EncryptedContent != "enc_token_abc" {
-		t.Errorf("EncryptedContent = %q, want enc_token_abc", thinkChunk.EncryptedContent)
+	if state.EncryptedContent != "enc_token_abc" {
+		t.Errorf("state.EncryptedContent = %q, want enc_token_abc", state.EncryptedContent)
 	}
 }
 
@@ -337,7 +341,11 @@ func TestConsumeStream_ReasoningItemNoEncryptedContent(t *testing.T) {
 	if thinkChunk.Text != "summary only" {
 		t.Errorf("Text = %q, want 'summary only'", thinkChunk.Text)
 	}
-	if thinkChunk.EncryptedContent != "" {
-		t.Errorf("EncryptedContent should be empty, got %q", thinkChunk.EncryptedContent)
+	var state openaiThinkingState
+	if err := json.Unmarshal(thinkChunk.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.EncryptedContent != "" {
+		t.Errorf("state.EncryptedContent should be empty, got %q", state.EncryptedContent)
 	}
 }

--- a/internal/llm/openai/translate.go
+++ b/internal/llm/openai/translate.go
@@ -15,29 +15,33 @@ import (
 // buildInput translates the provider-neutral MessageRequest history into the
 // Responses API input list. The system prompt is passed separately as
 // ResponseNewParams.Instructions; it is not included in the input list here.
-func buildInput(req llm.MessageRequest, names llm.ToolNameMapping) []responses.ResponseInputItemUnionParam {
+func buildInput(req llm.MessageRequest, names llm.ToolNameMapping) ([]responses.ResponseInputItemUnionParam, error) {
 	var items []responses.ResponseInputItemUnionParam
 	for _, turn := range req.History {
-		items = append(items, translateTurn(turn, names)...)
+		turnItems, err := translateTurn(turn, names)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, turnItems...)
 	}
-	return items
+	return items, nil
 }
 
 // translateTurn converts a single ConversationTurn into one or more input
 // items. The Responses API represents tool calls and results as separate
 // top-level items, not as nested content within a single message.
-func translateTurn(turn llm.ConversationTurn, names llm.ToolNameMapping) []responses.ResponseInputItemUnionParam {
+func translateTurn(turn llm.ConversationTurn, names llm.ToolNameMapping) ([]responses.ResponseInputItemUnionParam, error) {
 	switch turn.Role {
 	case llm.RoleAssistant:
 		return translateAssistantTurn(turn.Content, names)
 	case llm.RoleUser:
-		return translateUserTurn(turn.Content)
+		return translateUserTurn(turn.Content), nil
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
-func translateAssistantTurn(blocks []llm.ContentBlock, names llm.ToolNameMapping) []responses.ResponseInputItemUnionParam {
+func translateAssistantTurn(blocks []llm.ContentBlock, names llm.ToolNameMapping) ([]responses.ResponseInputItemUnionParam, error) {
 	var items []responses.ResponseInputItemUnionParam
 	var textParts []string
 
@@ -61,10 +65,18 @@ func translateAssistantTurn(blocks []llm.ContentBlock, names llm.ToolNameMapping
 			}
 			items = append(items, responses.ResponseInputItemParamOfFunctionCall(args, v.ID, name))
 		case llm.ThinkingBlock:
-			if v.ID == "" && v.EncryptedContent == "" {
-				// Non-OpenAI thinking block (e.g. from Anthropic). The Responses API
-				// requires an ID and reasoning content to round-trip, so skip it.
-				slog.Debug("openai: skipping ThinkingBlock with no ID and no encrypted_content (non-OpenAI source)")
+			if v.Provider != "" && v.Provider != "openai" {
+				slog.Debug("openai: skipping ThinkingBlock from non-OpenAI provider",
+					"block_provider", v.Provider)
+				continue
+			}
+			state, err := unmarshalThinkingState(v.ProviderState)
+			if err != nil {
+				return nil, fmt.Errorf("openai: translateAssistantTurn: %w", err)
+			}
+			if state.ID == "" && state.EncryptedContent == "" {
+				// No round-trip data — skip (non-OpenAI source or empty state).
+				slog.Debug("openai: skipping ThinkingBlock with no ID and no encrypted_content")
 				continue
 			}
 			// Flush accumulated text before emitting the reasoning item.
@@ -77,9 +89,9 @@ func translateAssistantTurn(blocks []llm.ContentBlock, names llm.ToolNameMapping
 			// (common with encrypted_content-only items). Always include at
 			// least one entry to satisfy the wire format.
 			summaryParams := []responses.ResponseReasoningItemSummaryParam{{Text: v.Text}}
-			item := responses.ResponseInputItemParamOfReasoning(v.ID, summaryParams)
-			if v.EncryptedContent != "" {
-				item.OfReasoning.EncryptedContent = param.NewOpt(v.EncryptedContent)
+			item := responses.ResponseInputItemParamOfReasoning(state.ID, summaryParams)
+			if state.EncryptedContent != "" {
+				item.OfReasoning.EncryptedContent = param.NewOpt(state.EncryptedContent)
 			}
 			items = append(items, item)
 		}
@@ -87,7 +99,7 @@ func translateAssistantTurn(blocks []llm.ContentBlock, names llm.ToolNameMapping
 	if len(textParts) > 0 {
 		items = append(items, assistantTextItem(strings.Join(textParts, "\n\n")))
 	}
-	return items
+	return items, nil
 }
 
 // assistantTextItem encodes a plain assistant text turn as an EasyInputMessage
@@ -205,11 +217,15 @@ func translateResponse(resp *responses.Response, names llm.ToolNameMapping) (*ll
 			// Only append when there is something to round-trip: encrypted content
 			// for multi-turn continuity, or summary text for audit display.
 			if v.EncryptedContent != "" || summaryText != "" {
+				state := openaiThinkingState{ID: v.ID, EncryptedContent: v.EncryptedContent}
+				raw, marshalErr := marshalThinkingState(state)
+				if marshalErr != nil {
+					return nil, fmt.Errorf("openai: translateResponse: %w", marshalErr)
+				}
 				out.Thinking = append(out.Thinking, llm.ThinkingBlock{
-					Provider:         "openai",
-					ID:               v.ID,
-					Text:             summaryText,
-					EncryptedContent: v.EncryptedContent,
+					Provider:      "openai",
+					Text:          summaryText,
+					ProviderState: raw,
 				})
 			}
 		default:

--- a/internal/llm/openai/translate_test.go
+++ b/internal/llm/openai/translate_test.go
@@ -165,7 +165,10 @@ func TestBuildInput_UserTurn(t *testing.T) {
 			{Role: llm.RoleUser, Content: []llm.ContentBlock{llm.TextBlock{Text: "Hello"}}},
 		},
 	}
-	items := buildInput(req, llm.ToolNameMapping{})
+	items, err := buildInput(req, llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput: %v", err)
+	}
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d; want 1", len(items))
 	}
@@ -183,7 +186,10 @@ func TestBuildInput_ToolResultTurn(t *testing.T) {
 			},
 		},
 	}
-	items := buildInput(req, llm.ToolNameMapping{})
+	items, err := buildInput(req, llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput: %v", err)
+	}
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d; want 1", len(items))
 	}
@@ -218,8 +224,14 @@ func TestTranslate_IgnoresProviderMetadata(t *testing.T) {
 		}
 	}
 
-	itemsWith := buildInput(makeReq(withMeta), llm.ToolNameMapping{})
-	itemsWithout := buildInput(makeReq(withoutMeta), llm.ToolNameMapping{})
+	itemsWith, err := buildInput(makeReq(withMeta), llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput (with): %v", err)
+	}
+	itemsWithout, err := buildInput(makeReq(withoutMeta), llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput (without): %v", err)
+	}
 
 	if len(itemsWith) != 1 || len(itemsWithout) != 1 {
 		t.Fatalf("expected 1 item each, got %d and %d", len(itemsWith), len(itemsWithout))
@@ -257,11 +269,15 @@ func TestTranslateResponse_ReasoningWithEncryptedContent(t *testing.T) {
 		t.Fatal("expected at least one thinking block")
 	}
 	tb := out.Thinking[0]
-	if tb.EncryptedContent != "enc_abc123" {
-		t.Errorf("EncryptedContent = %q, want enc_abc123", tb.EncryptedContent)
+	var state openaiThinkingState
+	if err := json.Unmarshal(tb.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
 	}
-	if tb.ID != "rs_001" {
-		t.Errorf("ID = %q, want rs_001", tb.ID)
+	if state.EncryptedContent != "enc_abc123" {
+		t.Errorf("state.EncryptedContent = %q, want enc_abc123", state.EncryptedContent)
+	}
+	if state.ID != "rs_001" {
+		t.Errorf("state.ID = %q, want rs_001", state.ID)
 	}
 }
 
@@ -301,8 +317,12 @@ func TestTranslateResponse_ReasoningNoEncryptedContent_WithSummary(t *testing.T)
 	if tb.Text != "thinking hard" {
 		t.Errorf("Text = %q, want thinking hard", tb.Text)
 	}
-	if tb.EncryptedContent != "" {
-		t.Errorf("EncryptedContent should be empty, got %q", tb.EncryptedContent)
+	var state openaiThinkingState
+	if err := json.Unmarshal(tb.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.EncryptedContent != "" {
+		t.Errorf("state.EncryptedContent should be empty, got %q", state.EncryptedContent)
 	}
 }
 
@@ -341,19 +361,23 @@ func TestTranslateResponse_ReasoningEmpty_Skipped(t *testing.T) {
 }
 
 func TestBuildInput_ThinkingBlockRoundTrip(t *testing.T) {
+	providerState, _ := marshalThinkingState(openaiThinkingState{ID: "rs_001", EncryptedContent: "enc123"})
 	req := llm.MessageRequest{
 		Model: "o3-mini",
 		History: []llm.ConversationTurn{
 			{
 				Role: llm.RoleAssistant,
 				Content: []llm.ContentBlock{
-					llm.ThinkingBlock{ID: "rs_001", Text: "summary text", EncryptedContent: "enc123"},
+					llm.ThinkingBlock{Provider: "openai", Text: "summary text", ProviderState: providerState},
 					llm.TextBlock{Text: "the answer"},
 				},
 			},
 		},
 	}
-	items := buildInput(req, llm.ToolNameMapping{})
+	items, err := buildInput(req, llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput: %v", err)
+	}
 	// Expect two items: reasoning item + assistant text item.
 	if len(items) != 2 {
 		t.Fatalf("len(items) = %d, want 2", len(items))
@@ -380,18 +404,22 @@ func TestBuildInput_ThinkingBlockEmptySummary_IncludesSummaryField(t *testing.T)
 	// produce a reasoning item with a non-nil summary array. The Responses API
 	// rejects input items where the summary field is absent (nil slice → omitted
 	// via omitzero).
+	providerState, _ := marshalThinkingState(openaiThinkingState{ID: "rs_010", EncryptedContent: "enc_opaque"})
 	req := llm.MessageRequest{
 		Model: "o3-mini",
 		History: []llm.ConversationTurn{
 			{
 				Role: llm.RoleAssistant,
 				Content: []llm.ContentBlock{
-					llm.ThinkingBlock{ID: "rs_010", Text: "", EncryptedContent: "enc_opaque"},
+					llm.ThinkingBlock{Provider: "openai", Text: "", ProviderState: providerState},
 				},
 			},
 		},
 	}
-	items := buildInput(req, llm.ToolNameMapping{})
+	items, err := buildInput(req, llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput: %v", err)
+	}
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d, want 1", len(items))
 	}
@@ -411,18 +439,22 @@ func TestBuildInput_ThinkingBlockEmptySummary_IncludesSummaryField(t *testing.T)
 func TestBuildInput_ThinkingBlockNoEncryptedContent(t *testing.T) {
 	// A ThinkingBlock with only summary text (no EncryptedContent) should still
 	// emit a reasoning input item.
+	providerState, _ := marshalThinkingState(openaiThinkingState{ID: "rs_002"})
 	req := llm.MessageRequest{
 		Model: "o3-mini",
 		History: []llm.ConversationTurn{
 			{
 				Role: llm.RoleAssistant,
 				Content: []llm.ContentBlock{
-					llm.ThinkingBlock{ID: "rs_002", Text: "some reasoning"},
+					llm.ThinkingBlock{Provider: "openai", Text: "some reasoning", ProviderState: providerState},
 				},
 			},
 		},
 	}
-	items := buildInput(req, llm.ToolNameMapping{})
+	items, err := buildInput(req, llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput: %v", err)
+	}
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d, want 1", len(items))
 	}
@@ -437,24 +469,28 @@ func TestBuildInput_ThinkingBlockNoEncryptedContent(t *testing.T) {
 }
 
 func TestBuildInput_ThinkingBlockNoIDNoEncrypted_Skipped(t *testing.T) {
-	// A ThinkingBlock with empty ID and empty EncryptedContent is a non-OpenAI
-	// block (e.g. from Anthropic). It should be silently dropped.
+	// A ThinkingBlock from a different provider (Anthropic) must be silently
+	// dropped — the OpenAI translator cannot round-trip Anthropic state.
+	providerState := json.RawMessage(`{"signature":"sig_xyz"}`)
 	req := llm.MessageRequest{
 		Model: "o3-mini",
 		History: []llm.ConversationTurn{
 			{
 				Role: llm.RoleAssistant,
 				Content: []llm.ContentBlock{
-					llm.ThinkingBlock{Text: "anthropic reasoning", Signature: "sig_xyz"},
+					llm.ThinkingBlock{Provider: "anthropic", Text: "anthropic reasoning", ProviderState: providerState},
 					llm.TextBlock{Text: "answer"},
 				},
 			},
 		},
 	}
-	items := buildInput(req, llm.ToolNameMapping{})
+	items, err := buildInput(req, llm.ToolNameMapping{})
+	if err != nil {
+		t.Fatalf("buildInput: %v", err)
+	}
 	// Only the text block should produce an item; ThinkingBlock is skipped.
 	if len(items) != 1 {
-		t.Fatalf("len(items) = %d, want 1 (ThinkingBlock with no ID/EncryptedContent should be skipped)", len(items))
+		t.Fatalf("len(items) = %d, want 1 (cross-provider ThinkingBlock should be skipped)", len(items))
 	}
 	raw, err := json.Marshal(items[0])
 	if err != nil {
@@ -462,5 +498,31 @@ func TestBuildInput_ThinkingBlockNoIDNoEncrypted_Skipped(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), "answer") {
 		t.Errorf("expected text 'answer' in item, got %s", raw)
+	}
+}
+
+func TestBuildInput_ThinkingBlockMalformedProviderState_Error(t *testing.T) {
+	// A ThinkingBlock with malformed ProviderState JSON must return an error.
+	req := llm.MessageRequest{
+		Model: "o3-mini",
+		History: []llm.ConversationTurn{
+			{
+				Role: llm.RoleAssistant,
+				Content: []llm.ContentBlock{
+					llm.ThinkingBlock{
+						Provider:      "openai",
+						Text:          "reasoning",
+						ProviderState: json.RawMessage([]byte("{not json")),
+					},
+				},
+			},
+		},
+	}
+	_, err := buildInput(req, llm.ToolNameMapping{})
+	if err == nil {
+		t.Fatal("expected error for malformed ProviderState, got nil")
+	}
+	if !strings.Contains(err.Error(), "unmarshal thinking state") {
+		t.Errorf("error message %q does not contain 'unmarshal thinking state'", err.Error())
 	}
 }

--- a/internal/llm/openaicompat/translate_test.go
+++ b/internal/llm/openaicompat/translate_test.go
@@ -343,7 +343,7 @@ func TestBuildChatCompletionRequest(t *testing.T) {
 				Model: "gpt-4o",
 				History: []llm.ConversationTurn{
 					{Role: llm.RoleAssistant, Content: []llm.ContentBlock{
-						llm.ThinkingBlock{Text: "reasoning", Signature: "sig"},
+						llm.ThinkingBlock{Provider: "anthropic", Text: "reasoning"},
 						llm.TextBlock{Text: "answer"},
 					}},
 				},


### PR DESCRIPTION
Closes #4

## Summary

Refactor `llm.ThinkingBlock` to stop carrying provider-specific named fields. The four existing fields (`Signature`, `RedactedData`, `EncryptedContent`, `ID`) are replaced with a single opaque `ProviderState json.RawMessage`. Each provider package that round-trips reasoning state defines its own unexported state struct and marshal/unmarshal helpers.

This removes the lowest-common-denominator leak before a 4th provider would widen it further.

## What changed

- `llm.ThinkingBlock` now has exactly `{Provider, Text, Redacted, ProviderState}`.
- `internal/llm/anthropic/state.go` and `internal/llm/openai/state.go` — new files containing `anthropicThinkingState` / `openaiThinkingState` structs and local marshal/unmarshal helpers.
- Widened signatures to propagate unmarshal errors:
  - `anthropic.buildMessages` → `([]anthropic.MessageParam, error)`
  - `anthropic.translateResponse` → `(*llm.MessageResponse, error)`
  - `openai.buildInput` / `translateTurn` / `translateAssistantTurn` / `buildParams` — all return errors.
- Cross-provider mismatch (e.g. OpenAI-shaped block fed to Anthropic builder) is silently skipped.
- Malformed `ProviderState` returns a wrapped error — continuity is never silently dropped.
- ADR-026 amended in place in `docs/ADR_Tracker.md`.

## Out of scope (intentionally)

- `ProviderHints any` — unchanged. Request-time configuration with a different lifecycle; typed-per-provider stays ergonomic.
- `ToolCallBlock.ProviderMetadata map[string][]byte` — unchanged. Already has the opaque-bytes property; used only by Google.
- Google has no `state.go` — no ThinkingBlock round-trip state today, no dead code added.

## No DB migration

The audit writer in `internal/agent/agent.go` persists only `{text, redacted}` for thinking steps. The four removed fields were never written to SQLite, never sent over SSE, and never read by the frontend. Nothing on-wire changes.

## Review cycles

- 1 plan-reviewer revision (REVISE → architect addressed: `translateResponse` signature widening, OpenAI error-propagation chain worked out, explicit stream error patterns, dropped the dead-code `google/state.go`, enumerated all test call sites).
- 1 code-review cycle (APPROVE with 3 non-blocking notes — a double-slash typo and a stray `.gitkeep` deletion from `npm run build` both addressed post-review).

## CLAUDE.md

No updates needed — scope is internal to `internal/llm`, no new packages / env vars / routes / run states / step types / roles.

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` on the branch history. Key decisions:

- Per-provider adoption of opaque bytes (not mandated uniformly — Google can stay typed if it ever adds state later).
- Empty `ProviderState` = pass-through text; same skip semantics as today's empty `Signature`.
- Malformed `ProviderState` is an error, not a silent drop.
- Cross-provider discriminator mismatch is skipped silently (Debug log).

</details>

🤖 Generated by the agentic `/dev-loop` pipeline.