### PR TITLE
feat: context-aware empty states guide users through setup in dependency order

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -213,7 +213,7 @@ Response envelope: `{ data: T }` for success, `{ error: string, detail?: string 
 Organized by feature area:
 
 - **Layout** — sidebar navigation, content area, theme toggle, connection status banner
-- **dashboard/** — StatsBar, StatusBadge, StatusBoard, TriggerChip, ActivityFeed, OnboardingSteps
+- **dashboard/** — StatsBar, StatusBadge, StatusBoard, TriggerChip, ActivityFeed, SetupChecklist (context-aware onboarding checklist that renders until all setup steps are complete)
 - **AgentEditor/** — the agent editor (EditorTopBar, FormMode with 7 form sections)
 - **AgentList/** — agent list with folder grouping
 - **RunDetail/** — RunHeader, StepTimeline, FilterBar, MetadataGrid, CapabilitySnapshotCard, ThoughtBlock, ThinkingBlock, ToolBlock, CompleteBlock, ErrorBlock, FeedbackBlock, ApprovalActions, FeedbackActions
@@ -224,7 +224,9 @@ Organized by feature area:
 
 ### Hooks (`src/hooks/`)
 
-~28 custom hooks. Data-fetching hooks follow the pattern: `use{Resource}` wraps a TanStack `useQuery`, `use{Action}` wraps a `useMutation`. All query keys go through `queryKeys.ts`.
+~29 custom hooks. Data-fetching hooks follow the pattern: `use{Resource}` wraps a TanStack `useQuery`, `use{Action}` wraps a `useMutation`. All query keys go through `queryKeys.ts`.
+
+`useSetupReadiness` — composes `useModels`, `useMcpServers`, and `usePolicies` to derive system readiness state (`hasModel`, `hasServer`, `hasAgent`, `nextStep`). Used by the dashboard and agents page empty states.
 
 ### Storybook
 

--- a/frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.tsx
+++ b/frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { ArrowRight } from 'lucide-react'
 import { useRuns } from '@/hooks/queries/runs'
+import { useSetupReadiness } from '@/hooks/useSetupReadiness'
 import { StatusBadge } from '@/components/dashboard/StatusBadge'
 import { EmptyState } from '@/components/EmptyState'
 import { SkeletonBlock } from '@/components/SkeletonBlock'
@@ -13,9 +14,41 @@ import {
 } from '@/utils/format'
 import styles from './RecentRunsFeed.module.css'
 
+const EMPTY_STATE_BY_STEP = {
+  model: {
+    headline: 'Start by adding a model API key',
+    subtext: 'Configure a provider API key so agents can talk to an LLM.',
+    ctaLabel: 'Go to Models',
+    ctaTo: '/admin/models',
+  },
+  server: {
+    headline: 'Add an MCP server to give agents tools',
+    subtext: 'MCP servers expose the tools your agents can call.',
+    ctaLabel: 'Go to Tools',
+    ctaTo: '/tools',
+  },
+  agent: {
+    headline: 'Create your first agent',
+    subtext: 'Agents bundle a trigger, a model, and the tools they are allowed to use.',
+    ctaLabel: 'New Agent',
+    ctaTo: '/agents/new',
+  },
+  ready: {
+    headline: 'No runs yet',
+    subtext: 'Trigger one of your agents to see runs here.',
+    ctaLabel: 'Go to Agents',
+    ctaTo: '/agents',
+  },
+}
+
 export function RecentRunsFeed() {
   const { runs, isLoading } = useRuns({ limit: 10, sort: 'started_at', order: 'desc' })
+  const readiness = useSetupReadiness()
   const navigate = useNavigate()
+
+  const emptyStateProps = readiness.isError
+    ? EMPTY_STATE_BY_STEP.ready
+    : EMPTY_STATE_BY_STEP[readiness.nextStep]
 
   return (
     <div>
@@ -42,13 +75,8 @@ export function RecentRunsFeed() {
           </>
         )}
 
-        {!isLoading && runs.length === 0 && (
-          <EmptyState
-            headline="No runs yet"
-            subtext="Create an agent and trigger your first run."
-            ctaLabel="Go to Agents"
-            ctaTo="/agents"
-          />
+        {!isLoading && !readiness.isLoading && runs.length === 0 && (
+          <EmptyState {...emptyStateProps} />
         )}
 
         {!isLoading && runs.map((run, idx) => {

--- a/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.module.css
+++ b/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.module.css
@@ -1,0 +1,93 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  width: 100%;
+  text-align: left;
+}
+
+.sectionTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--text-second);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.countBadge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-second);
+}
+
+.chevron {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+  margin-left: auto;
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.chevronCollapsed {
+  transform: rotate(-90deg);
+}
+
+.stepList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.stepRow {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.iconDone {
+  display: flex;
+  align-items: center;
+  color: var(--color-green);
+}
+
+.iconPending {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+}
+
+.label {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.labelDone {
+  font-size: var(--text-sm);
+  color: var(--text-second);
+}
+
+.cta {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-blue);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.cta:hover {
+  color: var(--accent-hover);
+}

--- a/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.stories.tsx
+++ b/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@/tokens.css'
+import { SetupChecklist } from './SetupChecklist'
+import storyStyles from '../dashboard-stories.module.css'
+
+const meta: Meta<typeof SetupChecklist> = {
+  title: 'Dashboard/SetupChecklist',
+  component: SetupChecklist,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <div className={storyStyles.storyWrapper}>
+            <Story />
+          </div>
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof SetupChecklist>
+
+export const AllIncomplete: Story = {
+  args: {
+    hasModel: false,
+    hasServer: false,
+    hasAgent: false,
+    hasFirstRun: false,
+    isLoading: false,
+  },
+}
+
+export const ModelDone: Story = {
+  args: {
+    hasModel: true,
+    hasServer: false,
+    hasAgent: false,
+    hasFirstRun: false,
+    isLoading: false,
+  },
+}
+
+export const ServerDone: Story = {
+  args: {
+    hasModel: true,
+    hasServer: true,
+    hasAgent: false,
+    hasFirstRun: false,
+    isLoading: false,
+  },
+}
+
+export const AgentDone: Story = {
+  args: {
+    hasModel: true,
+    hasServer: true,
+    hasAgent: true,
+    hasFirstRun: false,
+    isLoading: false,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    hasModel: false,
+    hasServer: false,
+    hasAgent: false,
+    hasFirstRun: false,
+    isLoading: true,
+  },
+}

--- a/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.test.tsx
+++ b/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { SetupChecklist } from './SetupChecklist'
+
+function renderChecklist(props: {
+  hasModel?: boolean
+  hasServer?: boolean
+  hasAgent?: boolean
+  hasFirstRun?: boolean
+  isLoading?: boolean
+}) {
+  return render(
+    <MemoryRouter>
+      <SetupChecklist
+        hasModel={props.hasModel ?? false}
+        hasServer={props.hasServer ?? false}
+        hasAgent={props.hasAgent ?? false}
+        hasFirstRun={props.hasFirstRun ?? false}
+        isLoading={props.isLoading ?? false}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('SetupChecklist', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders all four steps when nothing is done', () => {
+    renderChecklist({})
+
+    expect(screen.getByText('Add a model API key')).toBeInTheDocument()
+    expect(screen.getByText('Register an MCP server')).toBeInTheDocument()
+    expect(screen.getByText('Create an agent')).toBeInTheDocument()
+    expect(screen.getByText('Trigger your first run')).toBeInTheDocument()
+  })
+
+  it('shows pending icons for incomplete steps and done icons for completed ones', () => {
+    renderChecklist({ hasModel: true })
+
+    const doneIcons = screen.getAllByLabelText('done')
+    const pendingIcons = screen.getAllByLabelText('pending')
+
+    expect(doneIcons).toHaveLength(1)
+    expect(pendingIcons).toHaveLength(3)
+  })
+
+  it('shows CTA links pointing to the correct routes', () => {
+    renderChecklist({})
+
+    expect(screen.getByRole('link', { name: 'Go to Models' })).toHaveAttribute('href', '/admin/models')
+    expect(screen.getByRole('link', { name: 'Go to Tools' })).toHaveAttribute('href', '/tools')
+    expect(screen.getByRole('link', { name: 'New Agent' })).toHaveAttribute('href', '/agents/new')
+    expect(screen.getByRole('link', { name: 'Go to Agents' })).toHaveAttribute('href', '/agents')
+  })
+
+  it('does not show a CTA for completed steps', () => {
+    renderChecklist({ hasModel: true, hasServer: true })
+
+    expect(screen.queryByRole('link', { name: 'Go to Models' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Go to Tools' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'New Agent' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Go to Agents' })).toBeInTheDocument()
+  })
+
+  it('returns null when every step is done and not loading', () => {
+    const { container } = renderChecklist({
+      hasModel: true,
+      hasServer: true,
+      hasAgent: true,
+      hasFirstRun: true,
+      isLoading: false,
+    })
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does not return null when loading even if all steps would be done', () => {
+    renderChecklist({
+      hasModel: true,
+      hasServer: true,
+      hasAgent: true,
+      hasFirstRun: true,
+      isLoading: true,
+    })
+
+    expect(screen.getByText('SETUP')).toBeInTheDocument()
+  })
+
+  it('collapses and expands on toggle, persisting to localStorage', async () => {
+    renderChecklist({})
+
+    expect(screen.getByText('Add a model API key')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('Add a model API key')).not.toBeInTheDocument()
+
+    const stored = localStorage.getItem('gleipnir-setup-collapsed')
+    expect(JSON.parse(stored!)).toBe(true)
+
+    await userEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('Add a model API key')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.tsx
+++ b/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.tsx
@@ -1,0 +1,77 @@
+import { ChevronDown, CircleCheckBig, Circle } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+import styles from './SetupChecklist.module.css'
+
+const COLLAPSED_STORAGE_KEY = 'gleipnir-setup-collapsed'
+
+export interface SetupChecklistProps {
+  hasModel: boolean
+  hasServer: boolean
+  hasAgent: boolean
+  hasFirstRun: boolean
+  isLoading: boolean
+}
+
+interface Step {
+  label: string
+  done: boolean
+  href: string
+  cta: string
+}
+
+export function SetupChecklist({ hasModel, hasServer, hasAgent, hasFirstRun, isLoading }: SetupChecklistProps) {
+  const [collapsed, setCollapsed] = useLocalStorage(COLLAPSED_STORAGE_KEY, false)
+
+  const allDone = hasModel && hasServer && hasAgent && hasFirstRun
+
+  if (allDone && !isLoading) return null
+
+  const steps: Step[] = [
+    { label: 'Add a model API key', done: hasModel, href: '/admin/models', cta: 'Go to Models' },
+    { label: 'Register an MCP server', done: hasServer, href: '/tools', cta: 'Go to Tools' },
+    { label: 'Create an agent', done: hasAgent, href: '/agents/new', cta: 'New Agent' },
+    { label: 'Trigger your first run', done: hasFirstRun, href: '/agents', cta: 'Go to Agents' },
+  ]
+
+  const doneCount = steps.filter(s => s.done).length
+
+  function toggleCollapsed() {
+    setCollapsed(!collapsed)
+  }
+
+  return (
+    <section className={styles.section}>
+      <button className={styles.sectionHeader} onClick={toggleCollapsed}>
+        <span className={styles.sectionTitle}>SETUP</span>
+        <span className={styles.countBadge}>{doneCount}/{steps.length}</span>
+        <span className={`${styles.chevron} ${collapsed ? styles.chevronCollapsed : ''}`}>
+          <ChevronDown size={14} aria-hidden strokeWidth={2} />
+        </span>
+      </button>
+
+      {!collapsed && (
+        <div className={styles.stepList}>
+          {steps.map(step => (
+            <div key={step.label} className={styles.stepRow}>
+              <span className={step.done ? styles.iconDone : styles.iconPending}>
+                {step.done
+                  ? <CircleCheckBig size={16} aria-label="done" />
+                  : <Circle size={16} aria-label="pending" />
+                }
+              </span>
+              <span className={step.done ? styles.labelDone : styles.label}>
+                {step.label}
+              </span>
+              {!step.done && (
+                <Link to={step.href} className={styles.cta}>
+                  {step.cta}
+                </Link>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/SetupChecklist/index.ts
+++ b/frontend/src/components/dashboard/SetupChecklist/index.ts
@@ -1,0 +1,1 @@
+export { SetupChecklist } from './SetupChecklist'

--- a/frontend/src/hooks/useSetupReadiness.test.ts
+++ b/frontend/src/hooks/useSetupReadiness.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { createElement } from 'react'
+import { server } from '@/test/server'
+import { useSetupReadiness } from './useSetupReadiness'
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function setupHandlers(opts: {
+  models?: { provider: string; models: { name: string; display_name: string }[] }[]
+  servers?: { id: string; name: string }[]
+  policies?: { id: string; name: string }[]
+}) {
+  server.use(
+    http.get('/api/v1/models', () =>
+      HttpResponse.json({ data: opts.models ?? [] }),
+    ),
+    http.get('/api/v1/mcp/servers', () =>
+      HttpResponse.json({ data: opts.servers ?? [] }),
+    ),
+    http.get('/api/v1/policies', () =>
+      HttpResponse.json({ data: opts.policies ?? [] }),
+    ),
+  )
+}
+
+describe('useSetupReadiness', () => {
+  it('returns nextStep model when everything is empty', async () => {
+    setupHandlers({})
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.hasModel).toBe(false)
+    expect(result.current.hasServer).toBe(false)
+    expect(result.current.hasAgent).toBe(false)
+    expect(result.current.nextStep).toBe('model')
+  })
+
+  it('returns nextStep model when provider group exists but has no models (no API key configured)', async () => {
+    setupHandlers({ models: [{ provider: 'anthropic', models: [] }] })
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.hasModel).toBe(false)
+    expect(result.current.nextStep).toBe('model')
+  })
+
+  it('returns nextStep server when models are present but no servers', async () => {
+    setupHandlers({
+      models: [{ provider: 'anthropic', models: [{ name: 'claude-3', display_name: 'Claude 3' }] }],
+    })
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.hasModel).toBe(true)
+    expect(result.current.hasServer).toBe(false)
+    expect(result.current.nextStep).toBe('server')
+  })
+
+  it('returns nextStep agent when models and servers are present but no agents', async () => {
+    setupHandlers({
+      models: [{ provider: 'anthropic', models: [{ name: 'claude-3', display_name: 'Claude 3' }] }],
+      servers: [{ id: 's1', name: 'my-server' }],
+    })
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.hasModel).toBe(true)
+    expect(result.current.hasServer).toBe(true)
+    expect(result.current.hasAgent).toBe(false)
+    expect(result.current.nextStep).toBe('agent')
+  })
+
+  it('returns nextStep ready when all three are present', async () => {
+    setupHandlers({
+      models: [{ provider: 'anthropic', models: [{ name: 'claude-3', display_name: 'Claude 3' }] }],
+      servers: [{ id: 's1', name: 'my-server' }],
+      policies: [{ id: 'p1', name: 'my-agent' }],
+    })
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.hasModel).toBe(true)
+    expect(result.current.hasServer).toBe(true)
+    expect(result.current.hasAgent).toBe(true)
+    expect(result.current.nextStep).toBe('ready')
+  })
+
+  it('reports isLoading true while queries are in flight', () => {
+    setupHandlers({})
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('reports isError true when a query fails', async () => {
+    server.use(
+      http.get('/api/v1/models', () => HttpResponse.json({ error: 'server error' }, { status: 500 })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+    )
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.isError).toBe(true)
+  })
+})

--- a/frontend/src/hooks/useSetupReadiness.ts
+++ b/frontend/src/hooks/useSetupReadiness.ts
@@ -1,0 +1,41 @@
+import { useModels } from '@/hooks/queries/users'
+import { useMcpServers } from '@/hooks/queries/servers'
+import { usePolicies } from '@/hooks/queries/policies'
+
+export interface SetupReadiness {
+  hasModel: boolean
+  hasServer: boolean
+  hasAgent: boolean
+  isLoading: boolean
+  isError: boolean
+  nextStep: 'model' | 'server' | 'agent' | 'ready'
+}
+
+export function useSetupReadiness(): SetupReadiness {
+  const models = useModels()
+  const servers = useMcpServers()
+  const policies = usePolicies()
+
+  const isLoading = models.isLoading || servers.isLoading || policies.isLoading
+  const isError = models.isError || servers.isError || policies.isError
+
+  // The API can return [{provider: 'anthropic', models: []}] when no API key
+  // is configured, so we must check that at least one group has models — a
+  // length check on the outer array would give a false positive.
+  const hasModel = models.data?.some(g => g.models.length > 0) ?? false
+  const hasServer = (servers.data?.length ?? 0) > 0
+  const hasAgent = (policies.data?.length ?? 0) > 0
+
+  let nextStep: SetupReadiness['nextStep']
+  if (!hasModel) {
+    nextStep = 'model'
+  } else if (!hasServer) {
+    nextStep = 'server'
+  } else if (!hasAgent) {
+    nextStep = 'agent'
+  } else {
+    nextStep = 'ready'
+  }
+
+  return { hasModel, hasServer, hasAgent, isLoading, isError, nextStep }
+}

--- a/frontend/src/pages/AgentsPage.test.tsx
+++ b/frontend/src/pages/AgentsPage.test.tsx
@@ -28,6 +28,9 @@ const POLICIES: ApiPolicyListItem[] = [
   },
 ]
 
+const STUB_MODEL_RESPONSE = [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }]
+const STUB_SERVER_RESPONSE = [{ id: 's1', name: 'my-server', url: 'http://localhost:9000', tool_count: 1 }]
+
 function makeClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
@@ -49,6 +52,8 @@ describe('AgentsPage', () => {
         await delay(200)
         return HttpResponse.json({ data: POLICIES })
       }),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
     )
 
     const qc = makeClient()
@@ -62,11 +67,11 @@ describe('AgentsPage', () => {
     await waitFor(() => expect(screen.getByText('vikunja-triage')).toBeInTheDocument())
   })
 
-  it('shows empty state when no agents exist', async () => {
+  it('shows default empty state when no agents exist (model and server configured)', async () => {
     server.use(
-      http.get('/api/v1/policies', () => {
-        return HttpResponse.json({ data: [] })
-      }),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
     )
 
     const qc = makeClient()
@@ -84,11 +89,45 @@ describe('AgentsPage', () => {
     expect(ctaToNew).toBe(true)
   })
 
+  it('shows "Start by adding a model API key" empty state when no model is configured', async () => {
+    server.use(
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/models', () =>
+        HttpResponse.json({ data: [{ provider: 'anthropic', models: [] }] }),
+      ),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+    )
+
+    const qc = makeClient()
+    renderPage(qc)
+
+    await waitFor(() => {
+      expect(screen.getByText('Start by adding a model API key')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('link', { name: 'Go to Models' })).toHaveAttribute('href', '/admin/models')
+  })
+
+  it('shows "Add an MCP server" empty state when model is set but no server', async () => {
+    server.use(
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+    )
+
+    const qc = makeClient()
+    renderPage(qc)
+
+    await waitFor(() => {
+      expect(screen.getByText('Add an MCP server to give agents tools')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('link', { name: 'Go to Tools' })).toHaveAttribute('href', '/tools')
+  })
+
   it('edit button links to /agents/:id (editor)', async () => {
     server.use(
-      http.get('/api/v1/policies', () => {
-        return HttpResponse.json({ data: POLICIES })
-      }),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: POLICIES })),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
     )
 
     const qc = makeClient()
@@ -102,9 +141,9 @@ describe('AgentsPage', () => {
 
   it('"New Agent" button in header links to /agents/new', async () => {
     server.use(
-      http.get('/api/v1/policies', () => {
-        return HttpResponse.json({ data: POLICIES })
-      }),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: POLICIES })),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
     )
 
     const qc = makeClient()
@@ -122,6 +161,8 @@ describe('AgentsPage', () => {
       http.get('/api/v1/policies', () => {
         return HttpResponse.json({ error: 'internal server error' }, { status: 500 })
       }),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
     )
 
     const qc = makeClient()
@@ -144,6 +185,8 @@ describe('AgentsPage', () => {
         }
         return HttpResponse.json({ data: POLICIES })
       }),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
     )
 
     const qc = makeClient()

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -6,6 +6,7 @@ import { PolicyList } from '@/components/AgentList'
 import { TriggerRunModal } from '@/components/TriggerRunModal'
 import { PageHeader } from '@/components/PageHeader'
 import { usePolicies } from '@/hooks/queries/policies'
+import { useSetupReadiness } from '@/hooks/useSetupReadiness'
 import { queryKeys } from '@/hooks/queryKeys'
 import { QueryBoundary } from '@/components/QueryBoundary'
 import { usePageTitle } from '@/hooks/usePageTitle'
@@ -15,9 +16,31 @@ import styles from './AgentsPage.module.css'
 export default function AgentsPage() {
   usePageTitle('Agents')
   const { data: policies, status: policiesStatus } = usePolicies()
+  const readiness = useSetupReadiness()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const [triggerTarget, setTriggerTarget] = useState<{ id: string; name: string } | null>(null)
+
+  const emptyStateNode = readiness.nextStep === 'model'
+    ? <EmptyState
+        headline="Start by adding a model API key"
+        subtext="Before you can create an agent, configure a provider API key."
+        ctaLabel="Go to Models"
+        ctaTo="/admin/models"
+      />
+    : readiness.nextStep === 'server'
+    ? <EmptyState
+        headline="Add an MCP server to give agents tools"
+        subtext="Agents use MCP tools to do their work. Register a server first."
+        ctaLabel="Go to Tools"
+        ctaTo="/tools"
+      />
+    : <EmptyState
+        headline="No agents yet"
+        subtext="Create your first agent to get started"
+        ctaLabel="New Agent"
+        ctaTo="/agents/new"
+      />
 
   return (
     <div className={styles.page}>
@@ -31,14 +54,7 @@ export default function AgentsPage() {
         isEmpty={(policies ?? []).length === 0}
         errorMessage="Failed to load agents."
         onRetry={() => queryClient.invalidateQueries({ queryKey: queryKeys.policies.all })}
-        emptyState={
-          <EmptyState
-            headline="No agents yet"
-            subtext="Create your first agent to get started"
-            ctaLabel="New Agent"
-            ctaTo="/agents/new"
-          />
-        }
+        emptyState={emptyStateNode}
       >
         <PolicyList
           policies={policies ?? []}

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import { server } from '@/test/server'
 import DashboardPage from './DashboardPage'
-import type { ApiStats, ApiTimeSeriesResponse, ApiAttentionResponse, ApiRunsResponse } from '@/api/types'
+import type { ApiStats, ApiTimeSeriesResponse, ApiAttentionResponse, ApiRunsResponse, ApiPolicyListItem } from '@/api/types'
 
 // recharts uses ResizeObserver and getBoundingClientRect which are not available in jsdom.
 // Replace chart components with simple wrappers that render their children so the
@@ -52,6 +52,23 @@ const RUNS: ApiRunsResponse = {
   total: 0,
 }
 
+const STUB_POLICY: ApiPolicyListItem = {
+  id: 'p1',
+  name: 'test-policy',
+  trigger_type: 'manual',
+  folder: '',
+  model: 'claude-3',
+  tool_count: 0,
+  tool_refs: [],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  paused_at: null,
+  latest_run: null,
+  avg_token_cost: 0,
+  run_count: 0,
+  next_fire_at: null,
+}
+
 function makeClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
@@ -66,13 +83,23 @@ function renderDashboard(queryClient: QueryClient) {
   )
 }
 
+// Default handlers represent a fully-onboarded instance (nextStep === 'ready')
+// so existing "No runs yet" assertions remain valid and the SetupChecklist is hidden.
 function setupDefaultHandlers() {
   server.use(
     http.get('/api/v1/stats', () => HttpResponse.json({ data: STATS })),
     http.get('/api/v1/stats/timeseries', () => HttpResponse.json({ data: TIMESERIES })),
     http.get('/api/v1/attention', () => HttpResponse.json({ data: ATTENTION })),
     http.get('/api/v1/runs', () => HttpResponse.json({ data: RUNS })),
-    http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+    http.get('/api/v1/mcp/servers', () =>
+      HttpResponse.json({ data: [{ id: 's1', name: 'my-server', url: 'http://localhost:9000', tool_count: 1 }] }),
+    ),
+    http.get('/api/v1/models', () =>
+      HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }] }),
+    ),
+    http.get('/api/v1/policies', () =>
+      HttpResponse.json({ data: [STUB_POLICY] }),
+    ),
   )
 }
 
@@ -160,13 +187,148 @@ describe('DashboardPage', () => {
         }),
       ),
       http.get('/api/v1/runs', () => HttpResponse.json({ data: RUNS })),
-      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/mcp/servers', () =>
+        HttpResponse.json({ data: [{ id: 's1', name: 'my-server', url: 'http://localhost:9000', tool_count: 1 }] }),
+      ),
+      http.get('/api/v1/models', () =>
+        HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }] }),
+      ),
+      http.get('/api/v1/policies', () =>
+        HttpResponse.json({ data: [STUB_POLICY] }),
+      ),
     )
 
     renderDashboard(makeClient())
 
     await waitFor(() => {
       expect(screen.getByText('NEEDS ATTENTION')).toBeInTheDocument()
+    })
+  })
+
+  it('RecentRunsFeed empty state shows "Start by adding a model API key" when no model is configured', async () => {
+    server.use(
+      http.get('/api/v1/stats', () => HttpResponse.json({ data: STATS })),
+      http.get('/api/v1/stats/timeseries', () => HttpResponse.json({ data: TIMESERIES })),
+      http.get('/api/v1/attention', () => HttpResponse.json({ data: ATTENTION })),
+      http.get('/api/v1/runs', () => HttpResponse.json({ data: RUNS })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/models', () =>
+        HttpResponse.json({ data: [{ provider: 'anthropic', models: [] }] }),
+      ),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+    )
+
+    renderDashboard(makeClient())
+
+    await waitFor(() => {
+      expect(screen.getByText('Start by adding a model API key')).toBeInTheDocument()
+    })
+    // Both the SetupChecklist and the RecentRunsFeed empty state may render the same CTA,
+    // so use getAllByRole and verify at least one points to the correct href.
+    const modelsLinks = screen.getAllByRole('link', { name: 'Go to Models' })
+    expect(modelsLinks.every(l => l.getAttribute('href') === '/admin/models')).toBe(true)
+  })
+
+  it('RecentRunsFeed empty state shows "Add an MCP server" when model is set but no server', async () => {
+    server.use(
+      http.get('/api/v1/stats', () => HttpResponse.json({ data: STATS })),
+      http.get('/api/v1/stats/timeseries', () => HttpResponse.json({ data: TIMESERIES })),
+      http.get('/api/v1/attention', () => HttpResponse.json({ data: ATTENTION })),
+      http.get('/api/v1/runs', () => HttpResponse.json({ data: RUNS })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/models', () =>
+        HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }] }),
+      ),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+    )
+
+    renderDashboard(makeClient())
+
+    await waitFor(() => {
+      expect(screen.getByText('Add an MCP server to give agents tools')).toBeInTheDocument()
+    })
+    const toolsLinks = screen.getAllByRole('link', { name: 'Go to Tools' })
+    expect(toolsLinks.every(l => l.getAttribute('href') === '/tools')).toBe(true)
+  })
+
+  it('RecentRunsFeed empty state shows "Create your first agent" when model+server set but no agents', async () => {
+    server.use(
+      http.get('/api/v1/stats', () => HttpResponse.json({ data: STATS })),
+      http.get('/api/v1/stats/timeseries', () => HttpResponse.json({ data: TIMESERIES })),
+      http.get('/api/v1/attention', () => HttpResponse.json({ data: ATTENTION })),
+      http.get('/api/v1/runs', () => HttpResponse.json({ data: RUNS })),
+      http.get('/api/v1/mcp/servers', () =>
+        HttpResponse.json({ data: [{ id: 's1', name: 'my-server', url: 'http://localhost:9000', tool_count: 1 }] }),
+      ),
+      http.get('/api/v1/models', () =>
+        HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }] }),
+      ),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+    )
+
+    renderDashboard(makeClient())
+
+    await waitFor(() => {
+      expect(screen.getByText('Create your first agent')).toBeInTheDocument()
+    })
+    const agentLinks = screen.getAllByRole('link', { name: 'New Agent' })
+    expect(agentLinks.every(l => l.getAttribute('href') === '/agents/new')).toBe(true)
+  })
+
+  it('RecentRunsFeed empty state shows "No runs yet" when all setup steps are complete', async () => {
+    setupDefaultHandlers()
+    renderDashboard(makeClient())
+
+    await waitFor(() => {
+      expect(screen.getAllByText('No runs yet').length).toBeGreaterThanOrEqual(1)
+    })
+    const agentsLinks = screen.getAllByRole('link', { name: 'Go to Agents' })
+    expect(agentsLinks.some(l => l.getAttribute('href') === '/agents')).toBe(true)
+  })
+
+  it('SetupChecklist is visible when any setup step is pending', async () => {
+    server.use(
+      http.get('/api/v1/stats', () => HttpResponse.json({ data: STATS })),
+      http.get('/api/v1/stats/timeseries', () => HttpResponse.json({ data: TIMESERIES })),
+      http.get('/api/v1/attention', () => HttpResponse.json({ data: ATTENTION })),
+      http.get('/api/v1/runs', () => HttpResponse.json({ data: RUNS })),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/models', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+    )
+
+    renderDashboard(makeClient())
+
+    await waitFor(() => {
+      expect(screen.getByText('SETUP')).toBeInTheDocument()
+    })
+  })
+
+  it('SetupChecklist is absent when all four setup steps are complete', async () => {
+    server.use(
+      http.get('/api/v1/stats', () => HttpResponse.json({ data: STATS })),
+      http.get('/api/v1/stats/timeseries', () => HttpResponse.json({ data: TIMESERIES })),
+      http.get('/api/v1/attention', () => HttpResponse.json({ data: ATTENTION })),
+      http.get('/api/v1/runs', () =>
+        HttpResponse.json({ data: { runs: [{ id: 'r1', status: 'complete', policy_id: 'p1', policy_name: 'test', created_at: '2026-01-01T00:00:00Z', started_at: null, completed_at: null, token_cost: 0 }], total: 1 } }),
+      ),
+      http.get('/api/v1/mcp/servers', () =>
+        HttpResponse.json({ data: [{ id: 's1', name: 'my-server', url: 'http://localhost:9000', tool_count: 1 }] }),
+      ),
+      http.get('/api/v1/models', () =>
+        HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }] }),
+      ),
+      http.get('/api/v1/policies', () =>
+        HttpResponse.json({ data: [STUB_POLICY] }),
+      ),
+    )
+
+    renderDashboard(makeClient())
+
+    // Wait for all queries to settle — once the SETUP header disappears, all
+    // readiness checks have resolved and determined every step is complete.
+    await waitFor(() => {
+      expect(screen.queryByText('SETUP')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,8 +5,11 @@ import { RunActivityChart } from '@/components/dashboard/RunActivityChart'
 import { CostByModelChart } from '@/components/dashboard/CostByModelChart'
 import { AttentionQueue } from '@/components/dashboard/AttentionQueue'
 import { RecentRunsFeed } from '@/components/dashboard/RecentRunsFeed'
+import { SetupChecklist } from '@/components/dashboard/SetupChecklist'
 import { useTimeSeriesStats } from '@/hooks/queries/stats'
 import { useAttentionItems } from '@/hooks/useAttentionItems'
+import { useSetupReadiness } from '@/hooks/useSetupReadiness'
+import { useRuns } from '@/hooks/queries/runs'
 import styles from './DashboardPage.module.css'
 
 export default function DashboardPage() {
@@ -14,10 +17,20 @@ export default function DashboardPage() {
   useRechartsCleanup()
   const timeSeries = useTimeSeriesStats()
   const attention = useAttentionItems()
+  const readiness = useSetupReadiness()
+  const recentRuns = useRuns({ limit: 1 })
+  const hasFirstRun = recentRuns.runs.length > 0
 
   return (
     <div className={styles.page}>
       <PageHeader title="Control Center" />
+      <SetupChecklist
+        hasModel={readiness.hasModel}
+        hasServer={readiness.hasServer}
+        hasAgent={readiness.hasAgent}
+        hasFirstRun={hasFirstRun}
+        isLoading={readiness.isLoading || recentRuns.isLoading}
+      />
       <div className={styles.chartGrid}>
         <RunActivityChart data={timeSeries.data} isLoading={timeSeries.isLoading} />
         <CostByModelChart data={timeSeries.data} isLoading={timeSeries.isLoading} />


### PR DESCRIPTION
Closes #45

## Summary

- **`useSetupReadiness` hook** — composes `useModels`, `useMcpServers`, and `usePolicies` to derive `hasModel`, `hasServer`, `hasAgent`, and a `nextStep` enum (`'model' | 'server' | 'agent' | 'ready'`)
- **Dashboard empty state** — `RecentRunsFeed` switches on `nextStep` to show the right headline + CTA: "Start by adding a model API key" → "Add an MCP server" → "Create your first agent" → "No runs yet"
- **Agents page empty state** — same logic; guides users to Models or Tools before suggesting agent creation
- **`SetupChecklist` component** — collapsible 4-step checklist on the dashboard (model → server → agent → first run) that renders `null` once all steps are complete; persists collapsed state in localStorage

## Architecture

<details>
<summary>Implementation plan</summary>

```
IMPLEMENTATION PLAN
===================
Issue: ux: dashboard empty state should guide users through setup in dependency order (#45)

Readiness definition:
  - models ready: GET /api/v1/models returns provider groups where at least one
    group has models.length > 0. NOTE: providers?.length > 0 is NOT a valid shortcut
    — API can return [{provider: "anthropic", models: []}] when no API key is set.
  - servers ready: GET /api/v1/mcp/servers returns a non-empty array.
  - agents ready: GET /api/v1/policies returns a non-empty array.
  - runs ready: GET /api/v1/runs?limit=1 returns at least one run.

New files:
  - frontend/src/hooks/useSetupReadiness.ts
  - frontend/src/hooks/useSetupReadiness.test.ts
  - frontend/src/components/dashboard/SetupChecklist/ (5 files incl. stories + tests)

Modified files:
  - frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.tsx
  - frontend/src/pages/AgentsPage.tsx
  - frontend/src/pages/DashboardPage.tsx
  - frontend/src/pages/DashboardPage.test.tsx
  - frontend/src/pages/AgentsPage.test.tsx
  - frontend/CLAUDE.md
```

</details>

## Review cycles

2 cycles. Cycle 1 found: (1) `isLoading` not including `recentRuns.isLoading` causing a flash on fully-onboarded instances, (2) two story variants were identical, (3) an unrelated file deletion. All fixed. Cycle 2 found the story fix created a new duplicate — corrected directly by coordinator before PR creation.

## CLAUDE.md updated

`frontend/CLAUDE.md` updated: corrected stale `OnboardingSteps` reference to `SetupChecklist`, added `useSetupReadiness` to Hooks section.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)