### PR TITLE
docs(playbooks): streamable-HTTP supergateway transport across all playbooks

### DIFF
--- a/docs/playbooks/devops/README.md
+++ b/docs/playbooks/devops/README.md
@@ -140,12 +140,12 @@ In Gleipnir, go to **Tools → Add MCP server** four times. Use the LAN IP of th
 
 | Name | URL |
 |------|-----|
-| `docker` | `http://<HOST_IP>:8201/` |
-| `proxmox` | `http://<HOST_IP>:8202/` |
-| `technitium` | `http://<HOST_IP>:8203/` |
+| `docker` | `http://<HOST_IP>:8201/mcp` |
+| `proxmox` | `http://<HOST_IP>:8202/mcp` |
+| `technitium` | `http://<HOST_IP>:8203/mcp` |
 | `caddy` | `http://<HOST_IP>:8204/` |
 
-> **caddy-mcp transport:** Unlike the other three, `caddy-mcp` speaks the `httpstream` MCP transport natively — it does not wrap a stdio server. Gleipnir connects to it directly on port 8204 without supergateway in the path.
+> **Transports:** The first three wrap stdio MCP servers via supergateway with `--outputTransport streamableHttp`, which serves the streamable-HTTP transport at `/mcp`. `caddy-mcp` is a Go binary speaking the `httpstream` MCP transport natively — Gleipnir connects to it directly on port 8204 at the root path without supergateway in the path.
 
 After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below uses representative names. If Discover returns different names (e.g. `list_containers` instead of `docker_list_containers`), update the `tool:` entries in the policy before saving.
 
@@ -348,5 +348,5 @@ agent:
 | `technitium-mcp` returns 403 | API token invalid | Regenerate in Technitium → Administration → Sessions. |
 | `caddy-mcp` build fails | `go install` cannot reach the module proxy | Check internet access from the build host. If offline, add `--network=host` or pre-cache the module. |
 | `caddy-mcp` cannot reach Caddy | Caddy admin API bound to localhost only | On the Caddy host, change `admin localhost:2019` to `admin 0.0.0.0:2019` (or the Gleipnir host's LAN IP) in the Caddyfile and reload. |
-| Gleipnir cannot reach MCP servers | Wrong IP or ports not listening | Confirm MCP containers are up with `docker compose ps`. Test connectivity from the Gleipnir host: `curl http://<HOST_IP>:8201/`. |
+| Gleipnir cannot reach MCP servers | Wrong IP or ports not listening | Confirm MCP containers are up with `docker compose ps`. Test connectivity from the Gleipnir host: `curl http://<HOST_IP>:8201/mcp`. |
 | Tool names in policy don't match Discover output | MCP server updated its tool names | Click Discover again on the **Tools** page and update `tool:` entries in the policy. |

--- a/docs/playbooks/devops/docker-compose.yml
+++ b/docs/playbooks/devops/docker-compose.yml
@@ -8,7 +8,8 @@
 #   - .env file in this directory (README.md § Step 4).
 #
 # Ports are bound to all interfaces so Gleipnir can reach them via the
-# host's LAN IP. Register each server in Gleipnir as http://<HOST_IP>:820x/
+# host's LAN IP. Register each supergateway-wrapped server in Gleipnir as
+# http://<HOST_IP>:820x/mcp (caddy-mcp uses native httpstream — see README).
 
 services:
 
@@ -22,6 +23,7 @@ services:
     command: >
       npx -y supergateway
       --port 8201
+      --outputTransport streamableHttp
       --stdio "uvx docker-mcp"
     ports:
       - "8201:8201"
@@ -42,6 +44,7 @@ services:
     command: >
       npx -y supergateway
       --port 8202
+      --outputTransport streamableHttp
       --stdio "uvx mcp-proxmox"
     ports:
       - "8202:8202"
@@ -60,6 +63,7 @@ services:
     command: >
       npx -y supergateway
       --port 8203
+      --outputTransport streamableHttp
       --stdio "npx -y @rosschurchill/technitium-mcp-secure"
     ports:
       - "8203:8203"

--- a/docs/playbooks/todoist-research/README.md
+++ b/docs/playbooks/todoist-research/README.md
@@ -80,8 +80,8 @@ In Gleipnir, go to **Tools → Add MCP server** twice:
 
 | Name | URL (same Compose project) | URL (separate host) |
 |------|---------------------------|---------------------|
-| `todoist` | `http://todoist-mcp:8111/` | `http://<MCP_HOST>:8111/` |
-| `duckduckgo` | `http://duckduckgo-mcp:8112/` | `http://<MCP_HOST>:8112/` |
+| `todoist` | `http://todoist-mcp:8111/mcp` | `http://<MCP_HOST>:8111/mcp` |
+| `duckduckgo` | `http://duckduckgo-mcp:8112/mcp` | `http://<MCP_HOST>:8112/mcp` |
 
 Use the **service name** as the hostname (`todoist-mcp`, `duckduckgo-mcp`) when Gleipnir and the MCP servers are on the same Docker Compose network. Use the host IP and port numbers when they are on different hosts or Compose projects.
 

--- a/docs/playbooks/todoist-research/docker-compose.yml
+++ b/docs/playbooks/todoist-research/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     command: >
       npx -y supergateway
       --port 8111
+      --outputTransport streamableHttp
       --stdio "npx -y todoist-mcp"
     ports:
       - "8111:8111"
@@ -34,6 +35,7 @@ services:
     command: >
       npx -y supergateway
       --port 8112
+      --outputTransport streamableHttp
       --stdio "uvx duckduckgo-mcp-server"
     ports:
       - "8112:8112"


### PR DESCRIPTION
## Summary

Follow-up to #120, which fixed the meal-planning playbook. The same bug — supergateway serving the legacy two-endpoint SSE dialect that Gleipnir's MCP client (per ADR-004) cannot speak to — was latent in the other two playbooks.

- **todoist-research:** add `--outputTransport streamableHttp` to `todoist-mcp` (8111) and `duckduckgo-mcp` (8112); update README registration URLs to `/mcp`.
- **devops:** add the flag to `docker-mcp` (8201), `proxmox-mcp` (8202), and `technitium-mcp` (8203); update README URLs and the connectivity-test `curl` line to `/mcp`. Rewrite the transport callout to explain both transports side-by-side.
- **caddy-mcp** (port 8204) is intentionally untouched — it is a Go binary speaking native httpstream, no supergateway in the path. The READMEs now spell out the difference so it is obvious why one URL stays at `/`.

No code changes, no policy YAML changes — only the compose commands and doc snippets that operators copy when registering MCP servers.

## Test plan

- [ ] `docker compose up -d` from `docs/playbooks/todoist-research/` and confirm Discover succeeds at `http://<host>:8111/mcp` and `:8112/mcp`.
- [ ] `docker compose up -d --build` from `docs/playbooks/devops/` and confirm Discover succeeds at `:8201/mcp`, `:8202/mcp`, `:8203/mcp`, and that `:8204/` (caddy) still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)