### PR TITLE
chore: remove unneeded leftover files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "gleipnir",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary

- Removes root `package-lock.json` — empty stub (no packages, no corresponding `package.json`); all npm state lives in `frontend/`
- Removes `frontend/src/components/AgentEditor/FormMode/PolicyIdentitySection.module.css` — 0-byte file with no imports anywhere, leftover from a past refactor

## Test plan

- [ ] `go build ./...` passes
- [ ] `npm run build` (from `frontend/`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)