### PR TITLE
fix: surface real reason and run_id when run launch fails

### DIFF
--- a/frontend/src/api/fetch.test.ts
+++ b/frontend/src/api/fetch.test.ts
@@ -78,6 +78,49 @@ describe('apiFetch', () => {
     expect(apiErr.message).toBe('Bad Request')
   })
 
+  it('parses run_id from launch-failure error envelope', async () => {
+    server.use(
+      http.post(TEST_URL, () =>
+        HttpResponse.json(
+          {
+            error: 'failed to launch run',
+            detail: 'tool "ghost-server.foo" not found in registry',
+            run_id: '01HG7Z9NWDRX0000000000',
+          },
+          { status: 500 },
+        ),
+      ),
+    )
+    let caught: unknown
+    try { await apiFetch(TEST_PATH, { method: 'POST' }) } catch (err) { caught = err }
+    expect(caught).toBeInstanceOf(ApiError)
+    const apiErr = caught as ApiError
+    expect(apiErr.runId).toBe('01HG7Z9NWDRX0000000000')
+    expect(apiErr.detail).toContain('ghost-server.foo')
+  })
+
+  it('leaves runId undefined when run_id is absent', async () => {
+    server.use(
+      http.get(TEST_URL, () =>
+        HttpResponse.json({ error: 'bad request' }, { status: 400 }),
+      ),
+    )
+    let caught: unknown
+    try { await apiFetch(TEST_PATH) } catch (err) { caught = err }
+    expect((caught as ApiError).runId).toBeUndefined()
+  })
+
+  it('leaves runId undefined when run_id is empty string (omitempty server)', async () => {
+    server.use(
+      http.get(TEST_URL, () =>
+        HttpResponse.json({ error: 'bad', run_id: '' }, { status: 400 }),
+      ),
+    )
+    let caught: unknown
+    try { await apiFetch(TEST_PATH) } catch (err) { caught = err }
+    expect((caught as ApiError).runId).toBeUndefined()
+  })
+
   it('ignores detail when detail is not a string', async () => {
     server.use(
       http.get(TEST_URL, () =>

--- a/frontend/src/api/fetch.ts
+++ b/frontend/src/api/fetch.ts
@@ -7,13 +7,25 @@ export class ApiError extends Error {
   status: number
   detail?: string
   issues?: ApiErrorIssue[]
+  // runId is populated when the backend failed to launch a run *after* the
+  // run row was created — the row has been transitioned to failed with the
+  // underlying error stored on it. Callers can deep-link to /runs/:runId to
+  // show the operator the recorded reason.
+  runId?: string
 
-  constructor(status: number, message: string, detail?: string, issues?: ApiErrorIssue[]) {
+  constructor(
+    status: number,
+    message: string,
+    detail?: string,
+    issues?: ApiErrorIssue[],
+    runId?: string,
+  ) {
     super(message)
     this.name = 'ApiError'
     this.status = status
     this.detail = detail
     this.issues = issues
+    this.runId = runId
   }
 }
 
@@ -23,7 +35,7 @@ interface BaseRequestOptions {
 
 function parseApiErrorBody(
   body: unknown,
-): { error: string; detail?: string; issues?: ApiErrorIssue[] } | null {
+): { error: string; detail?: string; issues?: ApiErrorIssue[]; runId?: string } | null {
   if (
     typeof body === 'object' &&
     body !== null &&
@@ -44,6 +56,7 @@ function parseApiErrorBody(
       error: b.error as string,
       detail: typeof b.detail === 'string' ? b.detail : undefined,
       issues,
+      runId: typeof b.run_id === 'string' && b.run_id !== '' ? b.run_id : undefined,
     }
   }
   return null
@@ -70,6 +83,7 @@ async function baseRequest(
     let message = response.statusText
     let detail: string | undefined
     let issues: ApiErrorIssue[] | undefined
+    let runId: string | undefined
     try {
       const body = await response.json()
       const parsed = parseApiErrorBody(body)
@@ -77,11 +91,12 @@ async function baseRequest(
         message = parsed.error
         detail = parsed.detail
         issues = parsed.issues
+        runId = parsed.runId
       }
     } catch {
       // JSON parse failed, fall back to statusText already set above
     }
-    throw new ApiError(response.status, message, detail, issues)
+    throw new ApiError(response.status, message, detail, issues, runId)
   }
 
   return response

--- a/frontend/src/components/TriggerRunModal/TriggerRunModal.module.css
+++ b/frontend/src/components/TriggerRunModal/TriggerRunModal.module.css
@@ -3,3 +3,22 @@
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
+
+.errorDetail {
+  margin-top: var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  word-break: break-word;
+}
+
+.errorRunLink {
+  display: inline-block;
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  color: inherit;
+  text-decoration: underline;
+}
+
+.errorRunLink:hover {
+  text-decoration: none;
+}

--- a/frontend/src/components/TriggerRunModal/TriggerRunModal.test.tsx
+++ b/frontend/src/components/TriggerRunModal/TriggerRunModal.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TriggerRunModal } from './TriggerRunModal'
+import { ApiError } from '@/api/fetch'
+
+vi.mock('@/hooks/mutations/policies')
+
+import { useTriggerPolicy } from '@/hooks/mutations/policies'
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderModal(ui: React.ReactElement) {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('TriggerRunModal — launch failure surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders error.detail and a deep link to the failed run when ApiError carries runId', () => {
+    const apiErr = new ApiError(
+      500,
+      'failed to launch run',
+      'tool "ghost-server.foo" not found in registry',
+      undefined,
+      '01HG7Z9NWDRX0000000000',
+    )
+    vi.mocked(useTriggerPolicy).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: apiErr,
+    } as unknown as ReturnType<typeof useTriggerPolicy>)
+
+    renderModal(
+      <TriggerRunModal policyId="p1" policyName="Test" onClose={() => {}} onSuccess={() => {}} />,
+    )
+
+    expect(screen.getByText('failed to launch run')).toBeInTheDocument()
+    expect(screen.getByText(/ghost-server\.foo/)).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /view failed run/i })
+    expect(link).toHaveAttribute('href', '/runs/01HG7Z9NWDRX0000000000')
+  })
+
+  it('omits the deep link when ApiError has no runId (pre-CreateRun failure)', () => {
+    const apiErr = new ApiError(
+      500,
+      'failed to launch run',
+      'create run for policy abc: database is locked',
+    )
+    vi.mocked(useTriggerPolicy).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: apiErr,
+    } as unknown as ReturnType<typeof useTriggerPolicy>)
+
+    renderModal(
+      <TriggerRunModal policyId="p1" policyName="Test" onClose={() => {}} onSuccess={() => {}} />,
+    )
+
+    // The detail still shows.
+    expect(screen.getByText(/database is locked/)).toBeInTheDocument()
+    // But there's no run link to follow.
+    expect(screen.queryByRole('link', { name: /view failed run/i })).not.toBeInTheDocument()
+  })
+
+  it('clicking the failed-run link closes the modal so the page can navigate cleanly', async () => {
+    const onClose = vi.fn()
+    const apiErr = new ApiError(
+      500,
+      'failed to launch run',
+      'tool not found',
+      undefined,
+      '01HG7Z9NWDRX0000000000',
+    )
+    vi.mocked(useTriggerPolicy).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: apiErr,
+    } as unknown as ReturnType<typeof useTriggerPolicy>)
+
+    renderModal(
+      <TriggerRunModal policyId="p1" policyName="Test" onClose={onClose} onSuccess={() => {}} />,
+    )
+
+    const link = screen.getByRole('link', { name: /view failed run/i })
+    await userEvent.click(link)
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+})

--- a/frontend/src/components/TriggerRunModal/TriggerRunModal.tsx
+++ b/frontend/src/components/TriggerRunModal/TriggerRunModal.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { Modal } from '@/components/Modal/Modal'
 import { ModalFooter } from '@/components/ModalFooter'
+import { ApiError } from '@/api/fetch'
 import { useTriggerPolicy } from '@/hooks/mutations/policies'
 import { formatTimeAgo } from '@/utils/format'
 import formStyles from '@/styles/forms.module.css'
@@ -64,7 +66,21 @@ export function TriggerRunModal({ policyId, policyName, onClose, onSuccess, init
           </p>
         )}
         {error && (
-          <div className={alertStyles.alertError} role="alert">{error.message}</div>
+          <div className={alertStyles.alertError} role="alert">
+            <div>{error.message}</div>
+            {error instanceof ApiError && error.detail && (
+              <div className={styles.errorDetail}>{error.detail}</div>
+            )}
+            {error instanceof ApiError && error.runId && (
+              <Link
+                to={`/runs/${encodeURIComponent(error.runId)}`}
+                className={styles.errorRunLink}
+                onClick={onClose}
+              >
+                View failed run →
+              </Link>
+            )}
+          </div>
         )}
       </form>
     </Modal>

--- a/internal/execution/run/launcher.go
+++ b/internal/execution/run/launcher.go
@@ -60,7 +60,12 @@ type LaunchParams struct {
 	ParsedPolicy   *model.ParsedPolicy
 }
 
-// LaunchResult carries the output of a successful Launch call.
+// LaunchResult carries the output of a Launch call. RunID is populated on
+// success and on any failure path that occurred *after* the run row was
+// created — in those cases the row has been transitioned to status=failed
+// with the underlying error stored on it, so callers can deep-link to the
+// run detail page. RunID is empty only when the run row could not be created
+// at all (e.g. CreateRun returned a DB error).
 type LaunchResult struct {
 	RunID string
 }
@@ -189,7 +194,10 @@ func (l *RunLauncher) CheckConcurrency(ctx context.Context, policyID string, con
 // Launch creates a run record, resolves tools, constructs the agent, and
 // launches it in a background goroutine. On any setup error after the run row
 // is created, the run is marked failed before returning.
-// Returns LaunchResult with the new run ID on success.
+// Returns LaunchResult with the new run ID on success. On failure paths that
+// occurred after the run row was created, LaunchResult.RunID is also set so
+// the caller can surface a deep-link to the failed run row (which already has
+// the underlying error recorded on it).
 func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchResult, error) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	run, err := l.store.CreateRun(ctx, db.CreateRunParams{
@@ -226,7 +234,9 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 				slog.Error("transition to failed on tool resolution error", "run_id", run.ID, "err", tErr)
 			}
 		}
-		return LaunchResult{}, err
+		// Return RunID alongside the error so callers can link to the failed
+		// run row. The row already has the underlying error stored on it.
+		return LaunchResult{RunID: run.ID}, err
 	}
 
 	audit := agent.NewAuditWriter(l.store.Queries(), agent.WithPublisher(l.publisher))
@@ -260,7 +270,9 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 		if closeErr := audit.Close(); closeErr != nil {
 			slog.Error("audit writer drain error on failed launch", "run_id", run.ID, "err", closeErr)
 		}
-		return LaunchResult{}, err
+		// Return RunID alongside the error so callers can link to the failed
+		// run row. The row already has the underlying error stored on it.
+		return LaunchResult{RunID: run.ID}, err
 	}
 
 	// context.Background() is used intentionally so the agent goroutine outlives

--- a/internal/execution/run/launcher_test.go
+++ b/internal/execution/run/launcher_test.go
@@ -311,7 +311,7 @@ agent:
 		t.Fatalf("policy.Parse: %v", err)
 	}
 
-	_, launchErr := launcher.Launch(context.Background(), run.LaunchParams{
+	result, launchErr := launcher.Launch(context.Background(), run.LaunchParams{
 		PolicyID:       "p-tool-fail",
 		TriggerType:    model.TriggerTypeWebhook,
 		TriggerPayload: `{}`,
@@ -331,6 +331,14 @@ agent:
 	}
 	if runs[0].Status != string(model.RunStatusFailed) {
 		t.Errorf("run.Status = %q, want %q", runs[0].Status, model.RunStatusFailed)
+	}
+	// LaunchResult.RunID must point at the failed run row so callers (HTTP
+	// handlers, async trigger loggers) can deep-link to it.
+	if result.RunID == "" {
+		t.Error("Launch() returned empty RunID on tool resolution failure; expected the created run's ID so callers can deep-link to the failed row")
+	}
+	if result.RunID != runs[0].ID {
+		t.Errorf("Launch() returned RunID %q, want %q (the failed run's ID)", result.RunID, runs[0].ID)
 	}
 }
 
@@ -368,7 +376,7 @@ agent:
 		t.Fatalf("policy.Parse: %v", err)
 	}
 
-	_, launchErr := launcher.Launch(context.Background(), run.LaunchParams{
+	result, launchErr := launcher.Launch(context.Background(), run.LaunchParams{
 		PolicyID:       "p-agent-fail",
 		TriggerType:    model.TriggerTypeWebhook,
 		TriggerPayload: `{}`,
@@ -388,6 +396,14 @@ agent:
 	}
 	if runs[0].Status != string(model.RunStatusFailed) {
 		t.Errorf("run.Status = %q, want %q", runs[0].Status, model.RunStatusFailed)
+	}
+	// LaunchResult.RunID must point at the failed run row so callers (HTTP
+	// handlers, async trigger loggers) can deep-link to it.
+	if result.RunID == "" {
+		t.Error("Launch() returned empty RunID on agent construction failure; expected the created run's ID so callers can deep-link to the failed row")
+	}
+	if result.RunID != runs[0].ID {
+		t.Errorf("Launch() returned RunID %q, want %q (the failed run's ID)", result.RunID, runs[0].ID)
 	}
 }
 

--- a/internal/http/httputil/response.go
+++ b/internal/http/httputil/response.go
@@ -7,6 +7,8 @@
 //	{"data": T}                          for success
 //	{"error": "...", "detail": "..."}    for failure
 //	{"error": "...", "detail": "...", "issues": [...]} for validation failures
+//	{"error": "...", "detail": "...", "run_id": "..."} for run launch failures
+//	    where a run row was created and marked failed before the error returned
 package httputil
 
 import (
@@ -23,6 +25,12 @@ type errorEnvelope struct {
 	Error  string       `json:"error"`
 	Detail string       `json:"detail,omitempty"`
 	Issues []ErrorIssue `json:"issues,omitempty"`
+	// RunID is populated only when a run launch failed after the run row was
+	// created (e.g. tool resolution or agent construction error). The row has
+	// already been transitioned to status=failed with the error stored on it,
+	// so clients can deep-link to the run detail page to see the recorded
+	// error. Empty when no run row exists.
+	RunID string `json:"run_id,omitempty"`
 }
 
 // ErrorIssue is a structured validation failure with an optional field path.
@@ -52,6 +60,20 @@ func WriteError(w http.ResponseWriter, status int, msg, detail string) {
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(errorEnvelope{Error: msg, Detail: detail}); err != nil {
 		slog.Error("failed to encode JSON error response", "err", err)
+	}
+}
+
+// WriteLaunchError writes a JSON error response for a run launch failure.
+// When runID is non-empty, the run row was created and marked failed before
+// the error returned, so the response includes run_id so the client can link
+// to the run detail page (where the recorded error is visible). When runID is
+// empty, behaves identically to WriteError.
+func WriteLaunchError(w http.ResponseWriter, status int, msg, detail, runID string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	env := errorEnvelope{Error: msg, Detail: detail, RunID: runID}
+	if err := json.NewEncoder(w).Encode(env); err != nil {
+		slog.Error("failed to encode JSON launch error response", "err", err)
 	}
 }
 

--- a/internal/http/httputil/response_test.go
+++ b/internal/http/httputil/response_test.go
@@ -119,3 +119,57 @@ func TestWriteError(t *testing.T) {
 		}
 	})
 }
+
+func TestWriteLaunchError(t *testing.T) {
+	t.Run("includes run_id when non-empty", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		httputil.WriteLaunchError(w, http.StatusInternalServerError,
+			"failed to launch run",
+			`tool "my-server.foo" not found in registry`,
+			"01HG7Z9NWDRX0000000000",
+		)
+
+		var got map[string]any
+		if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if got["error"] != "failed to launch run" {
+			t.Errorf("got error=%q, want %q", got["error"], "failed to launch run")
+		}
+		if got["detail"] != `tool "my-server.foo" not found in registry` {
+			t.Errorf("got detail=%q, want the registry error", got["detail"])
+		}
+		if got["run_id"] != "01HG7Z9NWDRX0000000000" {
+			t.Errorf("got run_id=%q, want the supplied run id", got["run_id"])
+		}
+	})
+
+	t.Run("omits run_id when empty (pre-CreateRun failure)", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		httputil.WriteLaunchError(w, http.StatusInternalServerError,
+			"failed to launch run",
+			"create run for policy abc: database is locked",
+			"",
+		)
+
+		var got map[string]any
+		if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if _, present := got["run_id"]; present {
+			t.Error("expected 'run_id' key to be absent when runID is empty")
+		}
+		// Detail must still be present so the operator sees why it failed.
+		if got["detail"] != "create run for policy abc: database is locked" {
+			t.Errorf("got detail=%q, want the create-run error", got["detail"])
+		}
+	})
+
+	t.Run("uses the provided HTTP status code", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		httputil.WriteLaunchError(w, http.StatusInternalServerError, "x", "y", "")
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("got code %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+	})
+}

--- a/internal/trigger/cron.go
+++ b/internal/trigger/cron.go
@@ -313,7 +313,15 @@ func (c *CronRunner) fire(ctx context.Context, policyID string, parsed *model.Pa
 		ParsedPolicy:   parsed,
 	})
 	if err != nil {
-		slog.Error("cron: failed to launch run", "policy_id", policyID, "fired_at", firedAt, "err", err)
+		// run_id is populated when the failure happened after the row was
+		// created (tool resolution, agent construction). Operators can use it
+		// to find the failed run in history, where the recorded error lives.
+		slog.Error("cron: failed to launch run",
+			"policy_id", policyID,
+			"run_id", result.RunID,
+			"fired_at", firedAt,
+			"err", err,
+		)
 		return
 	}
 

--- a/internal/trigger/launch.go
+++ b/internal/trigger/launch.go
@@ -104,7 +104,20 @@ func checkConcurrencyAndLaunch(
 
 	result, err := launcher.Launch(ctx, params)
 	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to launch run", "")
+		// Log with the underlying error and run_id (when populated) so
+		// operators can correlate logs to the failed run row in history.
+		slog.ErrorContext(ctx, logPrefix+": failed to launch run",
+			"policy_id", params.PolicyID,
+			"run_id", result.RunID,
+			"err", err,
+		)
+		// Surface err.Error() as the response detail so the caller sees the
+		// real reason (e.g. `tool "my-server.foo" not found in registry`)
+		// instead of a generic 500. When result.RunID is non-empty, the run
+		// row was created and marked failed — include it so the UI can deep
+		// link to the run detail page where the recorded error is visible.
+		httputil.WriteLaunchError(w, http.StatusInternalServerError,
+			"failed to launch run", err.Error(), result.RunID)
 		return
 	}
 

--- a/internal/trigger/manual_test.go
+++ b/internal/trigger/manual_test.go
@@ -2,6 +2,7 @@ package trigger_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -267,6 +268,94 @@ func TestManualTriggerHandler_RunCreatedInDB(t *testing.T) {
 	}
 	if run.TriggerType != "manual" {
 		t.Errorf("run.TriggerType = %q, want %q", run.TriggerType, "manual")
+	}
+}
+
+// Policy that grants a tool not registered with any MCP server. Tool
+// resolution will fail and Launch should return an error after the run row
+// has already been created and marked failed.
+const policyWithMissingTool = `
+name: missing-tool-policy
+trigger:
+  type: manual
+capabilities:
+  tools:
+    - tool: ghost-server.nonexistent_tool
+agent:
+  model: claude-opus-4-6
+  task: "test task"
+`
+
+// When tool resolution fails, the manual trigger handler must return a 500
+// response that includes (a) the underlying error as `detail` so the operator
+// can see *what* went wrong (e.g. a removed tool) and (b) the `run_id` of the
+// failed run row so the UI can deep-link to it.
+func TestManualTriggerHandler_LaunchFailureSurfacesDetailAndRunID(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	insertTestManualPolicy(t, store, "mp-missing-tool", policyWithMissingTool)
+
+	// No MCP servers registered, so ghost-server.nonexistent_tool will fail
+	// to resolve.
+	registry := mcp.NewRegistry(store.Queries())
+	noopClient := testutil.NewNoopLLMClient()
+	providerReg := llm.NewProviderRegistry()
+	providerReg.Register("anthropic", noopClient)
+	resolver := stubDefaultModelResolver{provider: "anthropic", name: "claude-sonnet-4-6"}
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           run.NewAgentFactory(providerReg),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
+	h := trigger.NewManualTriggerHandler(store, launcher, resolver)
+
+	w := callManualHandler(t, h, "mp-missing-tool", `{"message": "test"}`)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+
+	// Top-level error should be the generic launch-failure label.
+	if body["error"] != "failed to launch run" {
+		t.Errorf(`body.error = %q, want %q`, body["error"], "failed to launch run")
+	}
+
+	// Detail must surface the underlying tool-resolution error so the operator
+	// can see exactly which tool is missing — that is the whole point of this
+	// PR. A bare "failed to launch run" with empty detail is a regression.
+	detail, ok := body["detail"].(string)
+	if !ok || detail == "" {
+		t.Fatalf("body.detail must be a non-empty string carrying the underlying error; got %v", body["detail"])
+	}
+	if !strings.Contains(detail, "nonexistent_tool") {
+		t.Errorf("body.detail = %q, expected it to mention the missing tool name", detail)
+	}
+
+	// run_id must be populated and must point at a real failed run row so the
+	// UI can deep-link to it.
+	runID, ok := body["run_id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("body.run_id must be a non-empty string when the run row was created; got %v", body["run_id"])
+	}
+	runs, err := store.ListRuns(context.Background(), db.ListRunsParams{PolicyID: "mp-missing-tool", Limit: 100})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected exactly 1 run row, got %d", len(runs))
+	}
+	if runs[0].ID != runID {
+		t.Errorf("body.run_id = %q, want %q (the failed run's ID)", runID, runs[0].ID)
+	}
+	if runs[0].Status != string(model.RunStatusFailed) {
+		t.Errorf("run.Status = %q, want %q", runs[0].Status, model.RunStatusFailed)
 	}
 }
 

--- a/internal/trigger/poll.go
+++ b/internal/trigger/poll.go
@@ -348,7 +348,14 @@ func (p *Poller) poll(ctx context.Context, policyID string, parsed *model.Parsed
 		ParsedPolicy:   parsed,
 	})
 	if err != nil {
-		slog.Error("poller: failed to launch run", "policy_id", policyID, "err", err)
+		// run_id is populated when the failure happened after the row was
+		// created (tool resolution, agent construction). Operators can use it
+		// to find the failed run in history, where the recorded error lives.
+		slog.Error("poller: failed to launch run",
+			"policy_id", policyID,
+			"run_id", launchResult.RunID,
+			"err", err,
+		)
 		return
 	}
 

--- a/internal/trigger/scheduled.go
+++ b/internal/trigger/scheduled.go
@@ -234,7 +234,15 @@ func (s *Scheduler) fire(ctx context.Context, policyID string, parsed *model.Par
 		ParsedPolicy:   parsed,
 	})
 	if err != nil {
-		slog.Error("scheduled: failed to launch run", "policy_id", policyID, "fire_at", fireTime, "err", err)
+		// run_id is populated when the failure happened after the row was
+		// created (tool resolution, agent construction). Operators can use it
+		// to find the failed run in history, where the recorded error lives.
+		slog.Error("scheduled: failed to launch run",
+			"policy_id", policyID,
+			"run_id", result.RunID,
+			"fire_at", fireTime,
+			"err", err,
+		)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Fixes the case the user hit where a manual trigger surfaced only the literal string `failed to launch run` with no further information — e.g. when a policy references an MCP tool that has since been removed or disabled.

Root cause: `RunLauncher.Launch` returned a meaningful wrapped error (`tool "my-server.foo" not found in registry`, `provider lookup: ...`, `create run for policy abc: <db error>`), but `internal/trigger/launch.go` discarded it before writing the HTTP response and never logged it. Webhook callers got the same opaque 500. Cron / scheduled / poll triggers logged the error but without `run_id`, so operators couldn't tie a log line to a row in run history.

Three changes, scoped together because they share a return-shape contract:

1. **`RunLauncher.Launch`** now populates `LaunchResult.RunID` on the tool-resolution and agent-construction failure paths. The run row already exists (transitioned to `failed` with the error stored on it); returning its ID lets callers deep-link to it. `RunID` stays empty only when `CreateRun` itself fails — the truly run-row-less case.
2. **`internal/trigger/launch.go`** (manual + webhook) now logs the underlying error with structured `policy_id` / `run_id` / `err` fields and passes `err.Error()` through as the response `detail`. When `result.RunID` is non-empty, a new `httputil.WriteLaunchError` helper adds `run_id` to the error envelope so the UI can offer a "View failed run" link.
3. **`cron.go`, `scheduled.go`, `poll.go`** include `run_id` in their structured failure logs. Async triggers have no caller to receive the detail, but log + run-history correlation is enough for an operator to find the failure.

**Frontend:**
- `ApiError` carries `runId`; `parseApiErrorBody` reads `run_id` from the envelope (treats empty string and absent key as undefined).
- `TriggerRunModal` renders the `detail` under the alert and shows a `View failed run →` link when `runId` is populated. Clicking the link closes the modal so navigation lands cleanly on the run page.

## Failure mode by trigger, before vs after

| Trigger | Before | After |
|---|---|---|
| Manual | HTTP 500 `failed to launch run`, no detail. Run row sometimes exists, no way to find it. | HTTP 500 with `detail: tool "..." not found in registry` and `run_id: 01H...`. UI shows "View failed run →" linking straight to the run detail page. |
| Webhook | Same as manual. | Same as manual — webhook sender now sees the real reason in the response body. |
| Scheduled / Cron / Poll | Log line `... failed to launch run` with `policy_id` and `err` but no `run_id`. | Log line includes `run_id` so it correlates 1:1 with the failed run row in history. |

## Test plan

- [x] `go test ./internal/http/httputil/...` — passes; `WriteLaunchError` includes/omits `run_id` correctly.
- [x] `go test ./internal/execution/run/...` — passes; existing tool-resolution and agent-construction failure tests now also assert `LaunchResult.RunID` matches the failed run's DB ID.
- [x] `go test ./internal/trigger/...` — passes; new `TestManualTriggerHandler_LaunchFailureSurfacesDetailAndRunID` exercises the end-to-end shape with a policy that grants a tool from an unregistered MCP server.
- [x] `go test ./...` — all backend packages green.
- [x] `npm run test:unit` — 56 files, 803 tests, all green. Includes new `fetch.test.ts` cases for `run_id` parsing and new `TriggerRunModal.test.tsx` covering the link rendering, link href, and `onClose` on click.
- [x] `npm run build` — frontend compiles clean.
- [ ] Manual smoke test: trigger a manual run on a policy that references a tool whose MCP server has been deleted, confirm the modal shows the underlying error and a working "View failed run →" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)