### PR TITLE
chore(deps): complete React 19 migration (bump react-dom + @types/react-dom)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "js-yaml": "^4.1.1",
         "lucide-react": "^1.8.0",
         "react": "^19.2.5",
-        "react-dom": "^18.3.0",
+        "react-dom": "^19.2.5",
         "react-router-dom": "^6.28.0",
         "recharts": "^3.8.1"
       },
@@ -32,7 +32,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.2.14",
-        "@types/react-dom": "^18.3.0",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/browser-playwright": "^4.1.5",
         "@vitest/coverage-v8": "^4.0.18",
@@ -2191,11 +2191,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -3697,7 +3698,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -4056,17 +4058,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -4558,16 +4549,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {
@@ -4835,13 +4825,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "js-yaml": "^4.1.1",
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
-    "react-dom": "^18.3.0",
+    "react-dom": "^19.2.5",
     "react-router-dom": "^6.28.0",
     "recharts": "^3.8.1"
   },
@@ -36,7 +36,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser-playwright": "^4.1.5",
     "@vitest/coverage-v8": "^4.0.18",

--- a/frontend/src/hooks/useScrollSentinel.ts
+++ b/frontend/src/hooks/useScrollSentinel.ts
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback, type RefObject } from 'react'
 
 export interface ScrollSentinelResult {
-  sentinelRef: RefObject<HTMLDivElement>
+  sentinelRef: RefObject<HTMLDivElement | null>
   showNewPill: boolean
   scrollToBottom: () => void
 }


### PR DESCRIPTION
## Summary

Dependabot PR #20 bumped `react` and `@types/react` to v19 but left `react-dom` and `@types/react-dom` at v18, producing a peer dependency conflict that breaks `npm ci` on `main`. This went undetected because CI was disabled when #20 merged.

This PR aligns all four React ecosystem packages on v19:

| Package | From | To |
|---|---|---|
| `react` | ^19.2.5 | unchanged |
| `react-dom` | ^18.3.0 | **^19.2.5** |
| `@types/react` | ^19.2.14 | unchanged |
| `@types/react-dom` | ^18.3.0 | **^19.2.3** |

## Code changes

One TypeScript adjustment in `src/hooks/useScrollSentinel.ts` — React 19 unified `RefObject<T>` to always include `| null` when no initial value is passed. The exported hook interface needed to match.

No runtime code changes were required; the rest of the frontend was already React-19-compatible (since `react` + `@types/react` had already been on v19).

## Verification

- `npx tsc --noEmit` — clean
- `npm run test:unit` — **667 tests pass** across 45 files
- `npm run build` — production build succeeds
- `npm run build-storybook` — storybook build succeeds

## Follow-up

This unblocks PR #24 (re-enable CI triggers), which was surfacing the broken `npm ci` as part of its merge-commit CI run. Once this lands, #24 can be rebased and merged.

It is also worth considering a `groups:` config in `.github/dependabot.yml` so React ecosystem bumps are proposed together — preventing this incoherent-peer-graph scenario from recurring. Tracked as a Tier 1.5 candidate.