### PR TITLE
feat(plugin): add GLEIPNIR_PLUGINS_ENABLED flag (off by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,7 @@ GLEIPNIR_LOG_LEVEL=info
 
 # How often to scan for feedback requests that have timed out.
 # GLEIPNIR_FEEDBACK_SCAN_INTERVAL=30s
+
+# Enable the host-side plugin loader. Off by default in this release; the
+# real loader lands in a later phase. See docs/developer/plugin-system-spec.md §15.2.
+# GLEIPNIR_PLUGINS_ENABLED=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ npm run storybook        # Storybook on port 6006
 | `GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT` | `30m` | Default timeout for feedback requests |
 | `GLEIPNIR_FEEDBACK_SCAN_INTERVAL` | `30s` | How often to check for timed-out feedback |
 | `GLEIPNIR_DEFAULT_PROVIDER` | `anthropic` | Default LLM provider |
+| `GLEIPNIR_PLUGINS_ENABLED` | `false` | Enable the host-side plugin loader (off by default this release; see docs/developer/plugin-system-spec.md §15.2). |
 | `GLEIPNIR_ENCRYPTION_KEY` | *(required)* | 64-char hex key (32-byte AES-256) for encrypting provider API keys and webhook secrets; generate with `openssl rand -hex 32` |
 
 **Provider API keys:** All LLM provider API keys (Anthropic, Google, OpenAI, and any OpenAI-compatible backends) are configured through the admin UI at `/admin/models` and stored encrypted in the database. Env vars like `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY` / `OPENAI_API_KEY` are intentionally ignored — a startup warning is logged if they are set.
@@ -134,6 +135,7 @@ internal/
     openaicompat/     — OpenAI-compatible provider loader (bootstraps third-party OpenAI-compatible backends)
   mcp/                — MCP HTTP client, tool registry, capability tags
   model/              — domain types (Policy, Run, RunStep, ApprovalRequest, enums, ...)
+  plugin/             — host-side plugin loader (stub; gated by GLEIPNIR_PLUGINS_ENABLED. Real loader lands in Phase 3 of the plugin system rollout — see docs/developer/plugin-system-spec.md)
   policy/             — YAML parser, validator, system prompt renderer
   settings/           — read-side accessor for system_settings (default model, public URL); injected into runtime so non-admin packages don't depend on the admin HTTP handler
   testutil/           — shared test helpers

--- a/internal/infra/config/config.go
+++ b/internal/infra/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -33,6 +34,7 @@ type Config struct {
 	DrainTimeout           time.Duration
 	PIDFile                string
 	EncryptionKey          string
+	PluginsEnabled         bool
 }
 
 // Load reads configuration from environment variables, applies defaults for
@@ -61,6 +63,7 @@ func Load() (Config, error) {
 		DrainTimeout:           envDuration("GLEIPNIR_DRAIN_TIMEOUT", 5*time.Minute),
 		PIDFile:                envOrDefault("GLEIPNIR_PID_FILE", "/var/run/gleipnir.pid"),
 		EncryptionKey:          raw,
+		PluginsEnabled:         envBool("GLEIPNIR_PLUGINS_ENABLED", false),
 	}, nil
 }
 
@@ -125,4 +128,17 @@ func envLogLevel(key string, def slog.Level) slog.Level {
 		return def
 	}
 	return level
+}
+
+func envBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: invalid bool value %q for %s, using default %v\n", v, key, def)
+		return def
+	}
+	return b
 }

--- a/internal/infra/config/config_test.go
+++ b/internal/infra/config/config_test.go
@@ -27,6 +27,7 @@ func TestLoad_Defaults(t *testing.T) {
 		"GLEIPNIR_FEEDBACK_SCAN_INTERVAL",
 		"GLEIPNIR_DRAIN_TIMEOUT",
 		"GLEIPNIR_PID_FILE",
+		"GLEIPNIR_PLUGINS_ENABLED",
 	} {
 		t.Setenv(key, "")
 	}
@@ -75,6 +76,9 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if cfg.EncryptionKey != validKey {
 		t.Errorf("EncryptionKey: got %q, want %q", cfg.EncryptionKey, validKey)
+	}
+	if cfg.PluginsEnabled != false {
+		t.Errorf("PluginsEnabled: got %v, want false", cfg.PluginsEnabled)
 	}
 }
 
@@ -192,6 +196,15 @@ func TestLoad_Overrides(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "plugins enabled",
+			env:  map[string]string{"GLEIPNIR_PLUGINS_ENABLED": "true"},
+			check: func(t *testing.T, cfg Config) {
+				if !cfg.PluginsEnabled {
+					t.Errorf("got false, want true")
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -204,7 +217,7 @@ func TestLoad_Overrides(t *testing.T) {
 				"GLEIPNIR_HTTP_WRITE_TIMEOUT", "GLEIPNIR_HTTP_IDLE_TIMEOUT",
 				"GLEIPNIR_APPROVAL_SCAN_INTERVAL",
 				"GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT", "GLEIPNIR_FEEDBACK_SCAN_INTERVAL",
-				"GLEIPNIR_DRAIN_TIMEOUT", "GLEIPNIR_PID_FILE",
+				"GLEIPNIR_DRAIN_TIMEOUT", "GLEIPNIR_PID_FILE", "GLEIPNIR_PLUGINS_ENABLED",
 			} {
 				t.Setenv(key, "")
 			}
@@ -299,6 +312,35 @@ func TestLoad_InvalidDuration(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Errorf("%s: got %v, want %v", tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoad_PluginsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     bool
+	}{
+		{"unset falls back to false", "", false},
+		{"true enables", "true", true},
+		{"false disables", "false", false},
+		{"1 enables", "1", true},
+		{"0 disables", "0", false},
+		{"bogus falls back to false", "bogus", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GLEIPNIR_ENCRYPTION_KEY", validKey)
+			t.Setenv("GLEIPNIR_PLUGINS_ENABLED", tc.envValue)
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() unexpected error: %v", err)
+			}
+			if cfg.PluginsEnabled != tc.want {
+				t.Errorf("PluginsEnabled: got %v, want %v", cfg.PluginsEnabled, tc.want)
 			}
 		})
 	}

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -1,0 +1,30 @@
+// Package plugin is the host-side plugin loader. The real loader lands in
+// Phase 3 of the plugin system rollout (see docs/developer/plugin-system-spec.md).
+// For this release the package exists only so the GLEIPNIR_PLUGINS_ENABLED
+// flag has a concrete consumer; Init is a no-op when disabled and a logged
+// stub when enabled.
+package plugin
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/felag-engineering/gleipnir/internal/infra/config"
+)
+
+type Loader struct{}
+
+func NewLoader() *Loader { return &Loader{} }
+
+// Init wires up the plugin subsystem. It is a no-op stub today: when
+// cfg.PluginsEnabled is false it returns nil immediately; when true it logs
+// that the loader is enabled but does not actually discover or launch any
+// plugins. The Phase 3 loader PR replaces this with the real implementation.
+func (l *Loader) Init(ctx context.Context, cfg config.Config) error {
+	if !cfg.PluginsEnabled {
+		slog.Default().Debug("plugin loader disabled")
+		return nil
+	}
+	slog.Default().Info("plugin loader enabled (stub — real loader pending)")
+	return nil
+}

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -1,0 +1,39 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/infra/config"
+)
+
+func TestLoader_Init_Disabled(t *testing.T) {
+	l := NewLoader()
+	err := l.Init(context.Background(), config.Config{PluginsEnabled: false})
+	if err != nil {
+		t.Fatalf("Init() with PluginsEnabled=false: got error %v, want nil", err)
+	}
+}
+
+func TestLoader_Init_Enabled(t *testing.T) {
+	// Swap slog default with a buffer-backed handler to capture log output.
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	original := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(original) })
+
+	l := NewLoader()
+	err := l.Init(context.Background(), config.Config{PluginsEnabled: true})
+	if err != nil {
+		t.Fatalf("Init() with PluginsEnabled=true: got error %v, want nil", err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "plugin loader enabled") {
+		t.Errorf("expected log to contain %q, got: %s", "plugin loader enabled", logged)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
 	runpkg "github.com/felag-engineering/gleipnir/internal/execution/run"
+	pluginpkg "github.com/felag-engineering/gleipnir/internal/plugin"
 	"github.com/felag-engineering/gleipnir/internal/http/api"
 	"github.com/felag-engineering/gleipnir/internal/http/auth"
 	"github.com/felag-engineering/gleipnir/internal/http/sse"
@@ -63,6 +64,13 @@ func run(cfg config.Config) error {
 	// Root context cancelled on shutdown so background components (Scheduler) can stop.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Plugin loader is a stub today; Init is a no-op when GLEIPNIR_PLUGINS_ENABLED
+	// is false (the default for this release; spec §15.2). Init currently cannot
+	// fail — the error return is for the Phase 3 loader.
+	if err := pluginpkg.NewLoader().Init(ctx, cfg); err != nil {
+		return fmt.Errorf("init plugin loader: %w", err)
+	}
 
 	store, err := db.Open(cfg.DBPath)
 	if err != nil {


### PR DESCRIPTION
Closes #174

## Summary
Lands the feature flag that will gate the host-side plugin loader and admin UI. Off by default per spec §15.2 lifecycle (off in N → on in N+1 → removed in N+2).

- New `internal/plugin` stub package — `Loader.Init` is a no-op when disabled and a logged stub when enabled
- `Config.PluginsEnabled` wired via new `envBool` helper that mirrors the existing `envDuration`/`envLogLevel` warn-and-fallback pattern
- `main.go` calls `NewLoader().Init` early so a future Phase 3 loader can fail-fast before heavier infra spins up
- CLAUDE.md env var table + Key packages list updated
- .env.example documents the optional flag

## ACs satisfied vacuously
`/admin/plugins` 404, audience editor hidden, plugin-instance pickers empty — the surfaces don't exist yet. `/admin/plugins` is served via the SPA shell like every other unrecognized `/admin/*` path; React renders its not-found view. Adding a backend route for one frontend path would break the SPA-shell pattern, so none was added.

## Process
- 1 architect pass + 1 plan-reviewer cycle (added test env-clear discipline, fixed CLAUDE.md row position, documented the SPA-shell intent for the 404 AC)
- 1 implementation cycle, 1 code-review cycle (APPROVE)
- CLAUDE.md updated (env vars table + Key packages list)

🤖 Generated by the agentic dev loop