### PR TITLE
feat: gleipnirctl reset-password subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ schemas/
   sql_schemas.sql     — schema that explains the different tables in our datastore
 
 cmd/
-  gleipnirctl/        — local admin CLI; direct DB-level maintenance operations (rotate-key, and planned: reset-password, create-user, list-users, purge-runs, verify-keys, check). Run via `docker compose run --rm api gleipnirctl <command>`.
+  gleipnirctl/        — local admin CLI; direct DB-level maintenance operations (rotate-key, reset-password, and planned: create-user, list-users, purge-runs, verify-keys, check). Run via `docker compose run --rm api gleipnirctl <command>`.
 
 internal/
   approval/           — approval-specific timeout wiring (thin wrapper over timeout/)

--- a/cmd/gleipnirctl/README.md
+++ b/cmd/gleipnirctl/README.md
@@ -17,7 +17,7 @@ The web UI handles day-to-day operations: managing policies, reviewing runs, app
 | Command | Status | Description |
 |---|---|---|
 | `rotate-key` | Available | Re-encrypt all at-rest secrets under a new encryption key |
-| `reset-password` | Coming soon | Reset a user's password directly in the database |
+| `reset-password` | Available | Reset a user's password directly in the database |
 | `create-user` | Coming soon | Create a new user account without going through the web UI |
 | `list-users` | Coming soon | List all user accounts and their roles |
 | `purge-runs` | Coming soon | Delete run history older than a given date |
@@ -129,3 +129,61 @@ docker compose run --rm api gleipnirctl rotate-key --old <current-key> --new <ne
 - **Atomicity:** All re-encryption happens in a single SQLite transaction. A crash or error mid-rotation leaves the database unchanged — the old key remains valid.
 - **In-memory key lifetime:** Key bytes are zeroed in memory when the command exits. Intermediate plaintext values (decrypted secrets) cannot be zeroed because Go strings are immutable; they are released to the garbage collector on function return.
 - **Server must be stopped:** The command probes for DB write-lock contention and refuses with exit code 3 if the server is running. This prevents the running process from caching stale plaintext while the DB holds new-key ciphertexts.
+
+---
+
+## reset-password
+
+Resets a user's password by writing a new bcrypt hash directly to the database. Uses the same bcrypt cost as the server so passwords set via CLI are accepted by the login handler.
+
+### When to use this
+
+- An admin is locked out of the UI and no other admin account exists to reset the password through the settings page
+- You need to set a known password on a user account during a recovery procedure
+
+### Full workflow
+
+**With auto-generated password** (recommended):
+
+```bash
+docker compose run --rm api gleipnirctl reset-password <username>
+```
+
+Example output:
+```
+generated password: dGhpcyBpcyBhIHRlc3Q
+password reset for user alice
+```
+
+The generated password is printed to stdout before the confirmation line. Store it immediately — it is shown only once.
+
+**With an explicit password:**
+
+```bash
+docker compose run --rm api gleipnirctl reset-password <username> --password <new-password>
+```
+
+The server does not need to be stopped. This command performs a single short UPDATE and does not require holding the database write lock across long operations.
+
+### Flags
+
+| Flag / Argument | Default | Description |
+|---|---|---|
+| `<username>` | *(required positional)* | Username of the account to update |
+| `--password` | *(auto-generated if omitted)* | New password. Must be at least 8 characters. |
+| `--db-path` | `$GLEIPNIR_DB_PATH` or `/data/gleipnir.db` | Path to the SQLite database file. |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Unexpected error (I/O failure, DB error, hashing failure) |
+| 2 | Bad input (password shorter than 8 characters) |
+| 4 | User not found |
+
+### Security notes
+
+- **Generated password is secret material.** It is printed to stdout so it can be captured by downstream tools (`... | tee password.txt`). Do not share terminal output containing this line.
+- **Rotate via the UI after logging in.** Once access is restored, change the password through the settings page so it is set according to your organization's password policy.
+- **Deactivated users.** This command resets the password hash only. It does not reactivate a deactivated account. Use the web UI (admin role) to reactivate a user.

--- a/cmd/gleipnirctl/main.go
+++ b/cmd/gleipnirctl/main.go
@@ -22,6 +22,7 @@ func newRootCmd() *cobra.Command {
 func main() {
 	root := newRootCmd()
 	root.AddCommand(newRotateKeyCmd())
+	root.AddCommand(newResetPasswordCmd())
 	if err := root.Execute(); err != nil {
 		root.PrintErrln("error:", err)
 		os.Exit(1)

--- a/cmd/gleipnirctl/reset_password.go
+++ b/cmd/gleipnirctl/reset_password.go
@@ -1,0 +1,93 @@
+// Package main implements the gleipnirctl local admin CLI.
+//
+// reset_password.go contains the core password-reset logic: ResetPassword looks
+// up a user by username, hashes the new password with the same bcrypt cost as
+// the server, and writes it in a single UPDATE. The Cobra command wiring lives
+// in resetpassword.go.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/http/auth"
+)
+
+// ResetPassword resets the password for username in the database at dbPath.
+// If password is empty the caller is responsible for generating one before
+// calling this function. Returns a shell exit code:
+//
+//	0 — success
+//	1 — unexpected error (I/O, DB error, hashing failure)
+//	2 — bad input (empty username, password shorter than 8 chars)
+//	4 — user not found
+func ResetPassword(ctx context.Context, dbPath, username, password string, out, errOut io.Writer) int {
+	if username == "" {
+		fmt.Fprintln(errOut, "error: username must not be empty")
+		return 2
+	}
+	if len(password) < 8 {
+		fmt.Fprintln(errOut, "error: password must be at least 8 characters")
+		return 2
+	}
+
+	store, err := db.Open(dbPath)
+	if err != nil {
+		fmt.Fprintf(errOut, "error: open db: %v\n", err)
+		return 1
+	}
+	defer store.Close()
+
+	// Migration is idempotent; ensures the command works against a restored
+	// backup that may be on an older schema version.
+	if err := store.Migrate(ctx); err != nil {
+		fmt.Fprintf(errOut, "error: migrate db: %v\n", err)
+		return 1
+	}
+
+	user, err := store.Queries().GetUserByUsername(ctx, username)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(errOut, "error: user %q not found\n", username)
+			return 4
+		}
+		fmt.Fprintf(errOut, "error: look up user %q: %v\n", username, err)
+		return 1
+	}
+
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		fmt.Fprintf(errOut, "error: hash password: %v\n", err)
+		return 1
+	}
+
+	// No lockout columns exist in the users table today (see schemas/sql_schemas.sql);
+	// this is a no-op placeholder for future lockout state.
+	if err := store.Queries().UpdateUserPassword(ctx, db.UpdateUserPasswordParams{
+		PasswordHash: hash,
+		ID:           user.ID,
+	}); err != nil {
+		fmt.Fprintf(errOut, "error: update password for %q: %v\n", username, err)
+		return 1
+	}
+
+	fmt.Fprintf(out, "password reset for user %s\n", username)
+	return 0
+}
+
+// generateRandomPassword returns a 24-character URL-safe base64 string derived
+// from 18 random bytes (144 bits of entropy). URL-safe base64 without padding
+// avoids characters (+, /, =) that require shell quoting.
+func generateRandomPassword() (string, error) {
+	buf := make([]byte, 18)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate random password: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/cmd/gleipnirctl/resetpassword.go
+++ b/cmd/gleipnirctl/resetpassword.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newResetPasswordCmd() *cobra.Command {
+	var password, dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "reset-password <username>",
+		Short: "Reset a user's password directly in the database",
+		Long: `Resets a Gleipnir user's password by writing a new bcrypt hash directly to the
+database. This is the primary recovery path when an admin is locked out of the
+web UI and no other admin account is available to reset the password through the
+settings page.
+
+The server does not need to be stopped — this command performs a single short
+UPDATE that resolves any write contention on its own via SQLite's busy retry.
+
+If --password is not provided, a cryptographically random 24-character password
+is generated and printed to stdout before the confirmation line. Store it
+immediately; it is printed only once.`,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			username := args[0]
+			out := cmd.OutOrStdout()
+			errOut := cmd.ErrOrStderr()
+
+			if password == "" {
+				generated, err := generateRandomPassword()
+				if err != nil {
+					fmt.Fprintf(errOut, "error: %v\n", err)
+					os.Exit(1)
+				}
+				password = generated
+				fmt.Fprintf(out, "generated password: %s\n", password)
+			}
+
+			code := ResetPassword(context.Background(), dbPath, username, password, out, errOut)
+			if code != 0 {
+				os.Exit(code)
+			}
+			return nil
+		},
+	}
+
+	// Resolve default DB path from env var, falling back to the hardcoded default.
+	envDBPath := os.Getenv("GLEIPNIR_DB_PATH")
+	if envDBPath == "" {
+		envDBPath = defaultDBPath
+	}
+
+	cmd.Flags().StringVar(&password, "password", "", "new password; if omitted a random password is generated and printed to stdout")
+	cmd.Flags().StringVar(&dbPath, "db-path", envDBPath, "path to the SQLite database file")
+
+	return cmd
+}

--- a/cmd/gleipnirctl/resetpassword_test.go
+++ b/cmd/gleipnirctl/resetpassword_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/http/auth"
+	"github.com/rapp992/gleipnir/internal/testutil"
+)
+
+// seedUser inserts a user with a placeholder password hash and returns the user ID.
+func seedUser(t *testing.T, s *db.Store, username string) string {
+	t.Helper()
+	const testUserID = "01HZZZZZZZZZZZZZZZZZZZZZZZ"
+	hash, err := auth.HashPassword("placeholder-password")
+	if err != nil {
+		t.Fatalf("hash placeholder password: %v", err)
+	}
+	_, err = s.Queries().CreateUser(context.Background(), db.CreateUserParams{
+		ID:           testUserID,
+		Username:     username,
+		PasswordHash: hash,
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("seed user %q: %v", username, err)
+	}
+	return testUserID
+}
+
+func TestResetPassword_SuccessWithExplicitPassword(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedUser(t, s, "alice")
+	path := storePath(t, s)
+	s.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := ResetPassword(context.Background(), path, "alice", "new-password-1234", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "password reset for user alice") {
+		t.Errorf("stdout missing confirmation: %q", stdout.String())
+	}
+
+	// Verify the new password hash is accepted.
+	s2 := openForVerify(t, path)
+	defer s2.Close()
+	user, err := s2.Queries().GetUserByUsername(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if err := auth.CheckPassword(user.PasswordHash, "new-password-1234"); err != nil {
+		t.Errorf("CheckPassword failed after reset: %v", err)
+	}
+}
+
+func TestResetPassword_UnknownUserReturns4(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	path := storePath(t, s)
+	s.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := ResetPassword(context.Background(), path, "ghost", "some-password", &stdout, &stderr)
+	if code != 4 {
+		t.Fatalf("expected exit 4, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `user "ghost" not found`) {
+		t.Errorf("stderr missing user-not-found message: %q", stderr.String())
+	}
+}
+
+func TestResetPassword_ShortPasswordRejected(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedUser(t, s, "alice")
+	path := storePath(t, s)
+	s.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := ResetPassword(context.Background(), path, "alice", "short", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("expected exit 2, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "at least 8 characters") {
+		t.Errorf("stderr missing minimum-length message: %q", stderr.String())
+	}
+}
+
+// TestResetPassword_GeneratedPasswordRoundtrip exercises the full Cobra wiring:
+// no --password flag, so a random password is generated, printed to stdout, and
+// the resulting hash must be accepted by auth.CheckPassword.
+func TestResetPassword_GeneratedPasswordRoundtrip(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedUser(t, s, "alice")
+	path := storePath(t, s)
+	s.Close()
+
+	cmd := newResetPasswordCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"alice", "--db-path", path})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command failed: %v; stderr: %s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	// Extract the generated password from the "generated password: <pwd>" line.
+	var generatedPwd string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "generated password: ") {
+			generatedPwd = strings.TrimPrefix(line, "generated password: ")
+			break
+		}
+	}
+	if generatedPwd == "" {
+		t.Fatalf("generated password line not found in stdout: %q", out)
+	}
+	if !strings.Contains(out, "password reset for user alice") {
+		t.Errorf("confirmation line missing from stdout: %q", out)
+	}
+
+	// Verify the generated password hash stored in DB.
+	s2 := openForVerify(t, path)
+	defer s2.Close()
+	user, err := s2.Queries().GetUserByUsername(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if err := auth.CheckPassword(user.PasswordHash, generatedPwd); err != nil {
+		t.Errorf("CheckPassword rejected generated password: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #86

## Summary

- Adds `gleipnirctl reset-password <username>` as the primary emergency recovery path for admins locked out of the UI
- Reuses `auth.HashPassword` (bcrypt cost 12) to ensure CLI-set passwords are accepted by the login handler
- Auto-generates a 24-char URL-safe password (144-bit entropy) from `crypto/rand` when `--password` is omitted; printed to stdout before confirmation
- Uses existing sqlc queries (`GetUserByUsername`, `UpdateUserPassword`) — no new SQL needed
- Follows the two-file `rotate.go`/`rotatekey.go` pattern: `reset_password.go` (core logic + exit codes) + `resetpassword.go` (Cobra wiring)

<details>
<summary>Architecture plan</summary>

**Affected files:**
- `cmd/gleipnirctl/reset_password.go` — new; exports `ResetPassword(ctx, dbPath, username, password string, out, errOut io.Writer) int`
- `cmd/gleipnirctl/resetpassword.go` — new; Cobra wiring + `os.Exit`
- `cmd/gleipnirctl/resetpassword_test.go` — new; 4 integration tests using real SQLite
- `cmd/gleipnirctl/main.go` — registers `newResetPasswordCmd()`
- `cmd/gleipnirctl/README.md` — updates status table and adds full `## reset-password` section
- `CLAUDE.md` — promotes reset-password from planned to available

**Key decisions:**
- No lockout columns exist in the schema (`users` has only `id, username, password_hash, created_at, deactivated_at`); "clear lockout state" is a documented no-op placeholder. `deactivated_at` is intentionally untouched — deactivation is soft-delete, not lockout.
- Exit codes: 0 (success), 1 (unexpected error), 2 (bad input), 4 (user not found)
- 8-char minimum password enforced in core function (not just Cobra RunE) so it's testable directly
- Single short UPDATE; no server-stop required (unlike rotate-key)

</details>

**Review cycles:** 1 (approved on first pass)

**CLAUDE.md updated:** Yes — `reset-password` promoted from planned to available in the `gleipnirctl/` package description

---
🤖 Generated with the agentic dev loop