### PR TITLE
ci(lint): enforce /plugins/* import boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,17 @@ jobs:
       - name: Check for drift
         run: git diff --exit-code plugin-sdk/gen/
 
+  lint-plugins:
+    name: Plugin import boundary
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint /plugins/ imports
+        run: make lint-plugins
+      - name: Self-test (fixture must fail the lint)
+        run: make lint-plugins-self-test
+
   # Build and test the plugin-sdk module independently of the root module.
   # Uses GOWORK=off so the workspace does not bleed into this job; the
   # replace directive in go.mod is the only cross-module link needed here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing. The full contributor guide lives in the developer documentation:
 
-- **[Contributing guide](docs/developer/contributing.md)** — code style, package boundaries, ADR process, PR conventions.
+- **[Contributing guide](docs/developer/contributing.md)** — code style, package boundaries, plugin import boundary, ADR process, PR conventions.
 - **[Building from source](docs/developer/building.md)** — how to get a local dev environment running.
 - **[Architecture overview](docs/developer/architecture.md)** — how the pieces fit together.
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-.PHONY: help build test security security-go security-frontend proto
+.PHONY: help build test security security-go security-frontend proto lint-plugins lint-plugins-self-test
 
 help:
 	@echo "Targets:"
-	@echo "  build              go build ./..."
-	@echo "  test               go test -race ./..."
-	@echo "  security           run all security scans (govulncheck + npm audit)"
-	@echo "  security-go        govulncheck ./..."
-	@echo "  security-frontend  npm audit --omit=dev (in frontend/)"
-	@echo "  proto              regenerate plugin-sdk/gen/ from .proto sources (requires buf)"
+	@echo "  build                      go build ./..."
+	@echo "  test                       go test -race ./..."
+	@echo "  security                   run all security scans (govulncheck + npm audit)"
+	@echo "  security-go                govulncheck ./..."
+	@echo "  security-frontend          npm audit --omit=dev (in frontend/)"
+	@echo "  proto                      regenerate plugin-sdk/gen/ from .proto sources (requires buf)"
+	@echo "  lint-plugins               enforce /plugins/* import boundary"
+	@echo "  lint-plugins-self-test     prove the lint catches a deliberate violation"
 
 build:
 	go build ./...
@@ -29,3 +31,9 @@ security-frontend:
 # The proto-gen-drift CI job ensures checked-in stubs are never stale.
 proto:
 	buf generate
+
+lint-plugins:
+	./scripts/lint-plugins.sh
+
+lint-plugins-self-test:
+	./scripts/lint-plugins-self-test.sh

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -23,6 +23,32 @@ Package boundaries are intentional. `internal/mcp` must have no import dependenc
 
 See [`architecture.md`](architecture.md) for the full package layout.
 
+## Plugin import boundary
+
+Go files under `/plugins/` may only import:
+
+- The Go standard library
+- Third-party dependencies
+- `github.com/felag-engineering/gleipnir/plugin-sdk/...`
+
+Importing anything else under `github.com/felag-engineering/gleipnir/` (e.g. `internal/db`, `internal/execution/agent`) is a boundary violation. This rule ensures that when v1.0 GA ships the plugin repo split (per the plugin system spec §14.7), moving `/plugins/` to its own repository is a `git mv` rather than a refactor.
+
+**How to check locally:**
+
+```bash
+make lint-plugins
+```
+
+The rule is enforced by `scripts/lint-plugins.sh`. It scans `/plugins/` for import lines that reference host internals and exits non-zero on any match. If `/plugins/` does not yet exist the script exits 0 silently — this is expected today.
+
+**Self-test:**
+
+```bash
+make lint-plugins-self-test
+```
+
+This passes the deliberate-violation fixture at `tests/lint-fixtures/plugins-forbidden-import/` to the script and asserts that the script correctly rejects it. Both `lint-plugins` and `lint-plugins-self-test` run as PR-only CI jobs.
+
 ## ADRs
 
 Architectural decisions are tracked in [`ADR_Tracker.md`](ADR_Tracker.md). When you make an architectural decision:

--- a/scripts/lint-plugins-self-test.sh
+++ b/scripts/lint-plugins-self-test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Proves scripts/lint-plugins.sh fires on a deliberate boundary violation.
+set -uo pipefail
+
+fixture="tests/lint-fixtures/plugins-forbidden-import"
+set +e
+./scripts/lint-plugins.sh "$fixture" >/dev/null 2>&1
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ]; then
+    echo "self-test FAILED: lint did not catch the deliberate violation in $fixture" >&2
+    exit 1
+fi
+echo "self-test OK: lint correctly rejected the fixture (exit $rc)"

--- a/scripts/lint-plugins.sh
+++ b/scripts/lint-plugins.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reject any Go file under ROOT (default: plugins/) whose imports reference
+# the host module outside of /plugin-sdk/. Plugins under /plugins/ may only
+# import the Go stdlib, third-party deps, and github.com/felag-engineering/
+# gleipnir/plugin-sdk/...; anything else under github.com/felag-engineering/
+# gleipnir/ is a boundary violation (see ADR-041 / docs/developer/contributing.md).
+
+root="${1:-plugins}"
+
+# If the directory is missing or contains no Go files, the lint is a no-op.
+# This is the expected state until the first reference plugin lands (#173).
+if [ ! -d "$root" ]; then
+    exit 0
+fi
+files=$(find "$root" -type f -name '*.go' 2>/dev/null)
+if [ -z "$files" ]; then
+    exit 0
+fi
+
+# Tight regex: a real import path appears either inside a parenthesized
+# import block (line starts with whitespace + `"`) OR as a single-line
+# import (line starts with `import` + whitespace + `"`). Anchoring on
+# either form eliminates false positives from comments, string literals,
+# and trailing comments that mention the module path.
+offending=$(printf '%s\0' $files \
+    | xargs -0 grep -nHE '^([[:space:]]+|import[[:space:]]+)"github\.com/felag-engineering/gleipnir/' \
+    | grep -vE '"github\.com/felag-engineering/gleipnir/plugin-sdk/' \
+    || true)
+
+if [ -n "$offending" ]; then
+    echo "Plugin import boundary violation:" >&2
+    echo "  Files under $root/ may only import the Go stdlib, third-party" >&2
+    echo "  packages, and github.com/felag-engineering/gleipnir/plugin-sdk/..." >&2
+    echo "  See docs/developer/contributing.md → 'Plugin import boundary'." >&2
+    echo "" >&2
+    echo "$offending" >&2
+    exit 1
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# tests/
+
+This directory holds **linter test fixtures**, NOT Go tests. Go tests live
+alongside production code as `*_test.go` files per Go convention.
+
+Subdirectories under `tests/lint-fixtures/` deliberately violate one or more
+project lint rules so the lint scripts can be self-tested in CI.

--- a/tests/lint-fixtures/plugins-forbidden-import/README.md
+++ b/tests/lint-fixtures/plugins-forbidden-import/README.md
@@ -1,0 +1,5 @@
+# Plugin import boundary — lint fixture
+
+This directory exists solely as input for `scripts/lint-plugins-self-test.sh`.
+Do not add real code here. The Go file deliberately violates the /plugins/
+import boundary; the `//go:build never` tag prevents it from compiling.

--- a/tests/lint-fixtures/plugins-forbidden-import/forbidden_import.go
+++ b/tests/lint-fixtures/plugins-forbidden-import/forbidden_import.go
@@ -1,0 +1,9 @@
+//go:build never
+
+// Fixture for scripts/lint-plugins-self-test.sh — never compiled.
+// Intentionally imports a host internal package; the lint rule must reject this.
+package fixture
+
+import (
+	"github.com/felag-engineering/gleipnir/internal/db"
+)


### PR DESCRIPTION
Closes #175

## Summary
Shell-based lint (issue's option-1 recommendation) preventing any Go file under `/plugins/` from importing host internals. Single source of truth: `scripts/lint-plugins.sh` + `make lint-plugins` — runs identically in CI and locally.

## How it works
- `scripts/lint-plugins.sh [ROOT]` (default `plugins`): finds Go files, greps for import lines starting with `github.com/felag-engineering/gleipnir/`, excludes `/plugin-sdk/`. Empty/missing dir exits 0.
- `scripts/lint-plugins-self-test.sh`: runs the lint against the fixture and asserts non-zero exit — proves the rule fires.
- Fixture lives at `tests/lint-fixtures/plugins-forbidden-import/forbidden_import.go` with `//go:build never` so `go build ./...` ignores it.

## Regex catches both import forms
| Form | Caught? |
|---|---|
| Block import (whitespace + quote) | ✅ |
| Single-line import (`import "..."`) | ✅ |
| `/plugin-sdk/` import | ✅ allowed |
| Trailing comment mentioning the path | ✅ ignored |

## Rationale chosen
Option 1 (shell grep) over revive/analysis.Analyzer:
- Zero new infra to maintain
- Failure mode is obvious (offending lines printed verbatim)
- Upgradeable later if more cross-package rules accumulate

## Process
- 1 architect pass + 1 plan-reviewer cycle (script interface, regex tightening, empty-input safety, .PHONY discipline, help-column width)
- 1 implementation cycle + coordinator-applied regex fix for single-line imports (developer's fixture used block-import form which masked the gap)
- 1 code-review cycle (APPROVE)
- CLAUDE.md not updated (meta-tooling, not architecture)

🤖 Generated by the agentic dev loop