### PR TITLE
feat(execution/agent): add inAppChannel with Resolve + ErrUnknownRequestID

### DIFF
--- a/internal/execution/agent/channel.go
+++ b/internal/execution/agent/channel.go
@@ -4,13 +4,27 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
 	"github.com/felag-engineering/gleipnir/internal/model"
 )
+
+// ErrUnknownRequestID is returned by inAppChannel.Resolve when the given
+// request_id has no registered waiter. This is the precursor to the
+// plugin-system-spec §4.2 feedback_response_late hard-rejection rule; #179
+// surfaces this through SubmitFeedback.
+var ErrUnknownRequestID = errors.New("unknown request_id: no waiter registered")
+
+// inAppResponse wraps the operator's response text. The struct wrapper preserves
+// forward-compat for #179 (e.g. adding metadata without changing the channel type).
+type inAppResponse struct {
+	text string
+}
 
 // channel is the internal service contract that each feedback channel must
 // satisfy. It mirrors the plugin-spec §4.2 ChannelService surface so that
@@ -164,4 +178,165 @@ func (c *localFeedbackChannel) Request(ctx context.Context, req feedbackRequest)
 	case <-ctx.Done():
 		return "", fmt.Errorf("context cancelled waiting for feedback: %w", ctx.Err())
 	}
+}
+
+// inAppChannel is the new in-process feedback channel implementation. It stores
+// pending requests in a waiter map keyed by feedback_id and routes Resolve calls
+// back to the blocking Request call. It satisfies the channel interface and is a
+// sibling of localFeedbackChannel — the swap of localFeedbackChannel for
+// inAppChannel in NewFeedbackHandler lands atomically in #179.
+type inAppChannel struct {
+	audit   *AuditWriter
+	sm      *RunStateMachine
+	mu      sync.Mutex
+	waiters map[string]chan inAppResponse
+}
+
+// newInAppChannel constructs an inAppChannel. audit and sm must not be nil.
+func newInAppChannel(audit *AuditWriter, sm *RunStateMachine) *inAppChannel {
+	return &inAppChannel{
+		audit:   audit,
+		sm:      sm,
+		waiters: make(map[string]chan inAppResponse),
+	}
+}
+
+// Notify is a no-op for the in-app channel. In-app operators see the
+// feedback_request step directly in the UI; no separate notification is needed.
+func (c *inAppChannel) Notify(_ context.Context, _ notifyRequest) error {
+	return nil
+}
+
+// Request registers a waiter for req.FeedbackID, transitions the run to
+// waiting_for_feedback, then blocks until Resolve delivers a response, the
+// timeout fires, or the context is cancelled.
+//
+// The waiter is registered BEFORE the state transition so that any concurrent
+// Resolve call arriving immediately after the SSE event (which fires on transition)
+// is never lost — relevant once #179 wires SubmitFeedback to Resolve.
+func (c *inAppChannel) Request(ctx context.Context, req feedbackRequest) (string, error) {
+	// 1. Allocate the buffered channel first (cap 1 — Resolve never blocks).
+	ch := make(chan inAppResponse, 1)
+
+	// 2. Register BEFORE state transition so an immediate Resolve cannot miss us.
+	c.mu.Lock()
+	c.waiters[req.FeedbackID] = ch
+	c.mu.Unlock()
+
+	// 3. Deferred unregister: if we return for any reason (timeout, ctx cancel,
+	//    or after a successful response), remove the waiter entry so a late
+	//    Resolve gets ErrUnknownRequestID rather than sending to a leaked channel.
+	defer func() {
+		c.mu.Lock()
+		delete(c.waiters, req.FeedbackID)
+		c.mu.Unlock()
+	}()
+
+	// 4. Write the audit step.
+	if err := c.audit.Write(ctx, Step{
+		RunID: req.RunID,
+		Type:  model.StepTypeFeedbackRequest,
+		Content: map[string]any{
+			"feedback_id": req.FeedbackID,
+			"tool":        req.ToolName,
+			"message":     req.Message,
+			"expires_at":  req.ExpiresAt,
+		},
+	}); err != nil {
+		return "", fmt.Errorf("writing feedback_request step: %w", err)
+	}
+
+	// 5. Transition to waiting_for_feedback.
+	if err := c.sm.Transition(ctx, model.RunStatusWaitingForFeedback, "", WithFeedbackPayload(FeedbackPayload{
+		FeedbackID:    req.FeedbackID,
+		ToolName:      req.ToolName,
+		ProposedInput: req.ProposedInput,
+		Message:       req.Message,
+		ExpiresAt:     req.ExpiresAt,
+	})); err != nil {
+		return "", fmt.Errorf("transitioning run to waiting_for_feedback: %w", err)
+	}
+
+	// nil timeoutCh (when Timeout == 0) blocks forever in the select,
+	// meaning no in-process timeout is applied. Use NewTimer so we can Stop it
+	// on early response — time.After leaks until the duration fires.
+	var timeoutCh <-chan time.Time
+	if req.Timeout > 0 {
+		timer := time.NewTimer(req.Timeout)
+		defer timer.Stop()
+		timeoutCh = timer.C
+	}
+
+	// 6. Block until one of the three arms fires.
+	select {
+	case resp := <-ch:
+		if err := c.audit.Write(ctx, Step{
+			RunID:   req.RunID,
+			Type:    model.StepTypeFeedbackResponse,
+			Content: map[string]any{"feedback_id": req.FeedbackID, "response": resp.text},
+		}); err != nil {
+			return "", fmt.Errorf("writing feedback_response step: %w", err)
+		}
+		if err := c.sm.Transition(ctx, model.RunStatusRunning, ""); err != nil {
+			return "", fmt.Errorf("transitioning run back to running after feedback: %w", err)
+		}
+		return resp.text, nil
+	case <-timeoutCh:
+		logctx.Logger(ctx).WarnContext(ctx, "feedback timeout reached",
+			"tool", req.ToolName,
+			"timeout", req.Timeout.String())
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		// Race the scanner: only the first writer (rows==1) owns the error step.
+		// If the scanner already resolved it (rows==0), return a sentinel error so
+		// Run() still terminates, but skip logAuditError to avoid a duplicate step.
+		rows, dbErr := c.sm.Queries().UpdateFeedbackRequestStatus(
+			context.Background(),
+			db.UpdateFeedbackRequestStatusParams{
+				Status:     "timed_out",
+				Response:   nil,
+				ResolvedAt: &now,
+				ID:         req.FeedbackID,
+			},
+		)
+		if dbErr != nil {
+			logctx.Logger(ctx).WarnContext(ctx, "failed to update feedback status on timeout", "feedback_id", req.FeedbackID, "err", dbErr)
+		}
+		if rows == 1 {
+			err := fmt.Errorf("feedback timeout: operator did not respond within %s", req.Timeout)
+			logAuditError(ctx, c.audit, Step{
+				RunID:   req.RunID,
+				Type:    model.StepTypeError,
+				Content: model.ErrorStepContent{Message: err.Error(), Code: model.ErrorCodeFeedbackTimeout},
+			})
+			return "", err
+		}
+		// Scanner won the race: it already wrote the error step and transitioned
+		// the run. Return a sentinel so Run() knows to stop, but avoid a duplicate step.
+		logctx.Logger(ctx).DebugContext(ctx, "feedback already resolved by scanner", "feedback_id", req.FeedbackID)
+		return "", fmt.Errorf("feedback timeout: already resolved by scanner for tool %s", req.ToolName)
+	case <-ctx.Done():
+		return "", fmt.Errorf("context cancelled waiting for feedback: %w", ctx.Err())
+	}
+}
+
+// Resolve delivers a response to the waiter registered for requestID.
+//
+// The ch <- send is intentionally OUTSIDE the lock. ch is buffered (cap 1) and
+// has a single reader (Request's select), so the send never blocks. Moving the
+// send inside the lock would serialize all Resolve calls and risk deadlock if a
+// future change makes the channel unbuffered. Do not "optimize" by hoisting the
+// send into the lock.
+func (c *inAppChannel) Resolve(requestID, body string) error {
+	c.mu.Lock()
+	ch, ok := c.waiters[requestID]
+	if ok {
+		delete(c.waiters, requestID)
+	}
+	c.mu.Unlock()
+
+	if !ok {
+		return ErrUnknownRequestID
+	}
+	ch <- inAppResponse{text: body}
+	return nil
 }

--- a/internal/execution/agent/channel_test.go
+++ b/internal/execution/agent/channel_test.go
@@ -1,0 +1,322 @@
+// Package agent — channel_test.go covers inAppChannel in isolation.
+// Tests construct inAppChannel directly via newInAppChannel (bypassing
+// FeedbackHandler) so they cannot regress the production path.
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+)
+
+// newInAppChannelForTest is a helper that seeds a DB with a policy and run,
+// then returns a ready-to-use inAppChannel together with the store and
+// AuditWriter so individual tests can inspect the audit trail.
+func newInAppChannelForTest(t *testing.T, runID string) (*inAppChannel, *db.Store, *AuditWriter) {
+	t.Helper()
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, runID, "p1", model.RunStatusRunning)
+
+	pub := &capturePublisher{}
+	sm := NewRunStateMachine(runID, model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
+	w := NewAuditWriter(s.Queries())
+	t.Cleanup(func() { w.Close() }) //nolint:errcheck
+
+	ch := newInAppChannel(w, sm)
+	return ch, s, w
+}
+
+// TestInAppChannel_Resolve_DeliversToWaiter verifies the happy path: a goroutine
+// calls Request, the waiter appears in the DB, Resolve delivers the response, and
+// the run transitions back to running with both audit steps present.
+func TestInAppChannel_Resolve_DeliversToWaiter(t *testing.T) {
+	const runID = "run1"
+	inApp, s, w := newInAppChannelForTest(t, runID)
+
+	type result struct {
+		text string
+		err  error
+	}
+	done := make(chan result, 1)
+
+	go func() {
+		text, err := inApp.Request(context.Background(), feedbackRequest{
+			RunID:      runID,
+			FeedbackID: "fb-1",
+			ToolName:   AskOperatorToolName,
+			Message:    "please answer",
+			Timeout:    2 * time.Second,
+		})
+		done <- result{text, err}
+	}()
+
+	// Poll until the feedback row appears in the DB (mirrors feedback_test.go lines 145-158).
+	deadline := time.Now().Add(2 * time.Second)
+	var feedbackID string
+	for time.Now().Before(deadline) {
+		rows, err := s.GetPendingFeedbackRequestsByRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetPendingFeedbackRequestsByRun: %v", err)
+		}
+		if len(rows) > 0 {
+			feedbackID = rows[0].ID
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if feedbackID == "" {
+		t.Fatal("timed out waiting for feedback row to appear in DB")
+	}
+
+	if err := inApp.Resolve(feedbackID, "operator response"); err != nil {
+		t.Fatalf("Resolve: unexpected error: %v", err)
+	}
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("Request: unexpected error: %v", res.err)
+		}
+		if res.text != "operator response" {
+			t.Errorf("response = %q, want %q", res.text, "operator response")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Request did not return within 2s")
+	}
+
+	// Flush writer and verify both audit steps exist.
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: runID, After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	var hasFeedbackRequest, hasFeedbackResponse bool
+	for _, step := range steps {
+		switch step.Type {
+		case string(model.StepTypeFeedbackRequest):
+			hasFeedbackRequest = true
+		case string(model.StepTypeFeedbackResponse):
+			hasFeedbackResponse = true
+		}
+	}
+	if !hasFeedbackRequest {
+		t.Error("expected feedback_request step in audit trail")
+	}
+	if !hasFeedbackResponse {
+		t.Error("expected feedback_response step in audit trail")
+	}
+}
+
+// TestInAppChannel_Resolve_UnknownRequestID verifies that Resolve on a fresh
+// channel with no registered waiter returns ErrUnknownRequestID.
+func TestInAppChannel_Resolve_UnknownRequestID(t *testing.T) {
+	inApp, _, _ := newInAppChannelForTest(t, "run1")
+
+	err := inApp.Resolve("nonexistent-id", "body")
+	if !errors.Is(err, ErrUnknownRequestID) {
+		t.Errorf("Resolve = %v, want ErrUnknownRequestID", err)
+	}
+}
+
+// TestInAppChannel_Resolve_AfterTimeout_ReturnsUnknown verifies that once a
+// Request returns due to timeout the deferred unregister has already run, so a
+// subsequent Resolve call yields ErrUnknownRequestID.
+func TestInAppChannel_Resolve_AfterTimeout_ReturnsUnknown(t *testing.T) {
+	const runID = "run1"
+	inApp, _, _ := newInAppChannelForTest(t, runID)
+
+	// 20ms timeout — short enough to make the test fast, long enough to be reliable.
+	_, _ = inApp.Request(context.Background(), feedbackRequest{
+		RunID:      runID,
+		FeedbackID: "fb-timeout",
+		ToolName:   AskOperatorToolName,
+		Message:    "please answer",
+		Timeout:    20 * time.Millisecond,
+	})
+	// Request has returned — deferred delete must have run by now.
+
+	err := inApp.Resolve("fb-timeout", "late response")
+	if !errors.Is(err, ErrUnknownRequestID) {
+		t.Errorf("Resolve after timeout = %v, want ErrUnknownRequestID", err)
+	}
+}
+
+// TestInAppChannel_Resolve_DoubleCall verifies that the first Resolve returns nil
+// and the second returns ErrUnknownRequestID (delete-under-lock prevents double
+// delivery).
+func TestInAppChannel_Resolve_DoubleCall(t *testing.T) {
+	const runID = "run1"
+	inApp, s, _ := newInAppChannelForTest(t, runID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := inApp.Request(context.Background(), feedbackRequest{
+			RunID:      runID,
+			FeedbackID: "fb-double",
+			ToolName:   AskOperatorToolName,
+			Message:    "please answer",
+			Timeout:    2 * time.Second,
+		})
+		done <- err
+	}()
+
+	// Wait for the feedback row (mirrors feedback_test.go lines 145-158).
+	deadline := time.Now().Add(2 * time.Second)
+	var feedbackID string
+	for time.Now().Before(deadline) {
+		rows, err := s.GetPendingFeedbackRequestsByRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetPendingFeedbackRequestsByRun: %v", err)
+		}
+		if len(rows) > 0 {
+			feedbackID = rows[0].ID
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if feedbackID == "" {
+		t.Fatal("timed out waiting for feedback row to appear in DB")
+	}
+
+	if err := inApp.Resolve(feedbackID, "first"); err != nil {
+		t.Fatalf("first Resolve: unexpected error: %v", err)
+	}
+
+	// Drain the goroutine.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Request did not return within 2s after first Resolve")
+	}
+
+	err := inApp.Resolve(feedbackID, "second")
+	if !errors.Is(err, ErrUnknownRequestID) {
+		t.Errorf("second Resolve = %v, want ErrUnknownRequestID", err)
+	}
+}
+
+// TestInAppChannel_Resolve_Concurrent launches 50 concurrent Request goroutines
+// each with a unique feedback_id, then resolves all 50 from 50 concurrent Resolve
+// goroutines. All responses must be delivered correctly and the waiter map must be
+// empty afterwards. The test is -race clean.
+func TestInAppChannel_Resolve_Concurrent(t *testing.T) {
+	const N = 50
+	s := testutil.NewTestStore(t)
+
+	// Seed a policy + N runs, each needing its own run/state-machine because
+	// RunStateMachine is bound to a single runID.
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+
+	type entry struct {
+		inApp      *inAppChannel
+		feedbackID string
+		done       chan error
+	}
+
+	entries := make([]entry, N)
+	for i := 0; i < N; i++ {
+		runID := fmt.Sprintf("run-%d", i)
+		testutil.InsertRun(t, s, runID, "p1", model.RunStatusRunning)
+
+		pub := &capturePublisher{}
+		sm := NewRunStateMachine(runID, model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
+		w := NewAuditWriter(s.Queries())
+		t.Cleanup(func() { w.Close() }) //nolint:errcheck
+
+		fbID := fmt.Sprintf("fb-%d", i)
+		entries[i] = entry{
+			inApp:      newInAppChannel(w, sm),
+			feedbackID: fbID,
+			done:       make(chan error, 1),
+		}
+	}
+
+	// Launch all Request goroutines.
+	var startWg sync.WaitGroup
+	startWg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		e := entries[i]
+		runID := fmt.Sprintf("run-%d", i)
+		go func() {
+			startWg.Done()
+			_, err := e.inApp.Request(context.Background(), feedbackRequest{
+				RunID:      runID,
+				FeedbackID: e.feedbackID,
+				ToolName:   AskOperatorToolName,
+				Message:    "concurrent request",
+				Timeout:    5 * time.Second,
+			})
+			e.done <- err
+		}()
+	}
+	startWg.Wait()
+
+	// Wait for all waiters to appear in the waiter map before resolving.
+	// Poll each inAppChannel until its waiter is registered.
+	deadline := time.Now().Add(2 * time.Second)
+	for i := 0; i < N; i++ {
+		e := entries[i]
+		for time.Now().Before(deadline) {
+			e.inApp.mu.Lock()
+			_, registered := e.inApp.waiters[e.feedbackID]
+			e.inApp.mu.Unlock()
+			if registered {
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// Resolve all 50 from 50 concurrent goroutines.
+	var resolveWg sync.WaitGroup
+	resolveWg.Add(N)
+	resolveErrs := make([]error, N)
+	for i := 0; i < N; i++ {
+		i := i
+		e := entries[i]
+		go func() {
+			defer resolveWg.Done()
+			resolveErrs[i] = e.inApp.Resolve(e.feedbackID, fmt.Sprintf("response-%d", i))
+		}()
+	}
+	resolveWg.Wait()
+
+	for i, err := range resolveErrs {
+		if err != nil {
+			t.Errorf("Resolve[%d]: unexpected error: %v", i, err)
+		}
+	}
+
+	// Collect all Request results.
+	for i, e := range entries {
+		select {
+		case err := <-e.done:
+			if err != nil {
+				t.Errorf("Request[%d]: unexpected error: %v", i, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("Request[%d] did not return within 5s", i)
+		}
+	}
+
+	// All waiter maps must be empty after delivery.
+	for i, e := range entries {
+		e.inApp.mu.Lock()
+		remaining := len(e.inApp.waiters)
+		e.inApp.mu.Unlock()
+		if remaining != 0 {
+			t.Errorf("inApp[%d].waiters has %d entries, want 0", i, remaining)
+		}
+	}
+}


### PR DESCRIPTION
Closes #178

## Summary
Additive PR. Introduces `inAppChannel` as a sibling of `localFeedbackChannel` (the verbatim hoist from #177) with:
- A per-request waiter map keyed by `request_id`
- `Resolve(requestID, body) error` returning `ErrUnknownRequestID` on miss (precursor to plugin-system-spec §4.2 / ADR-044 `feedback_response_late`)
- Notify is a no-op for the in-app channel (intentional — fan-out is a future concern)
- Register-before-transition ordering so a future Resolve cannot race the SSE-fired operator response

**Production path untouched.** `NewFeedbackHandler` still wires `localFeedbackChannel`. The atomic swap — together with routing `runsHandler.SubmitFeedback` through `inAppChannel.Resolve` — lands in #179. This is by design, per the revised plan (Option A).

## Lock discipline
Documented inline on `Resolve`: buffered size-1 per-waiter channel + delete-under-lock + send-outside-lock. Hoisting the send into the critical section would serialize Resolve calls and risk deadlock if the channel ever becomes unbuffered. Future readers, do not 'optimize' this.

## Acceptance criteria
- [x] inAppChannel struct implements the channel interface
- [x] Notify is a no-op (in-app == request-only today)
- [x] Request allocates request_id, stores waiter, returns synchronously
- [x] Resolve matches an existing waiter or returns ErrUnknownRequestID
- [x] Concurrent-safe; -race clean (50x50 fan-in test)

## Pipeline
- Triage: well-specified
- Architect → plan-reviewer: REVISE on first pass (caught a production-regression risk: swapping the dispatcher impl without #179's SubmitFeedback wiring would hang every feedback request). Revised to Option A (purely additive). Plan-reviewer would now APPROVE.
- Code-review cycles: 1 (APPROVE)
- CLAUDE.md: no updates needed
- Tests: \`go test -race ./internal/execution/agent/...\` green; \`go vet\` / \`go build\` clean
- Known informational diagnostic: \`newInAppChannel\` is reported unused in production code — expected dead-code-by-design until #179 wires it

🤖 Generated with the agentic dev loop