### PR TITLE
feat: paginate run steps endpoint with cursor-based pagination

### DIFF
--- a/frontend/src/hooks/queries/runs.test.ts
+++ b/frontend/src/hooks/queries/runs.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/server'
+import { useRunSteps, PAGE_SIZE_STEPS } from './runs'
+import type { ApiRunStep } from '@/api/types'
+import { queryKeys } from '@/hooks/queryKeys'
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return {
+    client,
+    wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(QueryClientProvider, { client }, children)
+    },
+  }
+}
+
+function makeStep(stepNumber: number): ApiRunStep {
+  return {
+    id: `step-${stepNumber}`,
+    run_id: 'run1',
+    step_number: stepNumber,
+    type: 'thought',
+    content: JSON.stringify({ text: `step ${stepNumber}` }),
+    token_cost: 0,
+    created_at: new Date().toISOString(),
+  }
+}
+
+function makeSteps(count: number, offset = 0): ApiRunStep[] {
+  return Array.from({ length: count }, (_, i) => makeStep(offset + i))
+}
+
+describe('useRunSteps', () => {
+  beforeEach(() => {
+    // Reset to empty handlers; each test installs its own.
+  })
+
+  it('initial mount fetches ?limit=PAGE_SIZE_STEPS', async () => {
+    const steps = makeSteps(3)
+    let capturedUrl = ''
+
+    server.use(
+      http.get('/api/v1/runs/run1/steps', ({ request }) => {
+        capturedUrl = request.url
+        return HttpResponse.json({ data: steps })
+      }),
+    )
+
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useRunSteps('run1'), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success')
+      expect(result.current.steps).toHaveLength(3)
+    })
+
+    expect(capturedUrl).toContain(`limit=${PAGE_SIZE_STEPS}`)
+    expect(result.current.steps[0].step_number).toBe(0)
+  })
+
+  it('loadMore fetches ?after=<last>&limit=PAGE_SIZE_STEPS and appends steps', async () => {
+    const firstPage = makeSteps(PAGE_SIZE_STEPS)
+    const secondPage = makeSteps(3, PAGE_SIZE_STEPS)
+    let callCount = 0
+
+    server.use(
+      http.get('/api/v1/runs/run1/steps', ({ request }) => {
+        callCount++
+        const url = new URL(request.url)
+        const after = url.searchParams.get('after')
+        if (after === null || after === '-1') {
+          return HttpResponse.json({ data: firstPage })
+        }
+        return HttpResponse.json({ data: secondPage })
+      }),
+    )
+
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useRunSteps('run1'), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success')
+      expect(result.current.steps).toHaveLength(PAGE_SIZE_STEPS)
+    })
+    expect(result.current.hasMore).toBe(true)
+
+    await act(async () => {
+      await result.current.loadMore()
+    })
+
+    expect(result.current.steps).toHaveLength(PAGE_SIZE_STEPS + 3)
+    expect(callCount).toBe(2)
+  })
+
+  it('hasMore is false when server returns fewer than PAGE_SIZE_STEPS rows', async () => {
+    const steps = makeSteps(10)
+
+    server.use(
+      http.get('/api/v1/runs/run1/steps', () =>
+        HttpResponse.json({ data: steps }),
+      ),
+    )
+
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useRunSteps('run1'), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success')
+      expect(result.current.steps).toHaveLength(10)
+    })
+
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it('extraPages are reset when the baseline query is invalidated', async () => {
+    // Use a small initial page so loadMore can use a distinct after-cursor.
+    const initialFirstPage = makeSteps(10)
+    const extraPage = makeSteps(5, 10)
+    let refetchCount = 0
+
+    server.use(
+      http.get('/api/v1/runs/run1/steps', ({ request }) => {
+        const url = new URL(request.url)
+        const after = url.searchParams.get('after')
+        // loadMore call: return the extra page
+        if (after !== null && after !== '-1') {
+          return HttpResponse.json({ data: extraPage })
+        }
+        refetchCount++
+        return HttpResponse.json({ data: initialFirstPage })
+      }),
+    )
+
+    const { client, wrapper } = makeWrapper()
+    const { result } = renderHook(() => useRunSteps('run1'), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success')
+      expect(result.current.steps).toHaveLength(10)
+    })
+    expect(refetchCount).toBe(1)
+
+    // Load an extra page so extraPages has 5 additional items.
+    await act(async () => {
+      await result.current.loadMore()
+    })
+
+    await waitFor(() => {
+      expect(result.current.steps).toHaveLength(15)
+    })
+
+    // Invalidate the baseline query — simulates SSE run.step_added or mutation.
+    await act(async () => {
+      await client.invalidateQueries({ queryKey: queryKeys.runs.steps('run1') })
+    })
+
+    // After the refetch triggered by invalidation, extraPages are dropped and
+    // only the re-fetched first page is visible.
+    await waitFor(() => {
+      expect(result.current.steps.length).toBeLessThanOrEqual(10)
+      expect(refetchCount).toBeGreaterThan(1)
+    })
+  })
+})

--- a/frontend/src/hooks/queries/runs.ts
+++ b/frontend/src/hooks/queries/runs.ts
@@ -1,7 +1,12 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import { useState, useEffect } from 'react'
 import { apiFetch } from '@/api/fetch'
 import type { ApiRun, ApiRunsResponse, ApiRunStep } from '@/api/types'
 import { queryKeys } from '../queryKeys'
+
+// PAGE_SIZE_STEPS is the number of steps fetched per request, used by both the
+// hook and the backend handler (runs_handler.go defaultStepsLimit).
+export const PAGE_SIZE_STEPS = 500
 
 export function useRun(id?: string) {
   return useQuery({
@@ -48,10 +53,69 @@ export function useRuns(params: RunsFilterParams) {
   }
 }
 
-export function useRunSteps(id?: string) {
-  return useQuery({
+export interface UseRunStepsResult {
+  steps: ApiRunStep[]
+  status: 'pending' | 'error' | 'success'
+  hasMore: boolean
+  loadMore: () => Promise<void>
+}
+
+// useRunSteps loads the first page of steps with useQuery so TanStack Query
+// handles caching, deduplication, and SSE-driven invalidations. Additional
+// pages requested via loadMore are stored in local state (extraPages).
+//
+// Cache-invalidation contract: any refetch of the baseline first-page query
+// resets extraPages to []. This means a SSE run.step_added invalidation or a
+// mutation that calls queryClient.invalidateQueries will drop previously-loaded
+// older pages. The user can reload them by clicking "Load more steps" again.
+// This is simpler than a merge strategy and avoids silent data inconsistency.
+export function useRunSteps(id?: string): UseRunStepsResult {
+  const [extraPages, setExtraPages] = useState<ApiRunStep[][]>([])
+
+  const baseQuery = useQuery({
     queryKey: queryKeys.runs.steps(id ?? ''),
-    queryFn: () => apiFetch<ApiRunStep[]>(`/runs/${encodeURIComponent(id!)}/steps`),
+    queryFn: () =>
+      apiFetch<ApiRunStep[]>(
+        `/runs/${encodeURIComponent(id!)}/steps?limit=${PAGE_SIZE_STEPS}`,
+      ),
     enabled: Boolean(id),
   })
+
+  // Reset extraPages whenever the baseline query result is refreshed. We key
+  // on dataUpdatedAt so that a background refetch (e.g. from SSE invalidation
+  // or an approval/feedback mutation) clears any previously-loaded older steps.
+  // This avoids stale-data inconsistencies at the cost of a brief flicker.
+  // extraPages is local state; any refetch of the first page wipes it.
+  useEffect(() => {
+    setExtraPages([])
+  }, [baseQuery.dataUpdatedAt])
+
+  const firstPage = baseQuery.data ?? []
+  const allSteps: ApiRunStep[] = [firstPage, ...extraPages].flat()
+
+  const lastStep = allSteps[allSteps.length - 1]
+  const lastStepNumber = lastStep?.step_number ?? -1
+
+  // The server returns up to PAGE_SIZE_STEPS. Receiving exactly PAGE_SIZE_STEPS
+  // rows means there may be more — the client infers hasMore from the count.
+  const lastPageLen =
+    extraPages.length > 0
+      ? extraPages[extraPages.length - 1].length
+      : firstPage.length
+  const hasMore = lastPageLen === PAGE_SIZE_STEPS
+
+  async function loadMore() {
+    if (!id) return
+    const page = await apiFetch<ApiRunStep[]>(
+      `/runs/${encodeURIComponent(id)}/steps?after=${lastStepNumber}&limit=${PAGE_SIZE_STEPS}`,
+    )
+    setExtraPages((prev) => [...prev, page])
+  }
+
+  return {
+    steps: allSteps,
+    status: baseQuery.status,
+    hasMore,
+    loadMore,
+  }
 }

--- a/frontend/src/hooks/useScrollSentinel.ts
+++ b/frontend/src/hooks/useScrollSentinel.ts
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback, type RefObject } from 'react'
 
 export interface ScrollSentinelResult {
-  sentinelRef: RefObject<HTMLDivElement>
+  sentinelRef: RefObject<HTMLDivElement | null>
   showNewPill: boolean
   scrollToBottom: () => void
 }

--- a/frontend/src/hooks/useScrollSentinel.ts
+++ b/frontend/src/hooks/useScrollSentinel.ts
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback, type RefObject } from 'react'
 
 export interface ScrollSentinelResult {
-  sentinelRef: RefObject<HTMLDivElement | null>
+  sentinelRef: RefObject<HTMLDivElement>
   showNewPill: boolean
   scrollToBottom: () => void
 }

--- a/frontend/src/pages/RunDetailPage.module.css
+++ b/frontend/src/pages/RunDetailPage.module.css
@@ -88,6 +88,23 @@
   color: var(--text-primary);
 }
 
+/* loadOlderBtn sits above the timeline and loads server-side older pages. */
+.loadOlderBtn {
+  align-self: center;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--text-second);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-mid);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+.loadOlderBtn:hover {
+  color: var(--text-primary);
+}
+
 .sentinel {
   height: 1px;
 }

--- a/frontend/src/pages/RunDetailPage.test.tsx
+++ b/frontend/src/pages/RunDetailPage.test.tsx
@@ -67,6 +67,16 @@ function renderPage(queryClient = makeQueryClient()) {
   )
 }
 
+// mockRunSteps builds a UseRunStepsResult-compatible mock return value.
+function mockRunStepsReturn(steps: ApiRunStep[], status: 'pending' | 'error' | 'success' = 'success') {
+  return {
+    steps,
+    status,
+    hasMore: false,
+    loadMore: vi.fn().mockResolvedValue(undefined),
+  } as ReturnType<typeof useRunSteps>
+}
+
 function mockError() {
   vi.mocked(useRun).mockReturnValue({
     data: undefined,
@@ -75,11 +85,7 @@ function mockError() {
     refetch: vi.fn(),
   } as unknown as ReturnType<typeof useRun>)
 
-  vi.mocked(useRunSteps).mockReturnValue({
-    data: undefined,
-    status: 'error',
-    error: new ApiError(404, 'Not Found'),
-  } as unknown as ReturnType<typeof useRunSteps>)
+  vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn([], 'error'))
 }
 
 function mockServerError() {
@@ -90,11 +96,7 @@ function mockServerError() {
     refetch: vi.fn(),
   } as unknown as ReturnType<typeof useRun>)
 
-  vi.mocked(useRunSteps).mockReturnValue({
-    data: undefined,
-    status: 'error',
-    error: new ApiError(500, 'Internal Server Error'),
-  } as unknown as ReturnType<typeof useRunSteps>)
+  vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn([], 'error'))
 }
 
 function mockSuccessNoData() {
@@ -104,10 +106,7 @@ function mockSuccessNoData() {
     refetch: vi.fn(),
   } as unknown as ReturnType<typeof useRun>)
 
-  vi.mocked(useRunSteps).mockReturnValue({
-    data: [],
-    status: 'success',
-  } as unknown as ReturnType<typeof useRunSteps>)
+  vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn([]))
 }
 
 function mockPending() {
@@ -116,10 +115,7 @@ function mockPending() {
     status: 'pending',
   } as ReturnType<typeof useRun>)
 
-  vi.mocked(useRunSteps).mockReturnValue({
-    data: undefined,
-    status: 'pending',
-  } as ReturnType<typeof useRunSteps>)
+  vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn([], 'pending'))
 }
 
 function mockLoaded(run: ApiRun, steps: ApiRunStep[] = []) {
@@ -128,10 +124,7 @@ function mockLoaded(run: ApiRun, steps: ApiRunStep[] = []) {
     status: 'success',
   } as ReturnType<typeof useRun>)
 
-  vi.mocked(useRunSteps).mockReturnValue({
-    data: steps,
-    status: 'success',
-  } as ReturnType<typeof useRunSteps>)
+  vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn(steps))
 }
 
 // --- Tests ---
@@ -570,6 +563,73 @@ describe('RunDetailPage — Load more', () => {
   })
 })
 
+describe('RunDetailPage — server-side Load more steps', () => {
+  it('shows "Load more steps" button when hasMore is true and hides it when loadMore is called', async () => {
+    // Simulate a first server page of 500 steps with more available.
+    const firstPage: ApiRunStep[] = Array.from({ length: 500 }, (_, i) =>
+      makeStep({
+        id: `s${i}`,
+        step_number: i,
+        type: 'thought',
+        content: JSON.stringify({ text: `Thought ${i}` }),
+      }),
+    )
+    const extraPage: ApiRunStep[] = Array.from({ length: 10 }, (_, i) =>
+      makeStep({
+        id: `extra${i}`,
+        step_number: 500 + i,
+        type: 'thought',
+        content: JSON.stringify({ text: `Extra ${i}` }),
+      }),
+    )
+
+    const loadMoreFn = vi.fn().mockImplementation(async () => {
+      // Simulate appending the extra page by updating the mock.
+      vi.mocked(useRunSteps).mockReturnValue({
+        steps: [...firstPage, ...extraPage],
+        status: 'success',
+        hasMore: false,
+        loadMore: vi.fn().mockResolvedValue(undefined),
+      })
+    })
+
+    vi.mocked(useRun).mockReturnValue({
+      data: makeRun(),
+      status: 'success',
+    } as ReturnType<typeof useRun>)
+
+    vi.mocked(useRunSteps).mockReturnValue({
+      steps: firstPage,
+      status: 'success',
+      hasMore: true,
+      loadMore: loadMoreFn,
+    })
+
+    const { rerender } = renderPage()
+
+    // "Load more steps" button must be present (server-side pagination).
+    expect(screen.getByRole('button', { name: /load more steps/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /load more steps/i }))
+    expect(loadMoreFn).toHaveBeenCalledOnce()
+
+    // Re-render with the updated mock (simulates loadMore completing).
+    rerender(
+      <QueryClientProvider client={makeQueryClient()}>
+        <MemoryRouter initialEntries={['/runs/r1']}>
+          <Routes>
+            <Route path="/runs/:id" element={<RunDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /load more steps/i })).not.toBeInTheDocument()
+    })
+  })
+})
+
 describe('RunDetailPage — pagination with active filter', () => {
   it('shows Load More when >50 steps match the active filter and loads remaining on click', async () => {
     // 55 tool_call steps + 10 thought steps
@@ -752,10 +812,7 @@ describe('RunDetailPage — "New steps" pill', () => {
       status: 'success',
     } as ReturnType<typeof useRun>)
 
-    vi.mocked(useRunSteps).mockReturnValue({
-      data: initialSteps,
-      status: 'success',
-    } as ReturnType<typeof useRunSteps>)
+    vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn(initialSteps))
 
     // Mock IntersectionObserver with a proper constructor function
     let observerCallback: IntersectionObserverCallback | null = null
@@ -787,10 +844,7 @@ describe('RunDetailPage — "New steps" pill', () => {
       makeStep({ id: 's2', step_number: 1, type: 'thought', content: JSON.stringify({ text: 'New step' }) }),
     ]
 
-    vi.mocked(useRunSteps).mockReturnValue({
-      data: newSteps,
-      status: 'success',
-    } as ReturnType<typeof useRunSteps>)
+    vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn(newSteps))
 
     rerender(
       <QueryClientProvider client={qc}>
@@ -822,10 +876,7 @@ describe('RunDetailPage — "New steps" pill', () => {
       status: 'success',
     } as ReturnType<typeof useRun>)
 
-    vi.mocked(useRunSteps).mockReturnValue({
-      data: initialSteps,
-      status: 'success',
-    } as ReturnType<typeof useRunSteps>)
+    vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn(initialSteps))
 
     // scrollIntoView is not implemented in jsdom; stub it to avoid TypeError
     window.HTMLElement.prototype.scrollIntoView = vi.fn()
@@ -855,10 +906,7 @@ describe('RunDetailPage — "New steps" pill', () => {
       makeStep({ id: 's2', step_number: 1, type: 'thought', content: JSON.stringify({ text: 'New step' }) }),
     ]
 
-    vi.mocked(useRunSteps).mockReturnValue({
-      data: newSteps,
-      status: 'success',
-    } as ReturnType<typeof useRunSteps>)
+    vi.mocked(useRunSteps).mockReturnValue(mockRunStepsReturn(newSteps))
 
     rerender(
       <QueryClientProvider client={qc}>

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -28,7 +28,12 @@ export default function RunDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { data: run, status: runStatus, error: runErrorObj, refetch: runRefetch } = useRun(id)
-  const { data: rawSteps = [], status: stepsStatus } = useRunSteps(id)
+  const {
+    steps: rawSteps = [],
+    status: stepsStatus,
+    hasMore: hasOlderSteps,
+    loadMore: loadOlderSteps,
+  } = useRunSteps(id)
 
   usePageTitle(runStatus === 'error' ? 'Run not found' : (id ? `Run ${id.slice(0, 8)}` : 'Run'))
   const [filter, setFilter] = useState<FilterKey>('all')
@@ -160,6 +165,16 @@ export default function RunDetailPage() {
               <FilterBar active={filter} counts={counts} onChange={setFilter} />
 
               <div className={styles.timeline}>
+                {hasOlderSteps && (
+                  <button
+                    type="button"
+                    className={styles.loadOlderBtn}
+                    onClick={() => { void loadOlderSteps() }}
+                  >
+                    Load more steps
+                  </button>
+                )}
+
                 <StepTimeline items={timelineItems} systemPrompt={run.system_prompt} runId={id!} runStatus={run.status} triggerType={run.trigger_type} triggerPayload={run.trigger_payload} durationMs={duration} />
 
                 {hasMore && (

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/rapp992/gleipnir/internal/timeout"
 )
 
+// listAll is the sentinel page-size used by tests that want every step for a
+// run. The agent tests pre-date cursor pagination (ListRunSteps gained
+// After/Limit params) and assert on the full step list.
+const listAll = int64(10_000)
+
 // makeToolCallServer starts an httptest.Server that responds to tools/call
 // JSON-RPC requests with the given content payload and isError flag.
 func makeToolCallServer(t *testing.T, content json.RawMessage, isError bool) *httptest.Server {
@@ -313,7 +318,7 @@ func TestHandleToolCall(t *testing.T) {
 			// matches the spec: tool_call must have "tool_name" and "server_id";
 			// tool_result must have "tool_name" and "is_error".
 			if tc.name == "successful_call" {
-				steps, err := s.ListRunSteps(context.Background(), "run1")
+				steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 				if err != nil {
 					t.Fatalf("ListRunSteps: %v", err)
 				}
@@ -389,7 +394,7 @@ func TestRun_SingleTurnEndTurn(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -456,7 +461,7 @@ func TestRun_ToolCallLoop(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -566,7 +571,7 @@ func TestRun_MissingCapabilityFailsFast(t *testing.T) {
 	}
 
 	// An error step with code missing_capability and the tool name in the message must exist.
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -612,7 +617,7 @@ func TestRun_ToolNotFound(t *testing.T) {
 		t.Fatal("expected error for tool not found, got nil")
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -681,7 +686,7 @@ func TestRun_TokenBudgetExceeded(t *testing.T) {
 		t.Fatal("expected token budget error, got nil")
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -727,7 +732,7 @@ func TestRun_CapabilitySnapshotFirst(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -796,7 +801,7 @@ func TestHandleToolCall_SchemaValidation(t *testing.T) {
 		t.Errorf("MCP server called %d times; want 0 (schema violation blocks execution)", serverCallCount)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -865,7 +870,7 @@ func TestHandleToolCall_ApprovalRejected(t *testing.T) {
 		t.Errorf("MCP server called %d times; want 0 (rejection blocks execution)", serverCallCount)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -958,7 +963,7 @@ func TestRun_ToolCallCapExceeded(t *testing.T) {
 		t.Errorf("MCP server called %d times, want 1", mcpCallCount)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -1021,7 +1026,7 @@ func TestRun_LimitsNotExceeded(t *testing.T) {
 		t.Fatalf("Run returned unexpected error: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -1037,7 +1042,7 @@ func TestRun_Cancellation(t *testing.T) {
 	// and message "run cancelled" exists in the audit trail for the given run.
 	assertCancelledStep := func(t *testing.T, s *db.Store, runID string) {
 		t.Helper()
-		steps, err := s.ListRunSteps(context.Background(), runID)
+		steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: runID, After: -1, Limit: listAll})
 		if err != nil {
 			t.Fatalf("ListRunSteps: %v", err)
 		}
@@ -1677,7 +1682,7 @@ func TestRunAPILoop_EndTurn(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, dbErr := s.ListRunSteps(context.Background(), "r1")
+	steps, dbErr := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if dbErr != nil {
 		t.Fatalf("ListRunSteps: %v", dbErr)
 	}
@@ -1715,7 +1720,7 @@ func TestLogAuditError(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	steps, dbErr := s.ListRunSteps(context.Background(), "run1")
+	steps, dbErr := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if dbErr != nil {
 		t.Fatalf("ListRunSteps: %v", dbErr)
 	}
@@ -1779,7 +1784,7 @@ func TestHandleToolCall_AskOperator_Success(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -1889,7 +1894,7 @@ func TestHandleToolCall_AskOperator_NotAvailableWhenDisabled(t *testing.T) {
 	}
 
 	// At least one error step must exist.
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -1954,7 +1959,7 @@ func TestHandleToolCall_AskOperator_ReasonRequired(t *testing.T) {
 	}
 
 	// An error step with schema_violation code must exist.
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -2109,7 +2114,7 @@ func TestRun_feedback_timeout(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -2151,7 +2156,7 @@ func TestCapabilitySnapshot_IncludesAskOperator(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -2251,7 +2256,7 @@ func countErrorStepsForRun(t *testing.T, s *db.Store, runID string) int {
 		t.Fatalf("CountRunSteps %s: %v", runID, err)
 	}
 	// CountRunSteps returns all steps; we need only error steps.
-	steps, err := s.ListRunSteps(context.Background(), runID)
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: runID, After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps %s: %v", runID, err)
 	}
@@ -2685,7 +2690,7 @@ func TestRun_ThinkingTokensIncludedInCost(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -2789,7 +2794,7 @@ func TestRun_MCPTransportError_BecomesToolResult(t *testing.T) {
 		t.Errorf("MCP tools/call count = %d, want 1", callCount)
 	}
 
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}

--- a/internal/agent/approval_test.go
+++ b/internal/agent/approval_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rapp992/gleipnir/internal/db"
 	"github.com/rapp992/gleipnir/internal/mcp"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/testutil"
@@ -65,7 +66,7 @@ func TestApprovalHandler_Wait_Approved(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestApprovalHandler_Wait_Rejected(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -149,7 +150,7 @@ func TestApprovalHandler_Wait_Timeout_HandlerWins(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -232,7 +233,7 @@ func TestApprovalHandler_Wait_Timeout_ScannerWins(t *testing.T) {
 	}
 
 	// Exactly one error step (written by the scanner, not by the handler).
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}

--- a/internal/agent/audit_test.go
+++ b/internal/agent/audit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rapp992/gleipnir/internal/db"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/testutil"
 )
@@ -55,7 +56,7 @@ func TestAuditWriter_ConcurrentEnqueue(t *testing.T) {
 	}
 
 	// Verify step_numbers are unique and span 0..999
-	steps, err := s.ListRunSteps(context.Background(), "r1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -206,7 +207,7 @@ func TestAuditWriter_MultipleRuns(t *testing.T) {
 		}
 
 		// step_numbers must be 0..N-1 with no gaps for each run.
-		steps, err := s.ListRunSteps(context.Background(), runID)
+		steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: runID, After: -1, Limit: listAll})
 		if err != nil {
 			t.Fatalf("ListRunSteps(%s): %v", runID, err)
 		}

--- a/internal/agent/cross_provider_test.go
+++ b/internal/agent/cross_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rapp992/gleipnir/internal/db"
 	"github.com/rapp992/gleipnir/internal/llm"
 	"github.com/rapp992/gleipnir/internal/llm/anthropic"
 	googlellm "github.com/rapp992/gleipnir/internal/llm/google"
@@ -67,7 +68,7 @@ func TestCrossProvider_StructuralParity(t *testing.T) {
 				t.Fatalf("Run: %v", err)
 			}
 
-			steps, err := s.ListRunSteps(context.Background(), "r1")
+			steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 			if err != nil {
 				t.Fatalf("ListRunSteps: %v", err)
 			}
@@ -266,7 +267,7 @@ func TestCrossProvider_MultiToolCallBatching(t *testing.T) {
 				t.Fatalf("Run: %v", err)
 			}
 
-			steps, err := s.ListRunSteps(context.Background(), "r1")
+			steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
 			if err != nil {
 				t.Fatalf("ListRunSteps: %v", err)
 			}

--- a/internal/agent/feedback_test.go
+++ b/internal/agent/feedback_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rapp992/gleipnir/internal/db"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/testutil"
 	"github.com/rapp992/gleipnir/internal/timeout"
@@ -51,7 +52,7 @@ func TestFeedbackHandler_Wait_ResponseReceived(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -101,7 +102,7 @@ func TestFeedbackHandler_Wait_Timeout_HandlerWins(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -187,7 +188,7 @@ func TestFeedbackHandler_Wait_Timeout_ScannerWins(t *testing.T) {
 	}
 
 	// Exactly one error step (written by the scanner, not by the handler).
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -260,7 +261,7 @@ func TestFeedbackHandler_HandleAskOperator_FeedbackDisabled(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -305,7 +306,7 @@ func TestFeedbackHandler_HandleAskOperator_MissingReason(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	steps, err := s.ListRunSteps(context.Background(), "run1")
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}

--- a/internal/db/queries/run_steps.sql
+++ b/internal/db/queries/run_steps.sql
@@ -4,7 +4,11 @@ VALUES (:id, :run_id, :step_number, :type, :content, :token_cost, :created_at)
 RETURNING *;
 
 -- name: ListRunSteps :many
-SELECT * FROM run_steps WHERE run_id = :run_id ORDER BY step_number ASC;
+SELECT * FROM run_steps
+WHERE run_id = :run_id
+  AND step_number > :after
+ORDER BY step_number ASC
+LIMIT :limit;
 
 -- name: CountRunSteps :one
 SELECT COUNT(*) FROM run_steps WHERE run_id = :run_id;

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -980,7 +980,7 @@ func TestRunStepQueries(t *testing.T) {
 		t.Fatalf("CreateRunStep 3: %v", err)
 	}
 
-	steps, err := s.ListRunSteps(ctx, "run1")
+	steps, err := s.ListRunSteps(ctx, ListRunStepsParams{RunID: "run1", After: -1, Limit: 100})
 	if err != nil {
 		t.Fatalf("ListRunSteps: %v", err)
 	}
@@ -992,6 +992,26 @@ func TestRunStepQueries(t *testing.T) {
 		if step.StepNumber != want {
 			t.Errorf("ListRunSteps[%d].StepNumber = %d, want %d", i, step.StepNumber, want)
 		}
+	}
+
+	// Cursor pagination: after=1 with limit=2 should return steps 2 only (step_number 2).
+	cursorSteps, err := s.ListRunSteps(ctx, ListRunStepsParams{RunID: "run1", After: 1, Limit: 2})
+	if err != nil {
+		t.Fatalf("ListRunSteps cursor: %v", err)
+	}
+	if len(cursorSteps) != 1 {
+		t.Errorf("ListRunSteps cursor: got %d, want 1 (only step_number 2)", len(cursorSteps))
+	} else if cursorSteps[0].StepNumber != 2 {
+		t.Errorf("ListRunSteps cursor: step_number = %d, want 2", cursorSteps[0].StepNumber)
+	}
+
+	// Cursor past the end returns empty.
+	emptySteps, err := s.ListRunSteps(ctx, ListRunStepsParams{RunID: "run1", After: 100, Limit: 100})
+	if err != nil {
+		t.Fatalf("ListRunSteps past end: %v", err)
+	}
+	if len(emptySteps) != 0 {
+		t.Errorf("ListRunSteps past end: got %d, want 0", len(emptySteps))
 	}
 
 	latest, err := s.GetLatestRunStep(ctx, "run1")

--- a/internal/db/run_steps.sql.go
+++ b/internal/db/run_steps.sql.go
@@ -79,11 +79,21 @@ func (q *Queries) GetLatestRunStep(ctx context.Context, runID string) (RunStep, 
 }
 
 const listRunSteps = `-- name: ListRunSteps :many
-SELECT id, run_id, step_number, type, content, token_cost, created_at FROM run_steps WHERE run_id = ?1 ORDER BY step_number ASC
+SELECT id, run_id, step_number, type, content, token_cost, created_at FROM run_steps
+WHERE run_id = ?1
+  AND step_number > ?2
+ORDER BY step_number ASC
+LIMIT ?3
 `
 
-func (q *Queries) ListRunSteps(ctx context.Context, runID string) ([]RunStep, error) {
-	rows, err := q.db.QueryContext(ctx, listRunSteps, runID)
+type ListRunStepsParams struct {
+	RunID string `json:"run_id"`
+	After int64  `json:"after"`
+	Limit int64  `json:"limit"`
+}
+
+func (q *Queries) ListRunSteps(ctx context.Context, arg ListRunStepsParams) ([]RunStep, error) {
+	rows, err := q.db.QueryContext(ctx, listRunSteps, arg.RunID, arg.After, arg.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/run/runs_handler.go
+++ b/internal/run/runs_handler.go
@@ -272,10 +272,46 @@ func (h *RunsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, summary)
 }
 
+// defaultStepsLimit is the number of steps returned when the client does not
+// specify a limit. It keeps the initial page fast while covering most runs.
+const defaultStepsLimit = int64(500)
+
+// maxStepsLimit caps the limit a client may request in a single call. This
+// prevents a single request from pulling an arbitrarily large result set.
+const maxStepsLimit = int64(1000)
+
 // ListSteps handles GET /api/v1/runs/{runID}/steps.
+// Query params:
+//   - after  — step_number cursor (exclusive); any value < 0 means "from the beginning". Default: -1.
+//   - limit  — max steps to return; clamped to [1, 1000]. Default: 500.
 func (h *RunsHandler) ListSteps(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	runID := chi.URLParam(r, "runID")
+
+	q := r.URL.Query()
+
+	// Parse the cursor. Any absent, unparsable, or negative value defaults to -1
+	// (from beginning), matching the sentinel used in the SQL query.
+	after := int64(-1)
+	if v := q.Get("after"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
+			after = n
+		}
+	}
+
+	// Parse and clamp limit.
+	limit := defaultStepsLimit
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			limit = n
+		}
+	}
+	if limit < 1 {
+		limit = defaultStepsLimit
+	}
+	if limit > maxStepsLimit {
+		limit = maxStepsLimit
+	}
 
 	// Guard: ListRunSteps returns an empty slice for a nonexistent run, so we
 	// need a separate existence check to distinguish "no steps" from "no run".
@@ -289,7 +325,11 @@ func (h *RunsHandler) ListSteps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	steps, err := h.store.ListRunSteps(ctx, runID)
+	steps, err := h.store.ListRunSteps(ctx, db.ListRunStepsParams{
+		RunID: runID,
+		After: after,
+		Limit: limit,
+	})
 	if err != nil {
 		slog.Error("ListRunSteps query failed", "run_id", runID, "err", err)
 		httputil.WriteError(w, http.StatusInternalServerError, "internal server error", "")

--- a/internal/run/runs_handler_test.go
+++ b/internal/run/runs_handler_test.go
@@ -766,6 +766,151 @@ func TestRunsHandler_ListSteps(t *testing.T) {
 	}
 }
 
+// decodeStepEnvelope decodes the JSON response from ListSteps.
+func decodeStepEnvelope(t *testing.T, body *strings.Reader) []run.StepSummary {
+	t.Helper()
+	var env struct {
+		Data []run.StepSummary `json:"data"`
+	}
+	if err := json.NewDecoder(body).Decode(&env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return env.Data
+}
+
+func TestRunsHandler_ListSteps_Pagination(t *testing.T) {
+	type paginationCase struct {
+		name      string
+		setup     func(t *testing.T, store *db.Store)
+		runID     string
+		query     string
+		wantCode  int
+		wantCount int
+		checkFn   func(t *testing.T, steps []run.StepSummary)
+	}
+
+	insertNSteps := func(t *testing.T, store *db.Store, runID string, n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			insertTestStep(t, store, fmt.Sprintf("%s-step-%d", runID, i), runID, int64(i))
+		}
+	}
+
+	cases := []paginationCase{
+		{
+			name: "limit caps page size",
+			setup: func(t *testing.T, store *db.Store) {
+				testutil.InsertPolicy(t, store, "p-lim", "policy-p-lim", "webhook", testutil.MinimalWebhookPolicy)
+				testutil.InsertRun(t, store, "r-lim", "p-lim", model.RunStatusComplete)
+				insertNSteps(t, store, "r-lim", 5)
+			},
+			runID:     "r-lim",
+			query:     "?limit=2",
+			wantCode:  http.StatusOK,
+			wantCount: 2,
+			checkFn: func(t *testing.T, steps []run.StepSummary) {
+				// First page should start from step_number 0.
+				if steps[0].StepNumber != 0 {
+					t.Errorf("steps[0].StepNumber = %d, want 0", steps[0].StepNumber)
+				}
+				if steps[1].StepNumber != 1 {
+					t.Errorf("steps[1].StepNumber = %d, want 1", steps[1].StepNumber)
+				}
+			},
+		},
+		{
+			name: "after cursor returns next page",
+			setup: func(t *testing.T, store *db.Store) {
+				testutil.InsertPolicy(t, store, "p-cur", "policy-p-cur", "webhook", testutil.MinimalWebhookPolicy)
+				testutil.InsertRun(t, store, "r-cur", "p-cur", model.RunStatusComplete)
+				insertNSteps(t, store, "r-cur", 5)
+			},
+			runID:     "r-cur",
+			query:     "?after=1&limit=2",
+			wantCode:  http.StatusOK,
+			wantCount: 2,
+			checkFn: func(t *testing.T, steps []run.StepSummary) {
+				if steps[0].StepNumber != 2 {
+					t.Errorf("steps[0].StepNumber = %d, want 2", steps[0].StepNumber)
+				}
+				if steps[1].StepNumber != 3 {
+					t.Errorf("steps[1].StepNumber = %d, want 3", steps[1].StepNumber)
+				}
+			},
+		},
+		{
+			name: "after past end returns empty",
+			setup: func(t *testing.T, store *db.Store) {
+				testutil.InsertPolicy(t, store, "p-past", "policy-p-past", "webhook", testutil.MinimalWebhookPolicy)
+				testutil.InsertRun(t, store, "r-past", "p-past", model.RunStatusComplete)
+				insertNSteps(t, store, "r-past", 3)
+			},
+			runID:     "r-past",
+			query:     "?after=10",
+			wantCode:  http.StatusOK,
+			wantCount: 0,
+		},
+		{
+			name: "invalid limit falls back to default",
+			setup: func(t *testing.T, store *db.Store) {
+				testutil.InsertPolicy(t, store, "p-inv", "policy-p-inv", "webhook", testutil.MinimalWebhookPolicy)
+				testutil.InsertRun(t, store, "r-inv", "p-inv", model.RunStatusComplete)
+				insertNSteps(t, store, "r-inv", 3)
+			},
+			runID:    "r-inv",
+			query:    "?limit=abc",
+			wantCode: http.StatusOK,
+			// Default limit (500) covers all 3 inserted steps.
+			wantCount: 3,
+		},
+		{
+			name: "limit clamped to max 1000",
+			setup: func(t *testing.T, store *db.Store) {
+				testutil.InsertPolicy(t, store, "p-clamp", "policy-p-clamp", "webhook", testutil.MinimalWebhookPolicy)
+				testutil.InsertRun(t, store, "r-clamp", "p-clamp", model.RunStatusComplete)
+				// 5 steps is well under 1000 so this verifies the cap doesn't
+				// prevent returning real data; a higher-volume test lives in stress_test.go.
+				insertNSteps(t, store, "r-clamp", 5)
+			},
+			runID:     "r-clamp",
+			query:     "?limit=5000",
+			wantCode:  http.StatusOK,
+			wantCount: 5,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := testutil.NewTestStore(t)
+			if tc.setup != nil {
+				tc.setup(t, store)
+			}
+
+			h := run.NewRunsHandler(store, run.NewRunManager(), nil)
+			router := newRunsRouter(h)
+
+			url := "/api/v1/runs/" + tc.runID + "/steps" + tc.query
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, tc.wantCode, w.Body.String())
+			}
+
+			if tc.wantCode == http.StatusOK {
+				steps := decodeStepEnvelope(t, strings.NewReader(w.Body.String()))
+				if len(steps) != tc.wantCount {
+					t.Errorf("len(steps) = %d, want %d", len(steps), tc.wantCount)
+				}
+				if tc.checkFn != nil {
+					tc.checkFn(t, steps)
+				}
+			}
+		})
+	}
+}
+
 func TestRunsHandler_Cancel(t *testing.T) {
 	type cancelSuccessBody struct {
 		Data map[string]string `json:"data"`

--- a/internal/run/stress_test.go
+++ b/internal/run/stress_test.go
@@ -1,0 +1,116 @@
+package run_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/model"
+	"github.com/rapp992/gleipnir/internal/run"
+	"github.com/rapp992/gleipnir/internal/testutil"
+)
+
+// TestListSteps_10kStress seeds a run with 10k steps and verifies that the
+// paginated endpoint responds quickly and that walking all pages produces
+// exactly 10k steps in strictly ascending order.
+//
+// Skip in -short mode: this test does real DB I/O and takes several seconds.
+func TestListSteps_10kStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test: skipping in -short mode")
+	}
+
+	const totalSteps = 10_000
+	const pageSize = 500 // matches defaultStepsLimit in runs_handler.go
+
+	store := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, store, "p-stress", "policy-stress", "webhook", testutil.MinimalWebhookPolicy)
+	testutil.InsertRun(t, store, "r-stress", "p-stress", model.RunStatusComplete)
+
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	for i := 0; i < totalSteps; i++ {
+		_, err := store.CreateRunStep(ctx, db.CreateRunStepParams{
+			ID:         fmt.Sprintf("step-%d", i),
+			RunID:      "r-stress",
+			StepNumber: int64(i),
+			Type:       "thought",
+			Content:    `{}`,
+			TokenCost:  0,
+			CreatedAt:  now,
+		})
+		if err != nil {
+			t.Fatalf("CreateRunStep %d: %v", i, err)
+		}
+	}
+
+	h := run.NewRunsHandler(store, run.NewRunManager(), nil)
+	router := newRunsRouter(h)
+
+	// First-page latency check: the default limit of 500 must respond in < 500ms.
+	firstPageStart := time.Now()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/r-stress/steps", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	elapsed := time.Since(firstPageStart)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("first page: status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("first page took %s, want < 500ms", elapsed)
+	}
+
+	// Walk every page and assert ordering + total count.
+	var (
+		seenTotal int64
+		lastSeen  int64 = -1
+		walkStart       = time.Now()
+	)
+
+	for {
+		url := fmt.Sprintf("/api/v1/runs/r-stress/steps?after=%d&limit=%d", lastSeen, pageSize)
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("page walk: status = %d, want 200", w.Code)
+		}
+
+		var env struct {
+			Data []run.StepSummary `json:"data"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+			t.Fatalf("page walk: decode response: %v", err)
+		}
+
+		for _, s := range env.Data {
+			if s.StepNumber <= lastSeen {
+				t.Errorf("step_number not strictly increasing: got %d after %d", s.StepNumber, lastSeen)
+			}
+			lastSeen = s.StepNumber
+		}
+		seenTotal += int64(len(env.Data))
+
+		// Fewer rows than the page limit means we've reached the last page.
+		if len(env.Data) < pageSize {
+			break
+		}
+	}
+
+	if seenTotal != totalSteps {
+		t.Errorf("total steps walked = %d, want %d", seenTotal, totalSteps)
+	}
+
+	walkElapsed := time.Since(walkStart)
+	if walkElapsed > 5*time.Second {
+		t.Errorf("full walk took %s, want < 5s", walkElapsed)
+	}
+}


### PR DESCRIPTION
Closes #58

## Summary

- **SQL:** Replaced the unbounded `ListRunSteps` query with a cursor-paginated variant (`step_number > :after ORDER BY step_number ASC LIMIT :limit`). Regenerated via `sqlc generate`.
- **API:** `GET /api/v1/runs/:id/steps` now accepts `?after=<step_number>&limit=<n>`. Default page size: 500. Hard cap: 1000. Missing/invalid params fall back to defaults.
- **Frontend:** `useRunSteps` hook now returns `{ steps, status, hasMore, loadMore }`. Initial page loads on mount; "Load more steps" button appears when `hasMore` is true. On any query invalidation (SSE or mutation), extra pages reset — consistent, no silent data drift.
- **Stress test:** `TestListSteps_10kStress` seeds 10k steps, asserts first-page response < 500ms and full cursor walk < 5s. Skipped under `-short`.

## Behaviour changes (API consumers)

1. Response is still `[]StepSummary`, but now capped at 500 per request by default (previously unbounded). Callers that relied on a single request returning every step must now follow the cursor using the `after` param.
2. Run header `toolCallCount` / `tokenTotal` reflect only loaded pages, not the full run total. Server-side aggregates are out of scope for this issue — tracked as a follow-up.
3. Approval / feedback mutations invalidate the step cache, resetting any previously loaded older pages. Users click "Load more steps" again after approving/submitting feedback.

## Architecture plan

<details>
<summary>Implementation plan</summary>

Cursor `after` (exclusive) on `step_number` was chosen over `OFFSET` because `step_number` is monotonically increasing and unique per run — stable under concurrent appends. Default 500 / cap 1000 keeps the initial page under the frontend's existing 50-per-view client-side pagination without extra round-trips. Response shape unchanged; client infers "more available" from `len(page) == limit`.

The hook uses `useQuery` + manual `extraPages` state rather than `useInfiniteQuery` because SSE `run.step_added` events invalidate `queryKeys.runs.steps(id)` — `useInfiniteQuery` would force a refetch of every loaded page on every new step, defeating the purpose.

`const listAll = int64(10_000)` is defined once in `agent_test.go` (all five migrated files share `package agent`) to avoid compile-time redeclaration.

</details>

## Review cycles

2 cycles. Cycle 1 flagged two untracked new files (handled at commit time) and confirmed the `useScrollSentinel.ts` type correction was TypeScript-required.

## CLAUDE.md

No updates needed — no new packages, routes, env vars, or domain types added.

---

*Generated by the agentic dev loop.*