### PR TITLE
docs(playbooks): meal-planning uses streamable-HTTP MCP transport, 100k tokens

### DIFF
--- a/docs/playbooks/meal-planning/README.md
+++ b/docs/playbooks/meal-planning/README.md
@@ -70,7 +70,9 @@ In Gleipnir, go to **Tools → Add MCP server**:
 
 | Name | URL (same Compose project) | URL (separate host) |
 |------|---------------------------|---------------------|
-| `mealie` | `http://mealie-mcp:8102/` | `http://<MCP_HOST>:8102/` |
+| `mealie` | `http://mealie-mcp:8102/mcp` | `http://<MCP_HOST>:8102/mcp` |
+
+Supergateway is configured with `--outputTransport streamableHttp`, so the MCP endpoint is served at `/mcp` (Gleipnir speaks the MCP streamable-HTTP transport, not the legacy two-endpoint SSE transport).
 
 Click **Discover** after saving. The policy references `mealie.get_recipes` and `mealie.create_mealplan_bulk`. If Discover returns different names, update the `tool:` entries in the policy to match before saving.
 
@@ -118,7 +120,7 @@ If you are unsure about a dietary constraint or encounter unexpected calendar
 data, use the feedback channel to ask the operator before proceeding.
 ```
 
-**Run limits:** max tokens 30000, max tool calls 20
+**Run limits:** max tokens 100000, max tool calls 20
 
 **Concurrency:** Skip
 
@@ -173,5 +175,6 @@ No additional tools needed — the calendar data is already in context from the 
 | `arcade.GoogleCalendar_ListEvents` returns `RefreshError` or `auth_required` | The Arcade gateway has stale or missing OAuth credentials for your user_id | Re-authorize the GoogleCalendar toolkit per the [Arcade playbook](../arcade/README.md) Step 5. If the error persists with a freshly authorized user_id, the issue is upstream of Gleipnir. |
 | Discover returns 0 tools for `arcade` | API key missing, wrong gateway URL, or no toolkits added in the Arcade dashboard | See the [Arcade playbook](../arcade/README.md) troubleshooting section. |
 | Discover returns 0 tools for `mealie-mcp` | `MEALIE_BASE_URL` or `MEALIE_API_KEY` not set, or Mealie unreachable | Check `.env` is in the same directory as `docker-compose.yml`. Verify Mealie is reachable: `curl $MEALIE_BASE_URL/api/app/about`. |
+| Discover hangs or returns connection errors against `http://.../sse` | Supergateway running with the legacy SSE transport instead of streamable HTTP | Confirm `--outputTransport streamableHttp` is in the supergateway command and register Gleipnir against the `/mcp` path, not `/sse`. |
 | `mealie.create_mealplan_bulk` fails | Recipe ID not found or date format wrong | Check Discover output for the exact parameter schema. Verify recipe IDs from `mealie.get_recipes` are passed through correctly. |
 | `.env` variables not applied | `.env` is in the wrong directory | The file must be in `docs/playbooks/meal-planning/`, the same directory where you run `docker compose up`. |

--- a/docs/playbooks/meal-planning/docker-compose.yml
+++ b/docs/playbooks/meal-planning/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     command: >
       npx -y supergateway
       --port 8102
+      --outputTransport streamableHttp
       --stdio "npx -y mealie-mcp-server-ts"
     ports:
       - "8102:8102"


### PR DESCRIPTION
## Summary

- Add `--outputTransport streamableHttp` to the supergateway command in the meal-planning playbook's `docker-compose.yml`. Gleipnir's MCP client only speaks streamable HTTP (per ADR-004); supergateway's default `sse` output is the legacy two-endpoint dialect and cannot be discovered.
- Update the registration URL in the README from `http://mealie-mcp:8102/` to `http://mealie-mcp:8102/mcp` to match supergateway's streamable-HTTP path.
- Raise the policy's `max tokens` from 30000 to 100000 — the original cap was getting blown by a typical week of calendar events + recipe browsing + bulk-create payload.
- Add a troubleshooting row pointing at the SSE-vs-streamable-HTTP pitfall so the next operator does not have to rediscover it.

Found while running through the playbook end-to-end on a fresh Mealie + Gleipnir setup. Discover returned no tools until the transport was switched; the run also hit the token cap before it could finish a full week of dinners.

## Test plan

- [ ] Stand up the playbook from scratch on a clean host: `docker compose up -d` from `docs/playbooks/meal-planning/`.
- [ ] In Gleipnir's UI, register the MCP at `http://mealie-mcp:8102/mcp` and confirm Discover returns `mealie.get_recipes` and `mealie.create_mealplan_bulk`.
- [ ] Trigger a manual run of the meal-planning policy and verify it completes without exceeding the new 100k-token limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)