### PR TITLE
fix: address 7 UI/UX bugs from Playwright walkthrough

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -28,7 +28,8 @@ npm run build-storybook  # static Storybook build
 /runs/:id           → reasoning timeline with live SSE updates
 /tools              → tool management + server registry
 /mcp                → redirect to /tools (legacy path)
-/users              → user management (admin)
+/users              → redirect to /admin/users (legacy path)
+/admin/users        → user management (admin)
 /admin/models       → model enable/disable, provider key management (admin)
 /admin/system       → system settings (public URL, run limits, system info) (admin)
 *                   → 404 not found
@@ -149,6 +150,8 @@ Canonical formatting helpers live in `src/utils/format.ts`:
 - `formatCountdown(expiresAt)` — countdown with urgency flag
 - `computeRunDuration(run)` — derives duration from started/completed timestamps
 - `formatProviderName(provider)` — display label for LLM providers (`openai` → `OpenAI`)
+
+`src/utils/inlineMarkdown.ts` — `renderInlineMarkdown(text)` tokenizes bold (`**`), italic (`*`/`_`), and inline code (`` ` ``) and returns a `ReactNode[]` for use inside JSX. No external markdown dependency.
 
 ## API types
 

--- a/frontend/src/components/AgentEditor/agentEditorUtils.test.ts
+++ b/frontend/src/components/AgentEditor/agentEditorUtils.test.ts
@@ -712,6 +712,9 @@ describe('defaultFormState', () => {
     expect(state.limits.max_tool_calls_per_run).toBe(50)
     expect(state.concurrency.concurrency).toBe('skip')
     expect(state.concurrency.queueDepth).toBe(0)
+    // task must start empty so the textarea placeholder guides the user and saving
+    // without editing correctly surfaces the "agent.task is required" validation error.
+    expect(state.task.task).toBe('')
   })
 
   it('matches what yamlToFormState(DEFAULT_YAML) returns', () => {

--- a/frontend/src/components/AgentEditor/agentEditorUtils.ts
+++ b/frontend/src/components/AgentEditor/agentEditorUtils.ts
@@ -33,8 +33,7 @@ trigger:
 capabilities:
   tools: []
 agent:
-  task: |
-    Describe what this agent should do.
+  task: ''
   limits:
     max_tokens_per_run: 20000
     max_tool_calls_per_run: 50

--- a/frontend/src/components/RunDetail/FilterBar.stories.tsx
+++ b/frontend/src/components/RunDetail/FilterBar.stories.tsx
@@ -19,6 +19,7 @@ const COUNTS: Record<FilterKey, number> = {
   thinking: 6,
   error: 3,
   approval: 2,
+  feedback: 2,
 }
 
 export const AllActive: Story = {
@@ -53,6 +54,14 @@ export const ApprovalsActive: Story = {
   },
 }
 
+export const FeedbackActive: Story = {
+  args: {
+    active: 'feedback',
+    counts: COUNTS,
+    onChange: () => {},
+  },
+}
+
 export const ToolsActive: Story = {
   args: {
     active: 'tool',
@@ -81,7 +90,7 @@ export const NoErrors: Story = {
 export const AllZeroCounts: Story = {
   args: {
     active: 'all',
-    counts: { all: 0, tool: 0, thought: 0, thinking: 0, error: 0, approval: 0 },
+    counts: { all: 0, tool: 0, thought: 0, thinking: 0, error: 0, approval: 0, feedback: 0 },
     onChange: () => {},
   },
 }

--- a/frontend/src/components/RunDetail/FilterBar.tsx
+++ b/frontend/src/components/RunDetail/FilterBar.tsx
@@ -1,6 +1,6 @@
 import styles from './FilterBar.module.css'
 
-export type FilterKey = 'all' | 'tool' | 'thought' | 'thinking' | 'error' | 'approval'
+export type FilterKey = 'all' | 'tool' | 'thought' | 'thinking' | 'error' | 'approval' | 'feedback'
 
 interface FilterChip {
   key: FilterKey
@@ -14,6 +14,7 @@ const CHIPS: FilterChip[] = [
   { key: 'thinking', label: 'Thinking' },
   { key: 'error', label: 'Errors' },
   { key: 'approval', label: 'Approvals' },
+  { key: 'feedback', label: 'Feedback' },
 ]
 
 interface Props {

--- a/frontend/src/components/RunDetail/ThoughtBlock.module.css
+++ b/frontend/src/components/RunDetail/ThoughtBlock.module.css
@@ -40,6 +40,14 @@
   word-break: break-word;
 }
 
+.content code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--bg-code);
+  padding: 0 var(--space-1);
+  border-radius: 3px;
+}
+
 .toggle {
   display: inline;
   margin-left: var(--space-2);

--- a/frontend/src/components/RunDetail/ThoughtBlock.stories.tsx
+++ b/frontend/src/components/RunDetail/ThoughtBlock.stories.tsx
@@ -43,6 +43,16 @@ export const LongThought: Story = {
   },
 }
 
+export const WithMarkdown: Story = {
+  args: {
+    step: parseStep(makeRaw({
+      content: JSON.stringify({
+        text: '**Result:** The `foo` function returned *success*.',
+      }),
+    })) as ReturnType<typeof parseStep> & { type: 'thought' },
+  },
+}
+
 export const MultiParagraph: Story = {
   args: {
     step: parseStep(makeRaw({

--- a/frontend/src/components/RunDetail/ThoughtBlock.tsx
+++ b/frontend/src/components/RunDetail/ThoughtBlock.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { renderInlineMarkdown } from '@/utils/inlineMarkdown'
 import type { ParsedStep } from './types'
 import styles from './ThoughtBlock.module.css'
 
@@ -23,7 +24,7 @@ export function ThoughtBlock({ step }: Props) {
         <span className={styles.label}>Thought</span>
       </div>
       <div className={styles.content}>
-        {displayText}
+        {renderInlineMarkdown(displayText)}
         {isLong && (
           <button
             type="button"

--- a/frontend/src/components/RunDetail/ToolBlock.module.css
+++ b/frontend/src/components/RunDetail/ToolBlock.module.css
@@ -197,3 +197,13 @@
   font-size: var(--text-sm);
   font-weight: 500;
 }
+
+.outputText {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-second);
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/frontend/src/components/RunDetail/ToolBlock.stories.tsx
+++ b/frontend/src/components/RunDetail/ToolBlock.stories.tsx
@@ -71,7 +71,7 @@ export const Success: Story = {
         created_at: '2026-03-10T12:00:02Z',
         content: JSON.stringify({
           tool_name: 'read_file',
-          output: JSON.stringify({ lines: ['INFO app started', 'INFO ready'] }),
+          output: JSON.stringify([{ type: 'text', text: 'INFO app started\nINFO ready' }]),
           is_error: false,
         }),
       })) as ToolBlockData['result'],
@@ -221,5 +221,63 @@ export const ApprovalDenied: Story = {
     } satisfies ToolBlockData,
     runId: 'run-1',
     runStatus: 'failed',
+  },
+}
+
+export const OutputPlainText: Story = {
+  name: 'Output: plain text (not JSON)',
+  args: {
+    block: {
+      approval: null,
+      call: parseStep(makeRaw({
+        id: 'step-call',
+        type: 'tool_call',
+        content: JSON.stringify({
+          tool_name: 'get_weather',
+          server_id: 'weather-server',
+          input: { city: 'London' },
+        }),
+      })) as ToolBlockData['call'],
+      result: parseStep(makeRaw({
+        id: 'step-result',
+        type: 'tool_result',
+        content: JSON.stringify({
+          tool_name: 'get_weather',
+          output: 'Weather in London: Sunny, 22°C',
+          is_error: false,
+        }),
+      })) as ToolBlockData['result'],
+    } satisfies ToolBlockData,
+    runId: 'run-1',
+    runStatus: 'complete',
+  },
+}
+
+export const OutputWithMixedContent: Story = {
+  name: 'Output: mixed MCP content (text + image, fallback to JSON)',
+  args: {
+    block: {
+      approval: null,
+      call: parseStep(makeRaw({
+        id: 'step-call',
+        type: 'tool_call',
+        content: JSON.stringify({
+          tool_name: 'capture_screenshot',
+          server_id: 'browser-server',
+          input: { url: 'https://example.com' },
+        }),
+      })) as ToolBlockData['call'],
+      result: parseStep(makeRaw({
+        id: 'step-result',
+        type: 'tool_result',
+        content: JSON.stringify({
+          tool_name: 'capture_screenshot',
+          output: JSON.stringify([{ type: 'text', text: 'Saved' }, { type: 'image', data: '...' }]),
+          is_error: false,
+        }),
+      })) as ToolBlockData['result'],
+    } satisfies ToolBlockData,
+    runId: 'run-1',
+    runStatus: 'complete',
   },
 }

--- a/frontend/src/components/RunDetail/ToolBlock.tsx
+++ b/frontend/src/components/RunDetail/ToolBlock.tsx
@@ -1,6 +1,7 @@
 import { Check, X } from 'lucide-react'
 import { CollapsibleJSON } from '@/components/CollapsibleJSON'
 import { ApprovalActions } from './ApprovalActions'
+import { parseToolOutput } from './toolOutput'
 import type { ToolBlockData } from './types'
 import styles from './ToolBlock.module.css'
 
@@ -53,15 +54,9 @@ export function ToolBlock({ block, runId, runStatus }: Props) {
     block.call?.content.input ?? block.approval?.content.input ?? {}
   const inputEmpty = Object.keys(inputValue).length === 0
 
-  // Output: parse the JSON string from tool_result.
-  let outputValue: unknown = null
-  if (block.result) {
-    try {
-      outputValue = JSON.parse(block.result.content.output)
-    } catch {
-      outputValue = block.result.content.output
-    }
-  }
+  const outputValue: unknown = block.result
+    ? parseToolOutput(block.result.content.output)
+    : null
 
   const dotClass = {
     success: styles.dotSuccess,
@@ -119,14 +114,18 @@ export function ToolBlock({ block, runId, runStatus }: Props) {
         {status === 'success' && (
           <div className={`${styles.pane} ${styles.paneOutput}`}>
             <div className={styles.paneLabel}>Output</div>
-            <CollapsibleJSON value={outputValue} />
+            {typeof outputValue === 'string'
+              ? <pre className={styles.outputText}>{outputValue}</pre>
+              : <CollapsibleJSON value={outputValue} />}
           </div>
         )}
 
         {status === 'error' && (
           <div className={`${styles.pane} ${styles.paneOutput} ${styles.paneError}`}>
             <div className={styles.paneLabel}>Output</div>
-            <CollapsibleJSON value={outputValue} />
+            {typeof outputValue === 'string'
+              ? <pre className={styles.outputText}>{outputValue}</pre>
+              : <CollapsibleJSON value={outputValue} />}
           </div>
         )}
 

--- a/frontend/src/components/RunDetail/toolOutput.test.ts
+++ b/frontend/src/components/RunDetail/toolOutput.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { parseToolOutput } from './toolOutput'
+
+describe('parseToolOutput', () => {
+  it('MCP text-only content array → joined string', () => {
+    const raw = JSON.stringify([
+      { type: 'text', text: 'INFO app started' },
+      { type: 'text', text: 'INFO ready' },
+    ])
+    expect(parseToolOutput(raw)).toBe('INFO app started\nINFO ready')
+  })
+
+  it('single text item → string (no trailing newline)', () => {
+    const raw = JSON.stringify([{ type: 'text', text: 'done' }])
+    expect(parseToolOutput(raw)).toBe('done')
+  })
+
+  it('MCP content with an image item → raw array (fallback)', () => {
+    const raw = JSON.stringify([
+      { type: 'text', text: 'Saved' },
+      { type: 'image', data: 'abc123' },
+    ])
+    const result = parseToolOutput(raw)
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toEqual([
+      { type: 'text', text: 'Saved' },
+      { type: 'image', data: 'abc123' },
+    ])
+  })
+
+  it('empty array → returned as-is (fallback)', () => {
+    const raw = JSON.stringify([])
+    const result = parseToolOutput(raw)
+    expect(Array.isArray(result)).toBe(true)
+    expect((result as unknown[]).length).toBe(0)
+  })
+
+  it('non-array JSON (plain object) → unchanged object', () => {
+    const obj = { lines: ['a', 'b'], count: 2 }
+    const result = parseToolOutput(JSON.stringify(obj))
+    expect(result).toEqual(obj)
+  })
+
+  it('unparseable string → original string unchanged', () => {
+    const raw = 'permission denied: /tmp/report.txt'
+    expect(parseToolOutput(raw)).toBe(raw)
+  })
+
+  it('JSON-encoded string (e.g. "Message sent") → unwrapped string', () => {
+    // JSON.parse('"Message sent"') → 'Message sent' (a string).
+    // parseToolOutput returns it as-is — not an array, so no envelope logic.
+    const raw = '"Message sent"'
+    expect(parseToolOutput(raw)).toBe('Message sent')
+  })
+})

--- a/frontend/src/components/RunDetail/toolOutput.ts
+++ b/frontend/src/components/RunDetail/toolOutput.ts
@@ -1,0 +1,31 @@
+// parseToolOutput extracts a display-ready value from the raw JSON string stored
+// in ToolResultContent.output. The MCP protocol wraps text responses in a
+// content-array envelope; per ADR-030 the UI abstracts over transport details,
+// so a text-only envelope is collapsed to a plain string.
+export function parseToolOutput(raw: string): unknown {
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    return raw
+  }
+
+  // MCP content envelope: an array whose items are { type, text, ... }.
+  // Collapse to a single newline-joined string only when every item is
+  // { type: "text", text: string }. Mixed arrays (e.g. text + image) fall
+  // through to the JSON view so no content is silently dropped.
+  if (Array.isArray(value) && value.length > 0) {
+    const allText = value.every(
+      (item) =>
+        typeof item === 'object' &&
+        item !== null &&
+        (item as Record<string, unknown>).type === 'text' &&
+        typeof (item as Record<string, unknown>).text === 'string',
+    )
+    if (allText) {
+      return value.map((item) => (item as { text: string }).text).join('\n')
+    }
+  }
+
+  return value
+}

--- a/frontend/src/components/Settings/ChangePasswordSection.tsx
+++ b/frontend/src/components/Settings/ChangePasswordSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Lock } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { useChangePassword } from '@/hooks/useSettings'
+import { useCurrentUser } from '@/hooks/queries/users'
 import type { ApiError } from '@/api/fetch'
 import { ErrorBanner } from '@/components/form/ErrorBanner'
 import styles from './Settings.module.css'
@@ -14,6 +15,8 @@ export function ChangePasswordSection() {
   const [success, setSuccess] = useState(false)
 
   const mutation = useChangePassword()
+  const { data: currentUser } = useCurrentUser()
+  const currentUsername = currentUser?.username ?? ''
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -55,6 +58,17 @@ export function ChangePasswordSection() {
       </div>
       <div className={styles.cardBody}>
         <form onSubmit={handleSubmit}>
+          {/* Hidden username field so password managers can associate the saved
+              credential with the correct account. The `hidden` attribute keeps
+              this out of the visible layout without inline styles. */}
+          <input
+            type="text"
+            name="username"
+            autoComplete="username"
+            value={currentUsername}
+            readOnly
+            hidden
+          />
           <div className={styles.formInner}>
             <div className={styles.fieldGroup}>
               <label htmlFor="current-password" className={styles.label}>

--- a/frontend/src/components/UsersPage/CreateUserModal/CreateUserModal.module.css
+++ b/frontend/src/components/UsersPage/CreateUserModal/CreateUserModal.module.css
@@ -34,6 +34,10 @@
   border-color: var(--color-blue);
 }
 
+.input[aria-invalid='true'] {
+  border-color: var(--color-red);
+}
+
 .checkboxGroup {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/UsersPage/CreateUserModal/CreateUserModal.tsx
+++ b/frontend/src/components/UsersPage/CreateUserModal/CreateUserModal.tsx
@@ -2,7 +2,8 @@ import { useState, type FormEvent } from 'react'
 import { Modal } from '@/components/Modal'
 import { ModalFooter } from '@/components/ModalFooter'
 import type { ApiError } from '@/api/fetch'
-import { ErrorBanner } from '@/components/form/ErrorBanner'
+import { ErrorBanner, type BannerIssue } from '@/components/form/ErrorBanner'
+import { FieldError } from '@/components/form/FieldError'
 import styles from './CreateUserModal.module.css'
 
 const ALL_ROLES = ['admin', 'operator', 'approver', 'auditor'] as const
@@ -18,6 +19,8 @@ export function CreateUserModal({ onClose, onSubmit, isPending, error }: Props) 
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [selectedRoles, setSelectedRoles] = useState<Set<string>>(new Set())
+  const [clientIssues, setClientIssues] = useState<BannerIssue[]>([])
+  const [fieldErrors, setFieldErrors] = useState<{ username?: string; password?: string }>({})
 
   function toggleRole(role: string) {
     setSelectedRoles((prev) => {
@@ -33,8 +36,38 @@ export function CreateUserModal({ onClose, onSubmit, isPending, error }: Props) 
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
+
+    // Reset stale client errors before re-validating.
+    setClientIssues([])
+    setFieldErrors({})
+
+    const issues: BannerIssue[] = []
+    const errors: { username?: string; password?: string } = {}
+
+    if (username.trim() === '') {
+      issues.push({ field: 'username', message: 'Username is required' })
+      errors.username = 'Username is required'
+    }
+    if (password === '') {
+      issues.push({ field: 'password', message: 'Password is required' })
+      errors.password = 'Password is required'
+    }
+
+    if (issues.length > 0) {
+      setClientIssues(issues)
+      setFieldErrors(errors)
+      return
+    }
+
     onSubmit(username, password, Array.from(selectedRoles))
   }
+
+  const bannerIssues: BannerIssue[] =
+    clientIssues.length > 0
+      ? clientIssues
+      : error
+        ? (error.issues ?? (error.detail ? [{ message: error.detail }] : [{ message: error.message }]))
+        : []
 
   const footer = (
     <ModalFooter
@@ -48,7 +81,12 @@ export function CreateUserModal({ onClose, onSubmit, isPending, error }: Props) 
 
   return (
     <Modal title="Create user" onClose={onClose} footer={footer}>
-      <form id="create-user-form" className={styles.form} onSubmit={handleSubmit}>
+      <form
+        id="create-user-form"
+        className={styles.form}
+        onSubmit={handleSubmit}
+        onInvalid={(e) => e.preventDefault()}
+      >
         <div className={styles.fieldGroup}>
           <label htmlFor="new-username" className={styles.label}>
             Username
@@ -60,8 +98,10 @@ export function CreateUserModal({ onClose, onSubmit, isPending, error }: Props) 
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             autoComplete="off"
-            required
+            aria-invalid={Boolean(fieldErrors.username)}
+            aria-describedby="new-username-error"
           />
+          <FieldError id="new-username-error" messages={fieldErrors.username} />
         </div>
 
         <div className={styles.fieldGroup}>
@@ -75,8 +115,10 @@ export function CreateUserModal({ onClose, onSubmit, isPending, error }: Props) 
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="new-password"
-            required
+            aria-invalid={Boolean(fieldErrors.password)}
+            aria-describedby="new-password-error"
           />
+          <FieldError id="new-password-error" messages={fieldErrors.password} />
         </div>
 
         <div className={styles.fieldGroup}>
@@ -95,13 +137,7 @@ export function CreateUserModal({ onClose, onSubmit, isPending, error }: Props) 
           </div>
         </div>
 
-        <ErrorBanner
-          issues={
-            error
-              ? (error.issues ?? (error.detail ? [{ message: error.detail }] : [{ message: error.message }]))
-              : []
-          }
-        />
+        <ErrorBanner issues={bannerIssues} />
       </form>
     </Modal>
   )

--- a/frontend/src/hooks/useRunTimeline.test.ts
+++ b/frontend/src/hooks/useRunTimeline.test.ts
@@ -116,6 +116,16 @@ describe('useRunTimeline — filter counts', () => {
     const { result } = renderHook(() => useRunTimeline(steps, 'all'))
     expect(result.current.counts.approval).toBe(1)
   })
+
+  it('counts feedback steps (feedback_request + feedback_response)', () => {
+    const feedbackSteps: ApiRunStep[] = [
+      makeStep({ id: 'f1', type: 'feedback_request', content: JSON.stringify({ tool: 'gleipnir.ask_operator', message: 'Please confirm' }) }),
+      makeStep({ id: 'f2', step_number: 1, type: 'feedback_response', content: JSON.stringify({ response: 'Yes' }) }),
+      makeStep({ id: 'f3', step_number: 2, type: 'thought', content: JSON.stringify({ text: 'noted' }) }),
+    ]
+    const { result } = renderHook(() => useRunTimeline(feedbackSteps, 'all'))
+    expect(result.current.counts.feedback).toBe(2)
+  })
 })
 
 describe('useRunTimeline — filtering', () => {
@@ -166,6 +176,18 @@ describe('useRunTimeline — filtering', () => {
     const { result } = renderHook(() => useRunTimeline(approvalSteps, 'approval'))
     expect(result.current.filteredItems).toHaveLength(1)
     expect(result.current.filteredItems[0]).toHaveProperty('approval')
+  })
+
+  it('filter "feedback" returns feedback_request and feedback_response items', () => {
+    const feedbackSteps: ApiRunStep[] = [
+      makeStep({ id: 'f1', type: 'feedback_request', content: JSON.stringify({ tool: 'gleipnir.ask_operator', message: 'Confirm?' }) }),
+      makeStep({ id: 'f2', step_number: 1, type: 'feedback_response', content: JSON.stringify({ response: 'Yes' }) }),
+      makeStep({ id: 'f3', step_number: 2, type: 'thought', content: JSON.stringify({ text: 'ok' }) }),
+    ]
+    const { result } = renderHook(() => useRunTimeline(feedbackSteps, 'feedback'))
+    expect(result.current.filteredItems).toHaveLength(2)
+    expect(result.current.filteredItems[0]).toMatchObject({ type: 'feedback_request' })
+    expect(result.current.filteredItems[1]).toMatchObject({ type: 'feedback_response' })
   })
 })
 

--- a/frontend/src/hooks/useRunTimeline.ts
+++ b/frontend/src/hooks/useRunTimeline.ts
@@ -56,6 +56,10 @@ export function useRunTimeline(
         ? item.approval !== null
         : item.type === 'approval_request'
     ).length,
+    feedback: pairedItems.filter((item) =>
+      !isToolBlock(item)
+        && (item.type === 'feedback_request' || item.type === 'feedback_response')
+    ).length,
   }
 
   // Apply filter to paired items. ToolBlockData always matches 'tool'. Filtering by
@@ -79,9 +83,9 @@ export function useRunTimeline(
             case 'thinking': return item.type === 'thinking'
             case 'error': return item.type === 'error'
             case 'approval': return item.type === 'approval_request'
-            // Types without a dedicated filter category (feedback_request, feedback_response,
-            // complete, orphan tool_result) are only visible under the 'all' filter. This is
-            // intentional — these are rare step types that don't warrant their own chip.
+            case 'feedback': return item.type === 'feedback_request' || item.type === 'feedback_response'
+            // Types without a dedicated filter category (complete, orphan tool_result) are
+            // only visible under the 'all' filter.
             default: return false
           }
         })

--- a/frontend/src/pages/RunsPage.test.tsx
+++ b/frontend/src/pages/RunsPage.test.tsx
@@ -297,16 +297,28 @@ describe('RunsPage — sort chip', () => {
 })
 
 describe('RunsPage — stats subtitle', () => {
-  it('shows "{total} runs" in deferred mode when backend stats absent', () => {
+  it('shows "<n> runs" for a plural total (e.g. 42)', () => {
     mockLoaded([makeRun()], 42)
     renderPage()
     expect(screen.getByText('42 runs')).toBeInTheDocument()
   })
 
+  it('shows "2 runs" for a plural total', () => {
+    mockLoaded([makeRun(), makeRun({ id: 'run-2222222222222222' })], 2)
+    renderPage()
+    expect(screen.getByText('2 runs')).toBeInTheDocument()
+  })
+
+  it('shows "1 run" (singular) when total is exactly 1', () => {
+    mockLoaded([makeRun()], 1)
+    renderPage()
+    expect(screen.getByText('1 run')).toBeInTheDocument()
+  })
+
   it('stats line is hidden when there are no runs', () => {
     mockLoaded([])
     renderPage()
-    expect(screen.queryByText(/\d+ runs/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/\d+ runs?/)).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/RunsPage.tsx
+++ b/frontend/src/pages/RunsPage.tsx
@@ -65,7 +65,7 @@ export default function RunsPage() {
 
   // Stats subtitle — deferred mode shows total count since backend doesn't
   // yet return per-status counts or token sums in the stats field.
-  const statsLine = total > 0 ? `${total} runs` : ''
+  const statsLine = total > 0 ? `${total} ${total === 1 ? 'run' : 'runs'}` : ''
 
   const sortLabel = sort === 'oldest' ? 'Oldest ▲' : 'Newest ▼'
   const sortAriaLabel =

--- a/frontend/src/pages/UsersPage.test.tsx
+++ b/frontend/src/pages/UsersPage.test.tsx
@@ -306,4 +306,33 @@ describe('UsersPage — create user modal', () => {
     const submitBtn = screen.getByRole('button', { name: /creating/i })
     expect(submitBtn).toBeDisabled()
   })
+
+  it('Create User modal — empty fields show inline errors, not native tooltip', () => {
+    const mutateMock = vi.fn()
+    vi.mocked(useCreateUser).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+      error: null,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useCreateUser>)
+
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /create user/i }))
+
+    // Submit without filling any inputs.
+    fireEvent.submit(document.querySelector('#create-user-form') as HTMLFormElement)
+
+    // Both error messages must appear (in the banner and/or inline FieldError).
+    // Use getAllByText because the message appears in both the FieldError element
+    // and the ErrorBanner summary list.
+    expect(screen.getAllByText(/username is required/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/password is required/i).length).toBeGreaterThan(0)
+
+    // Each field must be marked invalid for accessibility.
+    expect(screen.getByLabelText(/username/i)).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByLabelText(/password/i)).toHaveAttribute('aria-invalid', 'true')
+
+    // The mutation must not have been called — no server round-trip on empty inputs.
+    expect(mutateMock).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/utils/inlineMarkdown.test.ts
+++ b/frontend/src/utils/inlineMarkdown.test.ts
@@ -1,0 +1,89 @@
+import type React from 'react'
+import { describe, it, expect } from 'vitest'
+import { renderInlineMarkdown } from './inlineMarkdown'
+
+// Helper: flatten the ReactNode[] returned by renderInlineMarkdown into a
+// plain string representation for easy assertion. React elements are
+// represented as <tag>content</tag>.
+function stringify(nodes: ReturnType<typeof renderInlineMarkdown>): string {
+  return nodes
+    .map((node) => {
+      if (typeof node === 'string') return node
+      if (typeof node === 'number') return String(node)
+      if (node === null || node === undefined || typeof node === 'boolean') return ''
+      // ReactElement
+      const el = node as React.ReactElement<{ children?: unknown }>
+      const tag = el.type as string
+      const children = el.props.children
+      const childStr = Array.isArray(children)
+        ? children
+            .map((c: unknown) =>
+              typeof c === 'string' ? c : stringify([c as ReturnType<typeof renderInlineMarkdown>[number]]),
+            )
+            .join('')
+        : typeof children === 'string'
+          ? children
+          : stringify([children as ReturnType<typeof renderInlineMarkdown>[number]])
+      return `<${tag}>${childStr}</${tag}>`
+    })
+    .join('')
+}
+
+describe('renderInlineMarkdown', () => {
+  it('plain text — no change', () => {
+    expect(stringify(renderInlineMarkdown('Hello world'))).toBe('Hello world')
+  })
+
+  it('empty string', () => {
+    expect(stringify(renderInlineMarkdown(''))).toBe('')
+  })
+
+  it('**bold** produces <strong>', () => {
+    expect(stringify(renderInlineMarkdown('**Result**'))).toBe('<strong>Result</strong>')
+  })
+
+  it('*italic* produces <em>', () => {
+    expect(stringify(renderInlineMarkdown('*italic*'))).toBe('<em>italic</em>')
+  })
+
+  it('_italic_ produces <em>', () => {
+    expect(stringify(renderInlineMarkdown('_italic_'))).toBe('<em>italic</em>')
+  })
+
+  it('`code` produces <code>', () => {
+    expect(stringify(renderInlineMarkdown('`foo`'))).toBe('<code>foo</code>')
+  })
+
+  it('adjacent markers on one line', () => {
+    const result = stringify(renderInlineMarkdown('**bold** and *italic* and `code`'))
+    expect(result).toBe('<strong>bold</strong> and <em>italic</em> and <code>code</code>')
+  })
+
+  it('unmatched opener stays literal', () => {
+    expect(stringify(renderInlineMarkdown('**foo'))).toBe('**foo')
+  })
+
+  it('unmatched * stays literal', () => {
+    expect(stringify(renderInlineMarkdown('*foo'))).toBe('*foo')
+  })
+
+  it('newlines preserved between lines', () => {
+    const result = stringify(renderInlineMarkdown('line one\nline two'))
+    expect(result).toBe('line one\nline two')
+  })
+
+  it('mixed content with newlines', () => {
+    const result = stringify(renderInlineMarkdown('**Result:** The `foo` function returned *success*.'))
+    expect(result).toBe('<strong>Result:</strong> The <code>foo</code> function returned <em>success</em>.')
+  })
+
+  it('text before and after a bold span', () => {
+    const result = stringify(renderInlineMarkdown('before **mid** after'))
+    expect(result).toBe('before <strong>mid</strong> after')
+  })
+
+  it('multiple lines each with markup', () => {
+    const result = stringify(renderInlineMarkdown('**line1**\n*line2*'))
+    expect(result).toBe('<strong>line1</strong>\n<em>line2</em>')
+  })
+})

--- a/frontend/src/utils/inlineMarkdown.ts
+++ b/frontend/src/utils/inlineMarkdown.ts
@@ -1,0 +1,112 @@
+import { createElement } from 'react'
+import type { ReactNode } from 'react'
+
+// Inline markdown tokenizer supporting bold (**), italic (* and _), and inline code (`).
+// Only inline features — no block-level parsing (headings, lists, links). Unknown or
+// unmatched syntax is emitted verbatim. The caller is responsible for container
+// white-space: pre-wrap so newlines are preserved.
+
+type Token =
+  | { kind: 'text'; value: string }
+  | { kind: 'bold'; children: Token[] }
+  | { kind: 'italic'; children: Token[] }
+  | { kind: 'code'; value: string }
+
+// Delimiter specs: [delimiter, token kind]. Order matters — `**` must be
+// checked before `*` so the two-char sequence is not consumed as two singles.
+const DELIMITERS: [string, 'bold' | 'italic' | 'code'][] = [
+  ['**', 'bold'],
+  ['*', 'italic'],
+  ['_', 'italic'],
+  ['`', 'code'],
+]
+
+// Tokenize a single line. Scans for the earliest delimiter and, if a closing
+// delimiter exists on the same line, emits the corresponding token. Falls
+// through to plain text when no pair is found.
+function tokenizeLine(line: string): Token[] {
+  const tokens: Token[] = []
+  let rest = line
+
+  while (rest.length > 0) {
+    let earliest = -1
+    let matched: [string, 'bold' | 'italic' | 'code'] | null = null
+
+    for (const [delim, kind] of DELIMITERS) {
+      const idx = rest.indexOf(delim)
+      if (idx !== -1 && (earliest === -1 || idx < earliest)) {
+        earliest = idx
+        matched = [delim, kind]
+      }
+    }
+
+    if (matched === null || earliest === -1) {
+      tokens.push({ kind: 'text', value: rest })
+      break
+    }
+
+    const [delim, kind] = matched
+    const afterOpen = earliest + delim.length
+    const closeIdx = rest.indexOf(delim, afterOpen)
+
+    if (closeIdx === -1) {
+      // No closing delimiter — emit everything up to and including the opener
+      // literally and continue from after the opener.
+      tokens.push({ kind: 'text', value: rest.slice(0, afterOpen) })
+      rest = rest.slice(afterOpen)
+      continue
+    }
+
+    // Emit any text before the opener
+    if (earliest > 0) {
+      tokens.push({ kind: 'text', value: rest.slice(0, earliest) })
+    }
+
+    const inner = rest.slice(afterOpen, closeIdx)
+    rest = rest.slice(closeIdx + delim.length)
+
+    if (kind === 'code') {
+      tokens.push({ kind: 'code', value: inner })
+    } else {
+      // Bold / italic: recurse so nested inline tokens are honoured
+      tokens.push({ kind, children: tokenizeLine(inner) })
+    }
+  }
+
+  return tokens
+}
+
+function tokensToNodes(tokens: Token[], keyPrefix: string): ReactNode[] {
+  return tokens.map((token, i) => {
+    const key = `${keyPrefix}-${i}`
+    if (token.kind === 'text') {
+      return token.value
+    }
+    if (token.kind === 'code') {
+      return createElement('code', { key }, token.value)
+    }
+    if (token.kind === 'bold') {
+      return createElement('strong', { key }, ...tokensToNodes(token.children, key))
+    }
+    // italic
+    return createElement('em', { key }, ...tokensToNodes(token.children, key))
+  })
+}
+
+// Render a plain string with inline markdown (bold, italic, code) into an
+// array of React nodes. Newlines between lines are preserved as literal '\n'
+// strings so that a container with white-space: pre-wrap renders them correctly.
+export function renderInlineMarkdown(text: string): ReactNode[] {
+  const lines = text.split('\n')
+  const nodes: ReactNode[] = []
+
+  lines.forEach((line, lineIdx) => {
+    const lineNodes = tokensToNodes(tokenizeLine(line), `l${lineIdx}`)
+    nodes.push(...lineNodes)
+    if (lineIdx < lines.length - 1) {
+      nodes.push('\n')
+    }
+  })
+
+  return nodes
+}

--- a/internal/api/mcp_handler.go
+++ b/internal/api/mcp_handler.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -121,11 +124,12 @@ func (h *MCPHandler) TestConnection(w http.ResponseWriter, r *http.Request) {
 
 	tools, err := client.DiscoverTools(ctx)
 	if err != nil {
+		slog.Warn("MCP test connection failed", "url", body.URL, "err", err)
 		httputil.WriteJSON(w, http.StatusOK, testConnectionResponse{
 			OK:        false,
 			ToolCount: 0,
 			Tools:     []string{},
-			Error:     err.Error(),
+			Error:     humanizeMCPError(err),
 		})
 		return
 	}
@@ -358,4 +362,42 @@ func policyReferencesServer(rawYAML, serverPrefix string) bool {
 // isUniqueConstraintError reports whether err is a SQLite UNIQUE constraint violation.
 func isUniqueConstraintError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
+}
+
+// humanizeMCPError converts a low-level Go network/context error into a short,
+// user-facing message. The full error chain is always logged server-side before
+// this function is called, so diagnostic information is never lost.
+func humanizeMCPError(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "Connection timed out"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "Connection canceled"
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		// Inspect the underlying syscall errno to produce a specific message.
+		// errors.Is walks the chain, so this covers both direct and wrapped errnos.
+		switch {
+		case errors.Is(opErr.Err, syscall.ECONNREFUSED):
+			return "Could not reach server — connection refused"
+		case errors.Is(opErr.Err, syscall.EHOSTUNREACH), errors.Is(opErr.Err, syscall.ENETUNREACH):
+			return "Could not reach server — host unreachable"
+		}
+		return "Network error: " + opErr.Op + " failed"
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		inner := humanizeMCPError(urlErr.Err)
+		// If the inner error was not recognized, return a generic message rather
+		// than the raw URL error string which contains internal Go call chains.
+		if inner == "Could not complete MCP handshake" {
+			return "Could not reach server"
+		}
+		return inner
+	}
+
+	return "Could not complete MCP handshake"
 }

--- a/internal/api/mcp_handler_test.go
+++ b/internal/api/mcp_handler_test.go
@@ -604,6 +604,70 @@ func TestMCPServerTestConnectionHandler(t *testing.T) {
 		if envelope.Data.Error == "" {
 			t.Errorf("error must be non-empty for unreachable server")
 		}
+		// The raw Go error chain must not be surfaced to the user.
+		for _, fragment := range []string{"post tools/list:", "ensure session", "http do"} {
+			if strings.Contains(envelope.Data.Error, fragment) {
+				t.Errorf("error %q must not contain raw Go chain fragment %q", envelope.Data.Error, fragment)
+			}
+		}
+		// The message should be human-readable.
+		lowerErr := strings.ToLower(envelope.Data.Error)
+		if !strings.Contains(lowerErr, "connection refused") && !strings.Contains(lowerErr, "could not reach server") {
+			t.Errorf("error %q should mention connection refused or could not reach server", envelope.Data.Error)
+		}
+	})
+
+	t.Run("context deadline produces friendly message", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping: blocks for 5s waiting for context deadline")
+		}
+
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+
+		// done is closed just before the test server shuts down, unblocking any
+		// in-flight handler so httptest.Server.Close() does not stall.
+		done := make(chan struct{})
+
+		// This handler never sends a response, forcing the 5-second deadline inside
+		// TestConnection to expire. It blocks until done is closed.
+		blocking := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-done
+		}))
+		// Cleanup order: t.Cleanup calls in LIFO order — close(done) must be
+		// registered AFTER blocking.Close so it runs BEFORE it.
+		t.Cleanup(blocking.Close)
+		t.Cleanup(func() { close(done) })
+
+		srv := httptest.NewServer(newMCPRouter(store, registry))
+		t.Cleanup(srv.Close)
+
+		body, _ := json.Marshal(map[string]string{"url": blocking.URL})
+		resp, err := http.Post(srv.URL+"/servers/test", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /servers/test: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var envelope struct {
+			Data testResult `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if envelope.Data.OK {
+			t.Errorf("ok = true, want false on deadline")
+		}
+		if !strings.Contains(envelope.Data.Error, "Connection timed out") {
+			t.Errorf("error = %q, want to contain %q", envelope.Data.Error, "Connection timed out")
+		}
+		if strings.Contains(envelope.Data.Error, "context deadline exceeded") {
+			t.Errorf("error %q must not contain raw Go text %q", envelope.Data.Error, "context deadline exceeded")
+		}
 	})
 
 	t.Run("missing url returns 400", func(t *testing.T) {


### PR DESCRIPTION
Closes #37

## Summary

Fixes 7 bugs discovered during Playwright UI walkthrough and subsequent live-run testing (plus two accessibility/consistency improvements):

- **Bug 2 — MCP "Test connection" error humanization:** Raw Go error chain (`post tools/list: ensure session: initialize: ...`) is replaced with clean user-facing messages. A `humanizeMCPError` helper in `mcp_handler.go` maps `context.DeadlineExceeded`, `*net.OpError` (ECONNREFUSED/EHOSTUNREACH), and `*url.Error` to short strings; falls back to `"Could not complete MCP handshake"`.
- **Bug 3 — Agent editor default task placeholder:** `DEFAULT_YAML`'s `agent.task` was `"Describe what this agent should do."` — a non-empty string that bypassed required-field validation. Changed to `''` so the placeholder text guides users and leaving the field empty correctly fails validation.
- **Bug 4 — Create User modal validation:** Removed HTML `required` attributes; replaced with client-side validation using `FieldError` + `ErrorBanner` (matching the agent editor and change-password patterns). Added `aria-invalid` attributes and CSS border highlight on invalid inputs.
- **Bug 5 — Markdown in thought blocks:** LLM thought text renders raw markdown syntax. Added a bespoke `renderInlineMarkdown` tokenizer (`src/utils/inlineMarkdown.ts`) handling bold, italic, and inline code — no new npm dependency. Applied in `ThoughtBlock.tsx`.
- **Bug 6 — Feedback filter tab:** The step timeline filter bar lacked a "Feedback" tab. Added `feedback` to the `FilterKey` union, chip after Approvals, and count in `useRunTimeline.ts` covering `feedback_request` + `feedback_response` steps.
- **Bug 7 — "1 runs" pluralization:** Fixed `RunsPage.tsx:68` from `` `${total} runs` `` to `` `${total} ${total === 1 ? 'run' : 'runs'}` ``.
- **Bug 8 — Tool output MCP envelope:** Tool call OUTPUT was showing raw `[{"type":"text","text":"..."}]` JSON. Extracted `parseToolOutput` into `toolOutput.ts`; `ToolBlock.tsx` now branches on result type — strings render directly in `<pre>`, objects/arrays continue through `CollapsibleJSON`. Per ADR-030 (UI abstracts over tool transport).
- **Accessibility: ChangePasswordSection hidden username field:** Added a `hidden` username input for password-manager compatibility (browser accessibility warning).
- **Route docs:** `frontend/CLAUDE.md` updated — `/users` documented as legacy redirect, `/admin/users` added.

## Architecture plans

<details>
<summary>Plan — Bugs 2–4 + observations</summary>

See `.dev-loop/plan.md` (bugs 2–4: MCP error humanization, agent task default, Create User modal validation, ChangePasswordSection, CLAUDE.md route docs)

</details>

<details>
<summary>Plan — Bugs 5–8</summary>

See `.dev-loop/plan-bugs58.md` (bugs 5–8: thought markdown, Feedback filter, pluralization, tool output rendering)

</details>

## Test coverage

- `internal/api/mcp_handler_test.go` — tightened existing "unreachable server" test to assert no raw Go chain fragments; added deadline timeout sub-test (guarded with `testing.Short()`)
- `frontend/src/utils/inlineMarkdown.test.ts` — 12 table-driven tests for the tokenizer
- `frontend/src/components/RunDetail/toolOutput.test.ts` — 7 tests for MCP content-array parsing
- `frontend/src/hooks/useRunTimeline.test.ts` — feedback count and feedback filter tests
- `frontend/src/components/AgentEditor/agentEditorUtils.test.ts` — asserts `task.task === ''` for default state
- `frontend/src/pages/UsersPage.test.tsx` — empty-submit shows inline errors, mutation not called
- `frontend/src/pages/RunsPage.test.tsx` — singular ("1 run") and plural ("2 runs") assertions

## Review cycles

1 review cycle for Bugs 2–4 (plan revision after REVISE verdict — CollapsibleJSON string-rendering issue).
1 review cycle for Bugs 5–8 (plan revision after REVISE verdict — CollapsibleJSON string-rendering issue discovered).
Both implementations approved on first code review.

## Documentation

`frontend/CLAUDE.md` updated: route table corrected, `inlineMarkdown.ts` utility documented.

---
🤖 Generated with the agentic dev loop