### PR TITLE
fix: widen feedback status badge and add recent-runs drill-in

### DIFF
--- a/frontend/src/components/AgentList/PolicyCard.stories.tsx
+++ b/frontend/src/components/AgentList/PolicyCard.stories.tsx
@@ -42,7 +42,7 @@ concurrency:
   })
 
   // Key object must stay in sync with what useRuns constructs — a mismatch silently misses the preseed.
-  qc.setQueryData(queryKeys.runs.list({ policy_id: policyId, limit: '5', sort: 'started_at', order: 'desc' }), {
+  qc.setQueryData(queryKeys.runs.list({ policy_id: policyId, limit: '3', sort: 'started_at', order: 'desc' }), {
     runs: [
       { id: 'run-a', policy_id: policyId, status: 'complete', trigger_type: 'scheduled', started_at: '2026-04-08T02:00:00Z', completed_at: '2026-04-08T02:04:00Z', token_cost: 1200, error: null, created_at: '2026-04-08T02:00:00Z', system_prompt: null, model: 'claude-sonnet-4-20250514' },
       { id: 'run-b', policy_id: policyId, status: 'failed', trigger_type: 'scheduled', started_at: '2026-04-07T02:00:00Z', completed_at: '2026-04-07T02:01:00Z', token_cost: 400, error: 'Timeout', created_at: '2026-04-07T02:00:00Z', system_prompt: null, model: 'claude-sonnet-4-20250514' },

--- a/frontend/src/components/AgentList/PolicyCardExpanded.module.css
+++ b/frontend/src/components/AgentList/PolicyCardExpanded.module.css
@@ -72,17 +72,72 @@
   border: 1px solid color-mix(in srgb, var(--color-blue) 12%, transparent);
 }
 
-.recentDots {
+.recentLabel {
   display: inline-flex;
-  gap: 3px;
   align-items: center;
+  gap: var(--space-2);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: var(--space-2);
 }
 
-.recentDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--dot-color, var(--text-muted));
+.feedbackBadge {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  padding: 2px var(--space-2);
+  border-radius: 3px;
+  color: var(--color-purple);
+  background: color-mix(in srgb, var(--color-purple) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-purple) 24%, transparent);
+  text-transform: none;
+  letter-spacing: 0;
+  animation: feedbackPulse 2.4s ease-in-out infinite;
+}
+
+.recentList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.recentRow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.recentRow:hover {
+  background: var(--bg-elevated);
+}
+
+.recentTime {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+@keyframes feedbackPulse {
+  0%, 100% {
+    border-color: color-mix(in srgb, var(--color-purple) 24%, transparent);
+    box-shadow: 0 0 0 0 transparent;
+  }
+  50% {
+    border-color: color-mix(in srgb, var(--color-purple) 60%, transparent);
+    box-shadow: 0 0 6px 0 color-mix(in srgb, var(--color-purple) 20%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feedbackBadge {
+    animation: none;
+  }
 }
 
 .loading {

--- a/frontend/src/components/AgentList/PolicyCardExpanded.stories.tsx
+++ b/frontend/src/components/AgentList/PolicyCardExpanded.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import '@/tokens.css'
-import type { ApiPolicyListItem } from '@/api/types'
+import type { ApiPolicyListItem, ApiRun } from '@/api/types'
 import { PolicyCardExpanded } from './PolicyCardExpanded'
 import { queryKeys } from '@/hooks/queryKeys'
 
@@ -93,15 +94,16 @@ const BASE_LIST_ITEM: ApiPolicyListItem = {
   next_fire_at: null,
 }
 
-const RECENT_RUNS = [
+// 3 most recent runs — limit matches the useRuns({ limit: 3 }) call in PolicyCardExpanded.
+// Typed explicitly so that null fields stay assignable when building story variants.
+const RECENT_RUNS: ApiRun[] = [
   { id: 'run-1', policy_id: POLICY_ID, status: 'complete', trigger_type: 'webhook', started_at: '2026-04-08T08:00:00Z', completed_at: '2026-04-08T08:05:00Z', token_cost: 4200, error: null, created_at: '2026-04-08T08:00:00Z', system_prompt: null, model: 'claude-sonnet-4-20250514' },
   { id: 'run-2', policy_id: POLICY_ID, status: 'failed', trigger_type: 'webhook', started_at: '2026-04-07T14:00:00Z', completed_at: '2026-04-07T14:01:00Z', token_cost: 800, error: 'Timeout', created_at: '2026-04-07T14:00:00Z', system_prompt: null, model: 'claude-sonnet-4-20250514' },
   { id: 'run-3', policy_id: POLICY_ID, status: 'complete', trigger_type: 'webhook', started_at: '2026-04-06T09:00:00Z', completed_at: '2026-04-06T09:06:00Z', token_cost: 5100, error: null, created_at: '2026-04-06T09:00:00Z', system_prompt: null, model: 'claude-sonnet-4-20250514' },
-  { id: 'run-4', policy_id: POLICY_ID, status: 'complete', trigger_type: 'webhook', started_at: '2026-04-05T11:00:00Z', completed_at: '2026-04-05T11:07:00Z', token_cost: 4900, error: null, created_at: '2026-04-05T11:00:00Z', system_prompt: null, model: 'claude-sonnet-4-20250514' },
-  { id: 'run-5', policy_id: POLICY_ID, status: 'waiting_for_approval', trigger_type: 'webhook', started_at: '2026-04-04T15:00:00Z', completed_at: null, token_cost: 0, error: null, created_at: '2026-04-04T15:00:00Z', system_prompt: null, model: 'claude-sonnet-4-20250514' },
 ]
 
-const RUN_LIST_KEY = { policy_id: POLICY_ID, limit: '5', sort: 'started_at', order: 'desc' }
+// Key object must stay in sync with what useRuns constructs — a mismatch silently misses the preseed.
+const RUN_LIST_KEY = { policy_id: POLICY_ID, limit: '3', sort: 'started_at', order: 'desc' }
 
 function makeQueryClient(yaml: string, runsData = RECENT_RUNS): QueryClient {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -117,7 +119,6 @@ function makeQueryClient(yaml: string, runsData = RECENT_RUNS): QueryClient {
     paused_at: null,
   })
 
-  // Key object must stay in sync with what useRuns constructs — a mismatch silently misses the preseed.
   qc.setQueryData(queryKeys.runs.list(RUN_LIST_KEY), {
     runs: runsData,
     total: runsData.length,
@@ -126,9 +127,18 @@ function makeQueryClient(yaml: string, runsData = RECENT_RUNS): QueryClient {
   return qc
 }
 
+// MemoryRouter is required because PolicyCardExpanded renders <Link> from react-router-dom.
+// There is no global router decorator in preview.ts, so we add one here at the meta level.
 const meta: Meta<typeof PolicyCardExpanded> = {
   title: 'Components/PolicyCardExpanded',
   component: PolicyCardExpanded,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
 }
 
 export default meta
@@ -138,6 +148,25 @@ export const Default: Story = {
   decorators: [
     (Story) => (
       <QueryClientProvider client={makeQueryClient(SAMPLE_YAML)}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  args: { policy: BASE_LIST_ITEM },
+}
+
+// WaitingForFeedback — run-2 is mutated to waiting_for_feedback to show the
+// pulsing "feedback pending" pill and the purple Awaiting Feedback badge.
+export const WaitingForFeedback: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider
+        client={makeQueryClient(SAMPLE_YAML, [
+          RECENT_RUNS[0],
+          { ...RECENT_RUNS[1], status: 'waiting_for_feedback', completed_at: null, error: null },
+          RECENT_RUNS[2],
+        ])}
+      >
         <Story />
       </QueryClientProvider>
     ),

--- a/frontend/src/components/AgentList/PolicyCardExpanded.tsx
+++ b/frontend/src/components/AgentList/PolicyCardExpanded.tsx
@@ -1,23 +1,13 @@
+import { Link } from 'react-router-dom'
 import type { ApiPolicyListItem } from '@/api/types'
 import { usePolicy } from '@/hooks/queries/policies'
 import { useRuns } from '@/hooks/queries/runs'
 import { yamlToFormState } from '@/components/AgentEditor/agentEditorUtils'
-import { formatTokens } from '@/utils/format'
+import { formatTokens, formatTimeAgo } from '@/utils/format'
+import { StatusBadge } from '@/components/dashboard/StatusBadge'
+import { isRunStatus } from '@/constants/status'
+import type { RunStatus } from '@/constants/status'
 import styles from './PolicyCardExpanded.module.css'
-
-const RUN_STATUS_COLORS: Record<string, string> = {
-  complete: 'var(--color-green)',
-  failed: 'var(--color-red)',
-  running: 'var(--color-blue)',
-  waiting_for_approval: 'var(--color-amber)',
-  waiting_for_feedback: 'var(--color-purple)',
-  interrupted: 'var(--color-purple)',
-  pending: 'var(--text-muted)',
-}
-
-function dotColor(status: string): string {
-  return RUN_STATUS_COLORS[status] ?? 'var(--text-muted)'
-}
 
 // groupByServer groups tool names like "server.tool_name" by their server prefix.
 // Returns an array of "server (N)" strings.
@@ -39,7 +29,7 @@ export function PolicyCardExpanded({ policy }: Props) {
   const { data: detail, isLoading: detailLoading } = usePolicy(policy.id)
   const { runs, isLoading: runsLoading } = useRuns({
     policy_id: policy.id,
-    limit: 5,
+    limit: 3,
     sort: 'started_at',
     order: 'desc',
   })
@@ -61,6 +51,8 @@ export function PolicyCardExpanded({ policy }: Props) {
   const concurrency = formState?.concurrency.concurrency ?? 'skip'
   const concurrencyLabel = concurrency.charAt(0).toUpperCase() + concurrency.slice(1)
 
+  const hasFeedbackPending = runs.some(r => r.status === 'waiting_for_feedback')
+
   return (
     <div className={styles.expanded}>
       {description && <p className={styles.description}>{description}</p>}
@@ -69,7 +61,7 @@ export function PolicyCardExpanded({ policy }: Props) {
         <div className={styles.stat}>
           <span className={styles.statLabel}>Avg Tokens / Run</span>
           <span className={styles.statValue}>
-            {policy.run_count === 0 ? '\u2014' : formatTokens(policy.avg_token_cost)}
+            {policy.run_count === 0 ? '—' : formatTokens(policy.avg_token_cost)}
           </span>
         </div>
         <div className={styles.divider} />
@@ -84,25 +76,30 @@ export function PolicyCardExpanded({ policy }: Props) {
           <span className={styles.statLabel}>Concurrency</span>
           <span className={styles.statValue}>{concurrencyLabel}</span>
         </div>
-        {runs.length > 0 && (
-          <>
-            <div className={styles.divider} />
-            <div className={styles.stat}>
-              <span className={styles.statLabel}>Recent</span>
-              <span className={styles.recentDots}>
-                {runs.map(run => (
-                  <span
-                    key={run.id}
-                    className={styles.recentDot}
-                    style={{ '--dot-color': dotColor(run.status) } as React.CSSProperties}
-                    title={run.status}
-                  />
-                ))}
-              </span>
-            </div>
-          </>
-        )}
       </div>
+
+      {runs.length > 0 && (
+        <div>
+          <div className={styles.recentLabel}>
+            Recent Runs
+            {hasFeedbackPending && (
+              <span className={styles.feedbackBadge}>feedback pending</span>
+            )}
+          </div>
+          <div className={styles.recentList}>
+            {runs.map(run => (
+              <Link
+                key={run.id}
+                to={`/runs/${run.id}`}
+                className={styles.recentRow}
+              >
+                {isRunStatus(run.status) && <StatusBadge status={run.status as RunStatus} />}
+                <span className={styles.recentTime}>{formatTimeAgo(run.started_at)}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
 
       {serverPills.length > 0 && (
         <div>

--- a/frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.module.css
+++ b/frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.module.css
@@ -43,7 +43,7 @@
 
 .row {
   display: grid;
-  grid-template-columns: minmax(160px, 1.5fr) 100px 80px 80px 1fr;
+  grid-template-columns: minmax(160px, 1.5fr) 140px 80px 80px 1fr;
   align-items: center;
   padding: var(--space-3) var(--space-5);
   cursor: pointer;
@@ -60,7 +60,7 @@
 
 .skeletonRow {
   display: grid;
-  grid-template-columns: minmax(160px, 1.5fr) 100px 80px 80px 1fr;
+  grid-template-columns: minmax(160px, 1.5fr) 140px 80px 80px 1fr;
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-3) var(--space-5);

--- a/frontend/src/components/dashboard/StatusBadge/StatusBadge.stories.tsx
+++ b/frontend/src/components/dashboard/StatusBadge/StatusBadge.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof StatusBadge> = {
   argTypes: {
     status: {
       control: 'select',
-      options: ['complete', 'running', 'waiting_for_approval', 'failed', 'interrupted', 'pending'],
+      options: ['complete', 'running', 'waiting_for_approval', 'waiting_for_feedback', 'failed', 'interrupted', 'pending'],
     },
   },
 };
@@ -19,6 +19,7 @@ type Story = StoryObj<typeof StatusBadge>;
 export const Complete: Story = { args: { status: 'complete' } };
 export const Running: Story = { args: { status: 'running' } };
 export const AwaitingApproval: Story = { args: { status: 'waiting_for_approval' } };
+export const AwaitingFeedback: Story = { args: { status: 'waiting_for_feedback' } };
 export const Failed: Story = { args: { status: 'failed' } };
 export const Interrupted: Story = { args: { status: 'interrupted' } };
 export const Pending: Story = { args: { status: 'pending' } };
@@ -29,6 +30,7 @@ export const AllStates: Story = {
       <StatusBadge status="complete" />
       <StatusBadge status="running" />
       <StatusBadge status="waiting_for_approval" />
+      <StatusBadge status="waiting_for_feedback" />
       <StatusBadge status="failed" />
       <StatusBadge status="interrupted" />
       <StatusBadge status="pending" />


### PR DESCRIPTION
Closes #111

## Summary

Two presentation-only fixes around feedback-pending runs:

1. **Awaiting Feedback badge no longer clips on Control Center.** Widened the dashboard `RecentRunsFeed` status grid column from `100px` to `140px` so the longest `StatusBadge` labels (`Awaiting Feedback`, `Awaiting Approval`) render in full at viewports ≥1024px. Both `.row` and `.skeletonRow` were updated in lockstep so columns stay aligned during the loading state.
2. **Recent runs are now drillable from the Agents list.** Replaced the non-clickable colored dots in the expanded policy card (`PolicyCardExpanded`) with a clickable list of the 3 most recent runs — each row is a `<Link to=/runs/:id>` containing a `StatusBadge` + relative-time label. When any of the 3 most recent runs is `waiting_for_feedback`, a pulsing "feedback pending" pill renders at the top of the section so operators can spot it on the expanded card.

Storybook coverage: new `StatusBadge → AwaitingFeedback` story; new `PolicyCardExpanded → WaitingForFeedback` story; both story files keep their preseeded TanStack Query cache keys in sync with the new `useRuns({ limit: 3 })` call.

## How was it built

Generated by the agentic dev loop:

- Stage 3 architect produced an initial plan with the column-width fix and a clickable-row replacement strategy.
- Stage 4 plan-reviewer flagged 3 blocking issues (missing `MemoryRouter` decorator in stories, second cache-key preseed in `PolicyCard.stories.tsx`, and an undefined `recentLabelPulse` className that would have rendered as the literal string `"undefined"` in the DOM).
- Architect produced a revised plan addressing all three.
- Stage 6 code-reviewer **APPROVE**'d the implementation on the first try.

Review cycles: **1**.
CLAUDE.md updates: **none needed** (frontend presentation-only, no new packages/routes/hooks/components/query keys).
Brainstorming: **not triggered** — issue was well-specified.

<details>
<summary>Architecture plan</summary>

```
Affected files:
  1. frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.module.css
     — status column 100px → 140px (both .row and .skeletonRow)
  2. frontend/src/components/dashboard/StatusBadge/StatusBadge.stories.tsx
     — add waiting_for_feedback to options, AwaitingFeedback story, AllStates entry
  3. frontend/src/components/AgentList/PolicyCardExpanded.tsx
     — remove dead RUN_STATUS_COLORS / dotColor; useRuns limit 5 → 3
     — replace recent-dots with clickable <Link> rows (StatusBadge + formatTimeAgo)
     — compute hasFeedbackPending; render section-level feedback-pending pill
  4. frontend/src/components/AgentList/PolicyCardExpanded.module.css
     — delete .recentDots / .recentDot
     — add .recentLabel, .feedbackBadge (with feedbackPulse keyframe + prefers-reduced-motion guard),
       .recentList, .recentRow, .recentRow:hover, .recentTime
  5. frontend/src/components/AgentList/PolicyCardExpanded.stories.tsx
     — MemoryRouter meta-level decorator
     — RUN_LIST_KEY limit '5' → '3'; trim RECENT_RUNS to 3
     — new WaitingForFeedback story
  6. frontend/src/components/AgentList/PolicyCard.stories.tsx
     — preseed cache key limit '5' → '3' (mirrors hook change)

Constraints:
  - All styling via CSS Modules + design tokens (--space-*, --color-purple, etc.).
  - All spacing values 4px-grid-aligned (140 px is a 4 px multiple).
  - No inline style={}; the previous --dot-color inline style was deleted as dead code.
  - feedbackPulse animation guarded with prefers-reduced-motion: reduce.
  - No backend / DB / hook / query-key changes.
```

</details>

## Test plan

- [ ] On `/dashboard`, a run with status `waiting_for_feedback` renders the full `Awaiting Feedback` label without clipping
- [ ] `Awaiting Approval` also renders cleanly
- [ ] Other badges (Complete, Running, Failed, etc.) still align in the column
- [ ] On `/agents`, the expanded policy card shows up to 3 recent runs with status badge + relative time
- [ ] Clicking a recent-run row navigates to `/runs/:id`
- [ ] When any of the 3 most recent runs is `waiting_for_feedback`, the section shows the pulsing "feedback pending" pill
- [ ] Storybook: `Dashboard/StatusBadge → AwaitingFeedback` and `→ AllStates` show the full label
- [ ] Storybook: `Components/PolicyCardExpanded → WaitingForFeedback` shows the pulsing pill and a pulsing purple `Awaiting Feedback` badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)