### PR TITLE
ux: pre-select HMAC authentication as the default webhook auth mode

### DIFF
--- a/frontend/src/components/AgentEditor/agentEditorUtils.ts
+++ b/frontend/src/components/AgentEditor/agentEditorUtils.ts
@@ -30,6 +30,7 @@ export const DEFAULT_YAML = `name: ''
 description: ''
 trigger:
   type: webhook
+  auth: hmac
 capabilities:
   tools: []
 agent:


### PR DESCRIPTION
Closes #44

## Summary

- Changed `DEFAULT_YAML` in `agentEditorUtils.ts` to include `auth: hmac` in the webhook trigger section
- New agents now default to HMAC (recommended) instead of None (insecure) in the webhook auth radio group
- The warning banner for None remains intact for when users actively choose it

<details>
<summary>Architecture plan</summary>

```
IMPLEMENTATION PLAN
===================
Issue: ux: pre-select HMAC authentication as the default webhook auth mode

Summary:
  - Before: None (insecure) is checked by default in the New Agent form webhook auth radio group
  - After:  HMAC (recommended) is checked by default

Affected files:
  frontend/src/components/AgentEditor/agentEditorUtils.ts

Note: scope-gate skip — no architect pass. Developer implements directly from the issue.
```
</details>

- Review cycles: 1 (approved first pass)
- CLAUDE.md updated: No (no new packages, routes, components, or env vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)