### PR TITLE
feat: allow 0 = unlimited for policy run limits, plain numeric inputs

### DIFF
--- a/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.module.css
+++ b/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.module.css
@@ -3,3 +3,17 @@
   grid-template-columns: 1fr 1fr;
   gap: var(--space-3);
 }
+
+.hint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+  min-height: var(--space-4);
+}
+
+/* Suppress spinners defensively in case any environment ignores type=text */
+.fieldRow input::-webkit-outer-spin-button,
+.fieldRow input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.stories.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.stories.tsx
@@ -35,6 +35,13 @@ export const LowLimits: Story = {
   },
 };
 
+export const Unlimited: Story = {
+  args: {
+    value: { max_tokens_per_run: 0, max_tool_calls_per_run: 0 },
+    onChange: fn(),
+  },
+};
+
 function InteractiveRunLimitsSection() {
   const [value, setValue] = useState<RunLimitsFormState>({
     max_tokens_per_run: 100000,

--- a/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.test.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+import { RunLimitsSection } from './RunLimitsSection'
+import type { RunLimitsFormState } from './types'
+
+function renderSection(
+  value: RunLimitsFormState,
+  onChange = vi.fn(),
+) {
+  return render(<RunLimitsSection value={value} onChange={onChange} />)
+}
+
+// Wraps RunLimitsSection in local state so prop updates from onChange are
+// reflected back into the component, letting us test the full controlled loop.
+function ControlledRunLimitsSection({ initial }: { initial: RunLimitsFormState }) {
+  const [value, setValue] = useState(initial)
+  return <RunLimitsSection value={value} onChange={setValue} />
+}
+
+describe('RunLimitsSection — labels', () => {
+  it('renders labels with the (0 = unlimited) suffix', () => {
+    renderSection({ max_tokens_per_run: 20000, max_tool_calls_per_run: 50 })
+    expect(screen.getByText('Max tokens per run (0 = unlimited)')).toBeTruthy()
+    expect(screen.getByText('Max tool calls per run (0 = unlimited)')).toBeTruthy()
+  })
+})
+
+describe('RunLimitsSection — clearing the input', () => {
+  it('calls onChange with 0 when the user clears the tokens field', () => {
+    const onChange = vi.fn()
+    renderSection({ max_tokens_per_run: 20000, max_tool_calls_per_run: 50 }, onChange)
+    const [tokensInput] = screen.getAllByRole('textbox')
+    fireEvent.change(tokensInput, { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith({ max_tokens_per_run: 0, max_tool_calls_per_run: 50 })
+  })
+
+  it('calls onChange with 0 when the user clears the tool calls field', () => {
+    const onChange = vi.fn()
+    renderSection({ max_tokens_per_run: 20000, max_tool_calls_per_run: 50 }, onChange)
+    const [, toolCallsInput] = screen.getAllByRole('textbox')
+    fireEvent.change(toolCallsInput, { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith({ max_tokens_per_run: 20000, max_tool_calls_per_run: 0 })
+  })
+})
+
+describe('RunLimitsSection — accepting 0', () => {
+  it('calls onChange with 0 and shows the Unlimited hint under tokens', () => {
+    render(<ControlledRunLimitsSection initial={{ max_tokens_per_run: 20000, max_tool_calls_per_run: 50 }} />)
+    const [tokensInput] = screen.getAllByRole('textbox')
+    fireEvent.change(tokensInput, { target: { value: '0' } })
+    // After the controlled update, the prop is 0, so the hint appears.
+    expect(screen.getByText('Unlimited')).toBeTruthy()
+  })
+
+  it('does not show the Unlimited hint for the field that is still positive', () => {
+    render(<ControlledRunLimitsSection initial={{ max_tokens_per_run: 0, max_tool_calls_per_run: 50 }} />)
+    // Only one Unlimited hint should be present (for tokens).
+    const hints = screen.getAllByText('Unlimited')
+    expect(hints).toHaveLength(1)
+  })
+})
+
+describe('RunLimitsSection — non-digit stripping', () => {
+  it('strips non-digit characters and commits numeric value', () => {
+    const onChange = vi.fn()
+    renderSection({ max_tokens_per_run: 100, max_tool_calls_per_run: 10 }, onChange)
+    const [tokensInput] = screen.getAllByRole('textbox')
+    fireEvent.change(tokensInput, { target: { value: '12abc34' } })
+    expect(onChange).toHaveBeenLastCalledWith({ max_tokens_per_run: 1234, max_tool_calls_per_run: 10 })
+    expect((tokensInput as HTMLInputElement).value).toBe('1234')
+  })
+
+  it('strips a leading minus sign (paste of negative number becomes positive)', () => {
+    const onChange = vi.fn()
+    renderSection({ max_tokens_per_run: 100, max_tool_calls_per_run: 10 }, onChange)
+    const [tokensInput] = screen.getAllByRole('textbox')
+    fireEvent.change(tokensInput, { target: { value: '-5' } })
+    expect(onChange).toHaveBeenLastCalledWith({ max_tokens_per_run: 5, max_tool_calls_per_run: 10 })
+    expect((tokensInput as HTMLInputElement).value).toBe('5')
+  })
+})
+
+describe('RunLimitsSection — blur coercion', () => {
+  it('displays "0" after blur when the field is empty', () => {
+    render(<ControlledRunLimitsSection initial={{ max_tokens_per_run: 20000, max_tool_calls_per_run: 50 }} />)
+    const [tokensInput] = screen.getAllByRole('textbox')
+    fireEvent.change(tokensInput, { target: { value: '' } })
+    fireEvent.blur(tokensInput)
+    expect((tokensInput as HTMLInputElement).value).toBe('0')
+  })
+})
+
+describe('RunLimitsSection — external prop change resync', () => {
+  it('updates the input value when the parent supplies new prop values', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <RunLimitsSection value={{ max_tokens_per_run: 20000, max_tool_calls_per_run: 50 }} onChange={onChange} />,
+    )
+    const [tokensInput] = screen.getAllByRole('textbox')
+    expect((tokensInput as HTMLInputElement).value).toBe('20000')
+
+    rerender(
+      <RunLimitsSection value={{ max_tokens_per_run: 5000, max_tool_calls_per_run: 50 }} onChange={onChange} />,
+    )
+    expect((tokensInput as HTMLInputElement).value).toBe('5000')
+  })
+})
+
+describe('RunLimitsSection — Unlimited hint driven by prop', () => {
+  it('shows Unlimited under tokens when prop is 0', () => {
+    renderSection({ max_tokens_per_run: 0, max_tool_calls_per_run: 50 })
+    // Both hint divs exist; only the one for tokens has text content.
+    expect(screen.getByText('Unlimited')).toBeTruthy()
+  })
+
+  it('shows Unlimited under tool calls when prop is 0', () => {
+    renderSection({ max_tokens_per_run: 20000, max_tool_calls_per_run: 0 })
+    expect(screen.getByText('Unlimited')).toBeTruthy()
+  })
+
+  it('shows no Unlimited hint when both props are positive', () => {
+    renderSection({ max_tokens_per_run: 20000, max_tool_calls_per_run: 50 })
+    expect(screen.queryByText('Unlimited')).toBeNull()
+  })
+
+  it('shows two Unlimited hints when both props are 0', () => {
+    renderSection({ max_tokens_per_run: 0, max_tool_calls_per_run: 0 })
+    expect(screen.getAllByText('Unlimited')).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/RunLimitsSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import shared from './FormSections.module.css';
 import styles from './RunLimitsSection.module.css';
 import type { RunLimitsFormState, SectionIssues } from './types';
@@ -13,16 +14,53 @@ export function RunLimitsSection({ value, onChange, errors = [] }: RunLimitsSect
   const tokensErrors = errors.filter(e => e.field === 'agent.limits.max_tokens_per_run').map(e => e.message);
   const toolCallsErrors = errors.filter(e => e.field === 'agent.limits.max_tool_calls_per_run').map(e => e.message);
 
+  // Local string state lets the user clear the field while editing without
+  // immediately coercing a blank entry into the default value. The parent
+  // always receives a number — empty string commits as 0 (unlimited).
+  const [tokensText, setTokensText] = useState<string>(String(value.max_tokens_per_run));
+  const [toolCallsText, setToolCallsText] = useState<string>(String(value.max_tool_calls_per_run));
+
+  // Resync when the parent updates the value for a reason other than our own
+  // onChange (e.g. form reset or YAML round-trip). We intentionally omit the
+  // local text strings from deps so an in-flight empty string is not clobbered.
+  useEffect(() => {
+    const localNum = tokensText === '' ? 0 : parseInt(tokensText, 10);
+    if (localNum !== value.max_tokens_per_run) {
+      setTokensText(String(value.max_tokens_per_run));
+    }
+  }, [value.max_tokens_per_run]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const localNum = toolCallsText === '' ? 0 : parseInt(toolCallsText, 10);
+    if (localNum !== value.max_tool_calls_per_run) {
+      setToolCallsText(String(value.max_tool_calls_per_run));
+    }
+  }, [value.max_tool_calls_per_run]); // eslint-disable-line react-hooks/exhaustive-deps
+
   function handleTokensChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const parsed = parseInt(e.target.value, 10);
-    if (isNaN(parsed) || parsed <= 0) return;
-    onChange({ ...value, max_tokens_per_run: parsed });
+    const stripped = e.target.value.replace(/[^0-9]/g, '');
+    setTokensText(stripped);
+    const num = stripped === '' ? 0 : parseInt(stripped, 10);
+    onChange({ ...value, max_tokens_per_run: num });
   }
 
   function handleToolCallsChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const parsed = parseInt(e.target.value, 10);
-    if (isNaN(parsed) || parsed <= 0) return;
-    onChange({ ...value, max_tool_calls_per_run: parsed });
+    const stripped = e.target.value.replace(/[^0-9]/g, '');
+    setToolCallsText(stripped);
+    const num = stripped === '' ? 0 : parseInt(stripped, 10);
+    onChange({ ...value, max_tool_calls_per_run: num });
+  }
+
+  function handleTokensBlur() {
+    if (tokensText === '') {
+      setTokensText('0');
+    }
+  }
+
+  function handleToolCallsBlur() {
+    if (toolCallsText === '') {
+      setToolCallsText('0');
+    }
   }
 
   return (
@@ -31,28 +69,34 @@ export function RunLimitsSection({ value, onChange, errors = [] }: RunLimitsSect
 
       <div className={styles.fieldRow}>
         <div className={shared.field} data-field="agent.limits.max_tokens_per_run">
-          <label className={shared.label}>Max tokens per run</label>
+          <label className={shared.label}>Max tokens per run (0 = unlimited)</label>
           <input
             className={shared.input}
-            type="number"
-            min="1"
-            value={value.max_tokens_per_run}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={tokensText}
             aria-invalid={tokensErrors.length > 0 || undefined}
             onChange={handleTokensChange}
+            onBlur={handleTokensBlur}
           />
+          <div className={styles.hint}>{value.max_tokens_per_run === 0 ? 'Unlimited' : ''}</div>
           <FieldError messages={tokensErrors} />
         </div>
 
         <div className={shared.field} data-field="agent.limits.max_tool_calls_per_run">
-          <label className={shared.label}>Max tool calls per run</label>
+          <label className={shared.label}>Max tool calls per run (0 = unlimited)</label>
           <input
             className={shared.input}
-            type="number"
-            min="1"
-            value={value.max_tool_calls_per_run}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={toolCallsText}
             aria-invalid={toolCallsErrors.length > 0 || undefined}
             onChange={handleToolCallsChange}
+            onBlur={handleToolCallsBlur}
           />
+          <div className={styles.hint}>{value.max_tool_calls_per_run === 0 ? 'Unlimited' : ''}</div>
           <FieldError messages={toolCallsErrors} />
         </div>
       </div>

--- a/frontend/src/components/AgentEditor/agentEditorUtils.test.ts
+++ b/frontend/src/components/AgentEditor/agentEditorUtils.test.ts
@@ -724,3 +724,20 @@ describe('defaultFormState', () => {
     expect(fromDefault).toEqual(fromParsed)
   })
 })
+
+describe('yamlToFormState — zero limits preserved as unlimited', () => {
+  it('keeps explicit 0 for max_tokens_per_run and max_tool_calls_per_run', () => {
+    const yaml = `
+name: unlimited-test
+agent:
+  task: do it
+  limits:
+    max_tokens_per_run: 0
+    max_tool_calls_per_run: 0
+`
+    const state = yamlToFormState(yaml)
+    expect(state).not.toBeNull()
+    expect(state!.limits.max_tokens_per_run).toBe(0)
+    expect(state!.limits.max_tool_calls_per_run).toBe(0)
+  })
+})

--- a/frontend/src/components/AgentEditor/validateFormState.test.ts
+++ b/frontend/src/components/AgentEditor/validateFormState.test.ts
@@ -212,17 +212,29 @@ describe('validateFormState — model', () => {
 })
 
 describe('validateFormState — agent.limits', () => {
-  it('reports non-positive max_tokens_per_run', () => {
+  it('accepts zero max_tokens_per_run (unlimited)', () => {
     const s = valid()
     s.limits = { max_tokens_per_run: 0, max_tool_calls_per_run: 50 }
     const issues = validateFormState(s)
-    expect(findIssue(issues, 'agent.limits.max_tokens_per_run', 'must be positive')).toBe(true)
+    expect(issues.filter(i => i.field === 'agent.limits.max_tokens_per_run')).toHaveLength(0)
   })
-  it('reports non-positive max_tool_calls_per_run', () => {
+  it('accepts zero max_tool_calls_per_run (unlimited)', () => {
     const s = valid()
     s.limits = { max_tokens_per_run: 1000, max_tool_calls_per_run: 0 }
     const issues = validateFormState(s)
-    expect(findIssue(issues, 'agent.limits.max_tool_calls_per_run', 'must be positive')).toBe(true)
+    expect(issues.filter(i => i.field === 'agent.limits.max_tool_calls_per_run')).toHaveLength(0)
+  })
+  it('reports negative max_tokens_per_run', () => {
+    const s = valid()
+    s.limits = { max_tokens_per_run: -1, max_tool_calls_per_run: 50 }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.limits.max_tokens_per_run', 'must be zero (unlimited) or positive')).toBe(true)
+  })
+  it('reports negative max_tool_calls_per_run', () => {
+    const s = valid()
+    s.limits = { max_tokens_per_run: 1000, max_tool_calls_per_run: -1 }
+    const issues = validateFormState(s)
+    expect(findIssue(issues, 'agent.limits.max_tool_calls_per_run', 'must be zero (unlimited) or positive')).toBe(true)
   })
 })
 

--- a/frontend/src/components/AgentEditor/validateFormState.ts
+++ b/frontend/src/components/AgentEditor/validateFormState.ts
@@ -180,11 +180,11 @@ export function validateFormState(state: FormState): FormIssue[] {
   }
 
   // --- Run Limits ---
-  if (state.limits.max_tokens_per_run <= 0) {
-    add('agent.limits.max_tokens_per_run', 'agent.limits.max_tokens_per_run must be positive')
+  if (state.limits.max_tokens_per_run < 0) {
+    add('agent.limits.max_tokens_per_run', 'agent.limits.max_tokens_per_run must be zero (unlimited) or positive')
   }
-  if (state.limits.max_tool_calls_per_run <= 0) {
-    add('agent.limits.max_tool_calls_per_run', 'agent.limits.max_tool_calls_per_run must be positive')
+  if (state.limits.max_tool_calls_per_run < 0) {
+    add('agent.limits.max_tool_calls_per_run', 'agent.limits.max_tool_calls_per_run must be zero (unlimited) or positive')
   }
 
   // --- Concurrency ---

--- a/internal/http/api/policy_handler_test.go
+++ b/internal/http/api/policy_handler_test.go
@@ -1844,7 +1844,7 @@ agent:
   concurrency: skip
 `
 		assertValidationEnvelope(t, yaml, []issueJSON{
-			{Field: "agent.limits.max_tokens_per_run", Message: "must be positive"},
+			{Field: "agent.limits.max_tokens_per_run", Message: "must be zero (unlimited) or positive"},
 		})
 	})
 

--- a/internal/policy/parser.go
+++ b/internal/policy/parser.go
@@ -281,13 +281,15 @@ func convertAgent(r rawAgent, mc model.ModelConfig) model.AgentConfig {
 		ModelConfig: mc,
 	}
 
-	ac.Limits.MaxTokensPerRun = r.Limits.MaxTokensPerRun
-	if ac.Limits.MaxTokensPerRun == 0 {
+	if r.Limits.MaxTokensPerRun != nil {
+		ac.Limits.MaxTokensPerRun = *r.Limits.MaxTokensPerRun
+	} else {
 		ac.Limits.MaxTokensPerRun = defaultMaxTokensPerRun
 	}
 
-	ac.Limits.MaxToolCallsPerRun = r.Limits.MaxToolCallsPerRun
-	if ac.Limits.MaxToolCallsPerRun == 0 {
+	if r.Limits.MaxToolCallsPerRun != nil {
+		ac.Limits.MaxToolCallsPerRun = *r.Limits.MaxToolCallsPerRun
+	} else {
 		ac.Limits.MaxToolCallsPerRun = defaultMaxToolCallsPerRun
 	}
 
@@ -376,7 +378,9 @@ type rawAgent struct {
 	QueueDepth  int       `yaml:"queue_depth"`
 }
 
+// Pointer fields let us distinguish "field omitted" (nil → apply default)
+// from "field explicitly 0" (non-nil → preserve as-is, meaning unlimited).
 type rawLimits struct {
-	MaxTokensPerRun    int `yaml:"max_tokens_per_run"`
-	MaxToolCallsPerRun int `yaml:"max_tool_calls_per_run"`
+	MaxTokensPerRun    *int `yaml:"max_tokens_per_run"`
+	MaxToolCallsPerRun *int `yaml:"max_tool_calls_per_run"`
 }

--- a/internal/policy/parser_test.go
+++ b/internal/policy/parser_test.go
@@ -1089,3 +1089,32 @@ agent:
 		t.Errorf("trigger.cron_expr = %q, want %q (whitespace should be trimmed)", p.Trigger.CronExpr, "*/15 * * * *")
 	}
 }
+
+// TestConvertAgent_ZeroLimitsPreserved verifies that an explicit 0 in YAML is
+// not replaced by the default. 0 means "unlimited" at runtime (agent.go treats
+// <= 0 as no cap); the parser must not silently upgrade it to 20000/50.
+func TestConvertAgent_ZeroLimitsPreserved(t *testing.T) {
+	raw := `
+name: test
+trigger:
+  type: webhook
+capabilities:
+  tools:
+    - tool: s.t
+agent:
+  task: do it
+  limits:
+    max_tokens_per_run: 0
+    max_tool_calls_per_run: 0
+`
+	p, err := Parse(raw, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if p.Agent.Limits.MaxTokensPerRun != 0 {
+		t.Errorf("max_tokens_per_run = %d, want 0 (explicit zero must not be replaced by default)", p.Agent.Limits.MaxTokensPerRun)
+	}
+	if p.Agent.Limits.MaxToolCallsPerRun != 0 {
+		t.Errorf("max_tool_calls_per_run = %d, want 0 (explicit zero must not be replaced by default)", p.Agent.Limits.MaxToolCallsPerRun)
+	}
+}

--- a/internal/policy/validator.go
+++ b/internal/policy/validator.go
@@ -256,11 +256,11 @@ func validateAgent(a model.AgentConfig, c model.CapabilitiesConfig) []Issue {
 		add("model.provider", `model.provider "claude-code" is no longer supported; remove the policy or switch to an llm provider (anthropic, google, openai, openaicompat)`)
 	}
 
-	if a.Limits.MaxTokensPerRun <= 0 {
-		add("agent.limits.max_tokens_per_run", "agent.limits.max_tokens_per_run must be positive")
+	if a.Limits.MaxTokensPerRun < 0 {
+		add("agent.limits.max_tokens_per_run", "agent.limits.max_tokens_per_run must be zero (unlimited) or positive")
 	}
-	if a.Limits.MaxToolCallsPerRun <= 0 {
-		add("agent.limits.max_tool_calls_per_run", "agent.limits.max_tool_calls_per_run must be positive")
+	if a.Limits.MaxToolCallsPerRun < 0 {
+		add("agent.limits.max_tool_calls_per_run", "agent.limits.max_tool_calls_per_run must be zero (unlimited) or positive")
 	}
 
 	if !a.Concurrency.Valid() {

--- a/internal/policy/validator_test.go
+++ b/internal/policy/validator_test.go
@@ -274,13 +274,16 @@ func TestValidate_ReplacePlusApproval(t *testing.T) {
 func TestValidate_NegativeLimits(t *testing.T) {
 	p := validPolicy()
 	p.Agent.Limits.MaxTokensPerRun = -1
-	assertValidationContains(t, p, "max_tokens_per_run must be positive")
+	assertValidationContains(t, p, "max_tokens_per_run must be zero (unlimited) or positive")
 }
 
-func TestValidate_ZeroToolCalls(t *testing.T) {
+func TestValidate_ZeroLimitsAllowed(t *testing.T) {
 	p := validPolicy()
+	p.Agent.Limits.MaxTokensPerRun = 0
 	p.Agent.Limits.MaxToolCallsPerRun = 0
-	assertValidationContains(t, p, "max_tool_calls_per_run must be positive")
+	if err := Validate(p); err != nil {
+		t.Errorf("expected 0 limits to be valid (unlimited), got: %v", err)
+	}
 }
 
 func TestValidate_ToolWithApprovalValid(t *testing.T) {
@@ -747,13 +750,13 @@ func TestValidate_IssueFields(t *testing.T) {
 	t.Run("agent.limits.max_tokens_per_run field is tagged", func(t *testing.T) {
 		p := validPolicy()
 		p.Agent.Limits.MaxTokensPerRun = -1
-		assertIssueField(t, p, "agent.limits.max_tokens_per_run", "must be positive")
+		assertIssueField(t, p, "agent.limits.max_tokens_per_run", "must be zero (unlimited) or positive")
 	})
 
 	t.Run("agent.limits.max_tool_calls_per_run field is tagged", func(t *testing.T) {
 		p := validPolicy()
-		p.Agent.Limits.MaxToolCallsPerRun = 0
-		assertIssueField(t, p, "agent.limits.max_tool_calls_per_run", "must be positive")
+		p.Agent.Limits.MaxToolCallsPerRun = -1
+		assertIssueField(t, p, "agent.limits.max_tool_calls_per_run", "must be zero (unlimited) or positive")
 	})
 
 	t.Run("agent.concurrency field is tagged for invalid value", func(t *testing.T) {

--- a/schemas/policy.yaml
+++ b/schemas/policy.yaml
@@ -271,11 +271,13 @@ agent:
     # max_tokens_per_run: integer — optional, default: 20000
     #   Total token budget across the entire run (input + output).
     #   Run terminates with a failed state if exceeded.
+    #   Set to 0 for unlimited (no per-run cap).
     max_tokens_per_run: 20000
 
     # max_tool_calls_per_run: integer — optional, default: 50
     #   Maximum number of MCP tool calls across the entire run.
     #   Run terminates with a failed state if exceeded.
+    #   Set to 0 for unlimited (no per-run cap).
     max_tool_calls_per_run: 50
 
   # concurrency: skip | queue | parallel | replace — optional, default: skip


### PR DESCRIPTION
Closes #108

## Summary

Replaces the spinner-style number inputs for **Max tokens per run** and **Max tool calls per run** in the policy editor with plain numeric text inputs. Users can now:

- Clear the field while editing (the spinner used to block this since 0 was rejected as invalid).
- Set the value to `0` to mean **unlimited** for that limit.
- Type or paste digits without fighting clicker arrows; non-digit input is stripped.

The agent runtime already treated `<= 0` as "no cap" (see `internal/execution/agent/agent.go`), so this change is mostly in the configuration layer (parser, validator, UI) catching up to runtime semantics.

## Implementation highlights

- **Backend**: `rawLimits` switched from `int` to `*int` so YAML `0` is preserved as an explicit user choice rather than collapsing into the absent-key default. Validator now rejects `< 0` only (was `<= 0`); messages updated to "must be zero (unlimited) or positive".
- **Frontend**: `RunLimitsSection` holds local `useState<string>` buffers for the text inputs (initialized from props, resync via `useEffect`). The shared `RunLimitsFormState` type stays as `number` — the transient empty-string state is confined to the section component, avoiding type-cascading changes through `validateFormState`, `PolicyCardExpanded`, etc. On blur an empty input commits as `0`.
- **Hint**: Each field renders `Unlimited` beneath the input when its committed value is `0`. Labels read `(0 = unlimited)` so the meaning is discoverable without trial-and-error.
- **CSS**: `.hint` rule uses existing `--text-xs`, `--text-muted`, `--space-1` (4px), `--space-4` (16px reserved height to prevent layout shift). Webkit spinner-suppression is a defensive belt-and-braces over `type="text"`.

<details>
<summary>Architecture plan</summary>

```
Files changed (13):
  Backend:
    - internal/policy/parser.go        — rawLimits int -> *int; preserve explicit 0
    - internal/policy/validator.go     — reject only < 0; new error message
    - internal/policy/validator_test.go — TestValidate_ZeroLimitsAllowed; -1 still fails
    - internal/policy/parser_test.go    — TestConvertAgent_ZeroLimitsPreserved
    - internal/http/api/policy_handler_test.go — assertion message updated
    - schemas/policy.yaml               — comment: "0 = unlimited"
  Frontend:
    - RunLimitsSection.tsx              — text input + local string state + Unlimited hint
    - RunLimitsSection.module.css       — .hint rule + spinner suppression
    - RunLimitsSection.stories.tsx      — Unlimited story
    - RunLimitsSection.test.tsx (new)   — full coverage incl. prop-resync
    - validateFormState.ts              — reject only < 0
    - validateFormState.test.ts         — zero accepted, -1 rejected
    - agentEditorUtils.test.ts          — zero-limits round-trip test
```

Key decisions:
- `0 = unlimited` (matches the issue request and the runtime guard at `agent.go:156, :222`).
- `*int` in `rawLimits` distinguishes "field omitted" from "field explicitly 0".
- Local string state in `RunLimitsSection` keeps the shared `FormState` cleanly typed as `number`.
- No new shared `NumericInput` primitive — only two call sites; premature abstraction.

</details>

## Pipeline metadata

- Review cycles: **2** (one round of revisions; cycle 2 approved)
- CLAUDE.md updated: **No** (no new packages, env vars, routes, hooks, or shared components)
- Brainstorming triggered: **No** (issue was well-specified)

## Test plan

- [ ] `go test ./...` passes (verified via pre-commit hook)
- [ ] `npm run build` and `npx vitest run` pass (verified via pre-commit hook)
- [ ] Open the policy editor in the UI; clear the "Max tokens per run" field, type `0`, save. Confirm the hint reads `Unlimited` and the policy persists with `0`.
- [ ] Same for "Max tool calls per run".
- [ ] Re-open the same policy; confirm `0` round-trips through YAML and the hint still says `Unlimited`.
- [ ] Try pasting `-5` into a field; confirm only `5` lands in the input.
- [ ] Try pasting `12abc34`; confirm only `1234` lands.
- [ ] Open Storybook; confirm the new `Unlimited` story renders the hint visibly.

🤖 Generated by the Claude Code agentic dev loop.