### PR TITLE
feat: improve encryption key warning visual hierarchy on Models page

### DIFF
--- a/frontend/src/components/admin/EncryptionKeyNotice.module.css
+++ b/frontend/src/components/admin/EncryptionKeyNotice.module.css
@@ -1,24 +1,44 @@
 .banner {
   composes: alertWarning from '../../styles/alerts.module.css';
-}
-
-.titleRow {
   display: flex;
-  align-items: center;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
   gap: var(--space-2);
+  min-width: 0;
 }
 
-.title {
-  font-size: var(--text-sm);
+/* font-size override is required: the alertWarning base class sets
+   font-size: var(--text-sm) on the banner, which cascades into child <p>
+   elements. Without this explicit override, the primary line would inherit
+   --text-sm and the visual hierarchy fix would not take effect. */
+.primary {
+  font-size: var(--text-base);
   font-weight: var(--weight-semibold);
+  margin: 0;
+  line-height: 1.4;
 }
 
+/* margin: 0 on all paragraphs so vertical spacing comes only from the
+   container gap, preventing browser default paragraph margins from
+   doubling up with gap and breaking the 4px grid. */
 .body {
-  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  margin: 0;
+  opacity: 0.9;
 }
 
 .footnote {
-  margin-top: var(--space-2);
   font-size: var(--text-xs);
+  margin: 0;
   opacity: 0.75;
 }

--- a/frontend/src/components/admin/EncryptionKeyNotice.tsx
+++ b/frontend/src/components/admin/EncryptionKeyNotice.tsx
@@ -1,4 +1,4 @@
-import { ShieldAlert } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
 import styles from './EncryptionKeyNotice.module.css'
 
 /**
@@ -10,20 +10,18 @@ import styles from './EncryptionKeyNotice.module.css'
  */
 export function EncryptionKeyNotice() {
   return (
-    <div className={styles.banner}>
-      <div className={styles.titleRow}>
-        <ShieldAlert size={16} strokeWidth={1.5} />
-        <span className={styles.title}>Encryption key protects stored credentials</span>
+    <div className={styles.banner} role="alert">
+      <AlertTriangle size={20} strokeWidth={1.5} className={styles.icon} aria-hidden="true" />
+      <div className={styles.content}>
+        <p className={styles.primary}>
+          Back up <code>GLEIPNIR_ENCRYPTION_KEY</code> in a password manager or secrets vault.
+        </p>
+        <p className={styles.body}>
+          Provider API keys and webhook secrets are encrypted with this key. If it is lost, every
+          credential stored in the database becomes permanently unrecoverable.
+        </p>
+        <p className={styles.footnote}>Key rotation is not supported in v1.0 — see Operations docs.</p>
       </div>
-      <p className={styles.body}>
-        Provider API keys and webhook secrets are encrypted with the server's{' '}
-        <code>GLEIPNIR_ENCRYPTION_KEY</code>. If that key is lost, every credential stored in
-        the database becomes permanently unrecoverable. Back it up in a password manager or
-        secrets vault.
-      </p>
-      <p className={styles.footnote}>
-        Key rotation is not supported in v1.0 — see Operations docs.
-      </p>
     </div>
   )
 }


### PR DESCRIPTION
Closes #46

## Summary

- Replaced `ShieldAlert` icon with `AlertTriangle` to use the conventional ⚠ warning-triangle glyph that signals "act on this"
- Promoted the backup instruction (`Back up GLEIPNIR_ENCRYPTION_KEY...`) to the dominant visual line (15px semibold) — previously buried as small body text
- Demoted the explanatory text to 13px body and kept the footnote at 11px, creating a clear three-tier visual hierarchy
- Added `role="alert"` for accessibility; `aria-hidden="true"` on the decorative icon
- Kept the banner on the Models page (not moved to System settings) — it belongs on the credential-handling surface where operators actually paste API keys

<details>
<summary>Architecture plan</summary>

```
Affected files:
  1. frontend/src/components/admin/EncryptionKeyNotice.tsx
     - Replace ShieldAlert with AlertTriangle (size 20, strokeWidth 1.5)
     - Restructure JSX: icon + content column; backup instruction as primary <p>
     - Add role="alert" on banner, aria-hidden on icon
     - Remove titleRow/title wrapper (no longer needed)

  2. frontend/src/components/admin/EncryptionKeyNotice.module.css
     - New class set: .banner (flex, gap --space-3), .icon, .content (flex-col, gap --space-2)
     - .primary: font-size var(--text-base) — explicit override required to escape
       inherited --text-sm from the composed alertWarning base class
     - .body / .footnote: text-sm / text-xs, margin: 0 (prevents double-spacing with flex gap)
     - Retain composes: alertWarning (preserves amber color the issue says to keep)
     - Drop unused .titleRow and .title classes

Key decision: Keep banner on Models page. The issue says "consider moving" — 
not required. The banner text is credential-focused and belongs alongside 
the API key input forms, not on the general System settings page.
```

</details>

## Review cycles

1 cycle — APPROVE on first review pass.

## CLAUDE.md

No updates needed — no new pages, routes, hooks, components, or API endpoints.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via agentic dev loop