### PR TITLE
feat: add text labels to theme toggle in Settings

### DIFF
--- a/frontend/src/components/ThemeToggle/ThemeToggle.module.css
+++ b/frontend/src/components/ThemeToggle/ThemeToggle.module.css
@@ -8,8 +8,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
   background: none;
   border: none;
   border-radius: 4px;
@@ -30,8 +30,18 @@
   background: var(--bg-elevated);
 }
 
+.toggleLabel {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: 1;
+}
+
 .compactButton {
   composes: toggleButton;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  gap: 0;
 }
 
 .compactButton:hover {

--- a/frontend/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle/ThemeToggle.tsx
@@ -42,6 +42,7 @@ export function ThemeToggle({ compact }: ThemeToggleProps) {
         aria-pressed={theme === 'system'}
       >
         <Monitor size={16} aria-hidden strokeWidth={1.5} />
+        <span className={styles.toggleLabel}>System</span>
       </button>
       <button
         className={theme === 'light' ? `${styles.toggleButton} ${styles.toggleButtonActive}` : styles.toggleButton}
@@ -50,6 +51,7 @@ export function ThemeToggle({ compact }: ThemeToggleProps) {
         aria-pressed={theme === 'light'}
       >
         <Sun size={16} aria-hidden strokeWidth={1.5} />
+        <span className={styles.toggleLabel}>Light</span>
       </button>
       <button
         className={theme === 'dark' ? `${styles.toggleButton} ${styles.toggleButtonActive}` : styles.toggleButton}
@@ -58,6 +60,7 @@ export function ThemeToggle({ compact }: ThemeToggleProps) {
         aria-pressed={theme === 'dark'}
       >
         <Moon size={16} aria-hidden strokeWidth={1.5} />
+        <span className={styles.toggleLabel}>Dark</span>
       </button>
     </div>
   )


### PR DESCRIPTION
Closes #49

## Summary

- Added "System", "Light", and "Dark" text labels beside the icons in the expanded theme toggle (Settings → Appearance)
- Compact variant (used in the sidebar/header) is unchanged — still icon-only
- Labels inherit button text color so active/hover states apply naturally

## Changes

- `frontend/src/components/ThemeToggle/ThemeToggle.tsx` — Added `<span className={styles.toggleLabel}>` for each option in the non-compact branch
- `frontend/src/components/ThemeToggle/ThemeToggle.module.css` — Replaced fixed 24×24 sizing on `.toggleButton` with flex gap + padding; added `.toggleLabel` rule; restored 24×24 sizing in `.compactButton` to prevent compact regression

<details>
<summary>Architecture plan</summary>

**Labels inside the button (not stacked below):** keeps click target == visible option, fits the single-line `appearanceRow` layout, and matches the "beside" option from the issue.

**Compact variant untouched:** its contract per Storybook is a minimal single-icon cycle control. The `composes: toggleButton` pattern means the compact sizing must be explicitly re-applied after removing it from the base class.

**No behavior changes:** `useTheme`, `ThemePreference`, `CYCLE_ORDER`, storage, and props are all unchanged.

**CSS Modules only:** all new styling via CSS custom properties on the 4px spacing scale.
</details>

## Review

- 1 review cycle, APPROVE
- CLAUDE.md: no updates needed (UI-only change, no new packages/routes/hooks)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop