### PR TITLE
refactor: replace 7-parameter NewRunLauncher with RunLauncherConfig struct

### DIFF
--- a/internal/execution/run/launcher.go
+++ b/internal/execution/run/launcher.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/rapp992/gleipnir/internal/db"
-	"github.com/rapp992/gleipnir/internal/infra/event"
 	"github.com/rapp992/gleipnir/internal/execution/agent"
-	"github.com/rapp992/gleipnir/internal/llm"
+	"github.com/rapp992/gleipnir/internal/infra/event"
 	"github.com/rapp992/gleipnir/internal/infra/logctx"
+	"github.com/rapp992/gleipnir/internal/llm"
 	"github.com/rapp992/gleipnir/internal/mcp"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/policy"
@@ -91,21 +91,33 @@ type registryResolver interface {
 	ResolveForPolicy(ctx context.Context, p *model.ParsedPolicy) ([]mcp.ResolvedTool, error)
 }
 
+// RunLauncherConfig holds all dependencies for a RunLauncher. Field order
+// mirrors the former positional parameters so a grep-diff is auditable.
+type RunLauncherConfig struct {
+	Store                  *db.Store
+	Registry               registryResolver
+	Manager                *RunManager
+	AgentFactory           AgentFactory
+	Publisher              event.Publisher      // nil = no real-time events
+	DefaultFeedbackTimeout time.Duration
+	ModelResolver          defaultModelResolver // nil = use launch-time snapshot only
+}
+
 // NewRunLauncher returns a RunLauncher ready to use.
 // publisher may be nil, in which case no real-time events are emitted.
 // defaultFeedbackTimeout is used when a policy does not specify its own timeout.
 // modelResolver is used by the drain path to re-parse policies with current
 // system settings; it may be nil, in which case the drain path uses the
 // snapshot captured at launch time.
-func NewRunLauncher(store *db.Store, registry registryResolver, manager *RunManager, factory AgentFactory, publisher event.Publisher, defaultFeedbackTimeout time.Duration, modelResolver defaultModelResolver) *RunLauncher {
+func NewRunLauncher(cfg RunLauncherConfig) *RunLauncher {
 	return &RunLauncher{
-		store:                  store,
-		registry:               registry,
-		manager:                manager,
-		newAgent:               factory,
-		publisher:              publisher,
-		defaultFeedbackTimeout: defaultFeedbackTimeout,
-		modelResolver:          modelResolver,
+		store:                  cfg.Store,
+		registry:               cfg.Registry,
+		manager:                cfg.Manager,
+		newAgent:               cfg.AgentFactory,
+		publisher:              cfg.Publisher,
+		defaultFeedbackTimeout: cfg.DefaultFeedbackTimeout,
+		modelResolver:          cfg.ModelResolver,
 	}
 }
 

--- a/internal/execution/run/launcher_test.go
+++ b/internal/execution/run/launcher_test.go
@@ -152,7 +152,15 @@ func TestCheckConcurrency(t *testing.T) {
 			registry := mcp.NewRegistry(store.Queries())
 			manager := run.NewRunManager()
 			// factory is nil — CheckConcurrency never calls it.
-			launcher := run.NewRunLauncher(store, registry, manager, nil, nil, 0, nil)
+			launcher := run.NewRunLauncher(run.RunLauncherConfig{
+				Store:                  store,
+				Registry:               registry,
+				Manager:                manager,
+				AgentFactory:           nil,
+				Publisher:              nil,
+				DefaultFeedbackTimeout: 0,
+				ModelResolver:          nil,
+			})
 
 			err := launcher.CheckConcurrency(context.Background(), policyID, tc.concurrency)
 			if tc.wantNil {
@@ -193,7 +201,15 @@ func TestCheckConcurrency_Replace(t *testing.T) {
 		}()
 
 		registry := mcp.NewRegistry(store.Queries())
-		launcher := run.NewRunLauncher(store, registry, manager, nil, nil, 0, nil)
+		launcher := run.NewRunLauncher(run.RunLauncherConfig{
+			Store:                  store,
+			Registry:               registry,
+			Manager:                manager,
+			AgentFactory:           nil,
+			Publisher:              nil,
+			DefaultFeedbackTimeout: 0,
+			ModelResolver:          nil,
+		})
 
 		err := launcher.CheckConcurrency(context.Background(), policyID, model.ConcurrencyReplace)
 		if err != nil {
@@ -238,7 +254,15 @@ func TestCheckConcurrency_Replace(t *testing.T) {
 		}
 
 		registry := mcp.NewRegistry(store.Queries())
-		launcher := run.NewRunLauncher(store, registry, manager, nil, nil, 0, nil)
+		launcher := run.NewRunLauncher(run.RunLauncherConfig{
+			Store:                  store,
+			Registry:               registry,
+			Manager:                manager,
+			AgentFactory:           nil,
+			Publisher:              nil,
+			DefaultFeedbackTimeout: 0,
+			ModelResolver:          nil,
+		})
 
 		err := launcher.CheckConcurrency(context.Background(), policyID, model.ConcurrencyReplace)
 		if err != nil {
@@ -259,7 +283,15 @@ func TestLaunch_ToolResolutionFailure(t *testing.T) {
 	// No MCP server registered, so any tool reference will fail resolution.
 	registry := mcp.NewRegistry(store.Queries())
 	manager := run.NewRunManager()
-	launcher := run.NewRunLauncher(store, registry, manager, nil, nil, 0, nil)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           nil,
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          nil,
+	})
 
 	const policyWithMissingTool = `
 name: tool-failure-policy
@@ -308,7 +340,15 @@ func TestLaunch_AgentConstructionFailure(t *testing.T) {
 	manager := run.NewRunManager()
 
 	agentErr := errors.New("deliberate construction failure")
-	launcher := run.NewRunLauncher(store, registry, manager, failingAgentFactory(agentErr), nil, 0, nil)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           failingAgentFactory(agentErr),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          nil,
+	})
 
 	const launchPolicy = `
 name: agent-fail-policy
@@ -356,7 +396,15 @@ func TestLaunch_Successful(t *testing.T) {
 	// and payload, and LaunchResult.RunID should be non-empty.
 	store, registry := setupIntegrationFixture(t)
 	manager := run.NewRunManager()
-	launcher := run.NewRunLauncher(store, registry, manager, localAgentFactory(), nil, 0, nil)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           localAgentFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          nil,
+	})
 
 	const launchPolicy = `
 name: launch-success-policy
@@ -471,7 +519,15 @@ agent:
 			}
 
 			registry := mcp.NewRegistry(store.Queries())
-			launcher := run.NewRunLauncher(store, registry, run.NewRunManager(), nil, nil, 0, nil)
+			launcher := run.NewRunLauncher(run.RunLauncherConfig{
+				Store:                  store,
+				Registry:               registry,
+				Manager:                run.NewRunManager(),
+				AgentFactory:           nil,
+				Publisher:              nil,
+				DefaultFeedbackTimeout: 0,
+				ModelResolver:          nil,
+			})
 
 			parsed, err := policy.Parse(queuePolicyYAML, "anthropic", "claude-sonnet-4-6")
 			if err != nil {
@@ -517,7 +573,15 @@ agent:
 		testutil.InsertQueueEntry(t, store, "p-drain", "webhook")
 
 		manager := run.NewRunManager()
-		launcher := run.NewRunLauncher(store, registry, manager, localAgentFactory(), nil, 0, nil)
+		launcher := run.NewRunLauncher(run.RunLauncherConfig{
+			Store:                  store,
+			Registry:               registry,
+			Manager:                manager,
+			AgentFactory:           localAgentFactory(),
+			Publisher:              nil,
+			DefaultFeedbackTimeout: 0,
+			ModelResolver:          nil,
+		})
 
 		parsed, err := policy.Parse(policyYAML, "anthropic", "claude-sonnet-4-6")
 		if err != nil {
@@ -553,7 +617,15 @@ agent:
 		testutil.InsertPolicy(t, store, "p-drain-empty", "policy-p-drain-empty", "webhook", policyYAML)
 
 		manager := run.NewRunManager()
-		launcher := run.NewRunLauncher(store, registry, manager, nil, nil, 0, nil)
+		launcher := run.NewRunLauncher(run.RunLauncherConfig{
+			Store:                  store,
+			Registry:               registry,
+			Manager:                manager,
+			AgentFactory:           nil,
+			Publisher:              nil,
+			DefaultFeedbackTimeout: 0,
+			ModelResolver:          nil,
+		})
 
 		parsed, err := policy.Parse(policyYAML, "anthropic", "claude-sonnet-4-6")
 		if err != nil {
@@ -595,7 +667,15 @@ agent:
 		testutil.InsertQueueEntry(t, store, "p-drain-fail", "webhook")
 
 		manager := run.NewRunManager()
-		launcher := run.NewRunLauncher(store, registry, manager, nil, nil, 0, nil)
+		launcher := run.NewRunLauncher(run.RunLauncherConfig{
+			Store:                  store,
+			Registry:               registry,
+			Manager:                manager,
+			AgentFactory:           nil,
+			Publisher:              nil,
+			DefaultFeedbackTimeout: 0,
+			ModelResolver:          nil,
+		})
 
 		parsed, err := policy.Parse(policyYAML, "anthropic", "claude-sonnet-4-6")
 		if err != nil {
@@ -647,7 +727,15 @@ agent:
 
 		manager := run.NewRunManager()
 		registry := mcp.NewRegistry(store.Queries())
-		launcher := run.NewRunLauncher(store, registry, manager, nil, nil, 0, nil)
+		launcher := run.NewRunLauncher(run.RunLauncherConfig{
+			Store:                  store,
+			Registry:               registry,
+			Manager:                manager,
+			AgentFactory:           nil,
+			Publisher:              nil,
+			DefaultFeedbackTimeout: 0,
+			ModelResolver:          nil,
+		})
 
 		parsed, err := policy.Parse(policyYAML, "anthropic", "claude-sonnet-4-6")
 		if err != nil {
@@ -667,7 +755,15 @@ func TestLaunch_ToolResolutionFailure_PublishesEvent(t *testing.T) {
 	registry := mcp.NewRegistry(store.Queries())
 	manager := run.NewRunManager()
 	pub := &testutil.RecordingPublisher{}
-	launcher := run.NewRunLauncher(store, registry, manager, nil, pub, 0, nil)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           nil,
+		Publisher:              pub,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          nil,
+	})
 
 	const policyYAML = `
 name: tool-failure-event-policy
@@ -709,7 +805,15 @@ func TestLaunch_AgentConstructionFailure_PublishesEvent(t *testing.T) {
 	pub := &testutil.RecordingPublisher{}
 
 	agentErr := errors.New("deliberate construction failure")
-	launcher := run.NewRunLauncher(store, registry, manager, failingAgentFactory(agentErr), pub, 0, nil)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           failingAgentFactory(agentErr),
+		Publisher:              pub,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          nil,
+	})
 
 	const policyYAML = `
 name: agent-fail-event-policy

--- a/internal/http/api/router_test.go
+++ b/internal/http/api/router_test.go
@@ -39,7 +39,15 @@ func buildTestRouterWithStore(t *testing.T, store *db.Store) http.Handler {
 	adminQuerier := admin.NewQuerierAdapter(store.Queries())
 	adminHandler := admin.NewHandler(adminQuerier, nil, []string{"anthropic"}, nil, nil, nil)
 
-	launcher := run.NewRunLauncher(store, registry, runManager, run.NewAgentFactory(providerRegistry), broadcaster, 30*time.Minute, adminHandler)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                runManager,
+		AgentFactory:           run.NewAgentFactory(providerRegistry),
+		Publisher:              broadcaster,
+		DefaultFeedbackTimeout: 30 * time.Minute,
+		ModelResolver:          adminHandler,
+	})
 	webhookHandler := trigger.NewWebhookHandler(store, launcher, trigger.NewSecretLoader(store.Queries(), nil), adminHandler)
 	openaiCompatHandler := admin.NewOpenAICompatHandler(nil, nil, providerRegistry, noopConnectionTester)
 

--- a/internal/trigger/cron_test.go
+++ b/internal/trigger/cron_test.go
@@ -38,7 +38,15 @@ func setupCronFixture(t *testing.T) (*db.Store, *CronRunner) {
 	registry := mcp.NewRegistry(store.Queries())
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, cronAgentFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           cronAgentFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	runner := NewCronRunner(store, launcher, resolver)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -211,7 +219,15 @@ func TestCronRunner_Start_LoadsActivePolicies(t *testing.T) {
 	registry := mcp.NewRegistry(store.Queries())
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, cronAgentFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           cronAgentFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	runner := NewCronRunner(store, launcher, resolver)
 
 	yaml := minCronYAML("cron-start", "0 9 * * 1")
@@ -454,7 +470,15 @@ func TestCronRunner_Stop_DoesNotDeadlock(t *testing.T) {
 	registry := mcp.NewRegistry(store.Queries())
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, cronAgentFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           cronAgentFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	runner := NewCronRunner(store, launcher, resolver)
 
 	yaml := minCronYAML("cron-stop", "0 9 * * 1")

--- a/internal/trigger/integration_test.go
+++ b/internal/trigger/integration_test.go
@@ -44,7 +44,15 @@ func buildIntegrationRouter(store *db.Store, registry *mcp.Registry, llmClient l
 		return agent.New(cfg)
 	})
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, factory, nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           factory,
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	wh := trigger.NewWebhookHandler(store, launcher, trigger.NewSecretLoader(store.Queries(), nil), resolver)
 	rh := run.NewRunsHandler(store, manager, nil)
 

--- a/internal/trigger/manual_test.go
+++ b/internal/trigger/manual_test.go
@@ -208,7 +208,15 @@ func TestManualTriggerHandler(t *testing.T) {
 			providerReg := llm.NewProviderRegistry()
 			providerReg.Register("anthropic", noopClient)
 			resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-			launcher := run.NewRunLauncher(store, registry, run.NewRunManager(), run.NewAgentFactory(providerReg), nil, 0, resolver)
+			launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           run.NewAgentFactory(providerReg),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 			h := trigger.NewManualTriggerHandler(store, launcher, resolver)
 
 			w := callManualHandler(t, h, tc.policyID, tc.body)
@@ -228,7 +236,15 @@ func TestManualTriggerHandler_RunCreatedInDB(t *testing.T) {
 	providerReg := llm.NewProviderRegistry()
 	providerReg.Register("anthropic", noopClient)
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, run.NewRunManager(), run.NewAgentFactory(providerReg), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           run.NewAgentFactory(providerReg),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	h := trigger.NewManualTriggerHandler(store, launcher, resolver)
 
 	w := callManualHandler(t, h, "mp-run-created", `{"message": "test"}`)
@@ -263,7 +279,15 @@ func TestManualTriggerHandler_EmptyBody(t *testing.T) {
 	providerReg := llm.NewProviderRegistry()
 	providerReg.Register("anthropic", noopClient)
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, run.NewRunManager(), run.NewAgentFactory(providerReg), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           run.NewAgentFactory(providerReg),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	h := trigger.NewManualTriggerHandler(store, launcher, resolver)
 
 	// Empty body should be accepted (treated as '{}')

--- a/internal/trigger/notify_test.go
+++ b/internal/trigger/notify_test.go
@@ -37,7 +37,15 @@ func setupNotifyPollerFixture(t *testing.T) (*db.Store, *Poller) {
 	registry := mcp.NewRegistry(store.Queries())
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, notifyPollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           notifyPollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := NewPoller(store, launcher, registry, resolver)
 
 	// Set a root context so Notify can start loops.
@@ -175,7 +183,15 @@ func setupNotifySchedulerFixture(t *testing.T) (*db.Store, *Scheduler) {
 	registry := mcp.NewRegistry(store.Queries())
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, notifyPollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           notifyPollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := NewScheduler(store, launcher, resolver)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/trigger/poll_test.go
+++ b/internal/trigger/poll_test.go
@@ -240,7 +240,15 @@ func TestPoller_CheckMatchFires(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -269,7 +277,15 @@ func TestPoller_CheckNoMatchNoRun(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -306,7 +322,15 @@ func TestPoller_MatchAny_OnePassFires(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -357,7 +381,15 @@ agent:
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -393,7 +425,15 @@ func TestPoller_ToolErrorTreatedAsNotPassed(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -431,7 +471,15 @@ func TestPoller_ConcurrencySkip(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -466,7 +514,15 @@ func TestPoller_GracefulShutdown(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -566,7 +622,15 @@ func TestPoller_CheckTimeout_CancelsCallTool(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, resolver)
 
 	if err := poller.Start(ctx); err != nil {
@@ -622,7 +686,15 @@ func TestPoller_SkipsLoop_WhenNoSystemDefaultAndNoModelInYAML(t *testing.T) {
 	manager := run.NewRunManager()
 	// Resolver returns sql.ErrNoRows — simulates unconfigured system default.
 	noDefault := stubDefaultModelResolver{err: sql.ErrNoRows}
-	launcher := run.NewRunLauncher(store, registry, manager, pollerFactory(), nil, 0, noDefault)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          noDefault,
+	})
 	poller := trigger.NewPoller(store, launcher, registry, noDefault)
 
 	if err := poller.Start(ctx); err != nil {

--- a/internal/trigger/scheduled_test.go
+++ b/internal/trigger/scheduled_test.go
@@ -121,7 +121,15 @@ func TestScheduler_SkipsPastTimestampsOnStartup(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -156,7 +164,15 @@ func TestScheduler_FiresFutureTimestamp(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -192,7 +208,15 @@ func TestScheduler_AutoPausesAfterAllTimesConsumed(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -238,7 +262,15 @@ func TestScheduler_DeduplicatesAlreadyFiredTime(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -276,7 +308,15 @@ func TestScheduler_ConcurrencySkip_BlocksWhenActive(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -310,7 +350,15 @@ func TestScheduler_ConcurrencySkip_ProceedsWhenIdle(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -349,7 +397,15 @@ func TestScheduler_ConcurrencyQueue_EnqueuesWhenActive(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -393,7 +449,15 @@ func TestScheduler_ConcurrencyQueue_LaunchesWhenIdle(t *testing.T) {
 
 	manager := run.NewRunManager()
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, resolver)
 
 	if err := scheduler.Start(ctx); err != nil {
@@ -459,7 +523,15 @@ func TestScheduler_SkipsPolicy_WhenNoSystemDefaultAndNoModelInYAML(t *testing.T)
 	manager := run.NewRunManager()
 	// Resolver that returns sql.ErrNoRows — simulates unconfigured system default.
 	noDefault := stubDefaultModelResolver{err: sql.ErrNoRows}
-	launcher := run.NewRunLauncher(store, registry, manager, schedulerFactory(), nil, 0, noDefault)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          noDefault,
+	})
 	scheduler := trigger.NewScheduler(store, launcher, noDefault)
 
 	if err := scheduler.Start(ctx); err != nil {

--- a/internal/trigger/sse_integration_test.go
+++ b/internal/trigger/sse_integration_test.go
@@ -38,7 +38,15 @@ func buildSSERouter(t *testing.T, policyID string, llmClient llm.LLMClient, broa
 		return agent.New(cfg)
 	})
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, manager, factory, broadcaster, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           factory,
+		Publisher:              broadcaster,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	wh := trigger.NewWebhookHandler(store, launcher, trigger.NewSecretLoader(store.Queries(), nil), resolver)
 	rh := run.NewRunsHandler(store, manager, broadcaster)
 

--- a/internal/trigger/webhook_test.go
+++ b/internal/trigger/webhook_test.go
@@ -162,7 +162,15 @@ func newHandler(t *testing.T, store *db.Store, loader trigger.SecretLoaderInterf
 	providerReg := llm.NewProviderRegistry()
 	providerReg.Register("anthropic", noopClient)
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, run.NewRunManager(), run.NewAgentFactory(providerReg), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           run.NewAgentFactory(providerReg),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	return trigger.NewWebhookHandler(store, launcher, loader, resolver)
 }
 
@@ -526,7 +534,15 @@ func TestWebhookHandler_RunCreatedInDB(t *testing.T) {
 	providerReg := llm.NewProviderRegistry()
 	providerReg.Register("anthropic", noopClient)
 	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
-	launcher := run.NewRunLauncher(store, registry, run.NewRunManager(), run.NewAgentFactory(providerReg), nil, 0, resolver)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           run.NewAgentFactory(providerReg),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
 	h := trigger.NewWebhookHandler(store, launcher, trigger.NewSecretLoader(store.Queries(), nil), resolver)
 
 	w := callHandler(t, h, "p-run-created", `{"event": "test"}`)
@@ -596,7 +612,15 @@ func TestWebhookHandler_Returns500_WhenNoDefaultModelAndPolicyOmitsModel(t *test
 
 	// Resolver with no default configured.
 	noDefault := stubDefaultModelResolver{err: sql.ErrNoRows}
-	launcher := run.NewRunLauncher(store, registry, run.NewRunManager(), run.NewAgentFactory(providerReg), nil, 0, noDefault)
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           run.NewAgentFactory(providerReg),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          noDefault,
+	})
 	h := trigger.NewWebhookHandler(store, launcher, trigger.NewSecretLoader(store.Queries(), nil), noDefault)
 
 	w := callHandler(t, h, "p-no-model-500", `{"event": "test"}`)

--- a/main.go
+++ b/main.go
@@ -13,12 +13,12 @@ import (
 	"time"
 
 	"github.com/rapp992/gleipnir/internal/admin"
-	"github.com/rapp992/gleipnir/internal/infra/config"
 	"github.com/rapp992/gleipnir/internal/db"
 	runpkg "github.com/rapp992/gleipnir/internal/execution/run"
 	"github.com/rapp992/gleipnir/internal/http/api"
 	"github.com/rapp992/gleipnir/internal/http/auth"
 	"github.com/rapp992/gleipnir/internal/http/sse"
+	"github.com/rapp992/gleipnir/internal/infra/config"
 	"github.com/rapp992/gleipnir/internal/llm"
 	llmfactory "github.com/rapp992/gleipnir/internal/llm/factory"
 	openaicompatllm "github.com/rapp992/gleipnir/internal/llm/openaicompat"
@@ -189,7 +189,15 @@ func run(cfg config.Config) error {
 		slog.Warn("could not ensure default model is enabled", "err", err)
 	}
 
-	launcher := runpkg.NewRunLauncher(store, registry, runManager, runpkg.NewAgentFactory(providerRegistry), broadcaster, cfg.DefaultFeedbackTimeout, adminHandler)
+	launcher := runpkg.NewRunLauncher(runpkg.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                runManager,
+		AgentFactory:           runpkg.NewAgentFactory(providerRegistry),
+		Publisher:              broadcaster,
+		DefaultFeedbackTimeout: cfg.DefaultFeedbackTimeout,
+		ModelResolver:          adminHandler,
+	})
 
 	webhookSecretLoader := trigger.NewSecretLoader(store.Queries(), encryptionKey)
 	webhookHandler := trigger.NewWebhookHandler(store, launcher, webhookSecretLoader, adminHandler)


### PR DESCRIPTION
Closes #55

## Summary

- Added `RunLauncherConfig` struct in `internal/execution/run/launcher.go` with all 7 former positional parameters as named fields (including nil-intent comments on `Publisher` and `ModelResolver`)
- Updated `NewRunLauncher` to accept `RunLauncherConfig` by value
- Updated all 47 call sites across 12 files (1 production + 11 test files) to use the named struct form

## Architecture plan

<details>
<summary>Implementation plan</summary>

Purely mechanical refactor following the stdlib config-struct pattern (`http.Server`, `tls.Config`). Field order in `RunLauncherConfig` mirrors the former positional parameter order so the diff is trivially auditable. All seven fields are kept explicit in every test struct literal (even zero-valued ones) to make review a line-for-line check.

Key decision: `registryResolver` and `defaultModelResolver` remain unexported — Go allows exported struct fields typed as unexported interfaces; callers pass concrete types that satisfy the interface without naming it.

</details>

## Review cycles

1 cycle — APPROVE on first pass.

## CLAUDE.md

No updates needed — no new packages, env vars, API routes, model types, or trigger types added.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)