### PR TITLE
refactor: extract goroutine body in RunLauncher.Launch into a named method

### DIFF
--- a/internal/execution/run/launcher.go
+++ b/internal/execution/run/launcher.go
@@ -288,35 +288,46 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 	go func() {
 		defer cancel()
 		defer l.manager.Deregister(run.ID)
-		if err := ba.Run(runCtx, run.ID, payload); err != nil {
-			logctx.Logger(runCtx).ErrorContext(runCtx, "run failed", "trigger_type", string(params.TriggerType), "err", err)
-		}
-		// Drain the queue if this policy uses queue concurrency.
-		// ba.Run has completed so the run's DB status is terminal — DrainQueue's
-		// ListActiveRunsByPolicy (called inside Launch) will not see this run.
-		// Use context.Background() because runCtx may be cancelled.
-		// Re-fetch the policy so DrainQueue uses current settings (queue_depth,
-		// concurrency) rather than a snapshot captured at launch time.
-		if params.ParsedPolicy.Agent.Concurrency == model.ConcurrencyQueue {
-			drainCtx := context.Background()
-			currentPolicy := params.ParsedPolicy
-			if dbPol, dbErr := l.store.GetPolicy(drainCtx, params.PolicyID); dbErr == nil {
-				provider, modelName := l.drainResolveDefaults(drainCtx)
-				if provider == "" || modelName == "" {
-					slog.Warn("drain: system default model unavailable, using launch-time snapshot",
-						"policy_id", params.PolicyID)
-				} else if p, parseErr := policy.Parse(dbPol.Yaml, provider, modelName); parseErr == nil {
-					currentPolicy = p
-				} else {
-					slog.Warn("drain: failed to re-parse policy, using launch-time snapshot",
-						"policy_id", params.PolicyID, "err", parseErr)
-				}
-			}
-			l.DrainQueue(drainCtx, params.PolicyID, currentPolicy)
-		}
+		l.runAndDrain(runCtx, run.ID, params.TriggerType, params.PolicyID, params.ParsedPolicy, payload, ba)
 	}()
 
 	return LaunchResult{RunID: run.ID}, nil
+}
+
+// runAndDrain executes the agent run and, if the policy uses queue concurrency,
+// drains the next trigger from the queue. It is the body of the goroutine
+// launched by Launch — extracted so it can be tested independently.
+//
+// ctx should be the run-scoped context (already enriched with correlation IDs).
+// Use context.Background() for the drain step because ctx may be cancelled by
+// the time the run completes.
+func (l *RunLauncher) runAndDrain(ctx context.Context, runID string, triggerType model.TriggerType, policyID string, parsedPolicy *model.ParsedPolicy, payload string, ba *agent.BoundAgent) {
+	if err := ba.Run(ctx, runID, payload); err != nil {
+		logctx.Logger(ctx).ErrorContext(ctx, "run failed", "trigger_type", string(triggerType), "err", err)
+	}
+	// Drain the queue if this policy uses queue concurrency.
+	// ba.Run has completed so the run's DB status is terminal — DrainQueue's
+	// ListActiveRunsByPolicy (called inside Launch) will not see this run.
+	// Use context.Background() because ctx may be cancelled.
+	// Re-fetch the policy so DrainQueue uses current settings (queue_depth,
+	// concurrency) rather than a snapshot captured at launch time.
+	if parsedPolicy.Agent.Concurrency == model.ConcurrencyQueue {
+		drainCtx := context.Background()
+		currentPolicy := parsedPolicy
+		if dbPol, dbErr := l.store.GetPolicy(drainCtx, policyID); dbErr == nil {
+			provider, modelName := l.drainResolveDefaults(drainCtx)
+			if provider == "" || modelName == "" {
+				slog.Warn("drain: system default model unavailable, using launch-time snapshot",
+					"policy_id", policyID)
+			} else if p, parseErr := policy.Parse(dbPol.Yaml, provider, modelName); parseErr == nil {
+				currentPolicy = p
+			} else {
+				slog.Warn("drain: failed to re-parse policy, using launch-time snapshot",
+					"policy_id", policyID, "err", parseErr)
+			}
+		}
+		l.DrainQueue(drainCtx, policyID, currentPolicy)
+	}
 }
 
 // Enqueue checks queue depth and enqueues the trigger payload.

--- a/internal/execution/run/run_and_drain_test.go
+++ b/internal/execution/run/run_and_drain_test.go
@@ -1,0 +1,257 @@
+package run
+
+// Tests for RunLauncher.runAndDrain. This file uses package run (not run_test)
+// so it can call the unexported method directly.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/llm"
+	"github.com/felag-engineering/gleipnir/internal/mcp"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/policy"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+)
+
+// newStubMCPServerInternal mirrors the helper in launcher_test.go but lives in
+// package run so this internal test file can use it without a cross-file import.
+func newStubMCPServerInternal(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck
+		w.Header().Set("Content-Type", "application/json")
+		method, _ := req["method"].(string)
+		switch method {
+		case "tools/list":
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]any{
+					"tools": []map[string]any{{
+						"name":        "read_data",
+						"description": "reads data",
+						"inputSchema": map[string]any{
+							"type": "object", "properties": map[string]any{},
+						},
+					}},
+				},
+			})
+		default:
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]any{
+					"content": []map[string]any{{"type": "text", "text": "stub result"}},
+					"isError": false,
+				},
+			})
+		}
+	}))
+}
+
+// buildBoundAgent constructs a BoundAgent backed by a mock LLM client, wiring
+// the minimal dependencies (state machine, audit writer) against the given store
+// and run row. The run row must already exist in the DB.
+func buildBoundAgent(t *testing.T, store *db.Store, runRow db.Run, resolvedTools []mcp.ResolvedTool, parsedPolicy *model.ParsedPolicy) *agent.BoundAgent {
+	t.Helper()
+	sm := agent.NewRunStateMachine(
+		runRow.ID,
+		model.RunStatus(runRow.Status),
+		store.DB(),
+		store.Queries(),
+		agent.WithInitialVersion(runRow.Version),
+	)
+	audit := agent.NewAuditWriter(store.Queries())
+	ba, err := agent.New(agent.Config{
+		Tools:        resolvedTools,
+		Policy:       parsedPolicy,
+		Audit:        audit,
+		StateMachine: sm,
+		ApprovalCh:   make(chan bool, 1),
+		FeedbackCh:   make(chan string, 1),
+		LLMClient: testutil.NewMockLLMClient(
+			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
+		),
+	})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	return ba
+}
+
+// insertRunRow creates a run row via SQL directly so we can get the db.Run back.
+func insertRunRow(t *testing.T, store *db.Store, policyID string) db.Run {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	runRow, err := store.CreateRun(ctx, db.CreateRunParams{
+		ID:             model.NewULID(),
+		PolicyID:       policyID,
+		Model:          "claude-sonnet-4-6",
+		TriggerType:    string(model.TriggerTypeWebhook),
+		TriggerPayload: `{}`,
+		StartedAt:      now,
+		CreatedAt:      now,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return runRow
+}
+
+const parallelPolicyYAML = `
+name: run-and-drain-parallel
+trigger:
+  type: webhook
+capabilities:
+  tools:
+    - tool: stub-server.read_data
+agent:
+  model: claude-opus-4-5
+  task: "test task"
+  concurrency: parallel
+`
+
+const queuePolicyYAML = `
+name: run-and-drain-queue
+trigger:
+  type: webhook
+capabilities:
+  tools:
+    - tool: stub-server.read_data
+agent:
+  model: claude-opus-4-5
+  task: "test task"
+  concurrency: queue
+  queue_depth: 2
+`
+
+// TestRunAndDrain_NonQueuePolicy verifies that runAndDrain completes the agent
+// run without attempting a queue drain when the policy uses parallel concurrency.
+func TestRunAndDrain_NonQueuePolicy(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	mcpSrv := newStubMCPServerInternal(t)
+	t.Cleanup(mcpSrv.Close)
+	registry := mcp.NewRegistry(store.Queries())
+	if err := registry.RegisterServer(context.Background(), "stub-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServer: %v", err)
+	}
+
+	testutil.InsertPolicy(t, store, "p-parallel", "policy-p-parallel", "webhook", parallelPolicyYAML)
+	parsed, err := policy.Parse(parallelPolicyYAML, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("policy.Parse: %v", err)
+	}
+
+	resolvedTools, err := registry.ResolveForPolicy(context.Background(), parsed)
+	if err != nil {
+		t.Fatalf("ResolveForPolicy: %v", err)
+	}
+
+	runRow := insertRunRow(t, store, "p-parallel")
+	ba := buildBoundAgent(t, store, runRow, resolvedTools, parsed)
+
+	launcher := NewRunLauncher(RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                NewRunManager(),
+		AgentFactory:           nil,
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          nil,
+	})
+
+	launcher.runAndDrain(context.Background(), runRow.ID, model.TriggerTypeWebhook, "p-parallel", parsed, `{}`, ba)
+
+	// The run should be in a terminal state (complete or failed).
+	runs, err := store.ListRuns(context.Background(), db.ListRunsParams{PolicyID: "p-parallel", Limit: 100})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatal("expected run row, got none")
+	}
+	status := model.RunStatus(runs[0].Status)
+	if status != model.RunStatusComplete && status != model.RunStatusFailed {
+		t.Errorf("run.Status = %q, want complete or failed", status)
+	}
+
+	// No additional runs should be created (no drain for parallel policy).
+	if len(runs) != 1 {
+		t.Errorf("expected exactly 1 run (no drain), got %d", len(runs))
+	}
+}
+
+// TestRunAndDrain_QueuePolicy verifies that runAndDrain drains the next queued
+// trigger after the agent run completes when the policy uses queue concurrency.
+func TestRunAndDrain_QueuePolicy(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	mcpSrv := newStubMCPServerInternal(t)
+	t.Cleanup(mcpSrv.Close)
+	registry := mcp.NewRegistry(store.Queries())
+	if err := registry.RegisterServer(context.Background(), "stub-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServer: %v", err)
+	}
+
+	testutil.InsertPolicy(t, store, "p-queue", "policy-p-queue", "webhook", queuePolicyYAML)
+	parsed, err := policy.Parse(queuePolicyYAML, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("policy.Parse: %v", err)
+	}
+
+	// Pre-load a queue entry so DrainQueue has something to launch.
+	testutil.InsertQueueEntry(t, store, "p-queue", "webhook")
+
+	resolvedTools, err := registry.ResolveForPolicy(context.Background(), parsed)
+	if err != nil {
+		t.Fatalf("ResolveForPolicy: %v", err)
+	}
+
+	runRow := insertRunRow(t, store, "p-queue")
+	ba := buildBoundAgent(t, store, runRow, resolvedTools, parsed)
+
+	manager := NewRunManager()
+	launcher := NewRunLauncher(RunLauncherConfig{
+		Store:    store,
+		Registry: registry,
+		Manager:  manager,
+		AgentFactory: func(cfg agent.Config) (*agent.BoundAgent, error) {
+			cfg.LLMClient = testutil.NewMockLLMClient(
+				testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
+			)
+			return agent.New(cfg)
+		},
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          nil,
+	})
+
+	launcher.runAndDrain(context.Background(), runRow.ID, model.TriggerTypeWebhook, "p-queue", parsed, `{}`, ba)
+
+	// Wait for the drained run goroutine to finish.
+	manager.Wait()
+
+	// The original run plus the drained run should both exist.
+	runs, err := store.ListRuns(context.Background(), db.ListRunsParams{PolicyID: "p-queue", Limit: 100})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) < 2 {
+		t.Errorf("expected at least 2 runs (original + drained), got %d", len(runs))
+	}
+
+	// The queue should be empty after draining.
+	count, err := store.CountQueuedTriggers(context.Background(), "p-queue")
+	if err != nil {
+		t.Fatalf("CountQueuedTriggers: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected queue to be empty after drain, got %d entries", count)
+	}
+}


### PR DESCRIPTION
Closes #56

## Summary

Extracts the ~30-line inline goroutine body inside `RunLauncher.Launch` (`internal/execution/run/launcher.go`) into a named method `runAndDrain`. The goroutine launch site is now a thin 3-line wrapper:

```go
go func() {
    defer cancel()
    defer l.manager.Deregister(run.ID)
    l.runAndDrain(runCtx, run.ID, params, payload, ba)
}()
```

`runAndDrain` encapsulates the agent run + the queue-drain branch (including the `GetPolicy → drainResolveDefaults → policy.Parse` fallback chain and the final `DrainQueue` call). Zero behaviour change — every prior error path, log message, fallback case, and call order is preserved.

A new internal test file `internal/execution/run/run_and_drain_test.go` (`package run`, so it can reach the unexported method) adds direct tests for both the non-queue path and the queue-drain path.

## Plan

<details>
<summary>Implementation plan</summary>

```
IMPLEMENTATION PLAN
===================
Issue: refactor: extract goroutine body in RunLauncher.Launch into a named method

Summary:
  Extract the ~30-line inline goroutine body inside RunLauncher.Launch
  into a named method (e.g. `runAndDrain`). The goroutine should remain
  only as the wrapper that establishes the deferred cleanup
  (cancel + manager.Deregister) and calls the new method.

  Acceptance:
  - The extracted method is independently testable (a test should be added).
  - The launch site reads as intent, not implementation.
  - No behaviour change.

Affected files:
  internal/execution/run/launcher.go         — extract method
  internal/execution/run/launcher_test.go    — add direct test for new method

Note: scope-gate skip — no architect pass. Developer implements directly from the issue.
```

(Tests landed in a new file `run_and_drain_test.go` with `package run` rather than the external `package run_test` of `launcher_test.go`, since `runAndDrain` is unexported.)
</details>

## Review cycles

2 cycles. Cycle 1 approved the substantive refactor; cycle 2 fixed a `gofmt` struct alignment and an isolated import-group nit.

## Documentation

CLAUDE.md files were checked and require no updates — internal refactor only, no new packages / env vars / routes / domain types / ADRs.

---

🤖 Generated by the agentic dev loop.