### PR TITLE
feat: rename 'Approval' filter to 'Needs Approval' and show pending count badge

### DIFF
--- a/frontend/src/pages/RunsPage.test.tsx
+++ b/frontend/src/pages/RunsPage.test.tsx
@@ -6,7 +6,8 @@ import React from 'react'
 
 import RunsPage from './RunsPage'
 import { computePageNumbers } from '@/utils/pagination'
-import type { ApiRun, ApiPolicyListItem, ApiAttentionItem } from '@/api/types'
+import type { ApiRun, ApiPolicyListItem } from '@/api/types'
+import type { AttentionItem } from '@/hooks/useAttentionItems'
 
 // --- Mocks ---
 
@@ -339,7 +340,7 @@ describe('RunsPage — stats subtitle', () => {
 
 // --- Needs Approval chip badge ---
 
-function makeApprovalItem(overrides?: Partial<ApiAttentionItem>): ApiAttentionItem {
+function makeApprovalItem(overrides?: Partial<AttentionItem>): AttentionItem {
   return {
     type: 'approval',
     request_id: 'req-001',
@@ -350,6 +351,7 @@ function makeApprovalItem(overrides?: Partial<ApiAttentionItem>): ApiAttentionIt
     message: 'Approve?',
     expires_at: new Date(Date.now() + 60_000).toISOString(),
     created_at: new Date().toISOString(),
+    sortKey: 0,
     ...overrides,
   }
 }
@@ -381,7 +383,7 @@ describe('RunsPage — Needs Approval chip', () => {
   })
 
   it('excludes feedback and failure items from the badge count', () => {
-    const items: ApiAttentionItem[] = [
+    const items: AttentionItem[] = [
       makeApprovalItem({ request_id: 'req-001' }),
       makeApprovalItem({ request_id: 'req-002' }),
       { ...makeApprovalItem(), type: 'feedback', request_id: 'req-003' },

--- a/frontend/src/pages/RunsPage.test.tsx
+++ b/frontend/src/pages/RunsPage.test.tsx
@@ -1,22 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 
 import RunsPage from './RunsPage'
 import { computePageNumbers } from '@/utils/pagination'
-import type { ApiRun, ApiPolicyListItem } from '@/api/types'
+import type { ApiRun, ApiPolicyListItem, ApiAttentionItem } from '@/api/types'
 
 // --- Mocks ---
 
 vi.mock('@/hooks/queries/runs')
 vi.mock('@/hooks/queries/policies')
+vi.mock('@/hooks/useAttentionItems')
 
 import { useRuns } from '@/hooks/queries/runs'
 import { usePolicies } from '@/hooks/queries/policies'
+import { useAttentionItems } from '@/hooks/useAttentionItems'
 
 // --- Helpers ---
+
+const DEFAULT_ATTENTION_RETURN = {
+  items: [],
+  count: 0,
+  isLoading: false,
+  dismissFailure: vi.fn(),
+}
 
 function makeQueryClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -86,6 +95,8 @@ function mockPending() {
     data: undefined,
     status: 'pending',
   } as ReturnType<typeof usePolicies>)
+
+  vi.mocked(useAttentionItems).mockReturnValue(DEFAULT_ATTENTION_RETURN)
 }
 
 function mockLoaded(runs: ApiRun[], total?: number, policies?: ApiPolicyListItem[]) {
@@ -100,6 +111,8 @@ function mockLoaded(runs: ApiRun[], total?: number, policies?: ApiPolicyListItem
     data: policies ?? [makePolicy()],
     status: 'success',
   } as ReturnType<typeof usePolicies>)
+
+  vi.mocked(useAttentionItems).mockReturnValue(DEFAULT_ATTENTION_RETURN)
 }
 
 function mockError() {
@@ -114,6 +127,8 @@ function mockError() {
     data: undefined,
     status: 'pending',
   } as ReturnType<typeof usePolicies>)
+
+  vi.mocked(useAttentionItems).mockReturnValue(DEFAULT_ATTENTION_RETURN)
 }
 
 // --- Tests ---
@@ -227,7 +242,7 @@ describe('RunsPage — filters', () => {
     expect(screen.getByRole('radio', { name: 'Complete' })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: 'Running' })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: 'Failed' })).toBeInTheDocument()
-    expect(screen.getByRole('radio', { name: 'Approval' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /needs approval/i })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: 'All' })).toHaveAttribute('aria-checked', 'true')
   })
 
@@ -319,6 +334,67 @@ describe('RunsPage — stats subtitle', () => {
     mockLoaded([])
     renderPage()
     expect(screen.queryByText(/\d+ runs?/)).not.toBeInTheDocument()
+  })
+})
+
+// --- Needs Approval chip badge ---
+
+function makeApprovalItem(overrides?: Partial<ApiAttentionItem>): ApiAttentionItem {
+  return {
+    type: 'approval',
+    request_id: 'req-001',
+    run_id: 'run-001',
+    policy_id: 'p1',
+    policy_name: 'My Policy',
+    tool_name: 'some_tool',
+    message: 'Approve?',
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    created_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('RunsPage — Needs Approval chip', () => {
+  it('renders the label without a count badge when there are no pending approvals', () => {
+    // mockLoaded sets the default (empty) attention return, which is what we want here
+    mockLoaded([makeRun()])
+    renderPage()
+
+    const chip = screen.getByRole('radio', { name: /needs approval/i })
+    expect(chip).toBeInTheDocument()
+    // No numeric badge inside the chip
+    expect(within(chip).queryByText(/^\d+$/)).toBeNull()
+  })
+
+  it('shows a badge with the count and updates aria-label when there are 3 pending approvals', () => {
+    const approvalItems = [makeApprovalItem(), makeApprovalItem({ request_id: 'req-002' }), makeApprovalItem({ request_id: 'req-003' })]
+    // Call mockLoaded first (it sets the default attention mock), then override with pending items
+    mockLoaded([makeRun()])
+    vi.mocked(useAttentionItems).mockReturnValue({ items: approvalItems, count: 3, isLoading: false, dismissFailure: vi.fn() })
+    renderPage()
+
+    // aria-label includes the count for screen readers
+    const chip = screen.getByRole('radio', { name: /needs approval, 3 pending/i })
+    expect(chip).toBeInTheDocument()
+    // Visual badge text is present inside the button
+    expect(within(chip).getByText('3')).toBeInTheDocument()
+  })
+
+  it('excludes feedback and failure items from the badge count', () => {
+    const items: ApiAttentionItem[] = [
+      makeApprovalItem({ request_id: 'req-001' }),
+      makeApprovalItem({ request_id: 'req-002' }),
+      { ...makeApprovalItem(), type: 'feedback', request_id: 'req-003' },
+      { ...makeApprovalItem(), type: 'failure', request_id: 'req-004' },
+    ]
+    // Call mockLoaded first (it sets the default attention mock), then override with mixed items
+    mockLoaded([makeRun()])
+    vi.mocked(useAttentionItems).mockReturnValue({ items, count: 4, isLoading: false, dismissFailure: vi.fn() })
+    renderPage()
+
+    // Only the 2 approval items count — badge reads "2", not "4"
+    const chip = screen.getByRole('radio', { name: /needs approval, 2 pending/i })
+    expect(within(chip).getByText('2')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/RunsPage.tsx
+++ b/frontend/src/pages/RunsPage.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useRuns } from '@/hooks/queries/runs'
 import { usePolicies } from '@/hooks/queries/policies'
 import { useRunsFilters } from '@/hooks/useRunsFilters'
+import { useAttentionItems } from '@/hooks/useAttentionItems'
 import { queryKeys } from '@/hooks/queryKeys'
 import { QueryBoundary } from '@/components/QueryBoundary'
 import { StatusBadge } from '@/components/dashboard/StatusBadge'
@@ -23,7 +24,7 @@ const STATUS_FILTERS = [
   { key: 'complete', label: 'Complete' },
   { key: 'running', label: 'Running' },
   { key: 'failed', label: 'Failed' },
-  { key: 'waiting_for_approval', label: 'Approval' },
+  { key: 'waiting_for_approval', label: 'Needs Approval' },
 ] as const
 
 // Date range options for the secondary filter chip
@@ -57,6 +58,8 @@ export default function RunsPage() {
 
   usePageTitle('Run History')
   const { data: policies } = usePolicies()
+  const { items: attentionItems } = useAttentionItems()
+  const pendingApprovalCount = attentionItems.filter(i => i.type === 'approval').length
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
   const firstItem = offset + 1
@@ -86,15 +89,20 @@ export default function RunsPage() {
         <div role="radiogroup" aria-label="Filter by status" className={styles.statusGroup}>
           {STATUS_FILTERS.map(({ key, label }) => {
             const isActive = status === key
+            const showApprovalCount = key === 'waiting_for_approval' && pendingApprovalCount > 0
             return (
               <button
                 key={key}
                 role="radio"
                 aria-checked={isActive}
+                aria-label={showApprovalCount ? `Needs Approval, ${pendingApprovalCount} pending` : undefined}
                 className={isActive ? `${styles.chip} ${styles.chipActive}` : styles.chip}
                 onClick={() => setFilter('status', key)}
               >
                 {label}
+                {showApprovalCount && (
+                  <span className={styles.chipCount} aria-hidden="true">{pendingApprovalCount}</span>
+                )}
               </button>
             )
           })}


### PR DESCRIPTION
Closes #48

## Summary

- Renamed the "Approval" filter chip on the Run History page to "Needs Approval" to communicate that the filter surfaces actionable, time-sensitive runs
- Added a numeric count badge (e.g. `Needs Approval ●3`) to the chip that shows the number of currently pending approval items, sourced from `useAttentionItems` filtered to `type === 'approval'`
- Badge only appears when count > 0; chip label alone renders in the zero state
- Accessible: `aria-hidden` on the visual badge span, `aria-label` override on the button when count > 0 (e.g. "Needs Approval, 3 pending")
- No backend changes; no CSS changes (`.chipCount` class already existed in `RunsPage.module.css`)

<details>
<summary>Architecture plan</summary>

```
IMPLEMENTATION PLAN
===================
Issue: ux: rename 'Approval' filter to 'Needs Approval' and show pending count badge

Summary:
  Rename the "Approval" status filter chip on the Run History page to "Needs Approval"
  and append a numeric count badge that reflects the number of currently pending
  approval attention items (sourced from the existing /api/v1/attention endpoint via
  the useAttentionItems hook, filtered to type === 'approval').

Affected files:
  1. frontend/src/pages/RunsPage.tsx — modify (label rename, badge logic, attention hook)
  2. frontend/src/pages/RunsPage.module.css — no change (chipCount class already exists)
  3. frontend/src/pages/RunsPage.test.tsx — modify (mock useAttentionItems, update label assertion, add 3 new test cases)

Key decisions:
  - Badge count filtered to type === 'approval' only (not all attention items)
  - useAttentionItems chosen over stats endpoint for live SSE-backed updates
  - Reuse pre-existing .chipCount CSS class; no new tokens introduced
  - Badge inside <button role="radio"> preserves click and radiogroup semantics
```

</details>

## Review cycles

1 cycle (approved on first review)

## CLAUDE.md

No updates needed — no new packages, routes, hooks, components, or env vars introduced.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via agentic dev loop