### PR TITLE
fix: add drop counter and increase SSE buffers for observability

### DIFF
--- a/docs/ADR_Tracker.md
+++ b/docs/ADR_Tracker.md
@@ -272,6 +272,29 @@ fails). An idle watchdog aborts and reconnects the stream if no bytes (including
 on mobile / VPN paths. This addendum does not supersede ADR-016; it documents the
 client-side contract the Go handler already implements.
 
+**Addendum (2026-04): Drop observability and buffer sizing**
+
+When a subscriber's per-client channel buffer is full, the broadcaster drops the event for
+that subscriber rather than blocking delivery to all other subscribers. This is a hard
+guarantee, not a best-effort hint. The new counter `gleipnir_sse_events_dropped_total`
+(no labels, matching the unlabelled style of `gleipnir_approval_timeouts_total`) is the
+production signal for undersized buffers. A sustained non-zero rate means clients are
+receiving events faster than they can drain their channel and the defaults should be raised.
+
+The documented recovery path for a client that missed events is automatic. On reconnect the
+frontend sends `Last-Event-ID` and the server's `Replay` method returns every buffered event
+with a higher id. Per-route REST queries (`useRuns`, `useRunDetail`, `useRunSteps`, etc.)
+invalidate on each SSE event via TanStack Query and act as a reconciliation layer when the
+replay window is exceeded — the UI re-fetches current state and converges even if some events
+were dropped and the ring buffer has already overwritten them.
+
+Default buffer sizes were raised to 256 per-subscriber and 2048 ring (from 64 and 512
+respectively). The original defaults were chosen before per-step event streaming; under load
+they dropped too readily. These are code defaults, not env vars, to keep the operational
+surface small. `WithChannelSize` and `WithRingSize` remain the escape hatch for tests and
+future tuning without adding `GLEIPNIR_SSE_*` environment variables that have no concrete
+per-deployment need today.
+
 ---
 
 ## ADR-017: Policy-level parameter scoping for MCP tools

--- a/internal/sse/broadcaster.go
+++ b/internal/sse/broadcaster.go
@@ -2,6 +2,8 @@
 // It fans out published events to all connected subscribers using buffered channels.
 // Slow clients whose buffers fill up receive dropped events rather than blocking delivery
 // to other subscribers. A fixed ring buffer enables Last-Event-ID reconnection replay.
+// Dropped deliveries are counted by gleipnir_sse_events_dropped_total so operators
+// can detect undersized buffers.
 //
 // The EventBroadcaster interface is the seam for swapping in a distributed backend
 // (Redis Pub/Sub, NATS) when horizontal scaling is needed — callers depend on the
@@ -42,8 +44,8 @@ type Subscription struct {
 type Option func(*Broadcaster)
 
 // WithChannelSize sets the per-subscription channel depth.
-// The default is 64. Events published to a full channel are dropped silently
-// rather than blocking delivery to other subscribers.
+// The default is 256. Events published to a full channel are dropped and counted by
+// gleipnir_sse_events_dropped_total rather than blocking delivery to other subscribers.
 func WithChannelSize(n int) Option {
 	return func(b *Broadcaster) {
 		b.channelSize = n
@@ -51,7 +53,7 @@ func WithChannelSize(n int) Option {
 }
 
 // WithRingSize sets the capacity of the replay ring buffer.
-// The default is 512. Once full, the oldest event is overwritten.
+// The default is 2048. Once full, the oldest event is overwritten.
 func WithRingSize(n int) Option {
 	return func(b *Broadcaster) {
 		b.ringSize = n
@@ -79,8 +81,8 @@ var _ EventBroadcaster = (*Broadcaster)(nil)
 func NewBroadcaster(opts ...Option) *Broadcaster {
 	b := &Broadcaster{
 		subs:        make(map[uint64]*Subscription),
-		channelSize: 64,
-		ringSize:    512,
+		channelSize: 256,
+		ringSize:    2048,
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -147,7 +149,11 @@ func (b *Broadcaster) Publish(eventType string, data json.RawMessage) {
 		select {
 		case sub.ch <- ev:
 		default:
-			// Drop the event for this slow subscriber rather than blocking.
+			// Drop the event for this slow subscriber rather than blocking
+			// delivery to other subscribers. The counter is the observability
+			// hook; clients recover via Last-Event-ID replay on reconnect
+			// (see Replay and the useSSE hook on the frontend).
+			sseEventsDroppedTotal.Inc()
 		}
 	}
 }

--- a/internal/sse/broadcaster_test.go
+++ b/internal/sse/broadcaster_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func rawJSON(s string) json.RawMessage {
@@ -253,4 +255,53 @@ func TestBroadcaster_ConcurrentSubscribeUnsubscribe(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestBroadcaster_DropIncrementsCounter verifies that dropped events (subscriber
+// channel full) increment gleipnir_sse_events_dropped_total. Delta assertions are
+// used because the counter persists across tests in the same binary.
+func TestBroadcaster_DropIncrementsCounter(t *testing.T) {
+	b := NewBroadcaster(WithChannelSize(2))
+	sub := b.Subscribe()
+	defer b.Unsubscribe(sub)
+
+	before := promtestutil.ToFloat64(sseEventsDroppedTotal)
+
+	// Publish 5 events to a channel of depth 2; the first 2 are delivered,
+	// the remaining 3 are dropped.
+	const publish = 5
+	for range publish {
+		b.Publish("test", rawJSON(`{}`))
+	}
+
+	after := promtestutil.ToFloat64(sseEventsDroppedTotal)
+	if got := after - before; got != 3 {
+		t.Errorf("drop counter delta = %.0f, want 3", got)
+	}
+}
+
+// TestBroadcaster_SuccessfulPublishDoesNotIncrementDropCounter verifies that
+// events delivered without drops do not increment the counter.
+func TestBroadcaster_SuccessfulPublishDoesNotIncrementDropCounter(t *testing.T) {
+	b := NewBroadcaster()
+	sub := b.Subscribe()
+	defer b.Unsubscribe(sub)
+
+	before := promtestutil.ToFloat64(sseEventsDroppedTotal)
+
+	const publish = 3
+	for range publish {
+		b.Publish("test", rawJSON(`{}`))
+	}
+
+	// Drain the channel before asserting zero drops, to confirm all events
+	// were accepted by the subscriber.
+	for range publish {
+		<-sub.C
+	}
+
+	after := promtestutil.ToFloat64(sseEventsDroppedTotal)
+	if got := after - before; got != 0 {
+		t.Errorf("drop counter delta = %.0f, want 0", got)
+	}
 }

--- a/internal/sse/handler_test.go
+++ b/internal/sse/handler_test.go
@@ -299,7 +299,8 @@ func TestHandler_ConnectionsActiveGauge(t *testing.T) {
 // internal/mcp/metrics_test.go:TestMCPMetricFamiliesRegistered.
 func TestSSEMetricFamiliesRegistered(t *testing.T) {
 	want := map[string]bool{
-		"gleipnir_sse_connections_active": false,
+		"gleipnir_sse_connections_active":  false,
+		"gleipnir_sse_events_dropped_total": false,
 	}
 
 	ch := make(chan *prometheus.Desc, 1024)

--- a/internal/sse/metrics.go
+++ b/internal/sse/metrics.go
@@ -12,3 +12,12 @@ var sseConnectionsActive = promauto.With(metrics.Registry()).NewGauge(
 		Help: "Currently-connected SSE subscribers.",
 	},
 )
+
+var sseEventsDroppedTotal = promauto.With(metrics.Registry()).NewCounter(
+	prometheus.CounterOpts{
+		Name: "gleipnir_sse_events_dropped_total",
+		Help: "SSE events dropped because a subscriber's channel buffer was full. " +
+			"Clients recover via Last-Event-ID replay on reconnect; a sustained " +
+			"non-zero rate indicates buffers are undersized for event throughput.",
+	},
+)


### PR DESCRIPTION
Closes #59

## Summary

- **Prometheus counter:** `gleipnir_sse_events_dropped_total` is now incremented every time the broadcaster silently drops an event for a slow subscriber. The drop was previously invisible in production — now it's a Prometheus signal.
- **Buffer size increases:** Per-subscriber channel buffer raised 64→256; ring buffer raised 512→2048. Reduces drop frequency under load without adding env-var configuration complexity (the `WithChannelSize`/`WithRingSize` Option pattern remains the escape hatch for tests and deployments with different needs).
- **Reconnect recovery documented:** `Last-Event-ID` replay + REST state reconciliation via TanStack Query cache invalidation was already fully implemented. An ADR-016 addendum now documents this as the supported recovery path so operators know what to expect on reconnect.

## Architecture plan

<details>
<summary>Implementation plan</summary>

**Tier 1 — Counter (minimum):** `gleipnir_sse_events_dropped_total`, no labels, registered via `promauto.With(metrics.Registry())` in `internal/sse/metrics.go`, matching the `sseConnectionsActive` pattern exactly. Incremented in the `default:` arm of the non-blocking select in `Publish`.

**Tier 2 — Reconnect documentation (better):** Ring-buffer `Replay` and `Last-Event-ID` handler were already fully implemented. ADR-016 addendum documents the recovery path — no code change.

**Tier 3 — Buffer sizes (longer term):** Hardcoded defaults raised; doc comments updated; no env vars added (consistent with project policy that env vars are for per-deployment operational knobs, not internal sizing constants).

</details>

## Review cycles

1 cycle. Approved immediately. One non-blocking comment accuracy fix applied before commit.

## CLAUDE.md

No updates needed — no new packages, routes, env vars, or domain types added.

---

*Generated by the agentic dev loop.*