### PR TITLE
test: enforce trigger-type contract across schema, enum, and parser

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -39,6 +39,18 @@ const (
 	TriggerTypeCron      TriggerType = "cron"
 )
 
+// AllTriggerTypes lists every TriggerType constant. Update this slice when a
+// new TriggerType is added — the parser round-trip test in internal/policy
+// iterates it to enforce that schema, enum, and parser stay in sync.
+// Do not mutate this slice at runtime.
+var AllTriggerTypes = []TriggerType{
+	TriggerTypeWebhook,
+	TriggerTypeManual,
+	TriggerTypeScheduled,
+	TriggerTypePoll,
+	TriggerTypeCron,
+}
+
 // StepType identifies the kind of event recorded in a run's reasoning trace.
 type StepType string
 
@@ -184,9 +196,10 @@ func (s RunStatus) Valid() bool {
 
 func (t TriggerType) String() string { return string(t) }
 func (t TriggerType) Valid() bool {
-	switch t {
-	case TriggerTypeWebhook, TriggerTypeManual, TriggerTypeScheduled, TriggerTypePoll, TriggerTypeCron:
-		return true
+	for _, v := range AllTriggerTypes {
+		if t == v {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -4,6 +4,7 @@ package model
 
 import (
 	"crypto/rand"
+	"slices"
 	"sync"
 	"time"
 
@@ -196,12 +197,7 @@ func (s RunStatus) Valid() bool {
 
 func (t TriggerType) String() string { return string(t) }
 func (t TriggerType) Valid() bool {
-	for _, v := range AllTriggerTypes {
-		if t == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(AllTriggerTypes, t)
 }
 
 func (s StepType) String() string { return string(s) }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -28,7 +28,7 @@ func TestEnumValid(t *testing.T) {
 	})
 
 	t.Run("TriggerType", func(t *testing.T) {
-		valid := []TriggerType{TriggerTypeWebhook, TriggerTypeManual, TriggerTypeScheduled, TriggerTypePoll, TriggerTypeCron}
+		valid := AllTriggerTypes
 		for _, v := range valid {
 			if !v.Valid() {
 				t.Errorf("expected %q to be valid", v)

--- a/internal/policy/parser_test.go
+++ b/internal/policy/parser_test.go
@@ -1090,6 +1090,104 @@ agent:
 	}
 }
 
+// TestParse_AllTriggerTypesRoundTrip verifies that every TriggerType constant
+// in model.AllTriggerTypes can be parsed and validated successfully from a
+// minimal YAML body. This acts as a CI tripwire: adding a new TriggerType
+// without updating the parser or this test's fixture map will fail here.
+func TestParse_AllTriggerTypesRoundTrip(t *testing.T) {
+	// One minimal valid YAML body per trigger type.
+	// Each must include the universal required fields (name, trigger.type,
+	// capabilities.tools, agent.task) plus the per-type required fields from
+	// schemas/policy.yaml. Update this map when a new TriggerType is added.
+	yamls := map[model.TriggerType]string{
+		model.TriggerTypeWebhook: `
+name: rt-webhook
+trigger:
+  type: webhook
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`,
+		model.TriggerTypeManual: `
+name: rt-manual
+trigger:
+  type: manual
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`,
+		model.TriggerTypeScheduled: `
+name: rt-scheduled
+trigger:
+  type: scheduled
+  fire_at:
+    - "2099-01-01T00:00:00Z"
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`,
+		model.TriggerTypePoll: `
+name: rt-poll
+trigger:
+  type: poll
+  interval: 5m
+  checks:
+    - tool: srv.tool
+      path: "$.x"
+      equals: "y"
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`,
+		model.TriggerTypeCron: `
+name: rt-cron
+trigger:
+  type: cron
+  cron_expr: "0 9 * * 1"
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`,
+	}
+
+	// Catch the case where AllTriggerTypes grew but the fixture map above was not updated.
+	if len(yamls) != len(model.AllTriggerTypes) {
+		t.Fatalf("yamls fixture map has %d entries but model.AllTriggerTypes has %d — add a minimal YAML fixture for every new TriggerType", len(yamls), len(model.AllTriggerTypes))
+	}
+
+	for _, tt := range model.AllTriggerTypes {
+		tt := tt
+		t.Run(string(tt), func(t *testing.T) {
+			raw, ok := yamls[tt]
+			if !ok {
+				t.Fatalf("no minimal YAML fixture for trigger type %q — add one to keep parser, schema, and enum in sync", tt)
+			}
+
+			parsed, err := Parse(raw, "anthropic", "claude-sonnet-4-6")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			if parsed.Trigger.Type != tt {
+				t.Errorf("Trigger.Type = %q, want %q", parsed.Trigger.Type, tt)
+			}
+
+			if err := Validate(parsed); err != nil {
+				t.Errorf("Validate() error: %v", err)
+			}
+		})
+	}
+}
+
 // TestConvertAgent_ZeroLimitsPreserved verifies that an explicit 0 in YAML is
 // not replaced by the default. 0 means "unlimited" at runtime (agent.go treats
 // <= 0 as no cap); the parser must not silently upgrade it to 20000/50.


### PR DESCRIPTION
Closes #146

## Summary

Adds a round-trip test that, for every `model.TriggerType` value, parses a minimal valid YAML body through `policy.Parse` + `policy.Validate`. A new trigger type cannot be added without also updating the parser branches and the test fixture map — CI will fail until both are in sync.

Also derives `TriggerType.Valid()` from the new exported `AllTriggerTypes` slice, collapsing the parallel switch into a single source.

## Changes

- `internal/model/model.go` — new `AllTriggerTypes` slice; `Valid()` now iterates it
- `internal/model/model_test.go` — TriggerType subtest sources its valid list from `AllTriggerTypes`
- `internal/policy/parser_test.go` — new `TestParse_AllTriggerTypesRoundTrip`

## Drift surfaces (after this change)

- Add a constant but forget `AllTriggerTypes` → `Valid()` returns false at runtime when the validator runs
- Add the constant + slice entry but forget a fixture → length-equality guard fails CI
- Add fixture but the parser branch is missing required fields → `Validate` fails CI for that subtest

## Plan

<details>
<summary>Architecture plan</summary>

Round-trip test approach (option 1 from the issue). New exported `AllTriggerTypes` in `internal/model` so the parser test can iterate without re-listing constants. `Valid()` derives from the slice. YAML fixtures live in the parser test (not in model/) to keep the model package free of schema concerns.

Per-trigger fixture fields (beyond the universal `name`/`trigger.type`/`capabilities.tools`/`agent.task`):
- `webhook` — none (auth defaults to hmac)
- `manual` — none
- `scheduled` — `fire_at: ["2099-01-01T00:00:00Z"]`
- `poll` — `interval: "5m"`, one `checks` entry with tool `srv.tool`, path `$.x`, `equals: y`
- `cron` — `cron_expr: "0 9 * * 1"`

Provider/model defaults are injected by `Parse` so fixtures can omit a `model:` block.
</details>

## Review cycles

1 cycle, approved on first review.

## CLAUDE.md updates

None — test-only enforcement change, no new packages/routes/env vars/ADRs.

---

🤖 Generated by the agentic dev-loop pipeline.