### PR TITLE
feat: tool-level disable to prevent tools from appearing in policies

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -119,7 +119,8 @@ queryKeys.runs.detail(id)       // ['runs', id]
 queryKeys.runs.steps(id)        // ['runs', id, 'steps']
 queryKeys.runs.list(params)     // ['runs', 'list', params]
 queryKeys.servers.all           // ['servers']
-queryKeys.servers.tools(id)     // ['servers', id, 'tools']
+queryKeys.servers.tools(id)     // ['servers', id, 'tools']        — enabled tools only (used by policy form)
+queryKeys.servers.toolsAll(id)  // ['servers', id, 'tools', 'all'] — all tools incl. disabled (used by Tools page)
 queryKeys.stats.all             // ['stats']
 queryKeys.approvals.all         // ['approvals']
 queryKeys.users.all             // ['users']
@@ -180,7 +181,8 @@ GET    /api/v1/mcp/servers             POST   /api/v1/mcp/servers
 POST   /api/v1/mcp/servers/test
 DELETE /api/v1/mcp/servers/:id
 POST   /api/v1/mcp/servers/:id/discover
-GET    /api/v1/mcp/servers/:id/tools
+GET    /api/v1/mcp/servers/:id/tools           (?include_disabled=true for admin/operator)
+PUT    /api/v1/mcp/servers/:id/tools/:toolID/enabled
 
 Approvals:
 GET    /api/v1/approvals

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -150,6 +150,7 @@ export interface ApiMcpTool {
   name: string
   description: string
   input_schema: Record<string, unknown>
+  enabled: boolean
 }
 
 // --- Settings ---

--- a/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.stories.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.stories.tsx
@@ -34,6 +34,7 @@ const FIXTURE_TOOLS_SRV1: ApiMcpTool[] = [
     name: 'read_file',
     description: 'Read the contents of a file at the given path',
     input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    enabled: true,
   },
   {
     id: 'tool-2',
@@ -45,6 +46,7 @@ const FIXTURE_TOOLS_SRV1: ApiMcpTool[] = [
       properties: { path: { type: 'string' }, content: { type: 'string' } },
       required: ['path', 'content'],
     },
+    enabled: true,
   },
   {
     id: 'tool-3',
@@ -52,6 +54,7 @@ const FIXTURE_TOOLS_SRV1: ApiMcpTool[] = [
     name: 'list_directory',
     description: 'List files and directories at the given path',
     input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    enabled: true,
   },
 ];
 
@@ -70,6 +73,7 @@ const FIXTURE_TOOLS_SRV2: ApiMcpTool[] = [
       },
       required: ['repo', 'title'],
     },
+    enabled: true,
   },
   {
     id: 'tool-5',
@@ -77,6 +81,7 @@ const FIXTURE_TOOLS_SRV2: ApiMcpTool[] = [
     name: 'list_issues',
     description: 'List open issues for a GitHub repository',
     input_schema: { type: 'object', properties: { repo: { type: 'string' } }, required: ['repo'] },
+    enabled: true,
   },
 ];
 

--- a/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.test.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.test.tsx
@@ -36,6 +36,7 @@ const FIXTURE_TOOLS_SRV1: ApiMcpTool[] = [
     name: 'read_file',
     description: 'Read the contents of a file at the given path',
     input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    enabled: true,
   },
   {
     id: 'tool-2',
@@ -47,6 +48,7 @@ const FIXTURE_TOOLS_SRV1: ApiMcpTool[] = [
       properties: { path: { type: 'string' }, content: { type: 'string' } },
       required: ['path', 'content'],
     },
+    enabled: true,
   },
 ]
 
@@ -61,6 +63,7 @@ const FIXTURE_TOOLS_SRV2: ApiMcpTool[] = [
       properties: { repo: { type: 'string' }, title: { type: 'string' } },
       required: ['repo', 'title'],
     },
+    enabled: true,
   },
 ]
 

--- a/frontend/src/components/MCPPage/ServerCard/ServerCard.stories.tsx
+++ b/frontend/src/components/MCPPage/ServerCard/ServerCard.stories.tsx
@@ -21,13 +21,13 @@ const server: ApiMcpServer = {
 }
 
 const tools: ApiMcpTool[] = [
-  { id: 't1', server_id: 'srv1', name: 'echo', description: 'Echo message.', input_schema: {} },
-  { id: 't2', server_id: 'srv1', name: 'get_current_time', description: 'Get time.', input_schema: {} },
-  { id: 't3', server_id: 'srv1', name: 'get_system_status', description: 'Get status.', input_schema: {} },
-  { id: 't4', server_id: 'srv1', name: 'list_items', description: 'List items.', input_schema: {} },
-  { id: 't5', server_id: 'srv1', name: 'send_notification', description: 'Send notification.', input_schema: {} },
-  { id: 't6', server_id: 'srv1', name: 'update_item_stock', description: 'Update stock.', input_schema: {} },
-  { id: 't7', server_id: 'srv1', name: 'write_file', description: 'Write file.', input_schema: {} },
+  { id: 't1', server_id: 'srv1', name: 'echo', description: 'Echo message.', input_schema: {}, enabled: true },
+  { id: 't2', server_id: 'srv1', name: 'get_current_time', description: 'Get time.', input_schema: {}, enabled: true },
+  { id: 't3', server_id: 'srv1', name: 'get_system_status', description: 'Get status.', input_schema: {}, enabled: true },
+  { id: 't4', server_id: 'srv1', name: 'list_items', description: 'List items.', input_schema: {}, enabled: true },
+  { id: 't5', server_id: 'srv1', name: 'send_notification', description: 'Send notification.', input_schema: {}, enabled: true },
+  { id: 't6', server_id: 'srv1', name: 'update_item_stock', description: 'Update stock.', input_schema: {}, enabled: true },
+  { id: 't7', server_id: 'srv1', name: 'write_file', description: 'Write file.', input_schema: {}, enabled: true },
 ]
 
 export const Healthy: Story = {

--- a/frontend/src/components/MCPPage/ServerDetailModal/ServerDetailModal.stories.tsx
+++ b/frontend/src/components/MCPPage/ServerDetailModal/ServerDetailModal.stories.tsx
@@ -17,11 +17,13 @@ const tools: ApiMcpTool[] = [
     id: 't1', server_id: 'srv-1', name: 'echo',
     description: 'Echo the provided message back unchanged.',
     input_schema: { properties: { message: { type: 'string' } }, required: ['message'], type: 'object' },
+    enabled: true,
   },
   {
     id: 't2', server_id: 'srv-1', name: 'get_current_time',
     description: 'Return the current UTC time as an ISO 8601 string.',
     input_schema: { properties: {}, type: 'object' },
+    enabled: true,
   },
   {
     id: 't3', server_id: 'srv-1', name: 'send_notification',
@@ -30,6 +32,7 @@ const tools: ApiMcpTool[] = [
       properties: { channel: { type: 'string' }, message: { type: 'string' } },
       required: ['channel', 'message'], type: 'object',
     },
+    enabled: true,
   },
 ]
 
@@ -44,7 +47,7 @@ type Story = StoryObj<typeof ServerDetailModal>
 
 export const Healthy: Story = {
   args: {
-    server, tools, toolsLoading: false, isDiscovering: false,
+    server, tools, toolsLoading: false, isDiscovering: false, canManage: true,
     policies: [
       { id: 'p1', name: 'system-health-check', trigger_type: 'webhook', folder: 'testing',
         model: '', tool_count: 3, tool_refs: ['test-server.echo', 'test-server.get_current_time', 'test-server.get_system_status'],
@@ -52,6 +55,10 @@ export const Healthy: Story = {
     ],
     onClose: () => {}, onDiscover: () => {}, onDelete: () => {},
   },
+}
+
+export const ReadOnly: Story = {
+  args: { ...Healthy.args, canManage: false },
 }
 
 export const WithDrift: Story = {
@@ -68,4 +75,14 @@ export const Discovering: Story = {
 
 export const Loading: Story = {
   args: { ...Healthy.args, toolsLoading: true, tools: undefined },
+}
+
+export const WithDisabledTool: Story = {
+  args: {
+    ...Healthy.args,
+    tools: [
+      ...tools.slice(0, 2),
+      { ...tools[2], enabled: false },
+    ],
+  },
 }

--- a/frontend/src/components/MCPPage/ServerDetailModal/ServerDetailModal.test.tsx
+++ b/frontend/src/components/MCPPage/ServerDetailModal/ServerDetailModal.test.tsx
@@ -1,7 +1,14 @@
+import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ServerDetailModal } from './ServerDetailModal'
 import type { ApiMcpServer, ApiMcpTool } from '@/api/types'
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
 
 const server: ApiMcpServer = {
   id: 'srv-1',
@@ -23,6 +30,7 @@ const tools: ApiMcpTool[] = [
       required: ['message'],
       type: 'object',
     },
+    enabled: true,
   },
   {
     id: 't2',
@@ -30,6 +38,7 @@ const tools: ApiMcpTool[] = [
     name: 'get_time',
     description: 'Get current time.',
     input_schema: { properties: {}, type: 'object' },
+    enabled: true,
   },
 ]
 
@@ -39,6 +48,7 @@ const defaultProps = {
   toolsLoading: false,
   isDiscovering: false,
   policies: undefined,
+  canManage: false,
   onClose: vi.fn(),
   onDiscover: vi.fn(),
   onDelete: vi.fn(),
@@ -46,75 +56,75 @@ const defaultProps = {
 
 describe('ServerDetailModal', () => {
   it('renders server name and tool count', () => {
-    render(<ServerDetailModal {...defaultProps} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} />)
     expect(screen.getByText('test-server')).toBeInTheDocument()
     expect(screen.getByText('2 tools')).toBeInTheDocument()
   })
 
   it('renders server URL', () => {
-    render(<ServerDetailModal {...defaultProps} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} />)
     expect(screen.getByText(/mcp-test-server:8090/)).toBeInTheDocument()
   })
 
   it('renders all tool names in accordion', () => {
-    render(<ServerDetailModal {...defaultProps} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} />)
     expect(screen.getByText('echo')).toBeInTheDocument()
     expect(screen.getByText('get_time')).toBeInTheDocument()
   })
 
   it('calls onClose when close button is clicked', () => {
     const onClose = vi.fn()
-    render(<ServerDetailModal {...defaultProps} onClose={onClose} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} onClose={onClose} />)
     fireEvent.click(screen.getByLabelText('Close'))
     expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('calls onDiscover when Rediscover is clicked', () => {
     const onDiscover = vi.fn()
-    render(<ServerDetailModal {...defaultProps} onDiscover={onDiscover} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} onDiscover={onDiscover} />)
     fireEvent.click(screen.getByRole('button', { name: /rediscover/i }))
     expect(onDiscover).toHaveBeenCalledWith('srv-1')
   })
 
   it('calls onDelete when Delete is clicked', () => {
     const onDelete = vi.fn()
-    render(<ServerDetailModal {...defaultProps} onDelete={onDelete} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} onDelete={onDelete} />)
     fireEvent.click(screen.getByRole('button', { name: /delete/i }))
     expect(onDelete).toHaveBeenCalledWith(server, 2)
   })
 
   it('shows Discovering text when isDiscovering is true', () => {
-    render(<ServerDetailModal {...defaultProps} isDiscovering={true} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} isDiscovering={true} />)
     expect(screen.getByText(/discovering/i)).toBeInTheDocument()
   })
 
   it('shows Drift badge when server has_drift is true', () => {
     const driftServer = { ...server, has_drift: true }
-    render(<ServerDetailModal {...defaultProps} server={driftServer} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} server={driftServer} />)
     expect(screen.getByText('Drift')).toBeInTheDocument()
   })
 
   it('shows Unreachable badge when last_discovered_at is null', () => {
     const unreachableServer = { ...server, last_discovered_at: null }
-    render(<ServerDetailModal {...defaultProps} server={unreachableServer} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} server={unreachableServer} />)
     expect(screen.getByText('Unreachable')).toBeInTheDocument()
   })
 
   it('shows no status badge for healthy connected server', () => {
-    render(<ServerDetailModal {...defaultProps} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} />)
     expect(screen.queryByText('Drift')).not.toBeInTheDocument()
     expect(screen.queryByText('Unreachable')).not.toBeInTheDocument()
   })
 
   it('shows loading skeletons when toolsLoading is true', () => {
-    render(<ServerDetailModal {...defaultProps} toolsLoading={true} tools={undefined} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} toolsLoading={true} tools={undefined} />)
     const skeletons = document.querySelectorAll('[aria-hidden="true"]')
     expect(skeletons.length).toBeGreaterThan(0)
   })
 
   it('closes on Escape key', () => {
     const onClose = vi.fn()
-    render(<ServerDetailModal {...defaultProps} onClose={onClose} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} onClose={onClose} />)
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).toHaveBeenCalledOnce()
   })
@@ -122,19 +132,19 @@ describe('ServerDetailModal', () => {
 
 describe('ServerDetailModal — accessibility', () => {
   it("has role='dialog' and aria-modal='true' on the content box", () => {
-    render(<ServerDetailModal {...defaultProps} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} />)
     const dialog = screen.getByRole('dialog')
     expect(dialog).toHaveAttribute('aria-modal', 'true')
   })
 
   it('dialog has accessible name via aria-label', () => {
-    render(<ServerDetailModal {...defaultProps} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} />)
     const dialog = screen.getByRole('dialog')
     expect(dialog.getAttribute('aria-label')).toBe('test-server details')
   })
 
   it('wraps content in FocusTrap (all interactive elements inside dialog)', () => {
-    render(<ServerDetailModal {...defaultProps} />)
+    renderWithClient(<ServerDetailModal {...defaultProps} />)
     const dialog = screen.getByRole('dialog')
     const closeBtn = screen.getByRole('button', { name: 'Close' })
     const rediscoverBtn = screen.getByRole('button', { name: /rediscover/i })

--- a/frontend/src/components/MCPPage/ServerDetailModal/ServerDetailModal.tsx
+++ b/frontend/src/components/MCPPage/ServerDetailModal/ServerDetailModal.tsx
@@ -5,6 +5,7 @@ import type { ApiMcpServer, ApiMcpTool, ApiPolicyListItem } from '@/api/types'
 import { ToolAccordionRow } from '@/components/MCPPage/ToolAccordionRow'
 import { SkeletonBlock } from '@/components/SkeletonBlock'
 import { formatTimeAgo } from '@/utils/format'
+import { useSetMcpToolEnabled } from '@/hooks/mutations/servers'
 import styles from './ServerDetailModal.module.css'
 
 interface Props {
@@ -13,6 +14,10 @@ interface Props {
   toolsLoading: boolean
   isDiscovering: boolean
   policies: ApiPolicyListItem[] | undefined
+  // canManage controls whether enable/disable toggles are shown.
+  // Derived from the current user's roles in MCPPage and passed as a prop
+  // to keep this component controlled and prop-driven.
+  canManage: boolean
   onClose: () => void
   onDiscover: (serverId: string) => void
   onDelete: (server: ApiMcpServer, toolCount: number) => void
@@ -44,10 +49,12 @@ export function ServerDetailModal({
   toolsLoading,
   isDiscovering,
   policies,
+  canManage,
   onClose,
   onDiscover,
   onDelete,
 }: Props) {
+  const setToolEnabledMutation = useSetMcpToolEnabled()
   const [expandedToolId, setExpandedToolId] = useState<string | null>(null)
   const [filter, setFilter] = useState('')
   const toolCount = tools?.length ?? 0
@@ -190,6 +197,14 @@ export function ServerDetailModal({
                     expanded={expandedToolId === tool.id}
                     onToggle={() => setExpandedToolId(expandedToolId === tool.id ? null : tool.id)}
                     usedBy={usedBy}
+                    canManage={canManage}
+                    onSetEnabled={(enabled) =>
+                      setToolEnabledMutation.mutate({ serverId: server.id, toolId: tool.id, enabled })
+                    }
+                    isUpdatingEnabled={
+                      setToolEnabledMutation.isPending &&
+                      setToolEnabledMutation.variables?.toolId === tool.id
+                    }
                   />
                 )
               })

--- a/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.module.css
+++ b/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.module.css
@@ -109,3 +109,54 @@
   font-size: var(--text-xs);
   font-family: var(--font-mono);
 }
+
+/* Disabled tool row — reduced opacity signals the tool is inactive. */
+.rowDisabled {
+  opacity: 0.65;
+}
+
+/* Badge shown next to the tool name when enabled = false. */
+.disabledBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--space-2);
+  border-radius: 4px;
+  font-size: var(--text-xs);
+  font-family: var(--font-body);
+  font-weight: var(--weight-medium);
+  background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+  color: var(--color-amber);
+  margin-left: var(--space-2);
+  flex-shrink: 0;
+}
+
+/* Row containing the enable/disable toggle button inside the detail panel. */
+.toggleEnabledRow {
+  margin-top: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* Enable/disable toggle button. */
+.toggleEnabledBtn {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--text-second);
+  background: none;
+  border: 1px solid var(--border-mid);
+  border-radius: 4px;
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out);
+}
+
+.toggleEnabledBtn:hover:not(:disabled) {
+  background: var(--bg-subtle);
+  color: var(--text-primary);
+}
+
+.toggleEnabledBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.stories.tsx
+++ b/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.stories.tsx
@@ -19,6 +19,7 @@ export const Collapsed: Story = {
         properties: { message: { title: 'Message', type: 'string' } },
         required: ['message'], type: 'object',
       },
+      enabled: true,
     },
     expanded: false,
     onToggle: () => {},
@@ -41,6 +42,7 @@ export const ExpandedMultiParam: Story = {
         properties: { channel: { title: 'Channel', type: 'string' }, message: { title: 'Message', type: 'string' } },
         required: ['channel', 'message'], type: 'object',
       },
+      enabled: true,
     },
     expanded: true,
     onToggle: () => {},
@@ -53,8 +55,39 @@ export const NoParams: Story = {
       id: 't2', server_id: 'srv-1', name: 'get_current_time',
       description: 'Return the current UTC time as an ISO 8601 string.',
       input_schema: { properties: {}, type: 'object' },
+      enabled: true,
     },
     expanded: true,
     onToggle: () => {},
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    tool: {
+      id: 't4', server_id: 'srv-1', name: 'delete_everything',
+      description: 'Destructive tool pending security review.',
+      input_schema: { properties: {}, type: 'object' },
+      enabled: false,
+    },
+    expanded: true,
+    onToggle: () => {},
+    canManage: true,
+    onSetEnabled: () => {},
+  },
+}
+
+export const EnabledToggleable: Story = {
+  args: {
+    ...ExpandedSingleParam.args,
+    canManage: true,
+    onSetEnabled: () => {},
+  },
+}
+
+export const EnabledReadOnly: Story = {
+  args: {
+    ...ExpandedSingleParam.args,
+    canManage: false,
   },
 }

--- a/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.test.tsx
+++ b/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.test.tsx
@@ -15,6 +15,7 @@ const echoTool: ApiMcpTool = {
     required: ['message'],
     type: 'object',
   },
+  enabled: true,
 }
 
 const noParamTool: ApiMcpTool = {
@@ -23,6 +24,7 @@ const noParamTool: ApiMcpTool = {
   name: 'get_current_time',
   description: 'Return the current UTC time.',
   input_schema: { properties: {}, type: 'object' },
+  enabled: true,
 }
 
 const multiParamTool: ApiMcpTool = {
@@ -38,6 +40,7 @@ const multiParamTool: ApiMcpTool = {
     required: ['channel', 'message'],
     type: 'object',
   },
+  enabled: true,
 }
 
 const emptySchema: ApiMcpTool = {
@@ -46,6 +49,16 @@ const emptySchema: ApiMcpTool = {
   name: 'broken_tool',
   description: 'Has no schema.',
   input_schema: {},
+  enabled: true,
+}
+
+const disabledTool: ApiMcpTool = {
+  id: 't5',
+  server_id: 'srv-1',
+  name: 'delete_everything',
+  description: 'Destructive tool pending review.',
+  input_schema: { properties: {}, type: 'object' },
+  enabled: false,
 }
 
 const noop = () => {}
@@ -104,5 +117,68 @@ describe('ToolAccordionRow', () => {
     render(<ToolAccordionRow tool={echoTool} expanded={false} onToggle={onToggle} />)
     fireEvent.click(screen.getByRole('button'))
     expect(onToggle).toHaveBeenCalledOnce()
+  })
+
+  it('renders Disabled badge when enabled is false', () => {
+    render(<ToolAccordionRow tool={disabledTool} expanded={false} onToggle={noop} />)
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+  })
+
+  it('does not render Disabled badge when enabled is true', () => {
+    render(<ToolAccordionRow tool={echoTool} expanded={false} onToggle={noop} />)
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument()
+  })
+
+  it('applies muted styling class when disabled', () => {
+    const { container } = render(
+      <ToolAccordionRow tool={disabledTool} expanded={false} onToggle={noop} />,
+    )
+    // The outer row element should carry the rowDisabled class.
+    const row = container.firstChild as HTMLElement
+    expect(row.className).toMatch(/rowDisabled/)
+  })
+
+  it('calls onSetEnabled with true when Enable clicked on a disabled tool', () => {
+    const onSetEnabled = vi.fn()
+    render(
+      <ToolAccordionRow
+        tool={disabledTool}
+        expanded={true}
+        onToggle={noop}
+        canManage={true}
+        onSetEnabled={onSetEnabled}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /enable tool/i }))
+    expect(onSetEnabled).toHaveBeenCalledWith(true)
+  })
+
+  it('calls onSetEnabled with false when Disable clicked on an enabled tool', () => {
+    const onSetEnabled = vi.fn()
+    render(
+      <ToolAccordionRow
+        tool={echoTool}
+        expanded={true}
+        onToggle={noop}
+        canManage={true}
+        onSetEnabled={onSetEnabled}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /disable tool/i }))
+    expect(onSetEnabled).toHaveBeenCalledWith(false)
+  })
+
+  it('hides toggle button when canManage is false', () => {
+    render(
+      <ToolAccordionRow
+        tool={echoTool}
+        expanded={true}
+        onToggle={noop}
+        canManage={false}
+        onSetEnabled={noop as unknown as (enabled: boolean) => void}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /disable tool/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /enable tool/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.tsx
+++ b/frontend/src/components/MCPPage/ToolAccordionRow/ToolAccordionRow.tsx
@@ -7,6 +7,10 @@ interface Props {
   expanded: boolean
   onToggle: () => void
   usedBy?: string[]
+  // Enable/disable controls — only rendered when canManage is true.
+  canManage?: boolean
+  onSetEnabled?: (enabled: boolean) => void
+  isUpdatingEnabled?: boolean
 }
 
 interface ParsedParam {
@@ -31,11 +35,20 @@ function paramCountLabel(count: number): string {
   return `${count} param${count === 1 ? '' : 's'}`
 }
 
-export function ToolAccordionRow({ tool, expanded, onToggle, usedBy }: Props) {
+export function ToolAccordionRow({
+  tool,
+  expanded,
+  onToggle,
+  usedBy,
+  canManage,
+  onSetEnabled,
+  isUpdatingEnabled,
+}: Props) {
   const params = parseParams(tool.input_schema)
+  const isDisabled = tool.enabled === false
 
   return (
-    <div className={styles.row}>
+    <div className={`${styles.row} ${isDisabled ? styles.rowDisabled : ''}`}>
       <button
         type="button"
         className={`${styles.toggle} ${expanded ? styles.toggleExpanded : ''}`}
@@ -49,6 +62,7 @@ export function ToolAccordionRow({ tool, expanded, onToggle, usedBy }: Props) {
           &#9654;
         </span>
         <span className={styles.toolName}>{tool.name}</span>
+        {isDisabled && <span className={styles.disabledBadge}>Disabled</span>}
         <span className={styles.paramHint}>{paramCountLabel(params.length)}</span>
       </button>
 
@@ -75,6 +89,20 @@ export function ToolAccordionRow({ tool, expanded, onToggle, usedBy }: Props) {
               {usedBy.map((name) => (
                 <span key={name} className={styles.agentPill}>{name}</span>
               ))}
+            </div>
+          )}
+          {canManage && onSetEnabled && (
+            <div className={styles.toggleEnabledRow}>
+              <button
+                type="button"
+                className={styles.toggleEnabledBtn}
+                onClick={() => onSetEnabled(!tool.enabled)}
+                disabled={isUpdatingEnabled}
+              >
+                {isUpdatingEnabled
+                  ? isDisabled ? 'Enabling...' : 'Disabling...'
+                  : isDisabled ? 'Enable tool' : 'Disable tool'}
+              </button>
             </div>
           )}
         </div>

--- a/frontend/src/hooks/mutations/servers.ts
+++ b/frontend/src/hooks/mutations/servers.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiFetch, apiFetchVoid, ApiError } from '@/api/fetch'
 import type {
   ApiMcpServerCreateResponse,
+  ApiMcpTool,
   AddMcpServerRequest,
   TestMcpConnectionRequest,
   TestMcpConnectionResponse,
@@ -65,7 +66,26 @@ export function useDiscoverMcpServer() {
       }),
     onSuccess: (_data, serverId) => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.servers.tools(serverId) })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.servers.toolsAll(serverId) })
       void queryClient.invalidateQueries({ queryKey: queryKeys.servers.all })
+    },
+  })
+}
+
+export function useSetMcpToolEnabled() {
+  const queryClient = useQueryClient()
+
+  return useMutation<ApiMcpTool, ApiError, { serverId: string; toolId: string; enabled: boolean }>({
+    mutationFn: ({ serverId, toolId, enabled }) =>
+      apiFetch<ApiMcpTool>(
+        `/mcp/servers/${encodeURIComponent(serverId)}/tools/${encodeURIComponent(toolId)}/enabled`,
+        { method: 'PUT', body: JSON.stringify({ enabled }) },
+      ),
+    onSuccess: (_data, { serverId }) => {
+      // Invalidate both cache keys so the Tools page (toolsAll) and the policy
+      // form (tools) both reflect the updated enabled state.
+      void queryClient.invalidateQueries({ queryKey: queryKeys.servers.tools(serverId) })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.servers.toolsAll(serverId) })
     },
   })
 }

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -12,7 +12,10 @@ export const queryKeys = {
   },
   servers: {
     all: ['servers'] as const,
+    // enabled-only tool list — consumed by the policy form (CapabilitiesSection)
     tools: (serverId: string) => ['servers', serverId, 'tools'] as const,
+    // unfiltered tool list including disabled — consumed by the Tools management page only
+    toolsAll: (serverId: string) => ['servers', serverId, 'tools', 'all'] as const,
   },
   stats: {
     all: ['stats'] as const,

--- a/frontend/src/hooks/useMcpServers.stories.tsx
+++ b/frontend/src/hooks/useMcpServers.stories.tsx
@@ -31,6 +31,7 @@ const FIXTURE_TOOLS: ApiMcpTool[] = [
     name: 'read_file',
     description: 'Read the contents of a file at the given path',
     input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    enabled: true,
   },
   {
     id: 'tool-2',
@@ -42,6 +43,7 @@ const FIXTURE_TOOLS: ApiMcpTool[] = [
       properties: { path: { type: 'string' }, content: { type: 'string' } },
       required: ['path', 'content'],
     },
+    enabled: true,
   },
   {
     id: 'tool-3',
@@ -49,6 +51,7 @@ const FIXTURE_TOOLS: ApiMcpTool[] = [
     name: 'request_feedback',
     description: 'Send a message to the operator and wait for a response',
     input_schema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
+    enabled: true,
   },
 ]
 

--- a/frontend/src/pages/MCPPage.test.tsx
+++ b/frontend/src/pages/MCPPage.test.tsx
@@ -10,6 +10,7 @@ import type { ApiMcpServer, ApiMcpTool } from '@/api/types'
 // --- Mocks ---
 
 vi.mock('@/hooks/queries/servers')
+vi.mock('@/hooks/queries/users')
 vi.mock('@/hooks/mutations/servers')
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>()
@@ -20,7 +21,8 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
 })
 
 import { useMcpServers } from '@/hooks/queries/servers'
-import { useAddMcpServer, useDeleteMcpServer, useDiscoverMcpServer, useTestMcpConnection } from '@/hooks/mutations/servers'
+import { useCurrentUser } from '@/hooks/queries/users'
+import { useAddMcpServer, useDeleteMcpServer, useDiscoverMcpServer, useTestMcpConnection, useSetMcpToolEnabled } from '@/hooks/mutations/servers'
 import { useQueries } from '@tanstack/react-query'
 
 // --- Fixtures ---
@@ -53,6 +55,7 @@ const TOOL_1: ApiMcpTool = {
     required: ['namespace'],
     type: 'object',
   },
+  enabled: true,
 }
 
 const TOOL_2: ApiMcpTool = {
@@ -61,6 +64,7 @@ const TOOL_2: ApiMcpTool = {
   name: 'kubectl.delete_pod',
   description: 'Delete a pod.',
   input_schema: { properties: {}, type: 'object' },
+  enabled: true,
 }
 
 // --- Helpers ---
@@ -80,11 +84,16 @@ function renderPage(queryClient = makeQueryClient()) {
 }
 
 function mockNoopMutations() {
-  const noop = { mutate: vi.fn(), isPending: false, error: null, reset: vi.fn() }
+  const noop = { mutate: vi.fn(), isPending: false, error: null, reset: vi.fn(), variables: undefined }
   vi.mocked(useAddMcpServer).mockReturnValue(noop as unknown as ReturnType<typeof useAddMcpServer>)
   vi.mocked(useDeleteMcpServer).mockReturnValue(noop as unknown as ReturnType<typeof useDeleteMcpServer>)
   vi.mocked(useDiscoverMcpServer).mockReturnValue(noop as unknown as ReturnType<typeof useDiscoverMcpServer>)
   vi.mocked(useTestMcpConnection).mockReturnValue(noop as unknown as ReturnType<typeof useTestMcpConnection>)
+  vi.mocked(useSetMcpToolEnabled).mockReturnValue(noop as unknown as ReturnType<typeof useSetMcpToolEnabled>)
+  vi.mocked(useCurrentUser).mockReturnValue({
+    data: { id: 'u1', username: 'operator', roles: ['operator'] },
+    status: 'success',
+  } as ReturnType<typeof useCurrentUser>)
 }
 
 function mockServersLoaded(servers: ApiMcpServer[], toolsByServer: Map<string, ApiMcpTool[]> = new Map()) {

--- a/frontend/src/pages/MCPPage.tsx
+++ b/frontend/src/pages/MCPPage.tsx
@@ -5,6 +5,7 @@ import { useMcpServers } from '@/hooks/queries/servers'
 import { queryKeys } from '@/hooks/queryKeys'
 import { usePolicies } from '@/hooks/queries/policies'
 import { useAddMcpServer, useDeleteMcpServer, useDiscoverMcpServer } from '@/hooks/mutations/servers'
+import { useCurrentUser } from '@/hooks/queries/users'
 import { apiFetch } from '@/api/fetch'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import type { ApiMcpServer, ApiMcpTool } from '@/api/types'
@@ -33,12 +34,22 @@ export default function MCPPage() {
 
   const { data: servers, status: serversStatus } = useMcpServers()
   const { data: policies } = usePolicies()
+  const { data: currentUser } = useCurrentUser()
+  // canManage gates the enable/disable toggle — derived at page level so
+  // ServerDetailModal stays a controlled, prop-driven component.
+  const canManage =
+    currentUser?.roles?.some((r) => r === 'admin' || r === 'operator') ?? false
 
-  // Eagerly fetch all server tool lists for card chip previews.
+  // Eagerly fetch all tools including disabled ones (toolsAll key) for the
+  // management view. This uses a separate query key from queryKeys.servers.tools
+  // so the policy form's enabled-only cache is never polluted with disabled tools.
   const toolResults = useQueries({
     queries: (servers ?? []).map((server) => ({
-      queryKey: queryKeys.servers.tools(server.id),
-      queryFn: () => apiFetch<ApiMcpTool[]>(`/mcp/servers/${encodeURIComponent(server.id)}/tools`),
+      queryKey: queryKeys.servers.toolsAll(server.id),
+      queryFn: () =>
+        apiFetch<ApiMcpTool[]>(
+          `/mcp/servers/${encodeURIComponent(server.id)}/tools?include_disabled=true`,
+        ),
       enabled: Boolean(server.id),
       staleTime: 30_000,
     })),
@@ -192,6 +203,7 @@ export default function MCPPage() {
           toolsLoading={isToolsLoading(selectedServer.id)}
           isDiscovering={discoveringServerId === selectedServer.id}
           policies={policies}
+          canManage={canManage}
           onClose={() => setSelectedServer(null)}
           onDiscover={handleDiscover}
           onDelete={handleDeleteOpen}

--- a/internal/db/mcp_tools.sql.go
+++ b/internal/db/mcp_tools.sql.go
@@ -33,7 +33,7 @@ func (q *Queries) DeleteMCPToolsByServer(ctx context.Context, serverID string) e
 }
 
 const getMCPTool = `-- name: GetMCPTool :one
-SELECT id, server_id, name, description, input_schema, created_at FROM mcp_tools WHERE id = ?1
+SELECT id, server_id, name, description, input_schema, created_at, enabled FROM mcp_tools WHERE id = ?1
 `
 
 func (q *Queries) GetMCPTool(ctx context.Context, id string) (McpTool, error) {
@@ -46,12 +46,13 @@ func (q *Queries) GetMCPTool(ctx context.Context, id string) (McpTool, error) {
 		&i.Description,
 		&i.InputSchema,
 		&i.CreatedAt,
+		&i.Enabled,
 	)
 	return i, err
 }
 
 const getMCPToolByServerAndName = `-- name: GetMCPToolByServerAndName :one
-SELECT t.id, t.server_id, t.name, t.description, t.input_schema, t.created_at
+SELECT t.id, t.server_id, t.name, t.description, t.input_schema, t.created_at, t.enabled
 FROM mcp_tools t
 JOIN mcp_servers s ON t.server_id = s.id
 WHERE s.name = ?1 AND t.name = ?2
@@ -72,14 +73,54 @@ func (q *Queries) GetMCPToolByServerAndName(ctx context.Context, arg GetMCPToolB
 		&i.Description,
 		&i.InputSchema,
 		&i.CreatedAt,
+		&i.Enabled,
 	)
 	return i, err
 }
 
-const listMCPToolsByServer = `-- name: ListMCPToolsByServer :many
-SELECT id, server_id, name, description, input_schema, created_at FROM mcp_tools WHERE server_id = ?1 ORDER BY name ASC
+const listEnabledMCPToolsByServer = `-- name: ListEnabledMCPToolsByServer :many
+SELECT id, server_id, name, description, input_schema, created_at, enabled FROM mcp_tools WHERE server_id = ?1 AND enabled = 1 ORDER BY name ASC
 `
 
+// Returns only enabled tools. Used by the capability registry API so policy
+// authors never see disabled tools in the form.
+func (q *Queries) ListEnabledMCPToolsByServer(ctx context.Context, serverID string) ([]McpTool, error) {
+	rows, err := q.db.QueryContext(ctx, listEnabledMCPToolsByServer, serverID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []McpTool
+	for rows.Next() {
+		var i McpTool
+		if err := rows.Scan(
+			&i.ID,
+			&i.ServerID,
+			&i.Name,
+			&i.Description,
+			&i.InputSchema,
+			&i.CreatedAt,
+			&i.Enabled,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listMCPToolsByServer = `-- name: ListMCPToolsByServer :many
+SELECT id, server_id, name, description, input_schema, created_at, enabled FROM mcp_tools WHERE server_id = ?1 ORDER BY name ASC
+`
+
+// Returns all tools including disabled ones. Used by RefreshTools (which must
+// diff against every existing row) and the admin management endpoint.
 func (q *Queries) ListMCPToolsByServer(ctx context.Context, serverID string) ([]McpTool, error) {
 	rows, err := q.db.QueryContext(ctx, listMCPToolsByServer, serverID)
 	if err != nil {
@@ -96,6 +137,7 @@ func (q *Queries) ListMCPToolsByServer(ctx context.Context, serverID string) ([]
 			&i.Description,
 			&i.InputSchema,
 			&i.CreatedAt,
+			&i.Enabled,
 		); err != nil {
 			return nil, err
 		}
@@ -110,13 +152,27 @@ func (q *Queries) ListMCPToolsByServer(ctx context.Context, serverID string) ([]
 	return items, nil
 }
 
+const setMCPToolEnabled = `-- name: SetMCPToolEnabled :exec
+UPDATE mcp_tools SET enabled = ?1 WHERE id = ?2
+`
+
+type SetMCPToolEnabledParams struct {
+	Enabled int64  `json:"enabled"`
+	ID      string `json:"id"`
+}
+
+func (q *Queries) SetMCPToolEnabled(ctx context.Context, arg SetMCPToolEnabledParams) error {
+	_, err := q.db.ExecContext(ctx, setMCPToolEnabled, arg.Enabled, arg.ID)
+	return err
+}
+
 const upsertMCPTool = `-- name: UpsertMCPTool :one
 INSERT INTO mcp_tools (id, server_id, name, description, input_schema, created_at)
 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
 ON CONFLICT (server_id, name) DO UPDATE SET
     description  = excluded.description,
     input_schema = excluded.input_schema
-RETURNING id, server_id, name, description, input_schema, created_at
+RETURNING id, server_id, name, description, input_schema, created_at, enabled
 `
 
 type UpsertMCPToolParams struct {
@@ -145,6 +201,7 @@ func (q *Queries) UpsertMCPTool(ctx context.Context, arg UpsertMCPToolParams) (M
 		&i.Description,
 		&i.InputSchema,
 		&i.CreatedAt,
+		&i.Enabled,
 	)
 	return i, err
 }

--- a/internal/db/migrations/0001_initial.sql
+++ b/internal/db/migrations/0001_initial.sql
@@ -47,6 +47,7 @@ CREATE TABLE mcp_tools (
     description     TEXT    NOT NULL,
     input_schema    TEXT    NOT NULL,     -- JSON blob (MCP tool input schema)
     created_at      TEXT    NOT NULL,     -- ISO 8601 UTC
+    enabled         INTEGER NOT NULL DEFAULT 1,  -- operator-managed; 0 = disabled, 1 = enabled
     UNIQUE(server_id, name)
 );
 

--- a/internal/db/migrations/0027_add_mcp_tool_enabled.go
+++ b/internal/db/migrations/0027_add_mcp_tool_enabled.go
@@ -1,0 +1,50 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+)
+
+// AddMCPToolEnabled adds the enabled column to the mcp_tools table on existing
+// deployments. New deployments get it from 0001_initial.sql; this migration is
+// a no-op for them. SQLite supports ALTER TABLE ADD COLUMN for simple NOT NULL
+// DEFAULT columns without needing table recreation.
+//
+// The enabled flag is operator-managed: discovery never resets it, so a tool
+// disabled by an operator stays disabled after re-discovery runs.
+type AddMCPToolEnabled struct{}
+
+func (m *AddMCPToolEnabled) Version() int { return 17 }
+func (m *AddMCPToolEnabled) Name() string { return "add_mcp_tool_enabled" }
+
+func (m *AddMCPToolEnabled) ShouldSkip(ctx context.Context, db *sql.DB) (bool, error) {
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info(mcp_tools)")
+	if err != nil {
+		return false, fmt.Errorf("pragma table_info mcp_tools: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, colType string
+		var dflt any
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dflt, &pk); err != nil {
+			return false, fmt.Errorf("scan pragma row: %w", err)
+		}
+		if name == "enabled" {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func (m *AddMCPToolEnabled) Up(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE mcp_tools ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1`); err != nil {
+		return fmt.Errorf("alter table mcp_tools add enabled: %w", err)
+	}
+
+	slog.Info("migrated mcp_tools table to add enabled column")
+	return nil
+}

--- a/internal/db/migrations/registry.go
+++ b/internal/db/migrations/registry.go
@@ -20,5 +20,6 @@ func All() []Migration {
 		&DeleteUserPrefDefaultModel{},
 		&AddRunsVersion{},
 		&AddCronTriggerType{},
+		&AddMCPToolEnabled{},
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -46,6 +46,7 @@ type McpTool struct {
 	Description string `json:"description"`
 	InputSchema string `json:"input_schema"`
 	CreatedAt   string `json:"created_at"`
+	Enabled     int64  `json:"enabled"`
 }
 
 type ModelSetting struct {

--- a/internal/db/queries/mcp_tools.sql
+++ b/internal/db/queries/mcp_tools.sql
@@ -6,7 +6,14 @@ ON CONFLICT (server_id, name) DO UPDATE SET
     input_schema = excluded.input_schema
 RETURNING *;
 
+-- name: ListEnabledMCPToolsByServer :many
+-- Returns only enabled tools. Used by the capability registry API so policy
+-- authors never see disabled tools in the form.
+SELECT * FROM mcp_tools WHERE server_id = :server_id AND enabled = 1 ORDER BY name ASC;
+
 -- name: ListMCPToolsByServer :many
+-- Returns all tools including disabled ones. Used by RefreshTools (which must
+-- diff against every existing row) and the admin management endpoint.
 SELECT * FROM mcp_tools WHERE server_id = :server_id ORDER BY name ASC;
 
 -- name: GetMCPToolByServerAndName :one
@@ -23,3 +30,6 @@ SELECT * FROM mcp_tools WHERE id = :id;
 
 -- name: DeleteMCPToolByServerAndName :exec
 DELETE FROM mcp_tools WHERE server_id = :server_id AND name = :name;
+
+-- name: SetMCPToolEnabled :exec
+UPDATE mcp_tools SET enabled = :enabled WHERE id = :id;

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -539,6 +539,110 @@ func TestMCPToolQueries(t *testing.T) {
 	}
 }
 
+func TestMCPToolEnabledQueries(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	insertMcpServer(t, s, "srv2")
+
+	// Newly inserted tools default to enabled = 1.
+	tool1, err := s.UpsertMCPTool(ctx, UpsertMCPToolParams{
+		ID:          "etool1",
+		ServerID:    "srv2",
+		Name:        "alpha",
+		Description: "first",
+		InputSchema: "{}",
+		CreatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("UpsertMCPTool: %v", err)
+	}
+	if tool1.Enabled != 1 {
+		t.Errorf("new tool enabled = %d, want 1", tool1.Enabled)
+	}
+
+	// Insert a second tool so we can compare filtered vs unfiltered.
+	_, err = s.UpsertMCPTool(ctx, UpsertMCPToolParams{
+		ID:          "etool2",
+		ServerID:    "srv2",
+		Name:        "beta",
+		Description: "second",
+		InputSchema: "{}",
+		CreatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("UpsertMCPTool beta: %v", err)
+	}
+
+	// SetMCPToolEnabled toggles enabled 1 → 0.
+	if err := s.SetMCPToolEnabled(ctx, SetMCPToolEnabledParams{ID: "etool1", Enabled: 0}); err != nil {
+		t.Fatalf("SetMCPToolEnabled(0): %v", err)
+	}
+	got, err := s.GetMCPTool(ctx, "etool1")
+	if err != nil {
+		t.Fatalf("GetMCPTool after disable: %v", err)
+	}
+	if got.Enabled != 0 {
+		t.Errorf("after disable: enabled = %d, want 0", got.Enabled)
+	}
+
+	// Rediscovery upsert (same server+name) must NOT reset enabled back to 1.
+	if _, err := s.UpsertMCPTool(ctx, UpsertMCPToolParams{
+		ID:          "etool1-new",
+		ServerID:    "srv2",
+		Name:        "alpha",
+		Description: "refreshed desc",
+		InputSchema: `{"type":"object"}`,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertMCPTool rediscovery: %v", err)
+	}
+	got, err = s.GetMCPTool(ctx, "etool1")
+	if err != nil {
+		t.Fatalf("GetMCPTool after rediscovery upsert: %v", err)
+	}
+	if got.Enabled != 0 {
+		t.Errorf("after rediscovery upsert: enabled reset to %d, want 0 (operator flag must survive)", got.Enabled)
+	}
+	if got.Description != "refreshed desc" {
+		t.Errorf("after rediscovery: description = %q, want refreshed desc", got.Description)
+	}
+
+	// ListEnabledMCPToolsByServer returns only enabled rows.
+	enabled, err := s.ListEnabledMCPToolsByServer(ctx, "srv2")
+	if err != nil {
+		t.Fatalf("ListEnabledMCPToolsByServer: %v", err)
+	}
+	if len(enabled) != 1 {
+		t.Fatalf("ListEnabledMCPToolsByServer: got %d tools, want 1", len(enabled))
+	}
+	if enabled[0].Name != "beta" {
+		t.Errorf("ListEnabledMCPToolsByServer: got %q, want beta", enabled[0].Name)
+	}
+
+	// ListMCPToolsByServer returns all rows including disabled.
+	all, err := s.ListMCPToolsByServer(ctx, "srv2")
+	if err != nil {
+		t.Fatalf("ListMCPToolsByServer: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("ListMCPToolsByServer: got %d tools, want 2", len(all))
+	}
+
+	// SetMCPToolEnabled toggles 0 → 1 (re-enable).
+	if err := s.SetMCPToolEnabled(ctx, SetMCPToolEnabledParams{ID: "etool1", Enabled: 1}); err != nil {
+		t.Fatalf("SetMCPToolEnabled(1): %v", err)
+	}
+	got, err = s.GetMCPTool(ctx, "etool1")
+	if err != nil {
+		t.Fatalf("GetMCPTool after re-enable: %v", err)
+	}
+	if got.Enabled != 1 {
+		t.Errorf("after re-enable: enabled = %d, want 1", got.Enabled)
+	}
+}
+
 func TestPolicyQueries(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/internal/http/api/mcp_handler.go
+++ b/internal/http/api/mcp_handler.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/rapp992/gleipnir/internal/db"
+	"github.com/rapp992/gleipnir/internal/http/auth"
 	"github.com/rapp992/gleipnir/internal/http/httputil"
 	"github.com/rapp992/gleipnir/internal/mcp"
 	"github.com/rapp992/gleipnir/internal/model"
@@ -293,6 +295,7 @@ type mcpToolResponse struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
 	InputSchema json.RawMessage `json:"input_schema"`
+	Enabled     bool            `json:"enabled"`
 }
 
 func toolToResponse(t db.McpTool) mcpToolResponse {
@@ -304,10 +307,16 @@ func toolToResponse(t db.McpTool) mcpToolResponse {
 		// InputSchema is stored as a JSON string in the DB; cast directly to
 		// json.RawMessage to avoid double-encoding it as a JSON string in the response.
 		InputSchema: json.RawMessage(t.InputSchema),
+		Enabled:     t.Enabled != 0,
 	}
 }
 
 // ListTools handles GET /api/v1/mcp/servers/{id}/tools.
+//
+// By default only enabled tools are returned, so the policy form's capability
+// registry never surfaces disabled tools. Passing ?include_disabled=true
+// returns all tools (enabled and disabled), but only when the caller holds
+// admin or operator role — auditors receive the default enabled-only list.
 func (h *MCPHandler) ListTools(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	ctx := r.Context()
@@ -321,7 +330,27 @@ func (h *MCPHandler) ListTools(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := h.store.ListMCPToolsByServer(ctx, id)
+	// include_disabled is honored only for admin and operator; silently ignored
+	// for auditors so their existing read access continues to work unchanged.
+	includeDisabled := false
+	if v := r.URL.Query().Get("include_disabled"); v != "" {
+		if parsed, err := strconv.ParseBool(v); err == nil && parsed {
+			if user, ok := auth.UserFromContext(ctx); ok &&
+				(user.HasRole(model.RoleAdmin) || user.HasRole(model.RoleOperator)) {
+				includeDisabled = true
+			}
+		}
+	}
+
+	var (
+		rows []db.McpTool
+		err  error
+	)
+	if includeDisabled {
+		rows, err = h.store.ListMCPToolsByServer(ctx, id)
+	} else {
+		rows, err = h.store.ListEnabledMCPToolsByServer(ctx, id)
+	}
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to list MCP tools", err.Error())
 		return
@@ -333,6 +362,67 @@ func (h *MCPHandler) ListTools(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, items)
+}
+
+// SetToolEnabled handles PUT /api/v1/mcp/servers/{id}/tools/{toolID}/enabled.
+// Body: {"enabled": bool}. Admin or operator only (enforced by router middleware).
+func (h *MCPHandler) SetToolEnabled(w http.ResponseWriter, r *http.Request) {
+	serverID := chi.URLParam(r, "id")
+	toolID := chi.URLParam(r, "toolID")
+	ctx := r.Context()
+
+	if _, err := h.store.GetMCPServer(ctx, serverID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httputil.WriteError(w, http.StatusNotFound, "MCP server not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get MCP server", err.Error())
+		return
+	}
+
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	tool, err := h.store.GetMCPTool(ctx, toolID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httputil.WriteError(w, http.StatusNotFound, "MCP tool not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get MCP tool", err.Error())
+		return
+	}
+
+	if tool.ServerID != serverID {
+		httputil.WriteError(w, http.StatusBadRequest, "tool does not belong to this server", "")
+		return
+	}
+
+	var enabledVal int64
+	if body.Enabled {
+		enabledVal = 1
+	}
+	if err := h.store.SetMCPToolEnabled(ctx, db.SetMCPToolEnabledParams{
+		ID:      toolID,
+		Enabled: enabledVal,
+	}); err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update tool", err.Error())
+		return
+	}
+
+	// Re-fetch to return the canonical post-update row.
+	updated, err := h.store.GetMCPTool(ctx, toolID)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to re-fetch tool after update", err.Error())
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, toolToResponse(updated))
 }
 
 // policyReferencesServer returns true if the raw policy YAML contains any tool

--- a/internal/http/api/mcp_handler_test.go
+++ b/internal/http/api/mcp_handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rapp992/gleipnir/internal/db"
 	"github.com/rapp992/gleipnir/internal/http/api"
+	"github.com/rapp992/gleipnir/internal/http/auth"
 	"github.com/rapp992/gleipnir/internal/mcp"
 	"github.com/rapp992/gleipnir/internal/model"
 	"github.com/rapp992/gleipnir/internal/testutil"
@@ -31,7 +32,27 @@ func newMCPRouter(store *db.Store, registry *mcp.Registry) http.Handler {
 	r.Delete("/servers/{id}", h.Delete)
 	r.Post("/servers/{id}/discover", h.Discover)
 	r.Get("/servers/{id}/tools", h.ListTools)
+	r.Put("/servers/{id}/tools/{toolID}/enabled", h.SetToolEnabled)
 	return r
+}
+
+// withAdminUser returns a request copy with an admin UserContext injected so
+// the in-handler role gate for include_disabled can be exercised in tests.
+func withAdminUser(r *http.Request) *http.Request {
+	ctx := auth.WithUserContext(r.Context(), "u1", "admin", []string{string(model.RoleAdmin)})
+	return r.WithContext(ctx)
+}
+
+// withAuditorUser returns a request copy with an auditor UserContext injected.
+func withAuditorUser(r *http.Request) *http.Request {
+	ctx := auth.WithUserContext(r.Context(), "u2", "auditor", []string{string(model.RoleAuditor)})
+	return r.WithContext(ctx)
+}
+
+// withOperatorUser returns a request copy with an operator UserContext injected.
+func withOperatorUser(r *http.Request) *http.Request {
+	ctx := auth.WithUserContext(r.Context(), "u3", "operator", []string{string(model.RoleOperator)})
+	return r.WithContext(ctx)
 }
 
 // insertTestMCPTool inserts an MCP tool row directly via the store.
@@ -800,6 +821,280 @@ func TestMCPToolListHandler(t *testing.T) {
 
 		if resp.StatusCode != http.StatusNotFound {
 			t.Fatalf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+
+	t.Run("list tools omits disabled by default", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		serverID := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+		enabledID := insertTestMCPTool(t, store, serverID, "enabled-tool")
+		disabledID := insertTestMCPTool(t, store, serverID, "disabled-tool")
+
+		// Disable the second tool.
+		if err := store.SetMCPToolEnabled(context.Background(), db.SetMCPToolEnabledParams{
+			ID:      disabledID,
+			Enabled: 0,
+		}); err != nil {
+			t.Fatalf("SetMCPToolEnabled: %v", err)
+		}
+		_ = enabledID
+
+		h := api.NewMCPHandler(store, registry)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = setChiURLParams(req, "id", serverID)
+		w := httptest.NewRecorder()
+		h.ListTools(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+
+		var envelope struct {
+			Data []struct {
+				Name    string `json:"name"`
+				Enabled bool   `json:"enabled"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(envelope.Data) != 1 {
+			t.Fatalf("len(data) = %d, want 1 (disabled tool should be hidden)", len(envelope.Data))
+		}
+		if envelope.Data[0].Name != "enabled-tool" {
+			t.Errorf("data[0].name = %q, want enabled-tool", envelope.Data[0].Name)
+		}
+		if !envelope.Data[0].Enabled {
+			t.Errorf("enabled-tool should have enabled=true in response")
+		}
+	})
+
+	t.Run("include_disabled returns all for admin", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		serverID := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+		insertTestMCPTool(t, store, serverID, "enabled-tool")
+		disabledID := insertTestMCPTool(t, store, serverID, "disabled-tool")
+
+		if err := store.SetMCPToolEnabled(context.Background(), db.SetMCPToolEnabledParams{
+			ID:      disabledID,
+			Enabled: 0,
+		}); err != nil {
+			t.Fatalf("SetMCPToolEnabled: %v", err)
+		}
+
+		h := api.NewMCPHandler(store, registry)
+		req := httptest.NewRequest(http.MethodGet, "/?include_disabled=true", nil)
+		req = setChiURLParams(req, "id", serverID)
+		req = withAdminUser(req)
+		w := httptest.NewRecorder()
+		h.ListTools(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+
+		var envelope struct {
+			Data []struct {
+				Name    string `json:"name"`
+				Enabled bool   `json:"enabled"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(envelope.Data) != 2 {
+			t.Fatalf("len(data) = %d, want 2 (both tools)", len(envelope.Data))
+		}
+		// Results are ordered by name ASC: disabled-tool < enabled-tool.
+		if envelope.Data[0].Name != "disabled-tool" {
+			t.Errorf("data[0].name = %q, want disabled-tool", envelope.Data[0].Name)
+		}
+		if envelope.Data[0].Enabled {
+			t.Errorf("disabled-tool should have enabled=false in response")
+		}
+		if !envelope.Data[1].Enabled {
+			t.Errorf("enabled-tool should have enabled=true in response")
+		}
+	})
+
+	t.Run("include_disabled silently ignored for auditor", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		serverID := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+		insertTestMCPTool(t, store, serverID, "enabled-tool")
+		disabledID := insertTestMCPTool(t, store, serverID, "disabled-tool")
+
+		if err := store.SetMCPToolEnabled(context.Background(), db.SetMCPToolEnabledParams{
+			ID:      disabledID,
+			Enabled: 0,
+		}); err != nil {
+			t.Fatalf("SetMCPToolEnabled: %v", err)
+		}
+
+		h := api.NewMCPHandler(store, registry)
+		req := httptest.NewRequest(http.MethodGet, "/?include_disabled=true", nil)
+		req = setChiURLParams(req, "id", serverID)
+		req = withAuditorUser(req)
+		w := httptest.NewRecorder()
+		h.ListTools(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+
+		var envelope struct {
+			Data []struct {
+				Name string `json:"name"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		// Auditors get the default enabled-only list even with include_disabled=true.
+		if len(envelope.Data) != 1 {
+			t.Fatalf("len(data) = %d, want 1 (disabled tool invisible to auditor)", len(envelope.Data))
+		}
+		if envelope.Data[0].Name != "enabled-tool" {
+			t.Errorf("data[0].name = %q, want enabled-tool", envelope.Data[0].Name)
+		}
+	})
+}
+
+// setChiURLParams injects chi URL params into the request context so the handler
+// can read them via chi.URLParam. Used in direct handler tests that bypass the
+// chi router. Pairs must be provided as alternating key, value strings.
+func setChiURLParams(r *http.Request, keyVals ...string) *http.Request {
+	rctx := chi.NewRouteContext()
+	for i := 0; i+1 < len(keyVals); i += 2 {
+		rctx.URLParams.Add(keyVals[i], keyVals[i+1])
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestMCPSetToolEnabledHandler(t *testing.T) {
+	t.Run("disable then re-enable", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		serverID := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+		toolID := insertTestMCPTool(t, store, serverID, "my-tool")
+
+		h := api.NewMCPHandler(store, registry)
+
+		// Disable the tool.
+		body, _ := json.Marshal(map[string]bool{"enabled": false})
+		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = setChiURLParams(req, "id", serverID, "toolID", toolID)
+		w := httptest.NewRecorder()
+		h.SetToolEnabled(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("disable: status = %d, want 200", w.Code)
+		}
+		var envelope struct {
+			Data struct {
+				Enabled bool `json:"enabled"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode disable response: %v", err)
+		}
+		if envelope.Data.Enabled {
+			t.Error("after disable: enabled = true, want false")
+		}
+
+		// Re-enable the tool.
+		body, _ = json.Marshal(map[string]bool{"enabled": true})
+		req = httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = setChiURLParams(req, "id", serverID, "toolID", toolID)
+		w = httptest.NewRecorder()
+		h.SetToolEnabled(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("re-enable: status = %d, want 200", w.Code)
+		}
+		if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode re-enable response: %v", err)
+		}
+		if !envelope.Data.Enabled {
+			t.Error("after re-enable: enabled = false, want true")
+		}
+	})
+
+	t.Run("404 when server missing", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+
+		h := api.NewMCPHandler(store, registry)
+		body, _ := json.Marshal(map[string]bool{"enabled": false})
+		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = setChiURLParams(req, "id", "unknown-server", "toolID", "any-tool")
+		w := httptest.NewRecorder()
+		h.SetToolEnabled(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("404 when tool missing", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		serverID := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+
+		h := api.NewMCPHandler(store, registry)
+		body, _ := json.Marshal(map[string]bool{"enabled": false})
+		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = setChiURLParams(req, "id", serverID, "toolID", "unknown-tool")
+		w := httptest.NewRecorder()
+		h.SetToolEnabled(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("400 when tool belongs to different server", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		serverA := insertTestMCPServer(t, store, "server-a", "http://localhost:9991")
+		serverB := insertTestMCPServer(t, store, "server-b", "http://localhost:9992")
+		toolOnB := insertTestMCPTool(t, store, serverB, "tool-b")
+
+		h := api.NewMCPHandler(store, registry)
+		body, _ := json.Marshal(map[string]bool{"enabled": false})
+		// Use server A's ID but tool B's ID.
+		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = setChiURLParams(req, "id", serverA, "toolID", toolOnB)
+		w := httptest.NewRecorder()
+		h.SetToolEnabled(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("400 on malformed body", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		serverID := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+		toolID := insertTestMCPTool(t, store, serverID, "my-tool")
+
+		h := api.NewMCPHandler(store, registry)
+		req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader("not json"))
+		req.Header.Set("Content-Type", "application/json")
+		req = setChiURLParams(req, "id", serverID, "toolID", toolID)
+		w := httptest.NewRecorder()
+		h.SetToolEnabled(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", w.Code)
 		}
 	})
 }

--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -247,6 +247,8 @@ func newAPISubRouter(store *db.Store, svc *policy.Service, registry *mcp.Registr
 			r.With(auth.RequireRole(model.RoleAdmin, model.RoleOperator)).Delete("/{id}", mcpH.Delete)
 			r.With(auth.RequireRole(model.RoleAdmin, model.RoleOperator)).Post("/{id}/discover", mcpH.Discover)
 			r.With(auth.RequireRole(model.RoleOperator, model.RoleAuditor)).Get("/{id}/tools", mcpH.ListTools)
+			r.With(auth.RequireRole(model.RoleAdmin, model.RoleOperator)).
+				Put("/{id}/tools/{toolID}/enabled", mcpH.SetToolEnabled)
 		})
 	})
 

--- a/internal/http/auth/middleware.go
+++ b/internal/http/auth/middleware.go
@@ -56,6 +56,18 @@ func UserFromContext(ctx context.Context) (*UserContext, bool) {
 	return u, ok
 }
 
+// WithUserContext returns a copy of ctx with the given UserContext injected.
+// Intended for use in tests that need to simulate an authenticated request
+// without going through the full auth middleware stack.
+func WithUserContext(ctx context.Context, id, username string, roles []string) context.Context {
+	return context.WithValue(ctx, contextKey{}, &UserContext{
+		ID:       id,
+		Username: username,
+		Roles:    roles,
+		roleSet:  makeRoleSet(roles),
+	})
+}
+
 // RequireAuth returns a Chi middleware that validates the gleipnir_session
 // cookie. Unauthenticated or expired sessions receive a 401 and the handler
 // chain is short-circuited. Valid sessions inject a *UserContext into the

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -108,6 +108,10 @@ func (r *Registry) ResolveForPolicy(ctx context.Context, p *model.ParsedPolicy) 
 			return nil, fmt.Errorf("look up tool %q: %w", t.Tool, err)
 		}
 
+		if tool.Enabled == 0 {
+			return nil, fmt.Errorf("tool %q on server %q is disabled", toolName, serverName)
+		}
+
 		srv, err := r.queries.GetMCPServer(ctx, tool.ServerID)
 		if err != nil {
 			return nil, fmt.Errorf("get server for tool %q: %w", t.Tool, err)
@@ -163,6 +167,10 @@ func (r *Registry) ResolveToolByName(ctx context.Context, dotName string) (*Clie
 			return nil, "", fmt.Errorf("tool %q not found in registry", dotName)
 		}
 		return nil, "", fmt.Errorf("look up tool %q: %w", dotName, err)
+	}
+
+	if tool.Enabled == 0 {
+		return nil, "", fmt.Errorf("tool %q on server %q is disabled", toolName, serverName)
 	}
 
 	srv, err := r.queries.GetMCPServer(ctx, tool.ServerID)
@@ -271,6 +279,8 @@ func (r *Registry) RefreshTools(ctx context.Context, serverID string) (ToolDiff,
 
 	// Upsert all fresh tools. Preserve the existing ID for tools already in the
 	// DB so foreign key references (e.g. in audit steps) remain stable.
+	// ON CONFLICT does not touch the enabled column — operator-set disable state
+	// survives rediscovery (see the UpsertMCPTool query for the ON CONFLICT clause).
 	for _, t := range freshTools {
 		toolID := model.NewULID()
 		if old, exists := oldByName[t.Name]; exists {

--- a/internal/mcp/resolve_test.go
+++ b/internal/mcp/resolve_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rapp992/gleipnir/internal/db"
 	"github.com/rapp992/gleipnir/internal/model"
 )
 
@@ -275,5 +276,89 @@ func TestResolveForPolicy_ToolsOrdered(t *testing.T) {
 	}
 	if result[2].ToolName != "tool_c" {
 		t.Errorf("result[2].ToolName = %q, want tool_c", result[2].ToolName)
+	}
+}
+
+func TestResolveForPolicy_DisabledTool(t *testing.T) {
+	reg, store := newTestRegistry(t)
+
+	tools := []map[string]any{
+		{"name": "read_pods", "description": "list pods", "inputSchema": map[string]any{"type": "object"}},
+	}
+	srv := makeMCPServer(t, tools)
+
+	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServer: %v", err)
+	}
+
+	// Fetch the tool ID so we can disable it.
+	registered, err := store.Queries().GetMCPToolByServerAndName(context.Background(), db.GetMCPToolByServerAndNameParams{
+		ServerName: "my-server",
+		ToolName:   "read_pods",
+	})
+	if err != nil {
+		t.Fatalf("GetMCPToolByServerAndName: %v", err)
+	}
+
+	if err := store.Queries().SetMCPToolEnabled(context.Background(), db.SetMCPToolEnabledParams{
+		ID:      registered.ID,
+		Enabled: 0,
+	}); err != nil {
+		t.Fatalf("SetMCPToolEnabled: %v", err)
+	}
+
+	p := &model.ParsedPolicy{
+		Capabilities: model.CapabilitiesConfig{
+			Tools: []model.ToolCapability{
+				{Tool: "my-server.read_pods", Approval: model.ApprovalModeNone},
+			},
+		},
+	}
+
+	_, err = reg.ResolveForPolicy(context.Background(), p)
+	if err == nil {
+		t.Fatal("expected error for disabled tool, got nil")
+	}
+	if !strings.Contains(err.Error(), "read_pods") {
+		t.Errorf("error %q should mention tool name read_pods", err.Error())
+	}
+	if !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("error %q should contain the word 'disabled'", err.Error())
+	}
+}
+
+func TestResolveToolByName_DisabledTool(t *testing.T) {
+	reg, store := newTestRegistry(t)
+
+	tools := []map[string]any{
+		{"name": "read_pods", "description": "list pods", "inputSchema": map[string]any{"type": "object"}},
+	}
+	srv := makeMCPServer(t, tools)
+
+	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServer: %v", err)
+	}
+
+	registered, err := store.Queries().GetMCPToolByServerAndName(context.Background(), db.GetMCPToolByServerAndNameParams{
+		ServerName: "my-server",
+		ToolName:   "read_pods",
+	})
+	if err != nil {
+		t.Fatalf("GetMCPToolByServerAndName: %v", err)
+	}
+
+	if err := store.Queries().SetMCPToolEnabled(context.Background(), db.SetMCPToolEnabledParams{
+		ID:      registered.ID,
+		Enabled: 0,
+	}); err != nil {
+		t.Fatalf("SetMCPToolEnabled: %v", err)
+	}
+
+	_, _, err = reg.ResolveToolByName(context.Background(), "my-server.read_pods")
+	if err == nil {
+		t.Fatal("expected error for disabled tool, got nil")
+	}
+	if !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("error %q should contain the word 'disabled'", err.Error())
 	}
 }

--- a/schemas/sql_schemas.sql
+++ b/schemas/sql_schemas.sql
@@ -49,6 +49,7 @@ CREATE TABLE mcp_tools (
     description     TEXT    NOT NULL,
     input_schema    TEXT    NOT NULL,     -- JSON blob (MCP tool input schema)
     created_at      TEXT    NOT NULL,     -- ISO 8601 UTC
+    enabled         INTEGER NOT NULL DEFAULT 1,  -- operator-managed; 0 = disabled, 1 = enabled
     UNIQUE(server_id, name)
 );
 


### PR DESCRIPTION
Closes #99

## Summary

- Adds `enabled INTEGER NOT NULL DEFAULT 1` column to `mcp_tools` via migration `0027_add_mcp_tool_enabled` (preserves operator-set value across re-discovery)
- `ResolveForPolicy` and `ResolveToolByName` in `internal/mcp/registry.go` now fail fast with a descriptive error when a tool is disabled, giving runs a clear failure reason
- `GET /api/v1/mcp/servers/{id}/tools` filters to enabled-only by default; `?include_disabled=true` is honored for admin/operator roles only (silently ignored for auditors)
- New `PUT /api/v1/mcp/servers/{id}/tools/{toolID}/enabled` endpoint (admin/operator only) to toggle the flag
- Tools page shows disabled tools with a "Disabled" badge and a toggle button (admin/operator); policy form capability registry is unaffected because it uses a separate TanStack Query cache key (`toolsAll` vs `tools`)

## Architecture plan

<details>
<summary>Full implementation plan</summary>

The plan addresses 22 discrete changes across DB migration, sqlc queries, registry enforcement, HTTP API, and frontend. Key design decisions:

- **Two query keys**: `queryKeys.servers.tools(id)` (enabled-only, used by policy form `CapabilitiesSection`) and `queryKeys.servers.toolsAll(id)` (all tools incl. disabled, used by Tools page). This prevents TanStack Query cache pollution — disabled tools never appear in the policy form.
- **Server-side gating**: `include_disabled` is enforced in the handler by inspecting the caller's role, not only at the router middleware level. Auditors get the filtered list regardless of the query param.
- **`canManage` prop-drilled** from `MCPPage.tsx` → `ServerDetailModal` → `ToolAccordionRow` to keep the modal as a controlled component with no data-fetching of its own.
- **Upsert preserves `enabled`**: the `ON CONFLICT` clause in `UpsertMCPTool` does not touch `enabled`, so re-discovery never re-enables a disabled tool.

</details>

## Review cycles

1 cycle — APPROVE on first review pass.

## CLAUDE.md updated

`frontend/CLAUDE.md` updated: added `queryKeys.servers.toolsAll` to the query key families table and added the `PUT /api/v1/mcp/servers/:id/tools/:toolID/enabled` endpoint to the API surface section.

---
_Generated by the agentic development pipeline (dev-loop)_