### PR TITLE
docs: pre-public-launch polish (changelog, env example, README playbook list, architecture-at-a-glance)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,9 @@
 # Back it up securely (password manager or secrets vault) the moment you
 # generate it, before starting the stack for the first time.
 #
-# Rotating the key is NOT supported in v1.0 — see docs/user/operations.md for
-# the manual workaround if rotation is required.
+# To rotate the key, stop the server and run `gleipnirctl rotate-key` — see
+# cmd/gleipnirctl/README.md for the full procedure (dry-run validation,
+# atomic re-encryption of all at-rest secrets in a single transaction).
 GLEIPNIR_ENCRYPTION_KEY=
 
 # SQLite database file path inside the container.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 ### Security
+
+## [1.0.0] - 2026-04-27
+
+Initial public release.
+
+### Added
+
+- **Hard capability enforcement** (ADR-001). Tools not granted by a policy are never registered with the agent. There is no prompt-based restriction to bypass.
+- **Policy-gated approval** (ADR-008, ADR-029). Tools marked `approval: required` are intercepted by the runtime before execution, with timeout enforcement and an explicit state machine.
+- **Native feedback channel** (ADR-031). Agents can request operator input via `gleipnir.ask_operator`; the runtime manages the `waiting_for_feedback` state and timeout.
+- **Five trigger types**: `webhook` (HMAC or bearer auth), `manual`, `scheduled` (one-shot ISO-8601 timestamps), `poll` (recurring MCP probe with JSONPath checks), and `cron` (5-field POSIX expression).
+- **Multi-provider LLM support** (ADR-026). Anthropic, Google, OpenAI, and any OpenAI-compatible backend behind a common `internal/llm` interface. Provider API keys are configured through the admin UI and stored encrypted.
+- **MCP over HTTP transport** (ADR-004). Capability tags (`tool` / `feedback`) are stored in Gleipnir's DB, not the MCP server. Authenticated MCP servers (ADR-039) are supported via per-server encrypted auth headers.
+- **Arcade gateway pre-authorization** (ADR-040). One-click toolkit OAuth for Gmail, Google Calendar, Slack, GitHub, and other Arcade-hosted MCP toolkits.
+- **Encrypted secrets at rest.** Provider API keys, OpenAI-compatible backend keys, webhook secrets, and MCP auth headers are encrypted with AES-256-GCM under `GLEIPNIR_ENCRYPTION_KEY`.
+- **Atomic encryption-key rotation.** `gleipnirctl rotate-key` re-encrypts every at-rest secret in a single transaction, with `--dry-run` validation. See `cmd/gleipnirctl/README.md`.
+- **Atomic run-state transitions** (ADR-038). Every status change runs in a transaction with a version-column CAS guard.
+- **Capability snapshot as first run step** (ADR-018). Every run records the exact tools registered at run start.
+- **Reasoning trace.** Every step the agent takes — thoughts, tool calls, results, approvals, feedback — is recorded for after-the-fact review.
+- **Role-based access control.** Four roles (`admin`, `operator`, `approver`, `auditor`) enforced by middleware.
+- **Server-Sent Events** (ADR-016) push run status changes, new steps, and approval events to the UI in real time.
+- **Embedded React frontend.** The full UI is compiled into the Go binary via `go:embed` and served directly — no separate frontend container.
+- **Three end-to-end playbooks.** Meal planning (Google Calendar + Mealie), Todoist research (DuckDuckGo + Todoist), and homelab DevOps (Docker + Proxmox + Technitium + Caddy).
+
+### Security
+
+- All provider API keys, webhook secrets, and MCP auth headers are encrypted with AES-256-GCM at rest.
+- Webhook secrets live in a dedicated encrypted column outside the policy YAML blob (ADR-034); rotate/reveal is restricted to `admin` and `operator` roles.
+- MCP auth header values are write-only over the API; `GET` returns header *keys* only (ADR-039).
+- Passwords are bcrypt-hashed at cost 12. Session cookies are `HttpOnly`, `SameSite=Lax`, and `Secure` over HTTPS.
+- See [SECURITY.md](SECURITY.md) for the full threat model and security controls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,27 +20,27 @@ Initial public release.
 
 ### Added
 
-- **Hard capability enforcement** (ADR-001). Tools not granted by a policy are never registered with the agent. There is no prompt-based restriction to bypass.
-- **Policy-gated approval** (ADR-008, ADR-029). Tools marked `approval: required` are intercepted by the runtime before execution, with timeout enforcement and an explicit state machine.
-- **Native feedback channel** (ADR-031). Agents can request operator input via `gleipnir.ask_operator`; the runtime manages the `waiting_for_feedback` state and timeout.
+- **Hard capability enforcement.** Tools not granted by a policy are never registered with the agent. There is no prompt-based restriction to bypass.
+- **Policy-gated approval.** Tools marked `approval: required` are intercepted by the runtime before execution, with timeout enforcement and an explicit state machine.
+- **Native feedback channel.** Agents can request operator input via `gleipnir.ask_operator`; the runtime manages the `waiting_for_feedback` state and timeout.
 - **Five trigger types**: `webhook` (HMAC or bearer auth), `manual`, `scheduled` (one-shot ISO-8601 timestamps), `poll` (recurring MCP probe with JSONPath checks), and `cron` (5-field POSIX expression).
-- **Multi-provider LLM support** (ADR-026). Anthropic, Google, OpenAI, and any OpenAI-compatible backend behind a common `internal/llm` interface. Provider API keys are configured through the admin UI and stored encrypted.
-- **MCP over HTTP transport** (ADR-004). Capability tags (`tool` / `feedback`) are stored in Gleipnir's DB, not the MCP server. Authenticated MCP servers (ADR-039) are supported via per-server encrypted auth headers.
-- **Arcade gateway pre-authorization** (ADR-040). One-click toolkit OAuth for Gmail, Google Calendar, Slack, GitHub, and other Arcade-hosted MCP toolkits.
+- **Multi-provider LLM support.** Anthropic, Google, OpenAI, and any OpenAI-compatible backend behind a common `internal/llm` interface. Provider API keys are configured through the admin UI and stored encrypted.
+- **MCP over HTTP transport.** Capability tags (`tool` / `feedback`) are stored in Gleipnir's DB, not the MCP server. Authenticated MCP servers are supported via per-server encrypted auth headers.
+- **Arcade gateway pre-authorization.** One-click toolkit OAuth for Gmail, Google Calendar, Slack, GitHub, and other Arcade-hosted MCP toolkits.
 - **Encrypted secrets at rest.** Provider API keys, OpenAI-compatible backend keys, webhook secrets, and MCP auth headers are encrypted with AES-256-GCM under `GLEIPNIR_ENCRYPTION_KEY`.
 - **Atomic encryption-key rotation.** `gleipnirctl rotate-key` re-encrypts every at-rest secret in a single transaction, with `--dry-run` validation. See `cmd/gleipnirctl/README.md`.
-- **Atomic run-state transitions** (ADR-038). Every status change runs in a transaction with a version-column CAS guard.
-- **Capability snapshot as first run step** (ADR-018). Every run records the exact tools registered at run start.
+- **Atomic run-state transitions.** Every status change runs in a transaction with a version-column CAS guard.
+- **Capability snapshot as first run step.** Every run records the exact tools registered at run start.
 - **Reasoning trace.** Every step the agent takes — thoughts, tool calls, results, approvals, feedback — is recorded for after-the-fact review.
 - **Role-based access control.** Four roles (`admin`, `operator`, `approver`, `auditor`) enforced by middleware.
-- **Server-Sent Events** (ADR-016) push run status changes, new steps, and approval events to the UI in real time.
+- **Server-Sent Events** push run status changes, new steps, and approval events to the UI in real time.
 - **Embedded React frontend.** The full UI is compiled into the Go binary via `go:embed` and served directly — no separate frontend container.
 - **Three end-to-end playbooks.** Meal planning (Google Calendar + Mealie), Todoist research (DuckDuckGo + Todoist), and homelab DevOps (Docker + Proxmox + Technitium + Caddy).
 
 ### Security
 
 - All provider API keys, webhook secrets, and MCP auth headers are encrypted with AES-256-GCM at rest.
-- Webhook secrets live in a dedicated encrypted column outside the policy YAML blob (ADR-034); rotate/reveal is restricted to `admin` and `operator` roles.
-- MCP auth header values are write-only over the API; `GET` returns header *keys* only (ADR-039).
+- Webhook secrets live in a dedicated encrypted column outside the policy YAML blob; rotate/reveal is restricted to `admin` and `operator` roles.
+- MCP auth header values are write-only over the API; `GET` returns header *keys* only.
 - Passwords are bcrypt-hashed at cost 12. Session cookies are `HttpOnly`, `SameSite=Lax`, and `Secure` over HTTPS.
 - See [SECURITY.md](SECURITY.md) for the full threat model and security controls.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Gleipnir is a self-hosted runner for AI agents that quietly handle work you'd ra
 ## What you can do with it
 
 - **Plan the week's meals.** Checks your calendar for nights without dinner plans, picks recipes from Mealie for the empty slots, and schedules them in your meal plan. → [Playbook](docs/playbooks/meal-planning/README.md)
-- **Keep your homelab up when hardware fails.** Watches Uptime Kuma for outages, stands the affected service back up on a different host, and updates DNS so users never notice. → [Playbook](docs/playbooks/homelab-failover.md)
-- **Research your own todo list.** Finds Todoist tasks tagged `research`, gathers context, and updates each task with what it found. → [Playbook](docs/playbooks/todoist-research/README.md)
+- **Research your own todo list.** Finds Todoist tasks tagged `AI_Assist`, gathers context with web search, and posts the findings as a comment on each task. → [Playbook](docs/playbooks/todoist-research/README.md)
+- **Run homelab DevOps from natural language.** Restart Docker containers, fix Proxmox VMs, update Technitium DNS records, or reconfigure Caddy routes — every write is approval-gated. → [Playbook](docs/playbooks/devops/README.md)
 
 ## How it stays safe
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -8,6 +8,7 @@ Each diagram lives in its own file. Start with the system overview and runtime o
 
 | Diagram | What it shows |
 |---------|---------------|
+| [Architecture at a glance](diagrams/architecture-at-a-glance.md) | Subsystem map, ownership tree, and trigger fan-in — start here |
 | [System overview](diagrams/system-overview.md) | Deployment view — what's in the container, what's external |
 | [Package dependencies](diagrams/package-dependencies.md) | Internal packages grouped by layer with key import relationships |
 | [Runtime object graph](diagrams/runtime-object-graph.md) | What `main.go` creates and how triggers flow through to BoundAgent |

--- a/docs/developer/diagrams/architecture-at-a-glance.md
+++ b/docs/developer/diagrams/architecture-at-a-glance.md
@@ -1,0 +1,157 @@
+# Architecture at a Glance
+
+A single starting page for orienting yourself: which subsystems exist, who creates whom, and how a trigger gets to an agent. Pairs with the more detailed diagrams in this folder — start here, then drill in.
+
+## Subsystem map
+
+The codebase divides into six subsystems. Each box is one job stated in plain English.
+
+```mermaid
+graph TB
+    subgraph FE["<b>Frontend</b> · React + Vite, embedded via go:embed"]
+        FRONT["UI · talks to Go via REST + SSE"]
+    end
+
+    subgraph HTTP["<b>HTTP layer</b> · internal/http/*"]
+        HTTPL["chi router · auth middleware · per-domain handlers · SSE"]
+    end
+
+    subgraph TRIG["<b>Trigger dispatch</b> · internal/trigger/"]
+        TRIGL["webhook · manual · scheduled · poll · cron · pre-flight checks"]
+    end
+
+    subgraph EXE["<b>Execution</b> · internal/execution/*"]
+        EXEL["RunLauncher (concurrency) → BoundAgent (LLM loop) + AuditWriter + RunStateMachine"]
+    end
+
+    subgraph INT["<b>Integrations</b> · internal/{llm,mcp,policy,arcade}"]
+        INTL["LLM provider clients · MCP HTTP client · policy YAML parser · Arcade gateway helpers"]
+    end
+
+    subgraph PER["<b>Persistence + cross-cutting</b> · internal/{db,timeout,runstate,infra/*,admin}"]
+        PERL["sqlc-generated queries · timeout scanners · run-state CAS table · config / logctx / metrics / event · encrypted secrets"]
+    end
+
+    FE --> HTTP
+    HTTP --> TRIG
+    HTTP --> EXE
+    TRIG --> EXE
+    EXE --> INT
+    EXE --> PER
+    INT --> PER
+    HTTP --> PER
+```
+
+The single rule worth remembering: **dependencies always point downward**. The HTTP layer talks to triggers and execution; execution talks to integrations and persistence; persistence and `internal/infra/*` talk to nothing internal. `internal/mcp` is also forbidden from importing the agent package — see [package-dependencies.md](package-dependencies.md).
+
+## Ownership tree — what `main.go` creates
+
+`main.go` is the composition root. Every long-lived service is constructed here and wired explicitly. Read this top-down: a parent owns the lifetime and shutdown of its children.
+
+```mermaid
+graph TD
+    MAIN["<b>main.go</b><br/>process lifetime"]
+
+    %% Persistence + pub/sub
+    MAIN --> STORE["<b>db.Store</b><br/>SQLite + sqlc · WAL"]
+    MAIN --> BCAST["<b>SSE Broadcaster</b><br/>fan-out to browsers"]
+
+    %% Background timeout scanners
+    MAIN --> APPSCAN["<b>ApprovalScanner</b><br/>expires pending approvals"]
+    MAIN --> FBSCAN["<b>FeedbackScanner</b><br/>expires pending feedback"]
+
+    %% Provider + tool registries
+    MAIN --> PROVREG["<b>llm.ProviderRegistry</b><br/>provider name → LLMClient"]
+    MAIN --> ADMIN["<b>admin.Handler</b><br/>API key encryption,<br/>OpenAI-compat config"]
+    MAIN --> MCPREG["<b>mcp.Registry</b><br/>MCP servers + tool catalog"]
+
+    %% Run plumbing
+    MAIN --> RM["<b>RunManager</b><br/>tracks live agent goroutines"]
+    MAIN --> RL["<b>RunLauncher</b><br/>concurrency · DB-create-run · spawn"]
+    RL -. uses .-> STORE
+    RL -. uses .-> MCPREG
+    RL -. uses .-> RM
+    RL --> AF["<b>AgentFactory</b><br/>policy → BoundAgent"]
+    AF -. uses .-> PROVREG
+
+    %% Trigger handlers (one per trigger type)
+    MAIN --> WH["<b>WebhookHandler</b>"]
+    MAIN --> SCHED["<b>Scheduler</b><br/>fire_at one-shots"]
+    MAIN --> POLLER["<b>Poller</b><br/>recurring polls"]
+    MAIN --> CRON["<b>CronRunner</b><br/>cron expressions"]
+    WH -. calls .-> RL
+    SCHED -. calls .-> RL
+    POLLER -. calls .-> RL
+    CRON -. calls .-> RL
+
+    %% Auth + HTTP surface
+    MAIN --> AUTH["<b>auth.Handler</b><br/>login, sessions, roles"]
+    MAIN --> POLSVC["<b>policy.Service</b><br/>YAML CRUD + webhook secrets"]
+    MAIN --> ROUTER["<b>api.BuildRouter</b><br/>chi routes + middleware"]
+    ROUTER -. routes to .-> WH
+    ROUTER -. routes to .-> AUTH
+    ROUTER -. routes to .-> ADMIN
+    ROUTER -. routes to .-> POLSVC
+    ROUTER -. routes to .-> RL
+
+    %% Per-run goroutine
+    RL ==>|spawns goroutine per run| BA
+    subgraph perrun["Per-run goroutine (created on each Launch, dies when run completes)"]
+        BA["<b>BoundAgent</b>"]
+        BA --> AW["<b>AuditWriter</b><br/>serialized run_steps inserts"]
+        BA --> SM["<b>RunStateMachine</b><br/>status transitions w/ CAS"]
+        BA -. calls .-> LLMC["<b>LLMClient</b><br/>(borrowed from ProviderRegistry)"]
+        BA -. calls tools via .-> MCPC["<b>MCP client</b><br/>(borrowed from mcp.Registry)"]
+    end
+    AW -. publishes .-> BCAST
+    SM -. publishes .-> BCAST
+```
+
+Solid arrows = creates/owns. Dotted arrows = uses (borrowed reference, no ownership). The fat arrow into the per-run subgraph marks where short-lived goroutines fork off.
+
+A few things worth calling out:
+
+- **`main.go` owns everything long-lived.** The order in `run()` matters: persistence → broadcaster → registries → launcher → trigger handlers → router. Shutdown reverses this.
+- **Trigger handlers are sinks for a single dependency: `RunLauncher`.** All five trigger types end at the same call site. Adding a sixth means another handler that calls `launcher.Launch(...)` — see [adding-a-trigger-type.md](../adding-a-trigger-type.md).
+- **`BoundAgent` borrows, never owns, the LLM client and MCP clients.** Those live in registries with process-wide lifetime; the agent goroutine just holds a reference for the duration of one run.
+- **`AuditWriter` is per-run by design.** Every step insert flows through one goroutine to avoid SQLite write contention (see invariants in [architecture.md](../architecture.md)).
+
+## Trigger fan-in
+
+Five trigger types, one launcher. This is the architectural keystone: regardless of how a run is initiated, the rest of the system sees it identically.
+
+```mermaid
+graph LR
+    WHCALL["<b>HTTP POST</b><br/>/api/v1/webhooks/:id"] --> WH["WebhookHandler<br/>auth: hmac · bearer · none"]
+    MANCALL["<b>HTTP POST</b><br/>/api/v1/policies/:id/trigger"] --> MAN["ManualHandler<br/>role: operator+"]
+    TIMER1[("<b>Internal timer</b><br/>fire_at list")] --> SCHED["Scheduler<br/>one-shot, auto-pauses"]
+    TIMER2[("<b>Internal timer</b><br/>cron expression")] --> CRON["CronRunner<br/>recurring, no catch-up"]
+    POLLINT[("<b>Internal timer</b><br/>poll interval")] --> POLLER["Poller<br/>MCP call + JSONPath check"]
+
+    WH --> RL["<b>RunLauncher.Launch</b>"]
+    MAN --> RL
+    SCHED --> RL
+    CRON --> RL
+    POLLER --> RL
+
+    RL --> CHECK{"Concurrency<br/>policy"}
+    CHECK -->|allow| CREATE["INSERT runs<br/>(status=pending)"]
+    CHECK -->|skip / queue / replace| OUT1["return / enqueue / cancel-then-launch"]
+    CREATE --> SPAWN["go BoundAgent.Run(...)"]
+    SPAWN --> RM2["RunManager.Register"]
+```
+
+The funnel point — `RunLauncher.Launch` — is where the concurrency policy is enforced (`skip` / `queue` / `replace`), the run row is inserted, and the goroutine is spawned. From there, [run-execution-flow.md](run-execution-flow.md) takes over.
+
+## Where to go next
+
+| If you're trying to understand… | Read… |
+|---|---|
+| What happens during a run, step by step | [run-execution-flow.md](run-execution-flow.md) |
+| What status a run can be in | [run-state-machine.md](run-state-machine.md) |
+| How tools are restricted (and why prompt restrictions are not enough) | [capability-enforcement.md](capability-enforcement.md) |
+| How real-time updates reach the browser | [realtime-events.md](realtime-events.md) |
+| What's in the database | [data-model.md](data-model.md) |
+| How requests flow through middleware | [auth-request-flow.md](auth-request-flow.md) |
+| How shutdown is sequenced | [graceful-shutdown.md](graceful-shutdown.md) |
+| Internal package boundaries and forbidden imports | [package-dependencies.md](package-dependencies.md) |

--- a/docs/playbooks/devops/README.md
+++ b/docs/playbooks/devops/README.md
@@ -263,10 +263,10 @@ agent:
 
 - Read-only tools (`list_*`, `get_*`) have no approval gate so the agent can assess state without interrupting the operator. Write tools are approval-gated with explicit timeouts.
 - `proxmox.execute_command` — the "break glass" tool for cases where none of the typed Proxmox tools cover the fix — always requires approval since it runs arbitrary commands on the hypervisor.
-- `feedback.enabled: true` gives the agent `gleipnir.ask_operator` for ambiguous tasks (e.g. "which nginx container — there are three?") without failing the run (ADR-031).
+- `feedback.enabled: true` gives the agent `gleipnir.ask_operator` for ambiguous tasks (e.g. "which nginx container — there are three?") without failing the run.
 - `concurrency: skip` prevents a second run from stacking behind a first that is waiting for approval. Concurrent runs on the same host could conflict.
 - `caddy.get_caddy_config` is not approval-gated; it is a read that never modifies state. `update_caddy_config` is, because Caddy applies config changes live with no undo.
-- Tools not listed in `capabilities.tools` do not exist from the agent's perspective (ADR-001). The agent cannot call tools it was not granted, regardless of what it reasons.
+- Tools not listed in `capabilities.tools` do not exist from the agent's perspective. The agent cannot call tools it was not granted, regardless of what it reasons.
 
 ## Step 6 — Trigger a test run
 
@@ -279,7 +279,7 @@ agent:
 
 ### Restrict Proxmox operations to specific nodes or VMs
 
-Use parameter scoping (ADR-017) to prevent the agent from touching resources outside the intended scope. For example, to restrict `proxmox.restart_vm` to a specific VM ID:
+Use parameter scoping to prevent the agent from touching resources outside the intended scope. For example, to restrict `proxmox.restart_vm` to a specific VM ID:
 
 ```yaml
 - tool: proxmox.restart_vm

--- a/docs/playbooks/todoist-research/README.md
+++ b/docs/playbooks/todoist-research/README.md
@@ -189,9 +189,9 @@ agent:
 - `trigger.type: poll` with `interval: 15m` checks Todoist every 15 minutes. The poll check calls `todoist.get_tasks_list` filtered by the `AI_Assist` label, then evaluates `$[0].id not_equals ""` — this fires a run only when at least one matching task exists (non-empty array → first task has a non-empty ID), and stays silent when there are none. Polls that find no matching tasks consume one Todoist API call but do not start a run or burn LLM tokens.
 - The agent task tells the agent to read tasks from its trigger payload rather than re-fetching them. Gleipnir delivers the poll tool result as the first user message, so the task list is already in context — calling `get_tasks_list` again would double the API calls for no benefit.
 - Both `todoist.create_comments` and `todoist.update_tasks` are approval-gated. These are the only write operations — reading tasks and searching the web are read-only. The 1-hour approval window (longer than the meal-planning playbook's 30 minutes) gives you time to review the proposed comment and label removal before they are posted to Todoist. If you prefer fully automatic posting, set `approval: none` on both tools.
-- `feedback.enabled: true` gives the agent `gleipnir.ask_operator` (ADR-031) to handle ambiguous tasks without failing the run.
+- `feedback.enabled: true` gives the agent `gleipnir.ask_operator` to handle ambiguous tasks without failing the run.
 - `concurrency: queue` (depth 3) allows tasks labeled while a run is in progress to accumulate rather than being dropped. If more than 3 triggers queue up the extras are dropped with a warning in the Gleipnir logs; in practice 15-minute polling makes deep queuing unlikely.
-- Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective (ADR-001).
+- Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective.
 
 ## Step 6 — Label a task and test
 


### PR DESCRIPTION
## Summary

Last-second polish before today's public launch. Four fixes, all docs/no code.

- **`.env.example`** — Stale comment said encryption-key rotation was "NOT supported in v1.0", but `gleipnirctl rotate-key` shipped earlier this week. Replaced with a pointer at `cmd/gleipnirctl/README.md`. Otherwise visitors copying `.env.example` → `.env` would read a contradiction with the rest of the docs on day one.
- **`README.md`** — The front-page "What you can do with it" list included a "Keep your homelab up when hardware fails" bullet linking to a `Status: Planned` 7-line stub. Vapor on the headline list is a credibility hit. Replaced with the **homelab DevOps** playbook (which is shipped and complete), and tightened the Todoist bullet to use the real label name (`AI_Assist`, not `research`).
- **`CHANGELOG.md`** — Was empty under `[Unreleased]` only. An announcement linking an empty changelog reads worse than no changelog. Stamped `[1.0.0] - 2026-04-27` with an "Initial public release" entry covering the headline features (capability enforcement, approval gating, native feedback, multi-provider LLM, Arcade gateway, encrypted secrets + rotation, atomic state transitions) and the security posture.
- **`docs/developer/diagrams/architecture-at-a-glance.md` + `architecture.md` index entry** — Newcomer-oriented "start here" page (subsystem map, ownership tree, trigger fan-in) that was sitting uncommitted in the working tree alongside the index pointer that references it. Committed as a pair so the index entry doesn't 404 for cloners.

## Test plan

- [ ] `.env.example`: visual diff — line 20-22 now points at `gleipnirctl rotate-key` and the procedure doc.
- [ ] `README.md`: front-page "What you can do with it" list shows three bullets, all linked playbooks exist with `Status: Complete`.
- [ ] `CHANGELOG.md`: `[1.0.0] - 2026-04-27` section reads cleanly and the feature claims match what's actually in the code.
- [ ] `docs/developer/architecture.md`: clicking "Architecture at a glance" from the index resolves to the new file.
- [ ] No code changes — Go and frontend test suites do not need to re-run for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)