### PR TITLE
chore: use Docker Hub images in compose files instead of building locally

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,11 +1,15 @@
 # Local development stack — not for production use.
 # Adds the MCP test server to the base stack so you can register it by
 # container name (http://mcp-test-server:8090/mcp) from the Gleipnir UI.
+# Uses the :dev image (published on every merge to main).
 #
 # Usage:
-#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 
 services:
+  api:
+    image: felagengineering/gleipnir:dev
+
   mcp-test-server:
     build:
       context: ./mcp-test-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   api:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: felagengineering/gleipnir:latest
     ports:
       - "${GLEIPNIR_PORT:-3000}:8080"
     environment:


### PR DESCRIPTION
## Summary

- `docker-compose.yml` now pulls `felagengineering/gleipnir:latest` (published on release tags) instead of building from source
- `docker-compose.dev.yml` overrides the `api` image to `felagengineering/gleipnir:dev` (published on every merge to main) and removes `--build` from the usage comment — Compose auto-builds `mcp-test-server` on first run without it

The `mcp-test-server` service retains its `build:` block since it has no Docker Hub image. Pass `--build` manually if you need to force a rebuild of it after changes.