### PR TITLE
feat: write meal planning playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+gcp-oauth.keys.json
 .claude/agent-memory/go-code-reviewer/MEMORY.md
 .claude/worktrees/
 devflow/.devflow/

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -4,7 +4,7 @@ End-to-end setups for common Gleipnir automations. Each playbook includes the tr
 
 ## Available playbooks
 
-- [Plan the week's meals](meal-planning.md) — **Status: Planned**
+- [Plan the week's meals](meal-planning/README.md) — **Status: Complete**
 - [Keep your homelab up when hardware fails](homelab-failover.md) — **Status: Planned**
 - [Weekly budget check-in](budget-checkin.md) — **Status: Planned**
 - [Research your own todo list](todoist-research.md) — **Status: Planned**

--- a/docs/playbooks/meal-planning.md
+++ b/docs/playbooks/meal-planning.md
@@ -1,7 +1,0 @@
-# Plan the week's meals
-
-**Status:** Planned
-
-This playbook checks your Google Calendar for nights that don't already have a dinner plan, picks recipes for the empty slots, and drops the resulting grocery list into a Google Keep note. It runs on a weekly scheduled trigger and uses MCP servers for Google Calendar, a recipe source, and Google Keep.
-
-This playbook is not yet written. Track progress in the issue linked from the project roadmap.

--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -4,22 +4,22 @@
 
 ## What it does
 
-On a weekly scheduled trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a `dinner:` event. For each empty slot it searches your local [Mealie](https://mealie.io) instance for a recipe via `mealie.get_recipes` and retrieves full ingredient details via `mealie.get_recipe_detailed`, avoiding repeating a recipe within the same week. It aggregates all ingredients into a single deduplicated grocery list and then creates one Google Keep note titled `Grocery list — week of <YYYY-MM-DD>` via `keep.create_note`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
+On a weekly scheduled trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a dinner planned (any event whose title contains "dinner", "supper", or similar). For each empty slot it picks a recipe from your local [Mealie](https://mealie.io) instance via `mealie.get_recipes` and `mealie.get_recipe_detailed`, avoiding repeating a recipe within the same week. Once all slots are filled, it creates the week's meal plan in Mealie via `mealie.create_mealplan_bulk`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
 
 ## Prerequisites
 
 - A running Gleipnir instance (see main `README.md`).
 - Docker and Docker Compose available on the same host (or a host reachable from Gleipnir).
-- A Google account with access to Google Calendar and Google Keep.
+- A Google account with access to Google Calendar.
 - A Google Cloud project with the **Google Calendar API** enabled and an OAuth 2.0 Desktop application client configured (used by `gcal-mcp`).
+- A running Mealie instance with at least a few recipes added.
 
 ## MCP servers used
 
 | Server | Purpose | Source | Auth |
 |--------|---------|--------|------|
 | `gcal-mcp` | Read Google Calendar events | [nspady/google-calendar-mcp](https://github.com/nspady/google-calendar-mcp) | Google OAuth — Desktop app credentials JSON |
-| `mealie-mcp` | Search and retrieve recipes from Mealie | [that0n3guy/mealie-mcp-server-ts](https://github.com/that0n3guy/mealie-mcp-server-ts) | Mealie API key |
-| `keep-mcp` | Create Google Keep notes | [feuerdev/keep-mcp](https://github.com/feuerdev/keep-mcp) | Google master token (see below) |
+| `mealie-mcp` | Search recipes and create meal plans | [that0n3guy/mealie-mcp-server-ts](https://github.com/that0n3guy/mealie-mcp-server-ts) | Mealie API key |
 
 ## Step 1 — Get your credentials
 
@@ -50,19 +50,6 @@ This opens an authorization URL in your terminal. Open it in a browser, grant ac
 
 > **Token expiry warning:** OAuth refresh tokens issued while your GCP app is in "test mode" expire after 7 days, which forces weekly re-authentication. To avoid this, publish the app to production mode via **OAuth consent screen → PUBLISH APP** in Google Cloud Console. The app will still show an "unverified app" warning to users but tokens will not expire on a 7-day cycle. See [upstream re-authentication docs](https://github.com/nspady/google-calendar-mcp#re-authentication). Alternatively, re-run the `npx @cocal/google-calendar-mcp auth` command each week.
 
-### Google Keep master token
-
-`keep-mcp` uses [gkeepapi](https://gkeepapi.readthedocs.io/en/latest/) under the hood. gkeepapi does not accept a regular Google password — it requires a **master token** (a long-lived OAuth2 token scoped to Google services).
-
-> **Security warning:** The Google master token grants access to all Google services reachable via `gpsoauth`, not just Google Keep. Use a dedicated Google account for this integration rather than your primary account.
-
-Obtain the master token by following the [gkeepapi master token procedure](https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token). If your account has 2FA enabled, you must generate an [app password](https://support.google.com/accounts/answer/185833) and use that during the token retrieval flow.
-
-The two environment variables `keep-mcp` expects are:
-
-- `GOOGLE_EMAIL` — your Google account email address.
-- `GOOGLE_MASTER_TOKEN` — the master token obtained above.
-
 ### Mealie API key
 
 `mealie-mcp` connects to your self-hosted Mealie instance using an API key.
@@ -74,7 +61,7 @@ The two environment variables `keep-mcp` expects are:
 
 The two environment variables `mealie-mcp` expects are:
 
-- `MEALIE_BASE_URL` — the base URL of your Mealie instance, e.g. `http://mealie:9000` or `http://192.168.1.10:9000`. No trailing slash.
+- `MEALIE_BASE_URL` — the base URL of your Mealie instance, e.g. `http://192.168.1.10:9000`. No trailing slash. Use the LAN IP rather than a hostname — container DNS will not resolve bare hostnames that aren't on the same Compose network.
 - `MEALIE_API_KEY` — the API token generated above.
 
 ## Step 2 — Create .env
@@ -82,8 +69,6 @@ The two environment variables `mealie-mcp` expects are:
 Create a file named `.env` inside `docs/playbooks/meal-planning/` — **the same directory as `docker-compose.yml`**. Docker Compose reads `.env` from the directory it is invoked in; placing it anywhere else will silently leave the variables unset.
 
 ```
-GOOGLE_EMAIL=you@example.com
-GOOGLE_MASTER_TOKEN=<paste master token here>
 MEALIE_BASE_URL=http://<mealie-host>:<port>
 MEALIE_API_KEY=<paste Mealie API token here>
 ```
@@ -101,35 +86,31 @@ cd docs/playbooks/meal-planning
 docker compose up -d
 ```
 
-Verify all three services are running:
+Verify both services are running:
 
 ```bash
 docker compose ps
 ```
 
-All three should show `Up` status. If any show `Exited`, check the logs:
+Both should show `Up` status. If either shows `Exited`, check the logs:
 
 ```bash
 docker compose logs gcal-mcp
 docker compose logs mealie-mcp
-docker compose logs keep-mcp
 ```
-
-> **Note:** `keep-mcp` installs Python dependencies at container start (`pip install keep-mcp`) and then downloads Supergateway via `npx`. The first start takes 30–60 seconds. Subsequent starts are faster.
 
 ## Step 4 — Register each MCP server in Gleipnir
 
-In Gleipnir, go to **Settings → MCP Servers → Add Server** three times:
+In Gleipnir, go to **Settings → MCP Servers → Add Server** twice:
 
 | Name | URL (same Compose project) | URL (separate host) |
 |------|---------------------------|---------------------|
-| `gcal` | `http://gcal-mcp:8101/` | `http://<GLEIPNIR_HOST>:8101/` |
-| `mealie` | `http://mealie-mcp:8102/` | `http://<GLEIPNIR_HOST>:8102/` |
-| `keep` | `http://keep-mcp:8103/` | `http://<GLEIPNIR_HOST>:8103/` |
+| `gcal` | `http://gcal-mcp:8101/` | `http://<MCP_HOST>:8101/` |
+| `mealie` | `http://mealie-mcp:8102/` | `http://<MCP_HOST>:8102/` |
 
-Use the **service name** as the hostname (`gcal-mcp`, `mealie-mcp`, `keep-mcp`) when Gleipnir and the MCP servers are on the same Docker Compose network. Use the host IP or hostname and port numbers when they are on different hosts or Compose projects.
+Use the **service name** as the hostname (`gcal-mcp`, `mealie-mcp`) when Gleipnir and the MCP servers are on the same Docker Compose network. Use the host IP and port numbers when they are on different hosts or Compose projects.
 
-After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `gcal.list_events`, `mealie.get_recipes`, `mealie.get_recipe_detailed`, and `keep.create_note`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
+After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `gcal.list_events`, `mealie.get_recipes`, `mealie.get_recipe_detailed`, and `mealie.create_mealplan_bulk`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
 
 ## Step 5 — Create the policy
 
@@ -138,12 +119,11 @@ Go to **Policies → New Policy** and fill in the form. The YAML below is the pa
 Replace the substitution markers before saving:
 
 - `<YOUR_CALENDAR_ID>` — the calendar to check for dinner events. Use `primary` for your default calendar, or find the calendar ID in Google Calendar settings (it looks like `example@group.calendar.google.com`).
-- `<GROCERY_NOTE_TITLE_PREFIX>` — the prefix for the Keep note title. Default: `Grocery list — week of`.
 - `<FIRE_AT_TIMESTAMP>` — an ISO-8601 UTC timestamp for the first run (e.g. `2026-04-27T16:00:00Z` for next Sunday at 09:00 PT). Add more timestamps to schedule multiple weeks in advance.
 
 ```yaml
 name: meal-planning
-description: Fill empty dinner slots in Google Calendar and drop a grocery list into Google Keep.
+description: Check Google Calendar for unplanned dinners and fill them in Mealie's meal plan for the week.
 folder: Household
 
 model:
@@ -162,7 +142,7 @@ capabilities:
     - tool: gcal.list_events
     - tool: mealie.get_recipes
     - tool: mealie.get_recipe_detailed
-    - tool: keep.create_note
+    - tool: mealie.create_mealplan_bulk
       approval: required
       timeout: 30m
       on_timeout: reject
@@ -173,36 +153,36 @@ capabilities:
 
 agent:
   task: |
-    For each evening in the next 7 days starting tomorrow, check
-    <YOUR_CALENDAR_ID> via gcal.list_events for an event whose
-    title begins with "dinner:". For evenings without one, select
-    a recipe from the Mealie library:
-      1. Call mealie.get_recipes to list available recipes.
-      2. Call mealie.get_recipe_detailed for the chosen recipe to
-         retrieve its full ingredient list and quantities.
-    Avoid repeating a recipe within the same week.
+    Check <YOUR_CALENDAR_ID> via gcal.list_events for the next
+    7 days starting tomorrow. For each evening, look for any
+    event whose title suggests a dinner is already planned —
+    titles containing words like "dinner", "supper", "meal",
+    or a restaurant name. Evenings without such an event need
+    a recipe assigned.
 
-    When you have recipes for all empty slots, aggregate the
-    ingredients across all recipes into a single grocery list
-    (deduplicated, quantities summed where possible). Create a
-    Google Keep note via keep.create_note titled
-    "<GROCERY_NOTE_TITLE_PREFIX> <Monday of the week, YYYY-MM-DD>"
-    with the grocery list as the body and the chosen recipes
-    (with dates) as a header section.
+    For each evening that needs a recipe:
+      1. Call mealie.get_recipes to browse available recipes.
+      2. Call mealie.get_recipe_detailed on your chosen recipe
+         to confirm it exists and retrieve its details.
+    Avoid assigning the same recipe more than once in the week.
+
+    Once you have a recipe for every unplanned evening, call
+    mealie.create_mealplan_bulk to create all the meal plan
+    entries at once. Use entry type "dinner" for each.
 
     If you are unsure which calendar to read, or uncertain about
     a dietary constraint, use the feedback channel to ask the
-    operator.
+    operator before proceeding.
   limits:
-    max_tokens_per_run: 40000
-    max_tool_calls_per_run: 60
+    max_tokens_per_run: 30000
+    max_tool_calls_per_run: 40
   concurrency: skip
 ```
 
 **Why these choices:**
 
 - `trigger.type: scheduled` with `fire_at` is a list of one-shot ISO-8601 UTC timestamps. Add a new timestamp each week (or each month in advance) to keep it running. There is no recurring cron; when all timestamps are consumed the policy is automatically paused.
-- Only `keep.create_note` is approval-gated. Calendar reads and Mealie recipe lookups are read-only and do not require approval. The operator approves the Keep write before it executes, giving a final review of the grocery list.
+- Only `mealie.create_mealplan_bulk` is approval-gated — it is the only write operation. Calendar reads and recipe lookups are read-only and do not require approval. The operator approves the meal plan before it is written, giving a final review of the week's choices.
 - `feedback.enabled: true` gives the agent `gleipnir.ask_operator` (ADR-031) to handle dietary questions or calendar ambiguity without failing the run.
 - Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective (ADR-001).
 
@@ -212,10 +192,10 @@ Because `trigger.type: scheduled` is one-shot, the easiest way to test without c
 
 1. Duplicate the policy in Gleipnir (or create a second policy with the same body and `trigger.type: manual`).
 2. Go to **Policies → [your test policy] → Trigger** to start a run immediately.
-3. Watch the run appear in the **Runs** list. Click into it to see the reasoning trace: tool calls, tool results, and the approval request for `keep.create_note`.
-4. Approve the Keep write when prompted. Verify that a note appears in Google Keep.
+3. Watch the run appear in the **Runs** list. Click into it to see the reasoning trace: tool calls, tool results, and the approval request for `mealie.create_mealplan_bulk`.
+4. Review the proposed meal plan and approve. Verify the entries appear in Mealie under **Meal Plan**.
 
-Once you have confirmed the agent produces a correct grocery list, update the scheduled policy's `fire_at` list with real timestamps for future weeks.
+Once you have confirmed the agent produces a correct plan, update the scheduled policy's `fire_at` list with real timestamps for future weeks.
 
 ## Troubleshooting
 
@@ -223,11 +203,9 @@ Once you have confirmed the agent produces a correct grocery list, update the sc
 |---------|-------------|-----|
 | Discover returns 0 tools for `gcal-mcp` | `gcp-oauth.keys.json` not mounted or missing | Confirm the file exists at `docs/playbooks/meal-planning/gcp-oauth.keys.json` and the Compose volume mount path matches. |
 | Discover returns 0 tools for `mealie-mcp` | `MEALIE_BASE_URL` or `MEALIE_API_KEY` not set, or Mealie unreachable | Check that `.env` is in the same directory as `docker-compose.yml`. Verify Mealie is reachable from the Docker host: `curl $MEALIE_BASE_URL/api/app/about`. |
-| Discover returns 0 tools for `keep-mcp` | `GOOGLE_EMAIL` or `GOOGLE_MASTER_TOKEN` not set | Check that `.env` is in the same directory as `docker-compose.yml` and both variables are present. |
-| `gcal-mcp` tools fail with `-32600` or authentication errors | Refresh token missing or expired | Re-run the ephemeral auth container: `docker run --rm -it ... npx @cocal/google-calendar-mcp auth` (full command in Step 1). |
+| `gcal-mcp` tools fail with authentication errors | Refresh token missing or expired | Re-run the ephemeral auth container: `docker run --rm -it ... npx @cocal/google-calendar-mcp auth` (full command in Step 1). |
 | Google Calendar tokens expire after 7 days | GCP app is in "test mode" | Publish the OAuth consent screen to production mode, or re-run auth weekly. |
-| Keep master token rejected | 2FA on the Google account | Generate an app password and use it instead of your regular password when obtaining the master token. |
+| `mealie.create_mealplan_bulk` fails | Recipe ID not found, or date format wrong | Check Discover output for the exact tool parameter schema. Verify the recipe IDs returned by `get_recipe_detailed` are being passed through correctly. |
 | `.env` variables are not applied | `.env` is in the wrong directory | The file must be in `docs/playbooks/meal-planning/`, the same directory where you run `docker compose up`. |
 | `docker compose down -v` deleted my Calendar tokens | `-v` flag removes all named volumes including `gcal_tokens` | Use `docker compose down` (without `-v`) to stop services without removing volumes. Re-run auth if tokens were deleted. |
 | Tool names in policy don't match Discover output | MCP server updated its tool names | Click Discover again on each server in Settings → MCP Servers, then update the `tool:` entries in the policy to match the new names. |
-| `keep-mcp` container is slow to start | First-run pip install and npx download | Wait 60 seconds and check `docker compose ps` again. Subsequent starts are faster. |

--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -197,6 +197,51 @@ Because `trigger.type: scheduled` is one-shot, the easiest way to test without c
 
 Once you have confirmed the agent produces a correct plan, update the scheduled policy's `fire_at` list with real timestamps for future weeks.
 
+## Extensions
+
+### Avoid recently cooked meals
+
+The base policy only avoids repeating a recipe within the current week, so the same dish could appear two weeks in a row. To extend the lookback window, add `mealie.get_all_mealplans` to `capabilities.tools` and extend the agent task:
+
+```yaml
+capabilities:
+  tools:
+    - tool: mealie.get_all_mealplans   # add this
+    - tool: gcal.list_events
+    - tool: mealie.get_recipes
+    - tool: mealie.create_mealplan_bulk
+      approval: required
+      timeout: 30m
+      on_timeout: reject
+```
+
+Then prepend to the agent task:
+
+```
+Before selecting recipes, call mealie.get_all_mealplans to retrieve
+the meal plans for the past 3 weeks. Extract the recipe IDs already
+used in that window and exclude them from your selections this week.
+```
+
+`get_all_mealplans` accepts `startDate` and `endDate` parameters — pass the date 21 days ago and today to limit the response to recent history.
+
+### Calendar busyness-aware recipe selection
+
+The `gcal.list_events` response already includes full event details for each evening — start time, end time, and how many events are on the calendar. The agent can use this to calibrate recipe complexity: suggest something quick on a packed evening and something more involved when the calendar is clear.
+
+Extend the agent task with guidance on how to interpret busyness:
+
+```
+When selecting a recipe for each evening, also look at how many
+calendar events that day has and how late they run:
+- Evenings with events ending after 18:30, or 3+ events during
+  the day: prefer recipes tagged "quick" or with totalTime under
+  30 minutes if that information is available.
+- Evenings with no events after 17:00: any recipe is suitable.
+```
+
+This requires no additional tools or capabilities — the calendar data is already in context from the `gcal.list_events` call made earlier in the run.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -4,7 +4,7 @@
 
 ## What it does
 
-On a weekly cron trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a dinner planned (any event whose title contains "dinner", "supper", or similar). For each empty slot it picks a recipe from your local [Mealie](https://mealie.io) instance via `mealie.get_recipes` and `mealie.get_recipe_detailed`, avoiding repeating a recipe within the same week. Once all slots are filled, it creates the week's meal plan in Mealie via `mealie.create_mealplan_bulk`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
+On a weekly cron trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a dinner planned (any event whose title contains "dinner", "supper", or similar). For each empty slot it picks a recipe from your local [Mealie](https://mealie.io) instance via `mealie.get_recipes`, avoiding repeating a recipe within the same week. Once all slots are filled, it creates the week's meal plan in Mealie via `mealie.create_mealplan_bulk`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
 
 ## Prerequisites
 
@@ -182,6 +182,7 @@ agent:
 - `trigger.type: cron` with `cron_expr: "0 9 * * 0"` fires every Sunday at 09:00 UTC and runs indefinitely until the policy is paused. Adjust the time component to match your timezone offset (e.g. `0 17 * * 0` for 09:00 PT / UTC-8). The policy never auto-pauses — pause or delete it when you no longer want weekly runs.
 - Only `mealie.create_mealplan_bulk` is approval-gated — it is the only write operation. Calendar reads and recipe lookups are read-only and do not require approval. The operator approves the meal plan before it is written, giving a final review of the week's choices.
 - `feedback.enabled: true` gives the agent `gleipnir.ask_operator` (ADR-031) to handle dietary questions or calendar ambiguity without failing the run.
+- `concurrency: skip` prevents a second run from starting if the Sunday trigger fires while a previous run is still waiting for approval. Without it, two runs could race to write conflicting meal plans to Mealie.
 - Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective (ADR-001).
 
 ## Step 6 — Trigger a test run
@@ -247,7 +248,7 @@ This requires no additional tools or capabilities — the calendar data is alrea
 | Discover returns 0 tools for `mealie-mcp` | `MEALIE_BASE_URL` or `MEALIE_API_KEY` not set, or Mealie unreachable | Check that `.env` is in the same directory as `docker-compose.yml`. Verify Mealie is reachable from the Docker host: `curl $MEALIE_BASE_URL/api/app/about`. |
 | `gcal-mcp` tools fail with authentication errors | Refresh token missing or expired | Re-run the ephemeral auth container: `docker run --rm -it ... npx @cocal/google-calendar-mcp auth` (full command in Step 1). |
 | Google Calendar tokens expire after 7 days | GCP app is in "test mode" | Publish the OAuth consent screen to production mode, or re-run auth weekly. |
-| `mealie.create_mealplan_bulk` fails | Recipe ID not found, or date format wrong | Check Discover output for the exact tool parameter schema. Verify the recipe IDs returned by `get_recipe_detailed` are being passed through correctly. |
+| `mealie.create_mealplan_bulk` fails | Recipe ID not found, or date format wrong | Check Discover output for the exact tool parameter schema. Verify the recipe IDs returned by `mealie.get_recipes` are being passed through correctly. |
 | `.env` variables are not applied | `.env` is in the wrong directory | The file must be in `docs/playbooks/meal-planning/`, the same directory where you run `docker compose up`. |
 | `docker compose down -v` deleted my Calendar tokens | `-v` flag removes all named volumes including `gcal_tokens` | Use `docker compose down` (without `-v`) to stop services without removing volumes. Re-run auth if tokens were deleted. |
 | Tool names in policy don't match Discover output | MCP server updated its tool names | Click Discover again on each server in Settings → MCP Servers, then update the `tool:` entries in the policy to match the new names. |

--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -4,7 +4,7 @@
 
 ## What it does
 
-On a weekly scheduled trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a dinner planned (any event whose title contains "dinner", "supper", or similar). For each empty slot it picks a recipe from your local [Mealie](https://mealie.io) instance via `mealie.get_recipes` and `mealie.get_recipe_detailed`, avoiding repeating a recipe within the same week. Once all slots are filled, it creates the week's meal plan in Mealie via `mealie.create_mealplan_bulk`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
+On a weekly cron trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a dinner planned (any event whose title contains "dinner", "supper", or similar). For each empty slot it picks a recipe from your local [Mealie](https://mealie.io) instance via `mealie.get_recipes` and `mealie.get_recipe_detailed`, avoiding repeating a recipe within the same week. Once all slots are filled, it creates the week's meal plan in Mealie via `mealie.create_mealplan_bulk`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
 
 ## Prerequisites
 
@@ -119,7 +119,6 @@ Go to **Policies → New Policy** and fill in the form. The YAML below is the pa
 Replace the substitution markers before saving:
 
 - `<YOUR_CALENDAR_ID>` — the calendar to check for dinner events. Use `primary` for your default calendar, or find the calendar ID in Google Calendar settings (it looks like `example@group.calendar.google.com`).
-- `<FIRE_AT_TIMESTAMP>` — an ISO-8601 UTC timestamp for the first run (e.g. `2026-04-27T16:00:00Z` for next Sunday at 09:00 PT). Add more timestamps to schedule multiple weeks in advance.
 
 ```yaml
 name: meal-planning
@@ -133,9 +132,8 @@ model:
     enable_prompt_caching: true
 
 trigger:
-  type: scheduled
-  fire_at:
-    - "<FIRE_AT_TIMESTAMP>"   # e.g. 2026-04-27T16:00:00Z — next Sunday 09:00 PT
+  type: cron
+  cron_expr: "0 9 * * 0"   # 09:00 UTC every Sunday; adjust to match your timezone offset
 
 capabilities:
   tools:
@@ -181,21 +179,20 @@ agent:
 
 **Why these choices:**
 
-- `trigger.type: scheduled` with `fire_at` is a list of one-shot ISO-8601 UTC timestamps. Add a new timestamp each week (or each month in advance) to keep it running. There is no recurring cron; when all timestamps are consumed the policy is automatically paused.
+- `trigger.type: cron` with `cron_expr: "0 9 * * 0"` fires every Sunday at 09:00 UTC and runs indefinitely until the policy is paused. Adjust the time component to match your timezone offset (e.g. `0 17 * * 0` for 09:00 PT / UTC-8). The policy never auto-pauses — pause or delete it when you no longer want weekly runs.
 - Only `mealie.create_mealplan_bulk` is approval-gated — it is the only write operation. Calendar reads and recipe lookups are read-only and do not require approval. The operator approves the meal plan before it is written, giving a final review of the week's choices.
 - `feedback.enabled: true` gives the agent `gleipnir.ask_operator` (ADR-031) to handle dietary questions or calendar ambiguity without failing the run.
 - Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective (ADR-001).
 
 ## Step 6 — Trigger a test run
 
-Because `trigger.type: scheduled` is one-shot, the easiest way to test without consuming a real scheduled slot is to clone the policy and set `trigger.type: manual` on the clone:
+Before the first cron firing, test the policy by triggering it manually:
 
-1. Duplicate the policy in Gleipnir (or create a second policy with the same body and `trigger.type: manual`).
-2. Go to **Policies → [your test policy] → Trigger** to start a run immediately.
-3. Watch the run appear in the **Runs** list. Click into it to see the reasoning trace: tool calls, tool results, and the approval request for `mealie.create_mealplan_bulk`.
-4. Review the proposed meal plan and approve. Verify the entries appear in Mealie under **Meal Plan**.
+1. In Gleipnir, go to **Policies → meal-planning → Trigger** to start a run immediately.
+2. Watch the run appear in the **Runs** list. Click into it to see the reasoning trace: tool calls, tool results, and the approval request for `mealie.create_mealplan_bulk`.
+3. Review the proposed meal plan and approve. Verify the entries appear in Mealie under **Meal Plan**.
 
-Once you have confirmed the agent produces a correct plan, update the scheduled policy's `fire_at` list with real timestamps for future weeks.
+Once you have confirmed the agent produces a correct plan, the cron trigger will fire automatically each Sunday at the configured time. Pause the policy from the Policies list if you ever want to stop it.
 
 ## Extensions
 

--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -4,7 +4,7 @@
 
 ## What it does
 
-On a weekly scheduled trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a `dinner:` event. For each empty slot it selects a recipe from TheMealDB — a free public recipe database — by calling `fetch.fetch_json` against `https://www.themealdb.com/api/json/v1/1/`. It parses the returned JSON (meal name, instructions, and up to 20 ingredient/measure pairs), avoids repeating a recipe within the same week, aggregates all ingredients into a single deduplicated grocery list, and then creates one Google Keep note titled `Grocery list — week of <YYYY-MM-DD>` via `keep.create_note`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
+On a weekly scheduled trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a `dinner:` event. For each empty slot it searches your local [Mealie](https://mealie.io) instance for a recipe via `mealie.get_recipes` and retrieves full ingredient details via `mealie.get_recipe_detailed`, avoiding repeating a recipe within the same week. It aggregates all ingredients into a single deduplicated grocery list and then creates one Google Keep note titled `Grocery list — week of <YYYY-MM-DD>` via `keep.create_note`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
 
 ## Prerequisites
 
@@ -18,10 +18,8 @@ On a weekly scheduled trigger, this agent reads the next 7 days of your Google C
 | Server | Purpose | Source | Auth |
 |--------|---------|--------|------|
 | `gcal-mcp` | Read Google Calendar events | [nspady/google-calendar-mcp](https://github.com/nspady/google-calendar-mcp) | Google OAuth — Desktop app credentials JSON |
-| `fetch-mcp` | Generic HTTP fetch (calls TheMealDB REST API) | [zcaceres/fetch-mcp](https://github.com/zcaceres/fetch-mcp) | None |
+| `mealie-mcp` | Search and retrieve recipes from Mealie | [that0n3guy/mealie-mcp-server-ts](https://github.com/that0n3guy/mealie-mcp-server-ts) | Mealie API key |
 | `keep-mcp` | Create Google Keep notes | [feuerdev/keep-mcp](https://github.com/feuerdev/keep-mcp) | Google master token (see below) |
-
-[TheMealDB](https://www.themealdb.com/api.php) exposes a free public REST endpoint at `v1/1/` that requires no API key. The `fetch-mcp` server's `fetch_json` tool is used to call it — no dedicated recipe MCP server is required.
 
 ## Step 1 — Get your credentials
 
@@ -65,9 +63,19 @@ The two environment variables `keep-mcp` expects are:
 - `GOOGLE_EMAIL` — your Google account email address.
 - `GOOGLE_MASTER_TOKEN` — the master token obtained above.
 
-### Fetch server
+### Mealie API key
 
-`fetch-mcp` requires no credentials. TheMealDB's free tier (`v1/1/`) is unauthenticated.
+`mealie-mcp` connects to your self-hosted Mealie instance using an API key.
+
+1. Log in to your Mealie instance as an admin.
+2. Go to **Profile → API Tokens → Generate**.
+3. Give the token a name (e.g. `gleipnir`) and click **Generate**.
+4. Copy the token — it is shown only once.
+
+The two environment variables `mealie-mcp` expects are:
+
+- `MEALIE_BASE_URL` — the base URL of your Mealie instance, e.g. `http://mealie:9000` or `http://192.168.1.10:9000`. No trailing slash.
+- `MEALIE_API_KEY` — the API token generated above.
 
 ## Step 2 — Create .env
 
@@ -76,6 +84,8 @@ Create a file named `.env` inside `docs/playbooks/meal-planning/` — **the same
 ```
 GOOGLE_EMAIL=you@example.com
 GOOGLE_MASTER_TOKEN=<paste master token here>
+MEALIE_BASE_URL=http://<mealie-host>:<port>
+MEALIE_API_KEY=<paste Mealie API token here>
 ```
 
 `gcp-oauth.keys.json` is a file mount, not an environment variable — it does not go in `.env`.
@@ -101,7 +111,7 @@ All three should show `Up` status. If any show `Exited`, check the logs:
 
 ```bash
 docker compose logs gcal-mcp
-docker compose logs fetch-mcp
+docker compose logs mealie-mcp
 docker compose logs keep-mcp
 ```
 
@@ -114,12 +124,12 @@ In Gleipnir, go to **Settings → MCP Servers → Add Server** three times:
 | Name | URL (same Compose project) | URL (separate host) |
 |------|---------------------------|---------------------|
 | `gcal` | `http://gcal-mcp:8101/` | `http://<GLEIPNIR_HOST>:8101/` |
-| `fetch` | `http://fetch-mcp:8102/` | `http://<GLEIPNIR_HOST>:8102/` |
+| `mealie` | `http://mealie-mcp:8102/` | `http://<GLEIPNIR_HOST>:8102/` |
 | `keep` | `http://keep-mcp:8103/` | `http://<GLEIPNIR_HOST>:8103/` |
 
-Use the **service name** as the hostname (`gcal-mcp`, `fetch-mcp`, `keep-mcp`) when Gleipnir and the MCP servers are on the same Docker Compose network. Use the host IP or hostname and port numbers when they are on different hosts or Compose projects.
+Use the **service name** as the hostname (`gcal-mcp`, `mealie-mcp`, `keep-mcp`) when Gleipnir and the MCP servers are on the same Docker Compose network. Use the host IP or hostname and port numbers when they are on different hosts or Compose projects.
 
-After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `gcal.list_events`, `fetch.fetch_json`, and `keep.create_note`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
+After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `gcal.list_events`, `mealie.get_recipes`, `mealie.get_recipe_detailed`, and `keep.create_note`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
 
 ## Step 5 — Create the policy
 
@@ -150,7 +160,8 @@ trigger:
 capabilities:
   tools:
     - tool: gcal.list_events
-    - tool: fetch.fetch_json
+    - tool: mealie.get_recipes
+    - tool: mealie.get_recipe_detailed
     - tool: keep.create_note
       approval: required
       timeout: 30m
@@ -164,20 +175,17 @@ agent:
   task: |
     For each evening in the next 7 days starting tomorrow, check
     <YOUR_CALENDAR_ID> via gcal.list_events for an event whose
-    title begins with "dinner:". For evenings without one, pick
-    a recipe using TheMealDB's free public API by calling
-    fetch.fetch_json with one of:
-      - https://www.themealdb.com/api/json/v1/1/random.php
-      - https://www.themealdb.com/api/json/v1/1/search.php?s=<name>
-      - https://www.themealdb.com/api/json/v1/1/lookup.php?i=<id>
-    Parse the JSON response (meals[0].strMeal, .strInstructions,
-    and strIngredient1..20 / strMeasure1..20). Avoid repeating a
-    recipe within the same week.
+    title begins with "dinner:". For evenings without one, select
+    a recipe from the Mealie library:
+      1. Call mealie.get_recipes to list available recipes.
+      2. Call mealie.get_recipe_detailed for the chosen recipe to
+         retrieve its full ingredient list and quantities.
+    Avoid repeating a recipe within the same week.
 
-    When you have a full list, aggregate ingredients across all
-    chosen recipes into a single grocery list (deduplicated,
-    quantities summed where possible). Create a Google Keep
-    note via keep.create_note titled
+    When you have recipes for all empty slots, aggregate the
+    ingredients across all recipes into a single grocery list
+    (deduplicated, quantities summed where possible). Create a
+    Google Keep note via keep.create_note titled
     "<GROCERY_NOTE_TITLE_PREFIX> <Monday of the week, YYYY-MM-DD>"
     with the grocery list as the body and the chosen recipes
     (with dates) as a header section.
@@ -194,7 +202,7 @@ agent:
 **Why these choices:**
 
 - `trigger.type: scheduled` with `fire_at` is a list of one-shot ISO-8601 UTC timestamps. Add a new timestamp each week (or each month in advance) to keep it running. There is no recurring cron; when all timestamps are consumed the policy is automatically paused.
-- Only `keep.create_note` is approval-gated. Calendar reads and TheMealDB fetches are read-only and do not require approval. The operator approves the Keep write before it executes, giving a final review of the grocery list.
+- Only `keep.create_note` is approval-gated. Calendar reads and Mealie recipe lookups are read-only and do not require approval. The operator approves the Keep write before it executes, giving a final review of the grocery list.
 - `feedback.enabled: true` gives the agent `gleipnir.ask_operator` (ADR-031) to handle dietary questions or calendar ambiguity without failing the run.
 - Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective (ADR-001).
 
@@ -214,6 +222,7 @@ Once you have confirmed the agent produces a correct grocery list, update the sc
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | Discover returns 0 tools for `gcal-mcp` | `gcp-oauth.keys.json` not mounted or missing | Confirm the file exists at `docs/playbooks/meal-planning/gcp-oauth.keys.json` and the Compose volume mount path matches. |
+| Discover returns 0 tools for `mealie-mcp` | `MEALIE_BASE_URL` or `MEALIE_API_KEY` not set, or Mealie unreachable | Check that `.env` is in the same directory as `docker-compose.yml`. Verify Mealie is reachable from the Docker host: `curl $MEALIE_BASE_URL/api/app/about`. |
 | Discover returns 0 tools for `keep-mcp` | `GOOGLE_EMAIL` or `GOOGLE_MASTER_TOKEN` not set | Check that `.env` is in the same directory as `docker-compose.yml` and both variables are present. |
 | `gcal-mcp` tools fail with `-32600` or authentication errors | Refresh token missing or expired | Re-run the ephemeral auth container: `docker run --rm -it ... npx @cocal/google-calendar-mcp auth` (full command in Step 1). |
 | Google Calendar tokens expire after 7 days | GCP app is in "test mode" | Publish the OAuth consent screen to production mode, or re-run auth weekly. |

--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -110,7 +110,7 @@ In Gleipnir, go to **Settings → MCP Servers → Add Server** twice:
 
 Use the **service name** as the hostname (`gcal-mcp`, `mealie-mcp`) when Gleipnir and the MCP servers are on the same Docker Compose network. Use the host IP and port numbers when they are on different hosts or Compose projects.
 
-After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `gcal.list_events`, `mealie.get_recipes`, `mealie.get_recipe_detailed`, and `mealie.create_mealplan_bulk`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
+After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `gcal.list_events`, `mealie.get_recipes`, and `mealie.create_mealplan_bulk`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
 
 ## Step 5 — Create the policy
 
@@ -141,7 +141,6 @@ capabilities:
   tools:
     - tool: gcal.list_events
     - tool: mealie.get_recipes
-    - tool: mealie.get_recipe_detailed
     - tool: mealie.create_mealplan_bulk
       approval: required
       timeout: 30m
@@ -160,22 +159,23 @@ agent:
     or a restaurant name. Evenings without such an event need
     a recipe assigned.
 
-    For each evening that needs a recipe:
-      1. Call mealie.get_recipes to browse available recipes.
-      2. Call mealie.get_recipe_detailed on your chosen recipe
-         to confirm it exists and retrieve its details.
-    Avoid assigning the same recipe more than once in the week.
+    For each evening that needs a recipe, call mealie.get_recipes
+    to browse available recipes. Each result includes an "id"
+    (UUID) and "name" — that is all you need. Do not attempt to
+    fetch full recipe details. Avoid assigning the same recipe
+    more than once in the week.
 
     Once you have a recipe for every unplanned evening, call
-    mealie.create_mealplan_bulk to create all the meal plan
-    entries at once. Use entry type "dinner" for each.
+    mealie.create_mealplan_bulk with one entry per evening:
+    { date, recipe_id, entry_type: "dinner" }. Pass the "id"
+    field from get_recipes directly as recipe_id.
 
     If you are unsure which calendar to read, or uncertain about
     a dietary constraint, use the feedback channel to ask the
     operator before proceeding.
   limits:
     max_tokens_per_run: 30000
-    max_tool_calls_per_run: 40
+    max_tool_calls_per_run: 20
   concurrency: skip
 ```
 

--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -1,0 +1,224 @@
+# Plan the week's meals
+
+**Status:** Complete
+
+## What it does
+
+On a weekly scheduled trigger, this agent reads the next 7 days of your Google Calendar via `gcal.list_events` and identifies evenings that do not already have a `dinner:` event. For each empty slot it selects a recipe from TheMealDB — a free public recipe database — by calling `fetch.fetch_json` against `https://www.themealdb.com/api/json/v1/1/`. It parses the returned JSON (meal name, instructions, and up to 20 ingredient/measure pairs), avoids repeating a recipe within the same week, aggregates all ingredients into a single deduplicated grocery list, and then creates one Google Keep note titled `Grocery list — week of <YYYY-MM-DD>` via `keep.create_note`. If the agent is unsure which calendar to read or encounters an unexpected dietary constraint, it pauses the run and asks you via the feedback channel before proceeding.
+
+## Prerequisites
+
+- A running Gleipnir instance (see main `README.md`).
+- Docker and Docker Compose available on the same host (or a host reachable from Gleipnir).
+- A Google account with access to Google Calendar and Google Keep.
+- A Google Cloud project with the **Google Calendar API** enabled and an OAuth 2.0 Desktop application client configured (used by `gcal-mcp`).
+
+## MCP servers used
+
+| Server | Purpose | Source | Auth |
+|--------|---------|--------|------|
+| `gcal-mcp` | Read Google Calendar events | [nspady/google-calendar-mcp](https://github.com/nspady/google-calendar-mcp) | Google OAuth — Desktop app credentials JSON |
+| `fetch-mcp` | Generic HTTP fetch (calls TheMealDB REST API) | [zcaceres/fetch-mcp](https://github.com/zcaceres/fetch-mcp) | None |
+| `keep-mcp` | Create Google Keep notes | [feuerdev/keep-mcp](https://github.com/feuerdev/keep-mcp) | Google master token (see below) |
+
+[TheMealDB](https://www.themealdb.com/api.php) exposes a free public REST endpoint at `v1/1/` that requires no API key. The `fetch-mcp` server's `fetch_json` tool is used to call it — no dedicated recipe MCP server is required.
+
+## Step 1 — Get your credentials
+
+### Google Calendar OAuth credentials
+
+`gcal-mcp` uses OAuth 2.0 to read your calendar on your behalf. Follow the upstream [Google Cloud Setup guide](https://github.com/nspady/google-calendar-mcp#google-cloud-setup) to:
+
+1. Create (or select) a Google Cloud project.
+2. Enable the **Google Calendar API**.
+3. Create an **OAuth 2.0 Client ID** of type **Desktop app**.
+4. Download the JSON credentials file.
+5. Save the file as `gcp-oauth.keys.json` in this directory (next to `docker-compose.yml`). The Compose file mounts this path read-only into the `gcal-mcp` container.
+
+#### First-run OAuth token flow
+
+Supergateway wraps the `gcal-mcp` process and has no mechanism to handle interactive prompts. Before bringing `gcal-mcp` up under Compose, run an ephemeral container directly to complete the one-time OAuth consent flow:
+
+```bash
+docker run --rm -it \
+  -e GOOGLE_OAUTH_CREDENTIALS=/config/gcp-oauth.keys.json \
+  -v ./gcp-oauth.keys.json:/config/gcp-oauth.keys.json:ro \
+  -v gcal_tokens:/root/.config/google-calendar-mcp \
+  node:22-alpine \
+  npx @cocal/google-calendar-mcp auth
+```
+
+This opens an authorization URL in your terminal. Open it in a browser, grant access, and paste the authorization code back. The refresh token is stored in the `gcal_tokens` named Docker volume. The `gcal-mcp` Compose service mounts the same volume, so when you run `docker compose up -d` afterward the tokens are already in place and no further auth is needed.
+
+> **Token expiry warning:** OAuth refresh tokens issued while your GCP app is in "test mode" expire after 7 days, which forces weekly re-authentication. To avoid this, publish the app to production mode via **OAuth consent screen → PUBLISH APP** in Google Cloud Console. The app will still show an "unverified app" warning to users but tokens will not expire on a 7-day cycle. See [upstream re-authentication docs](https://github.com/nspady/google-calendar-mcp#re-authentication). Alternatively, re-run the `npx @cocal/google-calendar-mcp auth` command each week.
+
+### Google Keep master token
+
+`keep-mcp` uses [gkeepapi](https://gkeepapi.readthedocs.io/en/latest/) under the hood. gkeepapi does not accept a regular Google password — it requires a **master token** (a long-lived OAuth2 token scoped to Google services).
+
+> **Security warning:** The Google master token grants access to all Google services reachable via `gpsoauth`, not just Google Keep. Use a dedicated Google account for this integration rather than your primary account.
+
+Obtain the master token by following the [gkeepapi master token procedure](https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token). If your account has 2FA enabled, you must generate an [app password](https://support.google.com/accounts/answer/185833) and use that during the token retrieval flow.
+
+The two environment variables `keep-mcp` expects are:
+
+- `GOOGLE_EMAIL` — your Google account email address.
+- `GOOGLE_MASTER_TOKEN` — the master token obtained above.
+
+### Fetch server
+
+`fetch-mcp` requires no credentials. TheMealDB's free tier (`v1/1/`) is unauthenticated.
+
+## Step 2 — Create .env
+
+Create a file named `.env` inside `docs/playbooks/meal-planning/` — **the same directory as `docker-compose.yml`**. Docker Compose reads `.env` from the directory it is invoked in; placing it anywhere else will silently leave the variables unset.
+
+```
+GOOGLE_EMAIL=you@example.com
+GOOGLE_MASTER_TOKEN=<paste master token here>
+```
+
+`gcp-oauth.keys.json` is a file mount, not an environment variable — it does not go in `.env`.
+
+Do not commit `.env` or `gcp-oauth.keys.json` to version control. Both are listed in `.gitignore` at the repo root.
+
+## Step 3 — Start the MCP servers
+
+Run the following from this directory (the one containing `docker-compose.yml`):
+
+```bash
+cd docs/playbooks/meal-planning
+docker compose up -d
+```
+
+Verify all three services are running:
+
+```bash
+docker compose ps
+```
+
+All three should show `Up` status. If any show `Exited`, check the logs:
+
+```bash
+docker compose logs gcal-mcp
+docker compose logs fetch-mcp
+docker compose logs keep-mcp
+```
+
+> **Note:** `keep-mcp` installs Python dependencies at container start (`pip install keep-mcp`) and then downloads Supergateway via `npx`. The first start takes 30–60 seconds. Subsequent starts are faster.
+
+## Step 4 — Register each MCP server in Gleipnir
+
+In Gleipnir, go to **Settings → MCP Servers → Add Server** three times:
+
+| Name | URL (same Compose project) | URL (separate host) |
+|------|---------------------------|---------------------|
+| `gcal` | `http://gcal-mcp:8101/` | `http://<GLEIPNIR_HOST>:8101/` |
+| `fetch` | `http://fetch-mcp:8102/` | `http://<GLEIPNIR_HOST>:8102/` |
+| `keep` | `http://keep-mcp:8103/` | `http://<GLEIPNIR_HOST>:8103/` |
+
+Use the **service name** as the hostname (`gcal-mcp`, `fetch-mcp`, `keep-mcp`) when Gleipnir and the MCP servers are on the same Docker Compose network. Use the host IP or hostname and port numbers when they are on different hosts or Compose projects.
+
+After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `gcal.list_events`, `fetch.fetch_json`, and `keep.create_note`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
+
+## Step 5 — Create the policy
+
+Go to **Policies → New Policy** and fill in the form. The YAML below is the payload the form produces — it is included here as a reference and to make the field mapping explicit. The YAML tab was removed in the Gleipnir UI (ADR-019); use the form fields that correspond to each section.
+
+Replace the substitution markers before saving:
+
+- `<YOUR_CALENDAR_ID>` — the calendar to check for dinner events. Use `primary` for your default calendar, or find the calendar ID in Google Calendar settings (it looks like `example@group.calendar.google.com`).
+- `<GROCERY_NOTE_TITLE_PREFIX>` — the prefix for the Keep note title. Default: `Grocery list — week of`.
+- `<FIRE_AT_TIMESTAMP>` — an ISO-8601 UTC timestamp for the first run (e.g. `2026-04-27T16:00:00Z` for next Sunday at 09:00 PT). Add more timestamps to schedule multiple weeks in advance.
+
+```yaml
+name: meal-planning
+description: Fill empty dinner slots in Google Calendar and drop a grocery list into Google Keep.
+folder: Household
+
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  options:
+    enable_prompt_caching: true
+
+trigger:
+  type: scheduled
+  fire_at:
+    - "<FIRE_AT_TIMESTAMP>"   # e.g. 2026-04-27T16:00:00Z — next Sunday 09:00 PT
+
+capabilities:
+  tools:
+    - tool: gcal.list_events
+    - tool: fetch.fetch_json
+    - tool: keep.create_note
+      approval: required
+      timeout: 30m
+      on_timeout: reject
+  feedback:
+    enabled: true
+    timeout: 30m
+    on_timeout: fail
+
+agent:
+  task: |
+    For each evening in the next 7 days starting tomorrow, check
+    <YOUR_CALENDAR_ID> via gcal.list_events for an event whose
+    title begins with "dinner:". For evenings without one, pick
+    a recipe using TheMealDB's free public API by calling
+    fetch.fetch_json with one of:
+      - https://www.themealdb.com/api/json/v1/1/random.php
+      - https://www.themealdb.com/api/json/v1/1/search.php?s=<name>
+      - https://www.themealdb.com/api/json/v1/1/lookup.php?i=<id>
+    Parse the JSON response (meals[0].strMeal, .strInstructions,
+    and strIngredient1..20 / strMeasure1..20). Avoid repeating a
+    recipe within the same week.
+
+    When you have a full list, aggregate ingredients across all
+    chosen recipes into a single grocery list (deduplicated,
+    quantities summed where possible). Create a Google Keep
+    note via keep.create_note titled
+    "<GROCERY_NOTE_TITLE_PREFIX> <Monday of the week, YYYY-MM-DD>"
+    with the grocery list as the body and the chosen recipes
+    (with dates) as a header section.
+
+    If you are unsure which calendar to read, or uncertain about
+    a dietary constraint, use the feedback channel to ask the
+    operator.
+  limits:
+    max_tokens_per_run: 40000
+    max_tool_calls_per_run: 60
+  concurrency: skip
+```
+
+**Why these choices:**
+
+- `trigger.type: scheduled` with `fire_at` is a list of one-shot ISO-8601 UTC timestamps. Add a new timestamp each week (or each month in advance) to keep it running. There is no recurring cron; when all timestamps are consumed the policy is automatically paused.
+- Only `keep.create_note` is approval-gated. Calendar reads and TheMealDB fetches are read-only and do not require approval. The operator approves the Keep write before it executes, giving a final review of the grocery list.
+- `feedback.enabled: true` gives the agent `gleipnir.ask_operator` (ADR-031) to handle dietary questions or calendar ambiguity without failing the run.
+- Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective (ADR-001).
+
+## Step 6 — Trigger a test run
+
+Because `trigger.type: scheduled` is one-shot, the easiest way to test without consuming a real scheduled slot is to clone the policy and set `trigger.type: manual` on the clone:
+
+1. Duplicate the policy in Gleipnir (or create a second policy with the same body and `trigger.type: manual`).
+2. Go to **Policies → [your test policy] → Trigger** to start a run immediately.
+3. Watch the run appear in the **Runs** list. Click into it to see the reasoning trace: tool calls, tool results, and the approval request for `keep.create_note`.
+4. Approve the Keep write when prompted. Verify that a note appears in Google Keep.
+
+Once you have confirmed the agent produces a correct grocery list, update the scheduled policy's `fire_at` list with real timestamps for future weeks.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Discover returns 0 tools for `gcal-mcp` | `gcp-oauth.keys.json` not mounted or missing | Confirm the file exists at `docs/playbooks/meal-planning/gcp-oauth.keys.json` and the Compose volume mount path matches. |
+| Discover returns 0 tools for `keep-mcp` | `GOOGLE_EMAIL` or `GOOGLE_MASTER_TOKEN` not set | Check that `.env` is in the same directory as `docker-compose.yml` and both variables are present. |
+| `gcal-mcp` tools fail with `-32600` or authentication errors | Refresh token missing or expired | Re-run the ephemeral auth container: `docker run --rm -it ... npx @cocal/google-calendar-mcp auth` (full command in Step 1). |
+| Google Calendar tokens expire after 7 days | GCP app is in "test mode" | Publish the OAuth consent screen to production mode, or re-run auth weekly. |
+| Keep master token rejected | 2FA on the Google account | Generate an app password and use it instead of your regular password when obtaining the master token. |
+| `.env` variables are not applied | `.env` is in the wrong directory | The file must be in `docs/playbooks/meal-planning/`, the same directory where you run `docker compose up`. |
+| `docker compose down -v` deleted my Calendar tokens | `-v` flag removes all named volumes including `gcal_tokens` | Use `docker compose down` (without `-v`) to stop services without removing volumes. Re-run auth if tokens were deleted. |
+| Tool names in policy don't match Discover output | MCP server updated its tool names | Click Discover again on each server in Settings → MCP Servers, then update the `tool:` entries in the policy to match the new names. |
+| `keep-mcp` container is slow to start | First-run pip install and npx download | Wait 60 seconds and check `docker compose ps` again. Subsequent starts are faster. |

--- a/docs/playbooks/meal-planning/docker-compose.yml
+++ b/docs/playbooks/meal-planning/docker-compose.yml
@@ -25,16 +25,19 @@ services:
       - gcal_tokens:/root/.config/google-calendar-mcp
     restart: unless-stopped
 
-  # Generic HTTP fetch MCP server — used to call TheMealDB's free REST API.
-  # Repo: https://github.com/zcaceres/fetch-mcp
-  fetch-mcp:
+  # Mealie MCP server — reads recipes from your local Mealie instance.
+  # Repo: https://github.com/that0n3guy/mealie-mcp-server-ts
+  mealie-mcp:
     image: node:22-alpine
     command: >
       npx -y supergateway
       --port 8102
-      --stdio "npx -y mcp-fetch-server"
+      --stdio "npx -y mealie-mcp-server-ts"
     ports:
       - "8102:8102"
+    environment:
+      - MEALIE_BASE_URL=${MEALIE_BASE_URL}
+      - MEALIE_API_KEY=${MEALIE_API_KEY}
     restart: unless-stopped
 
   # Google Keep MCP server — creates grocery list notes.

--- a/docs/playbooks/meal-planning/docker-compose.yml
+++ b/docs/playbooks/meal-planning/docker-compose.yml
@@ -1,0 +1,65 @@
+# MCP servers for the meal-planning playbook.
+#
+# Run from this directory:
+#   docker compose up -d
+#
+# Before starting, complete the first-run Google Calendar auth — see README.md.
+# Secrets are loaded from .env in this directory (see README.md § Step 2).
+
+services:
+
+  # Google Calendar MCP server — reads calendar events.
+  # Repo: https://github.com/nspady/google-calendar-mcp
+  gcal-mcp:
+    image: node:22-alpine
+    command: >
+      npx -y supergateway
+      --port 8101
+      --stdio "npx -y @cocal/google-calendar-mcp"
+    ports:
+      - "8101:8101"
+    environment:
+      - GOOGLE_OAUTH_CREDENTIALS=/config/gcp-oauth.keys.json
+    volumes:
+      - ./gcp-oauth.keys.json:/config/gcp-oauth.keys.json:ro
+      - gcal_tokens:/root/.config/google-calendar-mcp
+    restart: unless-stopped
+
+  # Generic HTTP fetch MCP server — used to call TheMealDB's free REST API.
+  # Repo: https://github.com/zcaceres/fetch-mcp
+  fetch-mcp:
+    image: node:22-alpine
+    command: >
+      npx -y supergateway
+      --port 8102
+      --stdio "npx -y mcp-fetch-server"
+    ports:
+      - "8102:8102"
+    restart: unless-stopped
+
+  # Google Keep MCP server — creates grocery list notes.
+  # Repo: https://github.com/feuerdev/keep-mcp
+  # Uses python:3.11-alpine because keep-mcp is a Python package; Node is
+  # installed via apk so Supergateway (an npm tool) can run inside the same
+  # container.
+  keep-mcp:
+    image: python:3.11-alpine
+    command: >
+      sh -c "apk add --no-cache nodejs npm &&
+             pip install --break-system-packages keep-mcp &&
+             npx -y supergateway --port 8103 --stdio 'keep-mcp'"
+    ports:
+      - "8103:8103"
+    environment:
+      - GOOGLE_EMAIL=${GOOGLE_EMAIL}
+      - GOOGLE_MASTER_TOKEN=${GOOGLE_MASTER_TOKEN}
+    restart: unless-stopped
+
+volumes:
+  # Named volume persists the Google Calendar OAuth refresh tokens across
+  # container restarts. Use "docker compose down" (without -v) to keep tokens.
+  # The explicit name prevents Compose from prepending the project name, so the
+  # pre-auth "docker run" command (which references "gcal_tokens" directly)
+  # writes into the same volume that gcal-mcp mounts.
+  gcal_tokens:
+    name: gcal_tokens

--- a/docs/playbooks/meal-planning/docker-compose.yml
+++ b/docs/playbooks/meal-planning/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - gcal_tokens:/root/.config/google-calendar-mcp
     restart: unless-stopped
 
-  # Mealie MCP server — reads recipes from your local Mealie instance.
+  # Mealie MCP server — reads recipes and creates meal plans.
   # Repo: https://github.com/that0n3guy/mealie-mcp-server-ts
   mealie-mcp:
     image: node:22-alpine
@@ -38,24 +38,6 @@ services:
     environment:
       - MEALIE_BASE_URL=${MEALIE_BASE_URL}
       - MEALIE_API_KEY=${MEALIE_API_KEY}
-    restart: unless-stopped
-
-  # Google Keep MCP server — creates grocery list notes.
-  # Repo: https://github.com/feuerdev/keep-mcp
-  # Uses python:3.11-alpine because keep-mcp is a Python package; Node is
-  # installed via apk so Supergateway (an npm tool) can run inside the same
-  # container.
-  keep-mcp:
-    image: python:3.11-alpine
-    command: >
-      sh -c "apk add --no-cache nodejs npm &&
-             pip install --break-system-packages keep-mcp &&
-             npx -y supergateway --port 8103 --stdio 'keep-mcp'"
-    ports:
-      - "8103:8103"
-    environment:
-      - GOOGLE_EMAIL=${GOOGLE_EMAIL}
-      - GOOGLE_MASTER_TOKEN=${GOOGLE_MASTER_TOKEN}
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Closes #51

## Summary

- Converts the stub `docs/playbooks/meal-planning.md` into a full directory-based playbook at `docs/playbooks/meal-planning/`
- Creates `README.md` with all setup steps: Google Calendar OAuth credentials, `.env` configuration, MCP server registration in Gleipnir, policy creation, and test trigger
- Creates `docker-compose.yml` standing up three Supergateway-wrapped MCP servers: Google Calendar (`@cocal/google-calendar-mcp`), HTTP fetch for TheMealDB recipes (`mcp-fetch-server`), and Google Keep (`keep-mcp`)
- Updates `docs/playbooks/README.md` to link the new location and mark status Complete
- Adds `gcp-oauth.keys.json` to root `.gitignore` to prevent accidental credential commits

## Architecture plan

<details>
<summary>Implementation plan (from architect agent)</summary>

**MCP servers selected (all verified installable):**
- `gcal-mcp` — `@cocal/google-calendar-mcp` (npm, nspady/google-calendar-mcp) — Google Calendar read via OAuth
- `fetch-mcp` — `mcp-fetch-server` v1.1.2 (npm, zcaceres/fetch-mcp) — generic HTTP fetch used to hit TheMealDB's free public REST API for recipe lookup (no API key required)
- `keep-mcp` — `keep-mcp` v0.3.1 (PyPI, feuerdev/keep-mcp) — Google Keep note create via gkeepapi master token

All three are stdio-only and wrapped in Supergateway per `docs/stdio-mcp-servers.md`. The docker-compose volume for Google Calendar OAuth tokens uses `name: gcal_tokens` to prevent Docker Compose's project-name namespacing from breaking the pre-auth `docker run` flow.

**Policy shape:** `trigger.type: scheduled` with one-shot `fire_at` ISO-8601 list, three tool grants (`gcal.list_events`, `fetch.fetch_json`, `keep.create_note` with `approval: required`), feedback enabled.

</details>

## Review cycles

2 cycles — Cycle 1 fixed: (1) recipe server replaced (fabricated npm package → `mcp-fetch-server` + TheMealDB REST API), (2) Google Keep server replaced (fabricated PyPI package → `feuerdev/keep-mcp`), (3) Calendar OAuth flow corrected for Supergateway. Cycle 2 fixed: (1) OAuth token volume namespacing (`name: gcal_tokens` added to docker-compose), (2) false `.gitignore` claim corrected + `gcp-oauth.keys.json` added.

## Documentation

`CLAUDE.md` not updated — only `docs/` and `.gitignore` changed; no packages, routes, env vars, or model types affected.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code) agentic dev loop