### PR TITLE
feat: reduce visual weight of ADMIN sidebar section label

### DIFF
--- a/frontend/src/components/Layout/Layout.module.css
+++ b/frontend/src/components/Layout/Layout.module.css
@@ -253,9 +253,9 @@
 }
 
 .navSectionLabel {
-  font-size: 10px;
-  font-weight: var(--weight-semibold);
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-normal);
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--text-muted);
 }


### PR DESCRIPTION
Closes #50

## Summary

- Changed `.navSectionLabel` in `Layout.module.css` to reduce the visual weight of the ADMIN sidebar section divider
- Font size: `10px` → `var(--text-xs)` (11px, uses existing design token)
- Font weight: `var(--weight-semibold)` → `var(--weight-normal)` (removes heading-like emphasis)
- Letter spacing: `0.08em` → `0.04em` (keeps minor tracking for all-caps legibility while reducing prominence)
- Color: kept as `var(--text-muted)` — see deviation note below

## Architecture plan

<details>
<summary>Implementation plan</summary>

Pure CSS change to `frontend/src/components/Layout/Layout.module.css`:
- Target selector: `.navSectionLabel` (lines 255–261)
- Replace bare `10px` with `var(--text-xs)` design token
- Reduce font weight from semibold to normal
- Halve letter spacing from `0.08em` to `0.04em`
- No changes to `Layout.tsx`, tests, or Storybook stories needed

</details>

## Notable deviation

The plan called for switching color to `var(--text-faint)`, but this was intentionally kept as `var(--text-muted)`. In the dark theme, `--text-faint` resolves to `#3a4840` against a sidebar background of `#141a16` — near-zero contrast that would make the label effectively invisible. The reduced font weight and letter spacing accomplish the intended visual recession while `--text-muted` keeps the label legible in both themes.

## Review cycles

1 review cycle — APPROVED on first pass.

## CLAUDE.md

No documentation updates needed — pure CSS styling change to an existing component.

---

*Generated by the agentic dev loop.*