### PR TITLE
chore: remove SHA tags from Docker push jobs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,6 @@ jobs:
           push: true
           tags: |
             felagengineering/gleipnir:dev
-            felagengineering/gleipnir:${{ github.sha }}
           # Re-use layers from the previous push; mode=max caches all
           # intermediate stages, not just the final image.
           cache-from: type=gha
@@ -190,7 +189,6 @@ jobs:
           tags: |
             felagengineering/gleipnir:latest
             felagengineering/gleipnir:${{ github.ref_name }}
-            felagengineering/gleipnir:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary

- Removes the `felagengineering/gleipnir:${{ github.sha }}` tag from both `docker-push-dev` and `docker-push-release` jobs
- Dev pushes now only tag `:dev`; release pushes only tag `:latest` and the version tag (e.g. `:v1.2.3`)

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm Docker Hub only receives the expected tags on next push to main / tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)