### PR TITLE
fix: skip empty Gemini thought parts in streaming path

### DIFF
--- a/internal/llm/google/stream.go
+++ b/internal/llm/google/stream.go
@@ -63,6 +63,12 @@ func consumeStream(
 
 		for _, part := range candidate.Content.Parts {
 			if part.Thought {
+				// Gemini emits Thought-flagged parts with empty Text around tool calls;
+				// these carry no summary content and would surface as empty audit entries.
+				// Mirrors the guard in translateResponse (client.go).
+				if part.Text == "" {
+					continue
+				}
 				out <- llm.MessageChunk{Thinking: &llm.ThinkingBlock{
 					Provider: "google",
 					Text:     part.Text,

--- a/internal/llm/google/stream_test.go
+++ b/internal/llm/google/stream_test.go
@@ -171,6 +171,42 @@ func TestConsumeStream_ThinkingPart(t *testing.T) {
 	}
 }
 
+func TestConsumeStream_ThinkingPartEmptyTextSkipped(t *testing.T) {
+	// Gemini routinely emits Thought-flagged parts with empty Text around
+	// tool calls. These must not surface as empty Thinking chunks in the
+	// audit trail.
+	seq := makeStreamSeq([]*genai.GenerateContentResponse{
+		{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{Parts: []*genai.Part{
+					{Text: "", Thought: true},
+					{FunctionCall: &genai.FunctionCall{ID: "fc-1", Name: "noop", Args: nil}},
+					{Text: "", Thought: true},
+				}},
+				FinishReason: genai.FinishReasonStop,
+			}},
+		},
+	}, nil)
+
+	out := make(chan llm.MessageChunk, 32)
+	consumeStream(context.Background(), seq, out, emptyNames())
+	chunks := drainChunks(t, out)
+
+	for i, c := range chunks {
+		if c.Thinking != nil {
+			t.Errorf("chunks[%d] is an empty Thinking chunk; expected to be skipped", i)
+		}
+	}
+
+	// Expect: 1 tool call + 1 final chunk (both empty thoughts dropped).
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0].ToolCall == nil {
+		t.Errorf("chunks[0].ToolCall is nil; want tool call")
+	}
+}
+
 func TestConsumeStream_FunctionCallEmptyID(t *testing.T) {
 	seq := makeStreamSeq([]*genai.GenerateContentResponse{
 		{


### PR DESCRIPTION
## Summary
- Gemini's streaming API emits `Thought: true` parts with empty `Text` around tool calls. The streaming path in `internal/llm/google/stream.go` was emitting a `ThinkingBlock` for every thought-flagged part, surfacing bare "Thought" entries with no content in the run audit trail.
- The non-streaming `translateResponse` in `client.go` already had the correct `part.Thought && part.Text != ""` guard — this PR adds the symmetric guard to `consumeStream`.
- Reproduced on the live instance: a recent Gemini run showed three "Thought" steps, two of them empty. After the fix only thought parts with summary content are persisted.

## Why thought signatures aren't lost
Gemini 3 thought-signature continuity (the encrypted reasoning state that must be replayed) lives on `FunctionCall` parts via `ThoughtSignature`, copied into `ToolCallBlock.ProviderMetadata["google.thought_signature"]` by `buildToolCallBlockFromPart`. Empty thought summaries don't carry it, so dropping them is safe.

## Test plan
- [x] `go test ./internal/llm/google/...`
- [x] `go build ./...`
- [x] New regression test `TestConsumeStream_ThinkingPartEmptyTextSkipped` covers the exact shape Gemini emits (empty thought, function call, empty thought).
- [ ] Manually verify on the next Gemini run that no empty Thought entries appear in the audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)