### PR TITLE
Pre-launch polish for v1.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Gleipnir version
       description: Release tag, docker image tag, or commit SHA.
-      placeholder: "v0.1.0 or sha:abc123"
+      placeholder: "v1.0.0 or sha:abc123"
     validations:
       required: true
 
@@ -48,6 +48,7 @@ body:
         - manual
         - scheduled
         - poll
+        - cron
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting an improvement. Please check the [roadmap](https://github.com/Felag-Engineering/gleipnir/blob/main/docs/Backend_Roadmap.md) and [existing issues](https://github.com/Felag-Engineering/gleipnir/issues?q=is%3Aissue) first.
+        Thanks for suggesting an improvement. Please check [existing issues](https://github.com/Felag-Engineering/gleipnir/issues?q=is%3Aissue) first to avoid duplicates.
 
   - type: textarea
     id: problem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Initial public release.
 - **Role-based access control.** Four roles (`admin`, `operator`, `approver`, `auditor`) enforced by middleware.
 - **Server-Sent Events** push run status changes, new steps, and approval events to the UI in real time.
 - **Embedded React frontend.** The full UI is compiled into the Go binary via `go:embed` and served directly — no separate frontend container.
-- **Three end-to-end playbooks.** Meal planning (Google Calendar + Mealie), Todoist research (DuckDuckGo + Todoist), and homelab DevOps (Docker + Proxmox + Technitium + Caddy).
+- **Three end-to-end playbooks.** Meal planning (Google Calendar + Mealie), Todoist research (SearXNG + Todoist), and homelab DevOps (Docker + Proxmox + Technitium + Caddy).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Security
 
-## [1.0.0] - 2026-04-27
+## [1.0.0] - 2026-04-29
 
 Initial public release.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ schemas/
   sql_schemas.sql     — schema that explains the different tables in our datastore
 
 cmd/
-  gleipnirctl/        — local admin CLI; direct DB-level maintenance operations (rotate-key, reset-password, and planned: create-user, list-users, purge-runs, verify-keys, check). Run via `docker compose run --rm api gleipnirctl <command>`.
+  gleipnirctl/        — local admin CLI; direct DB-level maintenance operations (rotate-key, reset-password). Run via `docker compose run --rm api gleipnirctl <command>`.
 
 internal/
   approval/           — approval-specific timeout wiring (thin wrapper over timeout/)
@@ -125,6 +125,7 @@ internal/
     event/            — Publisher interface for internal pub/sub
     logctx/           — context-based structured log correlation (run_id + policy_id)
     metrics/          — custom Prometheus registry, histogram bucket presets (BucketsFast/BucketsSlow), shared label constants, Handler()/Registry() accessors (ADR-037)
+    version/          — single-source-of-truth release version constant; bump in the commit immediately preceding a release tag
   llm/                — LLM provider abstraction (ADR-026)
     anthropic/        — Anthropic API client
     factory/          — NewClientForProvider: maps a provider name string to a concrete LLMClient; lives in its own sub-package to avoid the cycle caused by provider packages importing internal/llm

--- a/cmd/gleipnirctl/README.md
+++ b/cmd/gleipnirctl/README.md
@@ -14,15 +14,10 @@ The web UI handles day-to-day operations: managing policies, reviewing runs, app
 
 ## Available commands
 
-| Command | Status | Description |
-|---|---|---|
-| `rotate-key` | Available | Re-encrypt all at-rest secrets under a new encryption key |
-| `reset-password` | Available | Reset a user's password directly in the database |
-| `create-user` | Coming soon | Create a new user account without going through the web UI |
-| `list-users` | Coming soon | List all user accounts and their roles |
-| `purge-runs` | Coming soon | Delete run history older than a given date |
-| `verify-keys` | Coming soon | Verify that the current encryption key decrypts all stored secrets |
-| `check` | Coming soon | Run a health check against the database and configuration |
+| Command | Description |
+|---|---|
+| `rotate-key` | Re-encrypt all at-rest secrets under a new encryption key |
+| `reset-password` | Reset a user's password directly in the database |
 
 ---
 

--- a/docs/developer/ADR_Tracker.md
+++ b/docs/developer/ADR_Tracker.md
@@ -235,7 +235,7 @@ The `Dispatcher` interface is designed for substitution. When multi-node Gleipni
 2. Migrate `scheduled.go`: register `scheduled_fire` handler, seed heap from `GetScheduledActivePolicies` on startup, call `Schedule()` from the policy save path, delete the `Scheduler` struct and its `PolicyNotifier` implementation. Closes #790.
 3. Migrate `poll.go`: register `poll_tick` handler that reschedules itself, seed first tick per active poll policy on startup, delete the `Poller` struct, its reconcile loop, and its `PolicyNotifier` implementation.
 
-Design detail, diagrams, and handler contracts live in [`docs/developer/dispatcher.md`](developer/dispatcher.md).
+Design detail, diagrams, and handler contracts live in [`docs/developer/dispatcher.md`](dispatcher.md).
 
 ---
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -18,5 +18,4 @@ For people writing Gleipnir code. If you're looking for how to *run* Gleipnir, s
 
 ### Reference
 - [Manual testing](manual-testing.md) — live integration test environment with real MCP servers.
-- [Stdio MCP servers](../stdio-mcp-servers.md) — wiring up stdio-only MCP servers via the Supergateway sidecar.
 - [Scheduler dispatcher](dispatcher.md) — design reference for the centralized scheduling layer (ADR-036).

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -8,4 +8,3 @@ End-to-end setups for common Gleipnir automations. Each playbook includes the tr
 - [Plan the week's meals](meal-planning/README.md)
 - [Research your own todo list](todoist-research/README.md)
 - [Homelab DevOps operations](devops/README.md)
-- [Keep your homelab up when hardware fails](homelab-failover.md) — **Status: Planned**

--- a/docs/playbooks/homelab-failover.md
+++ b/docs/playbooks/homelab-failover.md
@@ -1,7 +1,0 @@
-# Keep your homelab up when hardware fails
-
-**Status:** Planned
-
-This playbook watches Uptime Kuma for outages, stands the affected service back up on a different host using Docker, and updates the DNS entry so users never notice the move. It runs on a poll trigger against Uptime Kuma and uses MCP servers for Docker host management and DNS.
-
-This playbook is not yet written. Track progress in the issue linked from the project roadmap.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gleipnir-ui",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gleipnir-ui",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gleipnir-ui",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/internal/infra/version/version.go
+++ b/internal/infra/version/version.go
@@ -1,0 +1,8 @@
+// Package version exposes the build version of Gleipnir as a single source
+// of truth. Bump the constant in the commit immediately preceding a release
+// tag, then create the matching git tag (e.g. v1.0.0).
+package version
+
+// Version is the current Gleipnir release. It is reported through the API
+// metadata and sent to MCP servers in the initialize handshake's clientInfo.
+const Version = "1.0.0"

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/infra/version"
 )
 
 const (
@@ -183,7 +185,7 @@ func (c *Client) initialize(ctx context.Context) (string, error) {
 			"capabilities":    map[string]any{},
 			"clientInfo": map[string]any{
 				"name":    "gleipnir",
-				"version": "0.1.0",
+				"version": version.Version,
 			},
 		},
 	})

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/http/auth"
 	"github.com/felag-engineering/gleipnir/internal/http/sse"
 	"github.com/felag-engineering/gleipnir/internal/infra/config"
+	"github.com/felag-engineering/gleipnir/internal/infra/version"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	llmfactory "github.com/felag-engineering/gleipnir/internal/llm/factory"
 	openaicompatllm "github.com/felag-engineering/gleipnir/internal/llm/openaicompat"
@@ -27,9 +28,6 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/timeout"
 	"github.com/felag-engineering/gleipnir/internal/trigger"
 )
-
-// version is set via ldflags at build time.
-var version = "dev"
 
 // knownProviders is the list of LLM providers the system supports.
 var knownProviders = []string{"anthropic", "google", "openai"}
@@ -280,7 +278,7 @@ func run(cfg config.Config) error {
 		Handlers: handlers,
 		Services: services,
 		Metadata: api.Metadata{
-			Version:   version,
+			Version:   version.Version,
 			StartTime: startTime,
 			DBPath:    cfg.DBPath,
 		},


### PR DESCRIPTION
## Summary

Final repo sweep before tagging v1.0.0. Centralizes the build version, fixes broken docs links, drops stale "Coming soon" / "Planned" content, and bumps the frontend to 1.0.0.

- **Central version source.** New `internal/infra/version` package owns the release version constant. `main.go` (API metadata) and `internal/mcp/client.go` (clientInfo sent on MCP `initialize`) both read from it. Going forward, edit `version.go` only — the dead ldflags-injected `var version = "dev"` in `main.go` has been removed.
- **Frontend version.** `frontend/package.json` + lockfile bumped from `0.1.0` to `1.0.0`.
- **CHANGELOG.** Release date set to 2026-04-29; the stale "DuckDuckGo" reference in the playbooks line corrected to SearXNG (the swap landed in #124).
- **Docs cleanup.**
  - Dropped 5 "Coming soon" rows (and the now-redundant Status column) from `cmd/gleipnirctl/README.md`.
  - Removed the unwritten `homelab-failover.md` playbook stub and its index entry.
  - Fixed broken `dispatcher.md` link in `docs/developer/ADR_Tracker.md`.
  - Removed two stranded references to docs that were intentionally deleted in #93 (`stdio-mcp-servers.md`, `Backend_Roadmap.md`).
- **Issue templates.** Bug-report version placeholder `v0.1.0` → `v1.0.0`; added missing `cron` option to the trigger-type dropdown.
- **CLAUDE.md.** Reflects the new `internal/infra/version` package and the trimmed gleipnirctl scope.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all 30 packages pass
- [x] No broken relative `.md` links remain (full-tree link scan)
- [x] No "Fetter" / `rapp992` / personal-info leaks (full repo grep)
- [x] No `TODO` / `FIXME` / `HACK` markers in shipped code
- [ ] Reviewer: confirm v1.0.0 string appears in `/api/v1/health`-style metadata response after building from this branch

## Follow-ups (not in this PR)

- Tag `v1.0.0` after merge — that triggers the Docker Hub `felagengineering/gleipnir:latest` build referenced in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)