### PR TITLE
fix: parse structured model: block in policy list summary

### DIFF
--- a/docs/playbooks/todoist-research/README.md
+++ b/docs/playbooks/todoist-research/README.md
@@ -87,111 +87,97 @@ Use the **service name** as the hostname (`todoist-mcp`, `duckduckgo-mcp`) when 
 
 After adding each server, click **Discover**. Note the exact tool names returned — the policy YAML below references `todoist.get_tasks_list`, `todoist.create_comments`, `todoist.update_tasks`, and `duckduckgo.search`. If Discover returns different names, update the `tool:` entries in the policy YAML to match before saving.
 
-## Step 5 — Create the policy
+## Step 5 — Create the agent
 
-Go to **Agents → New Agent** and fill in the form. The YAML below is the payload the form produces — it is included here as a reference and to make the field mapping explicit.
+Go to **Agents → New Agent** and fill in the form. The form is the only editing surface (ADR-019); each section below maps to one section in the editor.
 
-```yaml
-name: todoist-research
-description: Poll Todoist for tasks labeled AI_Assist, research each one using web search, and post findings as a task comment.
-folder: Productivity
+**Identity**
 
-model:
-  provider: anthropic
-  name: claude-sonnet-4-6
-  options:
-    enable_prompt_caching: true
+- **Name:** `todoist-research`
+- **Description:** `Poll Todoist for tasks labeled AI_Assist, research each one using web search, and post findings as a task comment.`
+- **Folder:** `Productivity`
 
-trigger:
-  type: poll
-  interval: 15m
-  checks:
-    - tool: todoist.get_tasks_list
-      input:
-        label: AI_Assist
-      path: "$[0].id"
-      not_equals: ""
+**Model**
 
-capabilities:
-  tools:
-    - tool: todoist.get_tasks_list
-    - tool: duckduckgo.search
-    - tool: todoist.create_comments
-      approval: required
-      timeout: 1h
-      on_timeout: reject
-    - tool: todoist.update_tasks
-      approval: required
-      timeout: 1h
-      on_timeout: reject
-  feedback:
-    enabled: true
-    timeout: 30m
-    on_timeout: fail
+- **Provider:** `anthropic`
+- **Model:** `claude-sonnet-4-6`
+- **Prompt caching:** enabled
 
-agent:
-  task: |
-    Your trigger payload contains a JSON array of Todoist tasks that
-    have the AI_Assist label applied. Each task object includes an
-    "id" field (the task ID), a "content" field (the task title), and
-    a "description" field (optional extra context). Do not call
-    todoist.get_tasks_list again — use the tasks already in your
-    trigger payload.
+**Trigger**
 
-    For each task in the payload:
+- **Type:** `poll`
+- **Interval:** `15m`
+- **Match mode:** `all`
+- Add one **check**:
+  - **Tool:** `todoist.get_tasks_list`
+  - **Input:** paste the following JSON into the input textarea — the form takes JSON here, not YAML:
+    ```json
+    {"label": "AI_Assist"}
+    ```
+  - **JSONPath:** `$[0].id`
+  - **Comparator:** `not equals`
+  - **Value:** leave blank (empty string)
 
-    1. Read the "content" and "description" fields carefully to
-       understand what research is needed.
+The check fires a run only when the array of tasks is non-empty (first element has a non-empty `id`). When no tasks match, the poll runs silently — no run is created and no UI signal is emitted (see Troubleshooting).
 
-    2. Use duckduckgo.search to gather information. For most tasks,
-       2–4 targeted searches are enough. Prefer searches that return
-       specific, actionable results (business listings, official pages,
-       how-to guides) over broad informational queries.
+**Capabilities → Tools**
 
-    3. Synthesize the search results into a clear, structured comment.
-       Format guidelines:
-       - Lead with a one-sentence summary of what you found.
-       - Present options or results as a numbered list.
-       - For each item include: name, relevant detail (address/price/
-         description), website URL if available, and contact info if
-         applicable.
-       - Keep the comment concise — the goal is a useful reference,
-         not an essay. Aim for 200–500 words.
-       - If the task asks for local services, include distance or
-         neighborhood context when the search results provide it.
-       - Note the date the research was done at the bottom of the
-         comment so the user knows how fresh it is.
+Add four tools. The first two are read-only; the last two are the only writes and stay approval-gated.
 
-    4. Call todoist.create_comments to post the formatted research to
-       the task. Pass the task "id" from the trigger payload as the
-       task_id parameter.
+| Tool | Approval | Timeout | On timeout |
+|------|----------|---------|------------|
+| `todoist.get_tasks_list` | none | — | — |
+| `duckduckgo.search` | none | — | — |
+| `todoist.create_comments` | required | `1h` | `reject` |
+| `todoist.update_tasks` | required | `1h` | `reject` |
 
-    5. Call todoist.update_tasks to remove the AI_Assist label from
-       the task, so it is not re-processed on the next poll. Pass the
-       task "id" and a "labels" list that contains the task's existing
-       labels minus "AI_Assist". If the task has no other labels, pass
-       an empty list.
+**Capabilities → Feedback**
 
-    Process all tasks in the trigger payload before finishing.
-    If you are uncertain what a task is asking for — for example, the
-    title is ambiguous or missing key context like a location — use the
-    feedback channel to ask the operator before searching.
+- **Enabled:** on
+- **Timeout:** `30m`
+- **On timeout:** `fail`
 
-  limits:
-    max_tokens_per_run: 40000
-    max_tool_calls_per_run: 40
-  concurrency: queue
-  queue_depth: 3
-```
+This grants the agent `gleipnir.ask_operator` so it can ask for clarification on ambiguous tasks instead of guessing.
+
+**Task instructions**
+
+Paste the following into the task instructions field:
+
+> Your trigger payload contains a JSON object with a `poll_results` array. Each entry includes a `result` field that is itself an array of Todoist tasks. Each task object includes an `id` field (the task ID), a `content` field (the task title), and a `description` field (optional extra context). Do not call `todoist.get_tasks_list` again — use the tasks already in your trigger payload.
+>
+> For each task in the payload:
+>
+> 1. Read the `content` and `description` fields carefully to understand what research is needed.
+> 2. Use `duckduckgo.search` to gather information. For most tasks, 2–4 targeted searches are enough. Prefer searches that return specific, actionable results (business listings, official pages, how-to guides) over broad informational queries.
+> 3. Synthesize the search results into a clear, structured comment. Format guidelines:
+>    - Lead with a one-sentence summary of what you found.
+>    - Present options or results as a numbered list.
+>    - For each item include: name, relevant detail (address/price/description), website URL if available, and contact info if applicable.
+>    - Keep the comment concise — the goal is a useful reference, not an essay. Aim for 200–500 words.
+>    - If the task asks for local services, include distance or neighborhood context when the search results provide it.
+>    - Note the date the research was done at the bottom of the comment so the user knows how fresh it is.
+> 4. Call `todoist.create_comments` to post the formatted research to the task. Pass the task `id` from the trigger payload as the `task_id` parameter.
+> 5. Call `todoist.update_tasks` to remove the `AI_Assist` label from the task, so it is not re-processed on the next poll. Pass the task `id` and a `labels` list that contains the task's existing labels minus `AI_Assist`. If the task has no other labels, pass an empty list.
+>
+> Process all tasks in the trigger payload before finishing. If you are uncertain what a task is asking for — for example, the title is ambiguous or missing key context like a location — use the feedback channel to ask the operator before searching.
+
+**Run limits**
+
+- **Max tokens per run:** `40000`
+- **Max tool calls per run:** `40`
+
+**Concurrency**
+
+- **Policy:** `queue`
+- **Queue depth:** `3`
 
 **Why these choices:**
 
-- `trigger.type: poll` with `interval: 15m` checks Todoist every 15 minutes. The poll check calls `todoist.get_tasks_list` filtered by the `AI_Assist` label, then evaluates `$[0].id not_equals ""` — this fires a run only when at least one matching task exists (non-empty array → first task has a non-empty ID), and stays silent when there are none. Polls that find no matching tasks consume one Todoist API call but do not start a run or burn LLM tokens.
-- The agent task tells the agent to read tasks from its trigger payload rather than re-fetching them. Gleipnir delivers the poll tool result as the first user message, so the task list is already in context — calling `get_tasks_list` again would double the API calls for no benefit.
-- Both `todoist.create_comments` and `todoist.update_tasks` are approval-gated. These are the only write operations — reading tasks and searching the web are read-only. The 1-hour approval window (longer than the meal-planning playbook's 30 minutes) gives you time to review the proposed comment and label removal before they are posted to Todoist. If you prefer fully automatic posting, set `approval: none` on both tools.
-- `feedback.enabled: true` gives the agent `gleipnir.ask_operator` to handle ambiguous tasks without failing the run.
-- `concurrency: queue` (depth 3) allows tasks labeled while a run is in progress to accumulate rather than being dropped. If more than 3 triggers queue up the extras are dropped with a warning in the Gleipnir logs; in practice 15-minute polling makes deep queuing unlikely.
-- Tools not listed in `capabilities.tools` are not registered with the agent at all — they literally do not exist from the agent's perspective.
+- The 15-minute poll calls `todoist.get_tasks_list` filtered by `AI_Assist`, then evaluates `$[0].id not_equals ""` — fires only when at least one matching task exists, stays silent otherwise. Polls that find nothing consume one Todoist API call but no LLM tokens.
+- The task instructions tell the agent to read from its trigger payload rather than re-fetching. The runtime delivers poll results as the first user message, so the task list is already in context — calling `get_tasks_list` again would double API calls for no benefit.
+- `create_comments` and `update_tasks` are approval-gated because they are the only write operations. The 1-hour window gives you time to review before anything is posted to Todoist. If you prefer fully automatic posting, set both approvals to `none` (see Extensions).
+- `concurrency: queue` (depth 3) lets tasks labeled while a run is in progress accumulate rather than drop. With 15-minute polling, deep queuing is unlikely.
+- Tools you do not add to the **Capabilities → Tools** list are not registered with the agent at all — they literally do not exist from the agent's perspective.
 
 ## Step 6 — Label a task and test
 
@@ -210,43 +196,13 @@ Once you confirm the agent produces useful output, the poll trigger will fire au
 
 ### Skip approval for write operations
 
-If you trust the agent's output and find the approval step inconvenient, you can drop the gate on `create_comments` while keeping it on `update_tasks` (the label removal). This means you review the label removal before it happens but the comment is posted immediately:
-
-```yaml
-capabilities:
-  tools:
-    - tool: todoist.get_tasks_list
-    - tool: duckduckgo.search
-    - tool: todoist.create_comments    # no approval gate
-    - tool: todoist.update_tasks
-      approval: required
-      timeout: 1h
-      on_timeout: reject
-```
-
-Or remove all approval gates to make the whole pipeline fully automatic.
+If you trust the agent's output and find the approval step inconvenient, edit the agent and change the **Approval** dropdown on `todoist.create_comments` to **none**. The comment is then posted immediately, while the label removal on `todoist.update_tasks` still requires approval — so you only confirm one step per task instead of two. To make the whole pipeline fully automatic, set both tools' approvals to **none**.
 
 ### Add page fetching for deep dives
 
-The DuckDuckGo MCP server also exposes a `fetch_content` tool that reads the full text of a specific URL. This is useful for tasks that need more than search snippets — reading an official policy page, pulling contact details from a business website, or following up on a result. Add it alongside `search`:
+The DuckDuckGo MCP server also exposes a `fetch_content` tool that reads the full text of a specific URL. This is useful for tasks that need more than search snippets — reading an official policy page, pulling contact details from a business website, or following up on a result.
 
-```yaml
-capabilities:
-  tools:
-    - tool: todoist.get_tasks_list
-    - tool: duckduckgo.search
-    - tool: duckduckgo.fetch_content   # add: reads a specific URL
-    - tool: todoist.create_comments
-      approval: required
-      timeout: 1h
-      on_timeout: reject
-    - tool: todoist.update_tasks
-      approval: required
-      timeout: 1h
-      on_timeout: reject
-```
-
-No additional infrastructure is needed — `fetch_content` is already part of the `duckduckgo-mcp` container.
+Edit the agent, open **Capabilities → Tools**, click **Add tool**, pick `duckduckgo.fetch_content`, and leave the approval dropdown at **none** (it is read-only). No additional infrastructure is needed — `fetch_content` is already part of the `duckduckgo-mcp` container.
 
 ### Add a second label for high-priority tasks
 
@@ -256,12 +212,13 @@ If you want some tasks researched immediately rather than waiting for the next p
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| Poll fires but agent says no tasks found | `AI_Assist` label spelling mismatch | Todoist label names are case-sensitive. Check the exact label name on the task matches the `input.label` value in the policy trigger check. |
-| Poll never triggers a run, even with labeled tasks | `get_tasks_list` returning unexpected JSON structure | Click Discover on the `todoist` server in Gleipnir and call `get_tasks_list` manually with `label: AI_Assist`. Inspect the raw JSON to confirm `$[0].id` resolves to a task ID string. |
+| Poll seems silent — no runs appear, even with labeled tasks | Check condition is matching `false` (no tasks with the label) — non-matching evaluations are silent in the UI | The **Next:** time on the agent card is when the next *check* will run, not the next run start. Polls that find no tasks complete without producing a run or any UI signal. To confirm the poll is firing, set `GLEIPNIR_LOG_LEVEL=debug` and look for `poller: checks did not match` lines in the server log, or use **Run now** to trigger manually. |
+| Poll fires but agent says no tasks found | `AI_Assist` label spelling mismatch | Todoist label names are case-sensitive. Check the exact label name on the task matches the value you entered in the trigger check input JSON. |
+| Poll never triggers a run, even with labeled tasks | `get_tasks_list` returning unexpected JSON structure | On the **Tools** page, click Discover on the `todoist` server, then call `get_tasks_list` manually with `{"label": "AI_Assist"}`. Inspect the raw JSON to confirm `$[0].id` resolves to a task ID string. |
 | `todoist-mcp` Discover returns 0 tools | `TODOIST_API_KEY` not set in `.env` | Check that `.env` is in the same directory as `docker-compose.yml`. The compose file maps `TODOIST_API_KEY` to the `API_KEY` env var the package expects — confirm both names match. |
 | `duckduckgo-mcp` Discover returns 0 tools | Image not built or build failed | Run `docker compose build duckduckgo-mcp` and check for errors. Confirm `docker compose ps` shows the container as `Up`. |
-| DuckDuckGo returns no results for some queries | Rate limiting from DuckDuckGo | DuckDuckGo's endpoint may throttle bursts. Lower `max_tool_calls_per_run` to space out searches, or make each search broader to reduce the number of calls per task. |
-| Comment is posted but label not removed | `update_tasks` approval timed out (1h) | Approve the `update_tasks` request in Gleipnir before the timeout expires, or widen the timeout. Alternatively remove the approval gate on `update_tasks` to make label removal automatic. |
-| Run hits token limit | Too many tasks in one poll batch | Add a `limit` parameter to `todoist.get_tasks_list` in both the trigger check and the policy capabilities to cap the number of tasks per run (e.g. `limit: 3`). |
+| DuckDuckGo returns no results for some queries | Rate limiting from DuckDuckGo | DuckDuckGo's endpoint may throttle bursts. Lower **Max tool calls per run** in the agent's run limits to space out searches, or make each search broader to reduce the number of calls per task. |
+| Comment is posted but label not removed | `update_tasks` approval timed out (1h) | Approve the `update_tasks` request in Gleipnir before the timeout expires, or widen the timeout in the tool's settings. Alternatively change the approval on `update_tasks` to **none** to make label removal automatic. |
+| Run hits token limit | Too many tasks in one poll batch | Add a `limit` field to the trigger check input JSON (e.g. `{"label": "AI_Assist", "limit": 3}`) to cap the number of tasks per run. |
 | `.env` variables are not applied | `.env` is in the wrong directory | The file must be in `docs/playbooks/todoist-research/`, the same directory where you run `docker compose up`. |
-| Tool names in policy don't match Discover output | MCP server updated its tool names | Click Discover again on each server on the **Tools** page, then update the `tool:` entries in the policy to match the new names. |
+| Tool names in agent don't match Discover output | MCP server updated its tool names | Click Discover again on each server on the **Tools** page, then edit the agent and update the tool entries to match the new names. |

--- a/internal/http/api/policy_handler.go
+++ b/internal/http/api/policy_handler.go
@@ -108,7 +108,7 @@ func (h *PolicyHandler) List(w http.ResponseWriter, r *http.Request) {
 			Name:         row.Name,
 			TriggerType:  row.TriggerType,
 			Folder:       summary.Folder,
-			Model:        summary.Model,
+			Model:        summary.Model.Name,
 			ToolCount:    len(summary.Capabilities.Tools),
 			ToolRefs:     toolRefs,
 			AvgTokenCost: row.AvgTokenCost,
@@ -175,9 +175,18 @@ type policyToolEntry struct {
 	Tool string `yaml:"tool"`
 }
 
+// policyModelSummary mirrors the structured `model:` block in policy YAML
+// (see internal/policy/parser.go → rawModel). Declaring Model as a string
+// here previously caused every parse to fail with "cannot unmarshal !!map
+// into string" and silently dropped the model display from list responses.
+type policyModelSummary struct {
+	Provider string `yaml:"provider"`
+	Name     string `yaml:"name"`
+}
+
 type policyYAMLSummary struct {
-	Folder       string `yaml:"folder"`
-	Model        string `yaml:"model"`
+	Folder       string             `yaml:"folder"`
+	Model        policyModelSummary `yaml:"model"`
 	Capabilities struct {
 		Tools []policyToolEntry `yaml:"tools"`
 	} `yaml:"capabilities"`

--- a/internal/http/api/policy_handler_test.go
+++ b/internal/http/api/policy_handler_test.go
@@ -283,7 +283,9 @@ func TestPolicyListModelAndToolCount(t *testing.T) {
 	t.Run("model and tool_count extracted from YAML", func(t *testing.T) {
 		store := newPolicyHandlerStore(t)
 		yaml := `
-model: claude-opus-4-5
+model:
+  provider: anthropic
+  name: claude-opus-4-5
 trigger: webhook
 capabilities:
   tools:


### PR DESCRIPTION
## Summary

- **Bug fix**: `policyYAMLSummary.Model` was declared as `string`, but real policies store `model:` as a `{provider, name, options}` map (`internal/policy/parser.go` → `rawModel`). Every policy save logged `parsePolicySummary: failed to parse policy YAML: yaml: unmarshal errors: cannot unmarshal !!map into string` at warn, and the list endpoint silently returned `model=""` — hiding the model pill on the agent card. Fixed by making `Model` a struct and surfacing `summary.Model.Name` to the API. Updated the existing test (which had been passing only because it used a legacy bare-string `model:` shape that the rest of the system no longer accepts).
- **Playbook polish (`docs/playbooks/todoist-research`)**: replaced the Step 5 YAML block with a form-field walkthrough per ADR-019 (form view is the only editing surface), explicitly called out that the trigger check input field takes JSON in the form, fixed the task prompt's description of the trigger payload (it is `{"poll_results":[{tool,input,result}]}`, not a bare task array — verified at `internal/trigger/poll.go:365-389`), rewrote both Extensions sections as form changes, and added a troubleshooting entry clarifying that polls with non-matching checks are silent in the UI and the **Next:** label is the next *check*, not the next run.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/http/api/ -run TestPolicyList -count=1` passes
- [ ] Restart API; confirm the `parsePolicySummary` warn no longer appears on policy save
- [ ] Confirm the model pill renders on agent cards in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)