### PR TITLE
refactor: move LLM provider factory into internal/llm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,10 @@ internal/
     sse/              — Server-Sent Events broadcaster
   llm/                — LLM provider abstraction (ADR-026)
     anthropic/        — Anthropic API client
+    factory/          — NewClientForProvider: maps a provider name string to a concrete LLMClient; lives in its own sub-package to avoid the cycle caused by provider packages importing internal/llm
     google/           — Google AI client
+    openai/           — OpenAI API client
+    openaicompat/     — OpenAI-compatible provider loader (bootstraps third-party OpenAI-compatible backends)
   logctx/             — context-based structured log correlation (run_id + policy_id); leaf package, no internal imports
   mcp/                — MCP HTTP client, tool registry, capability tags
   metrics/            — custom Prometheus registry, histogram bucket presets (BucketsFast/BucketsSlow), shared label constants, Handler()/Registry() accessors; leaf package, no internal imports (ADR-037)

--- a/internal/http/api/attention_handler_test.go
+++ b/internal/http/api/attention_handler_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/testutil"
 )
 

--- a/internal/http/api/mcp_handler_test.go
+++ b/internal/http/api/mcp_handler_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/mcp"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/testutil"

--- a/internal/http/api/policy_handler_test.go
+++ b/internal/http/api/policy_handler_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/policy"
 	"github.com/rapp992/gleipnir/internal/testutil"

--- a/internal/http/api/stats_service_test.go
+++ b/internal/http/api/stats_service_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/testutil"
 )

--- a/internal/llm/factory/factory.go
+++ b/internal/llm/factory/factory.go
@@ -1,0 +1,36 @@
+// Package factory provides NewClientForProvider, which maps a provider name
+// string to a concrete LLMClient. It lives in its own sub-package to avoid
+// an import cycle: the provider packages (anthropic, google, openai) all
+// import internal/llm for the shared interface types, so the factory cannot
+// live in internal/llm itself.
+package factory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rapp992/gleipnir/internal/llm"
+	"github.com/rapp992/gleipnir/internal/llm/anthropic"
+	"github.com/rapp992/gleipnir/internal/llm/google"
+	"github.com/rapp992/gleipnir/internal/llm/openai"
+)
+
+// NewClientForProvider creates an LLMClient for the named provider using the
+// given API key. It returns an error for unknown provider names, so callers
+// have a single, obvious touch point when adding new providers.
+func NewClientForProvider(ctx context.Context, provider, apiKey string) (llm.LLMClient, error) {
+	switch provider {
+	case "anthropic":
+		return anthropic.NewClient(apiKey), nil
+	case "google":
+		client, err := google.NewClient(ctx, apiKey)
+		if err != nil {
+			return nil, fmt.Errorf("create google client: %w", err)
+		}
+		return client, nil
+	case "openai":
+		return openai.NewClient(apiKey), nil
+	default:
+		return nil, fmt.Errorf("unknown provider %q", provider)
+	}
+}

--- a/internal/llm/factory/factory_test.go
+++ b/internal/llm/factory/factory_test.go
@@ -1,0 +1,39 @@
+package factory_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rapp992/gleipnir/internal/llm/factory"
+)
+
+func TestNewClientForProvider(t *testing.T) {
+	ctx := context.Background()
+
+	knownProviders := []string{"anthropic", "google", "openai"}
+	for _, provider := range knownProviders {
+		t.Run(provider, func(t *testing.T) {
+			client, err := factory.NewClientForProvider(ctx, provider, "test-key")
+			if err != nil {
+				t.Fatalf("expected no error for provider %q, got: %v", provider, err)
+			}
+			if client == nil {
+				t.Fatalf("expected non-nil client for provider %q", provider)
+			}
+		})
+	}
+
+	t.Run("unknown provider", func(t *testing.T) {
+		client, err := factory.NewClientForProvider(ctx, "nonexistent", "test-key")
+		if err == nil {
+			t.Fatal("expected error for unknown provider, got nil")
+		}
+		if client != nil {
+			t.Fatal("expected nil client for unknown provider")
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error message should contain the unknown provider name; got: %q", err.Error())
+		}
+	})
+}

--- a/internal/trigger/sse_integration_test.go
+++ b/internal/trigger/sse_integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/rapp992/gleipnir/internal/execution/agent"
 	"github.com/rapp992/gleipnir/internal/execution/run"
-	"github.com/rapp992/gleipnir/internal/llm"
 	"github.com/rapp992/gleipnir/internal/http/sse"
+	"github.com/rapp992/gleipnir/internal/llm"
 	"github.com/rapp992/gleipnir/internal/testutil"
 	"github.com/rapp992/gleipnir/internal/trigger"
 )

--- a/main.go
+++ b/main.go
@@ -13,19 +13,17 @@ import (
 	"time"
 
 	"github.com/rapp992/gleipnir/internal/admin"
-	"github.com/rapp992/gleipnir/internal/http/api"
-	"github.com/rapp992/gleipnir/internal/http/auth"
 	"github.com/rapp992/gleipnir/internal/config"
 	"github.com/rapp992/gleipnir/internal/db"
 	runpkg "github.com/rapp992/gleipnir/internal/execution/run"
+	"github.com/rapp992/gleipnir/internal/http/api"
+	"github.com/rapp992/gleipnir/internal/http/auth"
+	"github.com/rapp992/gleipnir/internal/http/sse"
 	"github.com/rapp992/gleipnir/internal/llm"
-	anthropicllm "github.com/rapp992/gleipnir/internal/llm/anthropic"
-	googlellm "github.com/rapp992/gleipnir/internal/llm/google"
-	openaillm "github.com/rapp992/gleipnir/internal/llm/openai"
+	llmfactory "github.com/rapp992/gleipnir/internal/llm/factory"
 	openaicompatllm "github.com/rapp992/gleipnir/internal/llm/openaicompat"
 	"github.com/rapp992/gleipnir/internal/mcp"
 	"github.com/rapp992/gleipnir/internal/policy"
-	"github.com/rapp992/gleipnir/internal/http/sse"
 	"github.com/rapp992/gleipnir/internal/timeout"
 	"github.com/rapp992/gleipnir/internal/trigger"
 )
@@ -122,20 +120,9 @@ func run(cfg config.Config) error {
 	// configureProvider creates an LLM client and registers it in the provider
 	// registry. Called both at bootstrap (from DB) and when an admin saves a key.
 	configureProvider := func(ctx context.Context, provider string, apiKey string) error {
-		var client llm.LLMClient
-		var err error
-		switch provider {
-		case "anthropic":
-			client = anthropicllm.NewClient(apiKey)
-		case "google":
-			client, err = googlellm.NewClient(ctx, apiKey)
-			if err != nil {
-				return fmt.Errorf("create google client: %w", err)
-			}
-		case "openai":
-			client = openaillm.NewClient(apiKey)
-		default:
-			return fmt.Errorf("unknown provider %q", provider)
+		client, err := llmfactory.NewClientForProvider(ctx, provider, apiKey)
+		if err != nil {
+			return err
 		}
 		providerRegistry.Register(provider, client)
 		return nil


### PR DESCRIPTION
Closes #54

## Summary

- Extracted the inline provider factory switch from `main.go` into a new `internal/llm/factory` sub-package exposing `NewClientForProvider(ctx, provider, apiKey)`
- `main.go` now calls the factory instead of importing `anthropic`, `google`, and `openai` packages directly — three provider-specific imports removed
- The factory lives in a sub-package (not `internal/llm` itself) to avoid an import cycle: all provider packages import `internal/llm` for shared interface types, so `internal/llm` cannot import them back

## Architecture plan

<details>
<summary>Plan</summary>

```
IMPLEMENTATION PLAN
===================
Issue: refactor: move LLM provider factory into internal/llm

Summary:
  - main.go drops four provider-specific imports
  - Provider factory is testable in isolation
  - Adding a new provider has a single, obvious touch point

Affected files:
  - internal/llm/factory/ (new sub-package)
  - main.go (remove provider imports, replace switch with llmfactory.NewClientForProvider call)

Note: scope-gate skip — no architect pass. Developer implements directly from the issue.
```

</details>

## Review cycles

1 (approved on first pass)

## CLAUDE.md

Updated: added `factory/`, `openai/`, and `openaicompat/` entries to the Key packages section under `llm/`.

---

_Generated by the agentic dev loop_