### PR TITLE
fix: poll policies always show next-fire-at while active

### DIFF
--- a/internal/http/api/export_test.go
+++ b/internal/http/api/export_test.go
@@ -1,0 +1,8 @@
+package api
+
+// Exports for unit tests in package api_test.
+
+var ComputeNextFireAt = computeNextFireAt
+
+type PolicyYAMLSummary = policyYAMLSummary
+type RunSummary = runSummary

--- a/internal/http/api/policy_handler.go
+++ b/internal/http/api/policy_handler.go
@@ -129,7 +129,7 @@ func (h *PolicyHandler) List(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		item.NextFireAt = computeNextFireAt(row.TriggerType, summary, item.LatestRun)
+		item.NextFireAt = computeNextFireAt(row.TriggerType, summary, item.LatestRun, row.PausedAt)
 
 		items = append(items, item)
 	}
@@ -222,7 +222,7 @@ func parsePolicySummary(rawYAML string) policyYAMLSummary {
 // computeNextFireAt returns the next scheduled fire time for scheduled and poll
 // trigger types, or nil for all others. Parse errors are silently ignored so a
 // bad YAML value never breaks the list endpoint.
-func computeNextFireAt(triggerType string, summary policyYAMLSummary, latestRun *runSummary) *string {
+func computeNextFireAt(triggerType string, summary policyYAMLSummary, latestRun *runSummary, pausedAt *string) *string {
 	now := time.Now().UTC()
 
 	switch triggerType {
@@ -244,23 +244,32 @@ func computeNextFireAt(triggerType string, summary policyYAMLSummary, latestRun 
 		}
 
 	case string(model.TriggerTypePoll):
-		if latestRun == nil {
+		if pausedAt != nil {
 			return nil
 		}
 		interval, err := time.ParseDuration(summary.Trigger.Interval)
 		if err != nil || interval <= 0 {
 			return nil
 		}
-		startedAt, err := time.Parse(time.RFC3339Nano, latestRun.StartedAt)
-		if err != nil {
-			// Also try without nanoseconds
-			startedAt, err = time.Parse(time.RFC3339, latestRun.StartedAt)
+		// Use latestRun.StartedAt + interval as the candidate next fire time.
+		// If there is no prior run, or the candidate has already passed, fall
+		// back to now + interval so the UI always shows an upcoming estimate.
+		var candidate time.Time
+		if latestRun != nil {
+			startedAt, err := time.Parse(time.RFC3339Nano, latestRun.StartedAt)
 			if err != nil {
-				return nil
+				// Also try without nanoseconds
+				startedAt, err = time.Parse(time.RFC3339, latestRun.StartedAt)
+				if err != nil {
+					startedAt = time.Time{} // zero → candidate will be in the past
+				}
 			}
+			candidate = startedAt.Add(interval)
 		}
-		next := startedAt.Add(interval).UTC()
-		s := next.Format(time.RFC3339)
+		if !candidate.After(now) {
+			candidate = now.Add(interval)
+		}
+		s := candidate.UTC().Format(time.RFC3339)
 		return &s
 	}
 

--- a/internal/http/api/policy_handler_test.go
+++ b/internal/http/api/policy_handler_test.go
@@ -1875,3 +1875,85 @@ agent:
 		})
 	})
 }
+
+func TestComputeNextFireAt(t *testing.T) {
+	const interval = "5m"
+	pollSummary := api.PolicyYAMLSummary{}
+	pollSummary.Trigger.Interval = interval
+
+	paused := "2026-01-01T00:00:00Z"
+
+	t.Run("poll, no latestRun, not paused — returns now+interval", func(t *testing.T) {
+		before := time.Now().UTC().Truncate(time.Second)
+		result := api.ComputeNextFireAt(string(model.TriggerTypePoll), pollSummary, nil, nil)
+		after := time.Now().UTC().Truncate(time.Second)
+
+		if result == nil {
+			t.Fatal("expected non-nil next_fire_at for active poll policy with no runs")
+		}
+		got, err := time.Parse(time.RFC3339, *result)
+		if err != nil {
+			t.Fatalf("parse result: %v", err)
+		}
+		// The result is RFC3339 (second precision). Allow a 2-second window to
+		// account for the truncation and any sub-second execution time.
+		low := before.Add(5 * time.Minute)
+		high := after.Add(5 * time.Minute).Add(2 * time.Second)
+		if got.Before(low) || got.After(high) {
+			t.Errorf("next_fire_at = %v, want between %v and %v", got, low, high)
+		}
+	})
+
+	t.Run("poll, latestRun.StartedAt+interval in the future — returns that time", func(t *testing.T) {
+		futureStart := time.Now().UTC().Add(-2 * time.Minute) // started 2m ago; next = 3m from now
+		latestRun := &api.RunSummary{
+			StartedAt: futureStart.Format(time.RFC3339Nano),
+		}
+		result := api.ComputeNextFireAt(string(model.TriggerTypePoll), pollSummary, latestRun, nil)
+		if result == nil {
+			t.Fatal("expected non-nil next_fire_at")
+		}
+		got, err := time.Parse(time.RFC3339, *result)
+		if err != nil {
+			t.Fatalf("parse result: %v", err)
+		}
+		want := futureStart.Add(5 * time.Minute).Truncate(time.Second)
+		if got.Sub(want).Abs() > time.Second {
+			t.Errorf("next_fire_at = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("poll, latestRun.StartedAt+interval in the past — returns now+interval", func(t *testing.T) {
+		oldStart := time.Now().UTC().Add(-10 * time.Minute) // started 10m ago; next was 5m ago
+		latestRun := &api.RunSummary{
+			StartedAt: oldStart.Format(time.RFC3339Nano),
+		}
+		before := time.Now().UTC().Truncate(time.Second)
+		result := api.ComputeNextFireAt(string(model.TriggerTypePoll), pollSummary, latestRun, nil)
+		after := time.Now().UTC().Truncate(time.Second)
+
+		if result == nil {
+			t.Fatal("expected non-nil next_fire_at when candidate is stale")
+		}
+		got, err := time.Parse(time.RFC3339, *result)
+		if err != nil {
+			t.Fatalf("parse result: %v", err)
+		}
+		// Allow a 2-second window for RFC3339 truncation and execution time.
+		low := before.Add(5 * time.Minute)
+		high := after.Add(5 * time.Minute).Add(2 * time.Second)
+		if got.Before(low) || got.After(high) {
+			t.Errorf("next_fire_at = %v, want between %v and %v (fallback to now+interval)", got, low, high)
+		}
+	})
+
+	t.Run("poll, paused — returns nil", func(t *testing.T) {
+		latestRun := &api.RunSummary{
+			StartedAt: time.Now().UTC().Add(-2 * time.Minute).Format(time.RFC3339),
+		}
+		result := api.ComputeNextFireAt(string(model.TriggerTypePoll), pollSummary, latestRun, &paused)
+		if result != nil {
+			t.Errorf("expected nil for paused poll policy, got %v", *result)
+		}
+	})
+}


### PR DESCRIPTION
Closes #137

## Summary

Fixes the **Next: …** label on the agents list for `poll` trigger policies. The label was either hidden (no prior run) or showing a stale past timestamp (policy kept polling but never matched its trigger conditions).

`computeNextFireAt` in `internal/http/api/policy_handler.go` now accepts `pausedAt` and, in the `poll` branch:

- returns `nil` when paused
- returns `latestRun.StartedAt + interval` when that is in the future
- otherwise falls back to `now + interval` (no run yet, or candidate is stale)

This is a deliberate approximation — the in-memory ticker's exact next-tick timestamp is not persisted — but it gives operators a rolling "≈ next interval boundary" while polling is active, and the label disappears immediately on pause. Persisting tick state to `poll_states.next_poll_at` is a strictly better follow-up but out of scope.

## Tests

`TestComputeNextFireAt` covers all four branches:
- poll, no latestRun, not paused → `now + interval` (within tolerance)
- poll, future candidate → that exact time
- poll, stale candidate → `now + interval`
- poll, paused → `nil`

## Pipeline

<details>
<summary>Architecture plan</summary>

Scope-gate skip — issue named exactly two files and a localized helper change. Plan:

- Add `pausedAt *string` parameter to `computeNextFireAt`; pass `row.PausedAt` from the single call site at `policy_handler.go:132`.
- Rewrite the `poll` branch with the three-way logic above.
- Table-driven tests for the four cases in the issue's test plan.

</details>

- Review cycles: 1 (approved on first pass)
- Brainstorming: not triggered (issue was well-specified)
- CLAUDE.md updates: none needed

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.