### PR TITLE
style: regroup imports via goimports after module rename

### DIFF
--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
 	"github.com/felag-engineering/gleipnir/internal/llm"

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )

--- a/internal/admin/openai_compat_handler.go
+++ b/internal/admin/openai_compat_handler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	"github.com/felag-engineering/gleipnir/internal/llm/openaicompat"

--- a/internal/admin/openai_compat_handler_test.go
+++ b/internal/admin/openai_compat_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/db/instrumented_test.go
+++ b/internal/db/instrumented_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/db/metrics.go
+++ b/internal/db/metrics.go
@@ -3,6 +3,7 @@ package db
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/execution/agent/metrics.go
+++ b/internal/execution/agent/metrics.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/execution/agent/metrics_test.go
+++ b/internal/execution/agent/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	// Import packages that register their collectors at init time so the
 	// smoke test covers all seven metric families in a single Describe pass.
 	"github.com/prometheus/client_golang/prometheus"
+
 	_ "github.com/felag-engineering/gleipnir/internal/execution/agent"
 	_ "github.com/felag-engineering/gleipnir/internal/execution/runstate"
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"

--- a/internal/execution/run/runs_handler.go
+++ b/internal/execution/run/runs_handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
 	"github.com/felag-engineering/gleipnir/internal/infra/event"

--- a/internal/execution/run/runs_handler_test.go
+++ b/internal/execution/run/runs_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/execution/run"
 	"github.com/felag-engineering/gleipnir/internal/model"

--- a/internal/execution/runstate/metrics.go
+++ b/internal/execution/runstate/metrics.go
@@ -3,6 +3,7 @@ package runstate
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/model"
 )

--- a/internal/http/api/metrics_middleware.go
+++ b/internal/http/api/metrics_middleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/http/api/metrics_middleware_test.go
+++ b/internal/http/api/metrics_middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	dto "github.com/prometheus/client_model/go"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/http/api/policy_webhook_handler.go
+++ b/internal/http/api/policy_webhook_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
 	"github.com/felag-engineering/gleipnir/internal/policy"
 )

--- a/internal/http/api/policy_webhook_handler_test.go
+++ b/internal/http/api/policy_webhook_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/http/api"
 	"github.com/felag-engineering/gleipnir/internal/policy"
 	"github.com/felag-engineering/gleipnir/internal/testutil"

--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+
 	"github.com/felag-engineering/gleipnir/frontend"
 	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"

--- a/internal/http/sse/handler_test.go
+++ b/internal/http/sse/handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/http/sse/metrics.go
+++ b/internal/http/sse/metrics.go
@@ -3,6 +3,7 @@ package sse
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/infra/metrics/metrics_test.go
+++ b/internal/infra/metrics/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )

--- a/internal/llm/anthropic/client_test.go
+++ b/internal/llm/anthropic/client_test.go
@@ -12,6 +12,7 @@ import (
 	sdkanthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/llm/anthropic/stream.go
+++ b/internal/llm/anthropic/stream.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/llm/anthropic/stream_test.go
+++ b/internal/llm/anthropic/stream_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/llm/google/client.go
+++ b/internal/llm/google/client.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/genai"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/llm"
-	"google.golang.org/genai"
 )
 
 // contentGenerator abstracts genai.Models methods for test injection.

--- a/internal/llm/google/client_test.go
+++ b/internal/llm/google/client_test.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/felag-engineering/gleipnir/internal/llm"
 	"google.golang.org/genai"
+
+	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 
 // mockGenerator implements contentGenerator for tests. It stores the captured

--- a/internal/llm/google/stream.go
+++ b/internal/llm/google/stream.go
@@ -7,8 +7,9 @@ import (
 	"iter"
 
 	"github.com/google/uuid"
-	"github.com/felag-engineering/gleipnir/internal/llm"
 	"google.golang.org/genai"
+
+	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 
 // consumeStream reads responses from a Google GenerateContentStream iterator

--- a/internal/llm/google/stream_test.go
+++ b/internal/llm/google/stream_test.go
@@ -6,8 +6,9 @@ import (
 	"iter"
 	"testing"
 
-	"github.com/felag-engineering/gleipnir/internal/llm"
 	"google.golang.org/genai"
+
+	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 
 // makeStreamSeq builds an iter.Seq2 directly from a slice of responses and an

--- a/internal/llm/metrics.go
+++ b/internal/llm/metrics.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/llm/metrics_test.go
+++ b/internal/llm/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/responses"
 	"github.com/openai/openai-go/shared"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go/option"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/llm/openai/stream.go
+++ b/internal/llm/openai/stream.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/openai/openai-go/responses"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/llm/openai/stream_test.go
+++ b/internal/llm/openai/stream_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/openai/openai-go/responses"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/llm/openai/translate.go
+++ b/internal/llm/openai/translate.go
@@ -9,6 +9,7 @@ import (
 	openaisdk "github.com/openai/openai-go"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/responses"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/llm/openai/translate_test.go
+++ b/internal/llm/openai/translate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/openai/openai-go/responses"
+
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 

--- a/internal/mcp/metrics.go
+++ b/internal/mcp/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/mcp/metrics_test.go
+++ b/internal/mcp/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 )

--- a/internal/policy/parser.go
+++ b/internal/policy/parser.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/felag-engineering/gleipnir/internal/model"
 	"gopkg.in/yaml.v3"
+
+	"github.com/felag-engineering/gleipnir/internal/model"
 )
 
 const (

--- a/internal/policy/validator.go
+++ b/internal/policy/validator.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
+
+	"github.com/felag-engineering/gleipnir/internal/model"
 )
 
 // Issue pairs a canonical field path with its error message. Field is empty for

--- a/internal/testutil/mock_anthropic_server.go
+++ b/internal/testutil/mock_anthropic_server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go/option"
+
 	"github.com/felag-engineering/gleipnir/internal/llm/anthropic"
 )
 

--- a/internal/timeout/metrics.go
+++ b/internal/timeout/metrics.go
@@ -3,6 +3,7 @@ package timeout
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 )
 

--- a/internal/trigger/check.go
+++ b/internal/trigger/check.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ohler55/ojg/jp"
 	"github.com/ohler55/ojg/oj"
+
 	"github.com/felag-engineering/gleipnir/internal/model"
 )
 

--- a/internal/trigger/integration_helpers_test.go
+++ b/internal/trigger/integration_helpers_test.go
@@ -2,6 +2,7 @@ package trigger_test
 
 import (
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/execution/run"
 )
 

--- a/internal/trigger/manual.go
+++ b/internal/trigger/manual.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/execution/run"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"

--- a/internal/trigger/manual_test.go
+++ b/internal/trigger/manual_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/execution/run"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"

--- a/internal/trigger/webhook.go
+++ b/internal/trigger/webhook.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/execution/run"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"

--- a/internal/trigger/webhook_test.go
+++ b/internal/trigger/webhook_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/execution/run"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"


### PR DESCRIPTION
## Summary
- Ran `goimports -w -local github.com/felag-engineering/gleipnir` across the repo to restore the existing 3-group import convention (stdlib / third-party / project) that drifted after the `rapp992` → `felag-engineering` module rename in f162c40.
- 47 files touched; pure import-ordering changes — no behavior changes, no logic touched.
- `go build ./...` clean and `go test ./...` green locally.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)