### PR TITLE
fix: allow force delete of MCP servers in use by policies

### DIFF
--- a/frontend/src/components/MCPPage/DeleteServerModal/DeleteServerModal.stories.tsx
+++ b/frontend/src/components/MCPPage/DeleteServerModal/DeleteServerModal.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import '@/tokens.css'
+import { ApiError } from '@/api/fetch'
 import { DeleteServerModal } from './DeleteServerModal'
 
 const meta: Meta<typeof DeleteServerModal> = {
@@ -29,5 +30,22 @@ export const Pending: Story = {
     onConfirm: () => {},
     isPending: true,
     error: null,
+  },
+}
+
+// After a 409 the submit button switches to "Force delete" so the operator
+// can override the in-use check after seeing the affected policies.
+export const InUseConflict: Story = {
+  args: {
+    serverName: 'kubectl-mcp',
+    toolCount: 5,
+    onClose: () => {},
+    onConfirm: () => {},
+    isPending: false,
+    error: new ApiError(
+      409,
+      'MCP server is referenced by active policies',
+      'policies referencing this server: deploy-bot, smoke-tests — pass ?force=true to delete anyway',
+    ),
   },
 }

--- a/frontend/src/components/MCPPage/DeleteServerModal/DeleteServerModal.tsx
+++ b/frontend/src/components/MCPPage/DeleteServerModal/DeleteServerModal.tsx
@@ -8,19 +8,26 @@ interface Props {
   serverName: string
   toolCount: number
   onClose: () => void
-  onConfirm: () => void
+  onConfirm: (force: boolean) => void
   isPending: boolean
   error: ApiError | null
 }
 
 export function DeleteServerModal({ serverName, toolCount, onClose, onConfirm, isPending, error }: Props) {
+  // A 409 means the server is in use by one or more policies. The handler
+  // returns the conflicting policy names in error.detail. After the user has
+  // seen them, we let them retry with force=true to bypass the check.
+  const inUseConflict = error?.status === 409
+  const submitLabel = inUseConflict ? 'Force delete' : 'Delete MCP server'
+  const loadingLabel = inUseConflict ? 'Force deleting…' : 'Deleting…'
+
   const footer = (
     <ModalFooter
       onCancel={onClose}
-      onSubmit={onConfirm}
+      onSubmit={() => onConfirm(inUseConflict)}
       isLoading={isPending}
-      submitLabel="Delete MCP server"
-      loadingLabel="Deleting…"
+      submitLabel={submitLabel}
+      loadingLabel={loadingLabel}
       variant="danger"
     />
   )

--- a/frontend/src/hooks/mutations/servers.ts
+++ b/frontend/src/hooks/mutations/servers.ts
@@ -75,11 +75,11 @@ export function useDeleteMcpServerHeader() {
 export function useDeleteMcpServer() {
   const queryClient = useQueryClient()
 
-  return useMutation<void, ApiError, string>({
-    mutationFn: (serverId: string) =>
-      apiFetchVoid(`/mcp/servers/${encodeURIComponent(serverId)}`, {
-        method: 'DELETE',
-      }),
+  return useMutation<void, ApiError, { id: string; force?: boolean }>({
+    mutationFn: ({ id, force }) => {
+      const path = `/mcp/servers/${encodeURIComponent(id)}${force ? '?force=true' : ''}`
+      return apiFetchVoid(path, { method: 'DELETE' })
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.servers.all })
     },

--- a/frontend/src/pages/MCPPage.tsx
+++ b/frontend/src/pages/MCPPage.tsx
@@ -113,17 +113,20 @@ export default function MCPPage() {
     deleteMutation.reset()
   }
 
-  function handleDeleteConfirm() {
+  function handleDeleteConfirm(force: boolean) {
     if (!deleteTarget) return
-    deleteMutation.mutate(deleteTarget.server.id, {
-      onSuccess: () => {
-        setDeleteTarget(null)
-        // Close detail modal if the deleted server was open
-        if (selectedServer?.id === deleteTarget.server.id) {
-          setSelectedServer(null)
-        }
+    deleteMutation.mutate(
+      { id: deleteTarget.server.id, force },
+      {
+        onSuccess: () => {
+          setDeleteTarget(null)
+          // Close detail modal if the deleted server was open
+          if (selectedServer?.id === deleteTarget.server.id) {
+            setSelectedServer(null)
+          }
+        },
       },
-    })
+    )
   }
 
   function handleDeleteClose() {

--- a/internal/http/api/mcp_handler.go
+++ b/internal/http/api/mcp_handler.go
@@ -323,27 +323,34 @@ func (h *MCPHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check whether any active policy references a tool from this server.
-	// Tool references use dot-notation: serverName.toolName, so we check for
-	// the server name prefix to catch all tools from this server.
-	policies, err := h.store.ListPolicies(r.Context())
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to list policies", err.Error())
-		return
-	}
+	// ?force=true skips the conflict check below. Callers (the delete modal)
+	// use this after the user has acknowledged that referencing agents will
+	// fail to run.
+	force := r.URL.Query().Get("force") == "true"
 
-	prefix := server.Name + "."
-	var conflicting []string
-	for _, p := range policies {
-		if policyReferencesServer(p.Yaml, prefix) {
-			conflicting = append(conflicting, p.Name)
+	if !force {
+		// Check whether any active policy references a tool from this server.
+		// Tool references use dot-notation: serverName.toolName, so we check for
+		// the server name prefix to catch all tools from this server.
+		policies, err := h.store.ListPolicies(r.Context())
+		if err != nil {
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to list policies", err.Error())
+			return
 		}
-	}
 
-	if len(conflicting) > 0 {
-		httputil.WriteError(w, http.StatusConflict, "MCP server is referenced by active policies",
-			fmt.Sprintf("policies referencing this server: %s", strings.Join(conflicting, ", ")))
-		return
+		prefix := server.Name + "."
+		var conflicting []string
+		for _, p := range policies {
+			if policyReferencesServer(p.Yaml, prefix) {
+				conflicting = append(conflicting, p.Name)
+			}
+		}
+
+		if len(conflicting) > 0 {
+			httputil.WriteError(w, http.StatusConflict, "MCP server is referenced by active policies",
+				fmt.Sprintf("policies referencing this server: %s — pass ?force=true to delete anyway", strings.Join(conflicting, ", ")))
+			return
+		}
 	}
 
 	// mcp_tools rows are cascade-deleted by the FK constraint on DELETE.

--- a/internal/http/api/mcp_handler_test.go
+++ b/internal/http/api/mcp_handler_test.go
@@ -3,7 +3,9 @@ package api_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -423,6 +425,53 @@ agent:
 		}
 		if !strings.Contains(envelope.Detail, "ref-policy") {
 			t.Errorf("detail %q should mention ref-policy", envelope.Detail)
+		}
+	})
+
+	t.Run("delete server referenced by policy with force=true returns 204", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		registry := mcp.NewRegistry(store.Queries())
+		id := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+
+		policyYAML := `
+name: ref-policy
+trigger:
+  type: webhook
+capabilities:
+  tools:
+    - tool: my-server.some_tool
+agent:
+  task: test
+`
+		_, err := store.CreatePolicy(context.Background(), db.CreatePolicyParams{
+			ID:          model.NewULID(),
+			Name:        "ref-policy",
+			TriggerType: "webhook",
+			Yaml:        policyYAML,
+			CreatedAt:   "2024-01-01T00:00:00Z",
+			UpdatedAt:   "2024-01-01T00:00:00Z",
+		})
+		if err != nil {
+			t.Fatalf("CreatePolicy: %v", err)
+		}
+
+		srv := httptest.NewServer(newMCPRouter(store, registry))
+		t.Cleanup(srv.Close)
+
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/servers/"+id+"?force=true", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("DELETE /servers/%s?force=true: %v", id, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", resp.StatusCode)
+		}
+
+		// Server row must actually be gone.
+		if _, err := store.GetMCPServer(context.Background(), id); !errors.Is(err, sql.ErrNoRows) {
+			t.Errorf("GetMCPServer after force delete: err = %v, want sql.ErrNoRows", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `DELETE /api/v1/mcp/servers/:id` now accepts `?force=true` to bypass the in-use-by-policy check. Default behavior (409 with the conflicting policy list) is unchanged so non-UI API consumers keep their safety net.
- The delete modal previously warned that referencing agents would fail to run, but the backend then rejected the request with 409 — leaving operators no way to actually remove a server. After a 409 the modal now surfaces the conflicting policies in the error alert and switches the submit button to **Force delete**, so the operator confirms with full context.
- New Storybook story `InUseConflict` covers the post-409 force-delete state.

## Test plan

- [x] `go test ./internal/http/api/...` (added a test that asserts `?force=true` deletes a referenced server and that the row is gone)
- [x] `npm run build` (TypeScript check + production build clean)
- [x] `npm run test:unit` (809 tests, all passing)
- [ ] Manual: from the Tools page, delete an MCP server that has at least one policy referencing it — first click shows the conflicting policy list, second click force-deletes and the affected agent runs fail as warned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)