### PR TITLE
refactor(admin_handler): extract upsertModelEnabled helper

### DIFF
--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -152,10 +152,7 @@ func (h *Handler) autoEnableModelsForProvider(ctx context.Context, provider stri
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, m := range models {
-		if err := h.q.UpsertModelSetting(ctx, provider, m.Name, 1, now); err != nil {
-			slog.Warn("auto-enable: upsert model failed", "provider", provider, "model", m.Name, "err", err)
-			// Continue — best-effort, other models should still be enabled.
-		}
+		h.upsertModelEnabled(ctx, "auto-enable", provider, m.Name, 1, now)
 	}
 }
 
@@ -197,10 +194,18 @@ func (h *Handler) disableModelsForProvider(ctx context.Context, provider string)
 		if row.Provider != provider || row.Enabled == 0 {
 			continue
 		}
-		if err := h.q.UpsertModelSetting(ctx, provider, row.ModelName, 0, now); err != nil {
-			slog.Warn("disable-models: upsert model failed", "provider", provider, "model", row.ModelName, "err", err)
-			// Continue — best-effort, disable remaining models.
-		}
+		h.upsertModelEnabled(ctx, "disable-models", provider, row.ModelName, 0, now)
+	}
+}
+
+// upsertModelEnabled writes a single (provider, modelName) row with the
+// given enabled flag. The action label ("auto-enable" or "disable-models")
+// is propagated into the warn log so operators can grep enable vs disable
+// events the same way they do today.
+func (h *Handler) upsertModelEnabled(ctx context.Context, action, provider, modelName string, enabled int64, now string) {
+	if err := h.q.UpsertModelSetting(ctx, provider, modelName, enabled, now); err != nil {
+		slog.Warn(action+": upsert model failed", "provider", provider, "model", modelName, "err", err)
+		// Continue — best-effort, other models should still be processed.
 	}
 }
 


### PR DESCRIPTION
Refs #145 (sub-task 5d of umbrella).

## Summary

Extract a private `upsertModelEnabled(ctx, action, provider, modelName, enabled, now)` helper to share the per-row `UpsertModelSetting` + `slog.Warn` line between `autoEnableModelsForProvider` and `disableModelsForProvider`. Both outer functions are kept as-is — they retain their distinct sources of truth (provider lister API vs DB scan).

Pure refactor. No behavior change. Existing tests pass unmodified.

## Why not `setModelsForProvider(ctx, provider, enabled bool)` from the umbrella?

The umbrella issue framed the two functions as "inverse twins — same loop, opposite enabled flag" and proposed a single bool-toggled helper. Reading the code shows they aren't actually inverses:

- `autoEnableModelsForProvider` sources its model list from `h.lister.ListModels(ctx, provider)` (the provider's REST API) and is a no-op when `h.lister == nil`.
- `disableModelsForProvider` sources from `h.q.ListModelSettings(ctx)` (the DB) and filters with `row.Provider == provider && row.Enabled == 1`.

A single `setModelsForProvider(... enabled bool)` would either need an internal `if enabled { lister... } else { DB... }` branch (burying the source distinction) or would force one branch to misuse the other's data source. Keeping the two named call sites and extracting only the per-row line is closer to CLAUDE.md's "explicit over clever" — and removes the only thing actually duplicated.

## Behavior preservation

- Log strings "auto-enable: upsert model failed" and "disable-models: upsert model failed" preserved byte-for-byte (built as `action + ": upsert model failed"` with the existing prefix values).
- `now := time.Now().UTC().Format(time.RFC3339)` is still computed once per outer call and shared across every row in the batch — auditors / `updated_at` consumers see the same timestamp grouping as today.
- Best-effort semantics preserved: errors are log-only, never bubble to the `SetProviderKey` / `DeleteProviderKey` HTTP responses.
- `h.lister == nil` no-op preserved on the auto-enable path.
- The `Provider == provider && Enabled == 1` filter on the disable path preserved.

## Review cycles

1 cycle (APPROVE on first pass).

## CLAUDE.md

No updates needed — refactor stays within one file, no new packages / env vars / routes / domain concepts / ADRs.

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` (artifact, not committed). Single private helper added immediately after `disableModelsForProvider`:

```go
func (h *Handler) upsertModelEnabled(ctx context.Context, action, provider, modelName string, enabled int64, now string) {
    if err := h.q.UpsertModelSetting(ctx, provider, modelName, enabled, now); err != nil {
        slog.Warn(action+": upsert model failed", "provider", provider, "model", modelName, "err", err)
    }
}
```

`action` is a plain string ("auto-enable" / "disable-models") rather than a bool because its only purpose is the log-tag prefix; encoding as `enabled bool` would force a string mapping and lose extensibility for future callers with their own log prefixes. The helper is void rather than error-returning because both current callers already log-and-continue.

</details>

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/admin/...` — pass
- [x] No test files modified

🤖 Generated by the agentic [/dev-loop](https://github.com/anthropics/claude-code) pipeline.