### PR TITLE
fix: add per-evaluation timeout to poll trigger check tool calls

### DIFF
--- a/internal/trigger/poll.go
+++ b/internal/trigger/poll.go
@@ -281,10 +281,17 @@ func (p *Poller) poll(ctx context.Context, policyID string, parsed *model.Parsed
 			continue
 		}
 
-		result, err := client.CallTool(ctx, toolName, check.Input)
+		evalCtx, cancel := context.WithTimeout(ctx, parsed.Trigger.Interval)
+		result, err := client.CallTool(evalCtx, toolName, check.Input)
+		cancel()
 		if err != nil {
-			slog.Error("poller: check tool call failed",
-				"policy_id", policyID, "tool", check.Tool, "err", err)
+			if errors.Is(evalCtx.Err(), context.DeadlineExceeded) {
+				slog.Warn("poller: check tool call timed out",
+					"policy_id", policyID, "tool", check.Tool, "interval", parsed.Trigger.Interval)
+			} else {
+				slog.Error("poller: check tool call failed",
+					"policy_id", policyID, "tool", check.Tool, "err", err)
+			}
 			results[i] = checkResult{Err: err}
 			continue
 		}

--- a/internal/trigger/poll_test.go
+++ b/internal/trigger/poll_test.go
@@ -513,6 +513,98 @@ agent:
 `, name, intervalStr)
 }
 
+// hangingToolServer starts a test HTTP server that behaves as a minimal MCP
+// server until tools/call, at which point it blocks until the request context
+// is cancelled. This simulates an unresponsive MCP server for timeout tests.
+// initialize and notifications/initialized succeed immediately so the test
+// exercises the CallTool timeout, not the handshake path.
+func hangingToolServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck
+		w.Header().Set("Content-Type", "application/json")
+		method, _ := req["method"].(string)
+		switch method {
+		case "tools/list":
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]any{
+					"tools": []map[string]any{{
+						"name":        "check",
+						"description": "poll check tool",
+						"inputSchema": map[string]any{"type": "object", "properties": map[string]any{}},
+					}},
+				},
+			})
+		case "tools/call":
+			// Block until the client cancels the request — simulates a hung MCP server.
+			<-r.Context().Done()
+		default:
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]any{},
+			})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestPoller_CheckTimeout_CancelsCallTool verifies that when the check tool
+// server hangs, the per-evaluation timeout (derived from the poll interval)
+// cancels the call within one interval, no run is launched, and
+// poller.Wait() returns promptly after the parent context is cancelled.
+func TestPoller_CheckTimeout_CancelsCallTool(t *testing.T) {
+	mcpSrv := hangingToolServer(t)
+	store, registry := setupPollerFixture(t, mcpSrv)
+
+	yamlStr := pollPolicyYAML("poll-timeout", "100ms")
+	insertTestPollPolicy(t, store, "pol-timeout", "poll-timeout", yamlStr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	manager := run.NewRunManager()
+	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
+	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	poller := trigger.NewPoller(store, launcher, registry, resolver)
+
+	if err := poller.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait several poll intervals to give the poller multiple chances to
+	// attempt and time out the hanging tool call.
+	time.Sleep(600 * time.Millisecond)
+
+	runs, err := store.ListRuns(context.Background(), db.ListRunsParams{
+		PolicyID: "pol-timeout", Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("expected no runs when tool hangs (timed out), got %d", len(runs))
+	}
+
+	// Cancel the parent context and confirm the poll goroutine exits promptly,
+	// proving it is not wedged inside CallTool.
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		poller.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Goroutines exited cleanly.
+	case <-time.After(3 * time.Second):
+		t.Error("poller.Wait() did not return within 3s after context cancel — poll goroutine may be wedged")
+	}
+}
+
 // TestPoller_SkipsLoop_WhenNoSystemDefaultAndNoModelInYAML verifies that when
 // the system default model is unset (sql.ErrNoRows) and the policy YAML omits
 // the model block, startPollLoopLocked does not register the loop and no run


### PR DESCRIPTION
Closes #61

## Summary

- **Audit:** `GLEIPNIR_MCP_TIMEOUT` is already wired as an `http.Client.Timeout` on the MCP client used by the poll path — it bounds each individual HTTP round-trip. However it does NOT apply a context deadline across the full `CallTool` wall-clock duration (which makes up to 4 HTTP requests in the 401-retry case), and it doesn't integrate with goroutine cancellation.
- **Fix:** Each `CallTool()` call in the poll check loop is now wrapped in `context.WithTimeout(ctx, pollInterval)`. A poll evaluation that takes longer than its own interval is always hung — this caps it and returns an error the caller can handle.
- **Observability:** On timeout, `slog.Warn("poller: check tool call timed out", "policy_id", ..., "tool", ..., "interval", ...)` is logged so operators can identify the problematic tool. Non-timeout failures still log `slog.Error`.
- **Correct cancel placement:** `cancel()` is called explicitly at the end of each loop iteration — not `defer` — to avoid accumulating uncalled cancel funcs across iterations until `poll()` returns.
- **Shutdown vs timeout distinction:** Timeout is detected via `evalCtx.Err() == context.DeadlineExceeded`, not `ctx.Err()`, so a parent-context cancellation (shutdown) is not mislabelled as a tool timeout.

## Architecture plan

<details>
<summary>Implementation plan</summary>

`MCPTimeout` as `http.Client.Timeout` bounds individual HTTP round-trips but not total `CallTool` wall-clock time, and doesn't propagate through `ctx.Done()` for goroutine cancellation. A `context.WithTimeout(ctx, pollInterval)` wrap around `CallTool` is the correct additional safeguard — the poll interval is a natural upper bound since a tool call that exceeds its own poll cycle is by definition a hung call.

The `hangingToolServer` test helper blocks on `<-r.Context().Done()` only for `tools/call`, handling `initialize` and `notifications/initialized` normally. The test asserts zero runs launched and that `poller.Wait()` returns within 3 seconds after cancel.

Note: `ResolveToolByName` (which precedes `CallTool`) only makes SQLite queries — no network I/O — so it correctly stays on the parent `ctx`.

</details>

## Review cycles

1 cycle. Approved immediately.

## CLAUDE.md

No updates needed.

---

*Generated by the agentic dev loop.*