### PR TITLE
docs: fill out user and operator documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,24 @@ GLEIPNIR_PORT=3000
 # Log verbosity for the Go API server.
 # Valid values: debug, info, warn, error
 GLEIPNIR_LOG_LEVEL=info
+
+# ---------------------------------------------------------------------------
+# Optional tunables (defaults shown — only set to override)
+# ---------------------------------------------------------------------------
+
+# Timeout for individual MCP server calls.
+# GLEIPNIR_MCP_TIMEOUT=30s
+
+# HTTP server timeouts.
+# GLEIPNIR_HTTP_READ_TIMEOUT=15s
+# GLEIPNIR_HTTP_WRITE_TIMEOUT=15s
+# GLEIPNIR_HTTP_IDLE_TIMEOUT=60s
+
+# How often to scan for approval requests that have timed out.
+# GLEIPNIR_APPROVAL_SCAN_INTERVAL=30s
+
+# Default feedback timeout applied when a policy does not specify one.
+# GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT=30m
+
+# How often to scan for feedback requests that have timed out.
+# GLEIPNIR_FEEDBACK_SCAN_INTERVAL=30s

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Any tool can be marked as requiring approval. When the agent tries to use one, t
 
 ## Quick start
 
+**Option A — pre-built image (no clone required):**
+
+```bash
+docker pull felagengineering/gleipnir:latest
+```
+
+Create a `docker-compose.yml` and a `.env` file as shown in [Setup](docs/user/setup.md), then jump to step 3 below.
+
+**Option B — build from source:**
+
 1. Clone the repo and copy the environment template:
 
    ```bash
@@ -25,15 +35,22 @@ Any tool can be marked as requiring approval. When the agent tries to use one, t
    cp .env.example .env
    ```
 
-2. Start the stack:
+2. Generate an encryption key and add it to `.env`:
+
+   ```bash
+   openssl rand -hex 32
+   # Paste the output into GLEIPNIR_ENCRYPTION_KEY in .env
+   ```
+
+3. Start the stack:
 
    ```bash
    docker compose up -d
    ```
 
-3. Open `http://localhost:3000` in your browser.
+4. Open `http://localhost:3000` in your browser.
 
-4. Complete the first-run setup: create the admin user, then add your Anthropic API key on the `/admin/models` page.
+5. Complete the first-run setup: create the admin user, then add your LLM provider API key at **Admin → Models**.
 
 ### Back up your encryption key
 
@@ -43,10 +60,10 @@ Any tool can be marked as requiring approval. When the agent tries to use one, t
 
 Once the stack is running and you're logged in, here's how to wire up your first agent:
 
-1. Go to **Settings → MCP Servers** and click **Add Server**. Give it a name and the URL of any MCP server you have running.
+1. Go to **Tools** (`/tools`) and click **Add Server**. Give it a name and the URL of any MCP server you have running.
 2. Click **Discover** on the new server. Gleipnir reads the server's tool list and shows them in the UI.
 3. For each discovered tool, set its tag: `sensor` for read-only tools, `actuator` for tools that change something. Mark anything risky as requiring approval.
-4. Go to **Policies → New**. Pick a webhook trigger, write a short task description for the agent, and check the boxes for the tools you just tagged.
+4. Go to **Agents → New** (`/agents/new`). Pick a webhook trigger, write a short task description for the agent, and check the boxes for the tools you just tagged.
 5. Click **Trigger** on the new policy to fire a manual run.
 6. Open the run from the runs list and watch the trace populate as the agent works.
 
@@ -54,8 +71,11 @@ For fully worked examples against specific services, follow one of the [playbook
 
 ## More reading
 
+- [Setup](docs/user/setup.md) — detailed first-run walkthrough.
+- [Policies](docs/user/policies.md) — trigger types, capability grants, run states.
+- [Roles](docs/user/roles.md) — what each role can and cannot do.
+- [Operations](docs/user/operations.md) — upgrading, backups, environment variables.
 - [Playbooks](docs/playbooks/) — copy-pasteable setups for the use cases above.
-- [User docs](docs/user/) — encryption key, backups, logs, troubleshooting.
 - [Developer docs](docs/developer/) — architecture, building, contributing.
 - [Security notes](SECURITY.md)
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -4,5 +4,8 @@ For people running a Gleipnir instance. If you're looking for how to *build* Gle
 
 ## Contents
 
-- [Operations](operations.md) — backing up the database, viewing logs, resetting stuck runs.
-- [Troubleshooting](troubleshooting.md) — known issues and common fixes.
+- [Setup](setup.md) — first-run walkthrough: key generation, starting the stack, adding a provider, your first policy.
+- [Policies](policies.md) — trigger types, capability grants, run states, concurrency modes.
+- [Roles](roles.md) — what each role (admin, operator, approver, auditor) can and cannot do.
+- [Operations](operations.md) — upgrading, environment variables, database backups, viewing logs, resetting stuck runs.
+- [Troubleshooting](troubleshooting.md) — first-run failures and known issues.

--- a/docs/user/operations.md
+++ b/docs/user/operations.md
@@ -64,7 +64,45 @@ docker compose up -d
 docker compose exec api sqlite3 /data/gleipnir.db ".backup /data/gleipnir.backup.db"
 ```
 
-The `.backup` command uses SQLite's built-in online backup API, which is safe to run against a live database. Copy `/data/gleipnir.backup.db` out of the volume once the command completes.
+The `.backup` command uses SQLite's built-in online backup API, which is safe to run against a live database. Copy the file out of the volume once the command completes:
+
+```bash
+docker run --rm \
+  -v gleipnir_data:/data \
+  -v "$(pwd)":/backup \
+  alpine cp /data/gleipnir.backup.db /backup/gleipnir.backup.db
+```
+
+## Upgrading
+
+Pull the latest image and restart the stack. Docker Compose will stop the running container, pull the new image, and start a fresh container against the existing data volume.
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+The data volume (`gleipnir_data`) is preserved across upgrades. Taking a database backup before upgrading is good practice — see [Backing up the database](#backing-up-the-database) above.
+
+## Environment variable reference
+
+All variables are read at startup. Changing a value requires restarting the stack (`docker compose up -d`).
+
+| Variable | Default | Description |
+|---|---|---|
+| `GLEIPNIR_ENCRYPTION_KEY` | *(required)* | 64-char hex key (32-byte AES-256) for encrypting provider API keys and webhook secrets. Generate with `openssl rand -hex 32`. |
+| `GLEIPNIR_DB_PATH` | `/data/gleipnir.db` | SQLite file path inside the container. |
+| `GLEIPNIR_LISTEN_ADDR` | `:8080` | Internal HTTP listen address for the Go server. |
+| `GLEIPNIR_LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, or `error`. |
+| `GLEIPNIR_MCP_TIMEOUT` | `30s` | Timeout for individual MCP server calls. |
+| `GLEIPNIR_HTTP_READ_TIMEOUT` | `15s` | HTTP server read timeout. |
+| `GLEIPNIR_HTTP_WRITE_TIMEOUT` | `15s` | HTTP server write timeout. |
+| `GLEIPNIR_HTTP_IDLE_TIMEOUT` | `60s` | HTTP server idle timeout. |
+| `GLEIPNIR_APPROVAL_SCAN_INTERVAL` | `30s` | How often to check for timed-out approval requests. |
+| `GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT` | `30m` | Default timeout for feedback requests when not set in the policy. |
+| `GLEIPNIR_FEEDBACK_SCAN_INTERVAL` | `30s` | How often to check for timed-out feedback requests. |
+
+`GLEIPNIR_PORT` is a Docker Compose variable (not read by the Go server directly). It controls which host port the container exposes and defaults to `3000`.
 
 ## Viewing structured logs
 
@@ -98,7 +136,7 @@ docker compose logs api | jq 'select(.run_id == "<run_id>")'
 
 ## Resetting a stuck run
 
-On restart, Gleipnir automatically marks any run in `running` or `waiting_for_approval` as `interrupted`. This handles the common case of a clean restart after a crash or deployment.
+On restart, Gleipnir automatically marks any run in `running`, `waiting_for_approval`, or `waiting_for_feedback` as `interrupted`. This handles the common case of a clean restart after a crash or deployment.
 
 If a run is genuinely stuck — for example, after a manual DB edit left it in an inconsistent state — it can be reset directly with a SQL update:
 

--- a/docs/user/policies.md
+++ b/docs/user/policies.md
@@ -1,0 +1,184 @@
+# Policies
+
+A policy defines what an agent does, what triggers it, and what it is allowed to touch. This page covers every configurable part of a policy.
+
+## Trigger types
+
+Every policy has exactly one trigger.
+
+### `manual`
+
+Fired on demand from the UI (**Trigger** button on the policy detail page) or via the API. No additional configuration required. The trigger payload is empty unless you supply one through the API.
+
+```yaml
+trigger:
+  type: manual
+```
+
+### `webhook`
+
+Fired by an HTTP POST to `/api/v1/webhooks/{policyID}`. The request body (any JSON) is delivered to the agent as its first message.
+
+```yaml
+trigger:
+  type: webhook
+  auth: hmac   # hmac | bearer | none
+```
+
+The webhook URL and shared secret are shown on the policy detail page. Operators can rotate the secret from the UI or via `POST /api/v1/policies/{id}/webhook/rotate`. The current secret can be retrieved via `GET /api/v1/policies/{id}/webhook/secret` (operator and admin only).
+
+Authentication modes:
+- `hmac` — the caller signs the request body with the shared secret and sends the result in the `X-Gleipnir-Signature` header. The header value must be formatted as `sha256=<hex-encoded-HMAC-SHA256-of-body>`.
+- `bearer` — the shared secret is sent as a `Bearer` token in the `Authorization` header.
+- `none` — no authentication. Only use this behind a network boundary you control.
+
+### `scheduled`
+
+Fires once at each timestamp in `fire_at`. After all timestamps are consumed the policy is automatically paused.
+
+```yaml
+trigger:
+  type: scheduled
+  fire_at:
+    - "2026-06-01T09:00:00Z"
+    - "2026-07-01T09:00:00Z"
+```
+
+Timestamps must be ISO-8601 UTC. The runtime fires the run as soon as the timestamp passes (within the scheduler tick interval); there is no sub-second precision guarantee.
+
+### `poll`
+
+Runs on a recurring interval. Before starting the agent, Gleipnir calls one or more MCP tools and evaluates conditions on their responses. If the conditions are met, the agent runs; if not, the poll cycle ends silently.
+
+```yaml
+trigger:
+  type: poll
+  interval: 15m    # minimum 1m, Go duration format
+  match: all       # all (AND) | any (OR)
+  checks:
+    - tool: monitoring.get_service_status
+      input:
+        service: api
+      path: "$.status"
+      equals: "degraded"
+```
+
+Comparators: `equals`, `not_equals`, `greater_than`, `less_than`, `contains`. Exactly one comparator is required per check. `greater_than` and `less_than` require numeric values; `contains` requires strings. Types must match the JSONPath extraction result or the check will fail.
+
+The matching tool responses are included in the agent's first message so it has full context on what triggered it.
+
+## Capabilities
+
+Capabilities define the agent's permission boundary. Tools not listed here are never registered with the agent — they do not exist from the agent's perspective. The feedback channel is similarly absent unless explicitly enabled in the `feedback` block.
+
+### Tools
+
+```yaml
+capabilities:
+  tools:
+    - tool: server_name.tool_name
+```
+
+Tool references use dot notation: `server_name` is the name of a registered MCP server, `tool_name` is the tool name as discovered from that server.
+
+**With approval gate:**
+
+```yaml
+capabilities:
+  tools:
+    - tool: files.write_file
+      approval: required
+      timeout: 30m
+      on_timeout: reject
+```
+
+When a tool has `approval: required`, the agent's attempt to call it pauses the run in `waiting_for_approval`. A user with the **Approver** role sees the request in the UI with the full proposed call (tool name and arguments), and can approve or reject it. Nothing executes until a decision is made. If the timeout expires without a decision, the tool call is rejected and the run fails.
+
+### Feedback
+
+The feedback capability adds a special `gleipnir.ask_operator` tool to the agent's tool list. The agent can call it to pause the run and ask the operator a question. A user with the **Operator** or **Approver** role (or Admin) responds from the UI; the agent resumes with the freeform text response as its next message.
+
+```yaml
+capabilities:
+  feedback:
+    enabled: true
+    timeout: 30m
+    on_timeout: fail
+```
+
+**`gleipnir.ask_operator` arguments:**
+
+| Field | Required | Description |
+|---|---|---|
+| `reason` | Yes | Why the agent is asking. Displayed as the headline in the feedback request UI. |
+| `context` | No | Supporting detail the operator might need to decide or respond. |
+
+The operator sees `reason` and `context`, types a freeform response, and clicks submit. The agent receives that text as its next user message and resumes.
+
+## Run states
+
+| State | Meaning |
+|---|---|
+| `pending` | Run is queued, waiting for a worker slot. |
+| `running` | Agent is actively executing. |
+| `waiting_for_approval` | Agent called a tool with `approval: required`; waiting for a human decision. |
+| `waiting_for_feedback` | Agent called `gleipnir.ask_operator`; waiting for an operator response. |
+| `complete` | Agent finished and produced a result. |
+| `failed` | Run ended with an error (LLM error, tool error, timeout, rejection, token/call budget exceeded, or operator cancellation). |
+| `interrupted` | Run was in progress when the server restarted. On restart, Gleipnir marks these automatically so they do not appear stuck. |
+
+A run in any active state can be cancelled by an operator from the UI. Cancellation transitions the run to `failed` with a reason indicating it was cancelled — there is no distinct `cancelled` state.
+
+## Agent settings
+
+### Task
+
+The `task` field is the core instruction for the agent — what to do, what success looks like, any constraints. The trigger payload (webhook body, poll filter results) is delivered as the agent's first user message; reference it from the task as needed.
+
+### Preamble
+
+`preamble` is prepended to the system prompt before `task`. If omitted, Gleipnir uses its default BoundAgent preamble. Override it only if you need fundamentally different behavioral instructions. The runtime appends the capability list (tools and feedback status) after the preamble automatically — do not duplicate tool names in the preamble.
+
+### Limits
+
+```yaml
+agent:
+  limits:
+    max_tokens_per_run: 20000    # default: 20000
+    max_tool_calls_per_run: 50   # default: 50
+```
+
+Both limits are hard caps. When either is exceeded the run fails immediately with an error step in the trace.
+
+### Concurrency
+
+Controls what happens when a trigger fires while a run for this policy is already active.
+
+| Mode | Behavior |
+|---|---|
+| `skip` | Discard the new trigger. Safe default — nothing runs twice. |
+| `queue` | Hold the trigger and start a new run when the current one completes. |
+| `parallel` | Start a new run immediately alongside the active one. |
+| `replace` | Cancel the active run and start fresh with the new trigger. Not valid if any tool has `approval: required` — a run paused waiting for an approval decision cannot be safely discarded. |
+
+`queue_depth` (default: 10) sets the maximum number of queued triggers for the `queue` mode. Excess triggers are rejected with HTTP 429.
+
+## Model selection
+
+Omit the `model` block to use the instance default. Override it to pin a specific provider or model for a policy:
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-opus-4-7
+```
+
+Supported providers: `anthropic`, `google`, `openai`, `openaicompat`. Available model names depend on which providers have API keys configured in **Admin → Models**.
+
+## Folders
+
+Set `folder` to group policies in the UI. Policies with the same `folder` value appear together in a collapsible row on the policies list. Purely cosmetic — no effect on routing or execution.
+
+```yaml
+folder: homelab
+```

--- a/docs/user/roles.md
+++ b/docs/user/roles.md
@@ -1,0 +1,48 @@
+# Roles
+
+Gleipnir has four roles. Every user holds one or more roles; admins bypass all role checks and inherit every permission automatically.
+
+## Quick reference
+
+| Action | Admin | Operator | Approver | Auditor |
+|---|:---:|:---:|:---:|:---:|
+| View dashboard stats and attention items | ✓ | ✓ | ✓ | ✓ |
+| List and view runs, view reasoning trace | ✓ | ✓ | ✓ | ✓ |
+| List and view policies | ✓ | ✓ | — | ✓ |
+| List models | ✓ | ✓ | — | ✓ |
+| List MCP servers and their tools | ✓ | ✓ | — | ✓ |
+| Submit approval decisions | ✓ | — | ✓ | — |
+| Submit feedback responses | ✓ | ✓ | ✓ | — |
+| Trigger manual runs | ✓ | ✓ | — | — |
+| Cancel runs | ✓ | ✓ | — | — |
+| Create, update, pause, resume, delete policies | ✓ | ✓ | — | — |
+| Rotate and reveal webhook secrets | ✓ | ✓ | — | — |
+| Add, delete, and discover MCP servers | ✓ | ✓ | — | — |
+| Refresh available models list | ✓ | ✓ | — | — |
+| Manage users | ✓ | — | — | — |
+| Configure LLM provider API keys | ✓ | — | — | — |
+| Enable or disable models | ✓ | — | — | — |
+| Edit system settings | ✓ | — | — | — |
+| Add or remove OpenAI-compatible providers | ✓ | — | — | — |
+
+## Role descriptions
+
+### Admin
+
+Full access. Admins can do everything in the table above and are the only role that can manage users and provider credentials. The first user created during the setup wizard is always an admin.
+
+### Operator
+
+Day-to-day management of policies and runs. Operators build and maintain policies, fire manual runs, and cancel or monitor active runs. They can respond to feedback requests but cannot submit approval decisions — a separate approver role exists so that the person requesting a sensitive action cannot also approve it.
+
+### Approver
+
+Reviews and acts on approval requests. Approvers can see the full run list and reasoning trace so they have the context needed to make a decision, and can also respond to feedback requests. They cannot view policies, models, or MCP server configuration — and cannot create, modify, or trigger runs. The role is intentionally narrow: the person who sets up a policy that requests approval should not be the same person who grants it.
+
+### Auditor
+
+Read-only access. Auditors can see everything that happened — runs, steps, policies, MCP server configurations — but cannot modify any state. Useful for compliance review or handing someone access to investigate an incident without giving them write access.
+
+## Assigning roles
+
+Users and their roles are managed at **Users** (`/admin/users`) in the Admin section of the sidebar (admin only). A user can hold multiple roles simultaneously — for example, a small team might give one person both `operator` and `approver`.

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -1,0 +1,135 @@
+# Setup
+
+Getting from zero to a running Gleipnir instance with its first agent.
+
+## Prerequisites
+
+- Docker and Docker Compose v2 (`docker compose version`)
+- `openssl` (available on macOS and most Linux distributions by default)
+
+## Option A: Pre-built image (no clone required)
+
+Create a working directory and add two files:
+
+**`docker-compose.yml`**
+```yaml
+services:
+  api:
+    image: felagengineering/gleipnir:latest
+    ports:
+      - "${GLEIPNIR_PORT:-3000}:8080"
+    environment:
+      - GLEIPNIR_DB_PATH=${GLEIPNIR_DB_PATH:-/data/gleipnir.db}
+      - GLEIPNIR_ENCRYPTION_KEY=${GLEIPNIR_ENCRYPTION_KEY:?Set GLEIPNIR_ENCRYPTION_KEY in .env}
+    volumes:
+      - gleipnir_data:/data
+    restart: unless-stopped
+
+volumes:
+  gleipnir_data:
+```
+
+**`.env`**
+```
+GLEIPNIR_ENCRYPTION_KEY=<paste-64-hex-chars-here>
+GLEIPNIR_PORT=3000
+```
+
+Generate the key and paste it into `.env` before starting:
+
+```bash
+openssl rand -hex 32
+```
+
+**Back this value up to a password manager or secrets vault immediately.** Losing the key makes every stored credential permanently unrecoverable. See [Operations — Backing up the encryption key](operations.md#backing-up-the-encryption-key).
+
+Then skip to [Start the stack](#start-the-stack) below.
+
+## Option B: Build from source
+
+```bash
+git clone https://github.com/Felag-Engineering/gleipnir.git
+cd gleipnir
+cp .env.example .env
+```
+
+## Generate the encryption key
+
+Gleipnir encrypts all provider API keys and webhook secrets using AES-256-GCM. The key is required before the stack will start.
+
+```bash
+openssl rand -hex 32
+```
+
+Open `.env` and paste the output as the value of `GLEIPNIR_ENCRYPTION_KEY`:
+
+```
+GLEIPNIR_ENCRYPTION_KEY=<paste-64-hex-chars-here>
+```
+
+**Back this value up to a password manager or secrets vault immediately.** Losing the key makes every stored credential permanently unrecoverable — there is no fallback decryption path. See [Operations — Backing up the encryption key](operations.md#backing-up-the-encryption-key).
+
+## Start the stack
+
+```bash
+docker compose up -d
+```
+
+The container will be healthy once the `/api/v1/health` endpoint responds. You can check:
+
+```bash
+docker compose ps
+```
+
+## Complete the setup wizard
+
+Open `http://localhost:3000` in your browser. On first run, Gleipnir redirects to the setup wizard. If it doesn't, navigate directly to `http://localhost:3000/setup`. The setup page is only reachable until the first admin account is created — after that it redirects to the login page.
+
+1. **Create the admin account.** Choose a username and a strong password. This is the only account until you add more users.
+2. Log in with the credentials you just created.
+
+## Add an LLM provider
+
+Gleipnir needs at least one LLM provider before it can run agents.
+
+1. Go to **Admin → Models** (`/admin/models`).
+2. Click **Add provider** and enter your API key for the provider you want to use (Anthropic, Google, or an OpenAI-compatible endpoint).
+3. Click **Refresh** to fetch the available models from that provider.
+4. Enable the models you want agents to use.
+
+## Set the public URL
+
+If your Gleipnir instance will be accessible from the internet or from other machines on your network, set the public URL so webhook URLs shown in the UI are correct.
+
+1. Go to **Admin → System** (`/admin/system`).
+2. Set **Public URL** to the externally reachable base URL, e.g. `https://gleipnir.example.com`. No trailing slash.
+
+If this is a local-only instance, you can skip this step.
+
+## Add an MCP server
+
+Gleipnir calls external tools over MCP (Model Context Protocol). You need at least one MCP server configured before creating a useful policy.
+
+1. Go to **Tools** (`/tools`).
+2. Click **Add Server**, give it a name, and enter the HTTP URL of your MCP server (e.g. `http://my-mcp-server:8000`). Note: `localhost` inside the container refers to the Gleipnir container itself — use a hostname or the Docker network alias for servers running on the host.
+3. Click **Discover** to fetch its tool list.
+4. For each tool, set the tag: `sensor` for read-only tools, `actuator` for tools that change state. The tags inform the approval workflow and operator review — label tools accurately.
+5. Mark any tool that requires human confirmation as requiring **Approval**.
+
+## Create and verify your first policy
+
+1. Go to **Agents → New** (`/agents/new`).
+2. Set the trigger to **Manual** — no external event source needed to test.
+3. Write a short task description in the **Task** field.
+4. Under **Capabilities**, check at least one tool from the MCP server you just added.
+5. Save the policy, then click **Trigger** to fire a manual run.
+6. Open the run from the runs list and watch the reasoning trace populate.
+
+If the run completes, the stack is working end to end.
+
+## Next steps
+
+- [Policies](policies.md) — trigger types, capability grants, run states
+- [Roles](roles.md) — add more users with appropriate permissions
+- [Operations](operations.md) — database backups, key management, upgrading
+- [Playbooks](../playbooks/) — worked examples for common use cases

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -2,6 +2,45 @@
 
 Common issues will be added here as they come up. If you hit something not listed below, please open an issue.
 
+## First-run failures
+
+### Stack fails to start: `GLEIPNIR_ENCRYPTION_KEY must be set`
+
+Docker Compose will refuse to start the container if `GLEIPNIR_ENCRYPTION_KEY` is empty or missing from the environment. The error appears before any container is created.
+
+**Fix:** Generate a key and add it to `.env`:
+
+```bash
+openssl rand -hex 32
+# Paste the output into GLEIPNIR_ENCRYPTION_KEY in .env
+```
+
+Then re-run `docker compose up -d`. Back the key up to a password manager before doing anything else — see [Operations — Backing up the encryption key](operations.md#backing-up-the-encryption-key).
+
+### Stack starts but runs fail immediately: no LLM provider configured
+
+If no provider API key has been added, any run will fail at its first LLM call. The run will appear in `failed` state and the reasoning trace will contain an error step with a message indicating the provider is unavailable or authentication failed.
+
+**Fix:** Add at least one provider key at **Admin → Models** (`/admin/models`). After saving the key, click **Refresh** to fetch the available model list and enable the models you want to use.
+
+### Run fails with tool discovery error: MCP server unreachable
+
+At run start, Gleipnir re-validates all tool references in the policy against the current MCP registry. If a registered server is unreachable or returns an error, the run fails before the agent starts. The error step will name the server and the HTTP status or connection error.
+
+**Fix:** Check that the MCP server is running and reachable from the Gleipnir container. Test connectivity from the shell:
+
+```bash
+docker compose exec api wget -qO- http://<mcp-server-host>:<port>/health
+```
+
+If the server URL uses a hostname, verify it resolves inside the container network. If you recently changed the server URL, update the entry at **Settings → MCP Servers** and run **Discover** again.
+
+### Run shows `interrupted` after a restart
+
+On restart, Gleipnir automatically moves any run that was in `running`, `waiting_for_approval`, or `waiting_for_feedback` to `interrupted`. This is expected — the agent process was killed mid-run and the run cannot resume where it left off.
+
+**What to do:** Review the reasoning trace to see what the agent completed before the restart. Re-trigger the policy manually if the work needs to be retried.
+
 ## Known issues
 
 ### Lost encryption key


### PR DESCRIPTION
Closes #7.

## Summary

- **New `docs/user/setup.md`** — end-to-end first-run walkthrough: key generation, pre-built image and build-from-source options, setup wizard, LLM provider, `public_url` system setting, MCP server registration, and first policy verification
- **New `docs/user/policies.md`** — all four trigger types with working YAML examples, capability grants (tools, approval gates, `gleipnir.ask_operator` with full argument schema), run states (including cancellation behaviour), concurrency modes
- **New `docs/user/roles.md`** — permission table derived directly from route guards in `router.go`; Approver correctly scoped to runs and approval/feedback submissions only
- **Updated `README.md`** — key generation step added to quick start, Docker Hub pull option, fixed nav labels (Tools / Agents → New), expanded More reading
- **Updated `docs/user/operations.md`** — Upgrading section, full env var reference table, online backup extract command, `waiting_for_feedback` added to interrupted state
- **Updated `docs/user/troubleshooting.md`** — four first-run failure scenarios seeded
- **Updated `.env.example`** — all optional tunables exposed as commented-out entries

## Accuracy notes

This PR went through a dual-agent (Opus 4.7 + Sonnet) review pass against the live codebase. Fixes applied from that review:

- Approver role: cannot list policies, models, or MCP servers — verified against `router.go` route guards
- HMAC webhook signature format documented (`sha256=<hex-HMAC-SHA256-of-body>`) — verified against webhook handler
- `gleipnir.ask_operator` argument shape (`reason`, `context`) documented from the static schema in `feedback.go`
- Cancellation transitions to `failed`; no distinct `cancelled` state — verified against `runstate` package
- `waiting_for_feedback` added to restart/interrupted behaviour — verified against `ListOrphanedRuns` SQL query
- Nav labels corrected to match frontend routes (`routes.tsx`): Tools at `/tools`, Agents at `/agents/new`
- `GLEIPNIR_DEFAULT_PROVIDER` removed from env var table — does not exist in `config.go`

## Test plan

- [ ] Follow `docs/user/setup.md` from scratch on a clean machine — confirm every step works and produces the expected UI state
- [ ] Verify webhook HMAC signing with `sha256=` prefix against a real webhook-triggered policy
- [ ] Confirm Approver-role user cannot see Policies, Tools, or Models pages in the UI
- [ ] Confirm all nav label breadcrumbs (`/tools`, `/agents/new`, `/admin/users`) match the live UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)