### PR TITLE
feat(plugin): fsnotify watcher + tarball install pipeline (#187)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ npm run storybook        # Storybook on port 6006
 | `GLEIPNIR_DEFAULT_PROVIDER` | `anthropic` | Default LLM provider |
 | `GLEIPNIR_PLUGINS_ENABLED` | `false` | Enable the host-side plugin loader (off by default this release; see docs/developer/plugin-system-spec.md §15.2). |
 | `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS` | `false` | When `true`, the loader accepts plugins lacking a Minisign `.minisig`/`signing.pub` pair (instance health = `unsigned_permissive`). Every load emits a high-severity audit event; admin UI shows a non-dismissible red banner; `/api/v1/health` reports `signature_verification: disabled`. **Signed plugins are still fully verified even in permissive mode.** Scope is global, not per-plugin. Read once at startup. See ADR-045 §6. |
+| `GLEIPNIR_PLUGINS_DIR` | `/plugins` | Directory watched by the fsnotify watcher for plugin tarballs (`.tar.gz`/`.tgz`). Only consulted when `GLEIPNIR_PLUGINS_ENABLED=true`. |
 | `GLEIPNIR_ENCRYPTION_KEY` | *(required)* | 64-char hex key (32-byte AES-256) for encrypting provider API keys and webhook secrets; generate with `openssl rand -hex 32` |
 
 **Provider API keys:** All LLM provider API keys (Anthropic, Google, OpenAI, and any OpenAI-compatible backends) are configured through the admin UI at `/admin/models` and stored encrypted in the database. Env vars like `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY` / `OPENAI_API_KEY` are intentionally ignored — a startup warning is logged if they are set.
@@ -136,7 +137,7 @@ internal/
     openaicompat/     — OpenAI-compatible provider loader (bootstraps third-party OpenAI-compatible backends)
   mcp/                — MCP HTTP client, tool registry, capability tags
   model/              — domain types (Policy, Run, RunStep, ApprovalRequest, enums, ...)
-  plugin/             — host-side plugin loader (stub; gated by GLEIPNIR_PLUGINS_ENABLED. Real loader lands in Phase 3 of the plugin system rollout — see docs/developer/plugin-system-spec.md)
+  plugin/             — host-side plugin loader; gated by GLEIPNIR_PLUGINS_ENABLED. Implements fsnotify watcher, tarball extractor, minisign verifier, and DB installer. Out-of-process subprocess spawning and generation refcounts remain as follow-up work.
   policy/             — YAML parser, validator, system prompt renderer
   settings/           — read-side accessor for system_settings (default model, public URL); injected into runtime so non-admin packages don't depend on the admin HTTP handler
   testutil/           — shared test helpers

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.9
 require (
 	github.com/anthropics/anthropic-sdk-go v1.37.0
 	github.com/felag-engineering/gleipnir/plugin-sdk v0.0.0-00010101000000-000000000000
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/uuid v1.6.0
 	github.com/ohler55/ojg v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/internal/infra/config/config.go
+++ b/internal/infra/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	EncryptionKey          string
 	PluginsEnabled         bool
 	AllowUnsignedPlugins   bool
+	PluginsDir             string
 }
 
 // Load reads configuration from environment variables, applies defaults for
@@ -66,6 +67,7 @@ func Load() (Config, error) {
 		EncryptionKey:          raw,
 		PluginsEnabled:         envBool("GLEIPNIR_PLUGINS_ENABLED", false),
 		AllowUnsignedPlugins:   envBool("GLEIPNIR_ALLOW_UNSIGNED_PLUGINS", false),
+		PluginsDir:             envOrDefault("GLEIPNIR_PLUGINS_DIR", "/plugins"),
 	}, nil
 }
 

--- a/internal/infra/config/config_test.go
+++ b/internal/infra/config/config_test.go
@@ -29,6 +29,7 @@ func TestLoad_Defaults(t *testing.T) {
 		"GLEIPNIR_PID_FILE",
 		"GLEIPNIR_PLUGINS_ENABLED",
 		"GLEIPNIR_ALLOW_UNSIGNED_PLUGINS",
+		"GLEIPNIR_PLUGINS_DIR",
 	} {
 		t.Setenv(key, "")
 	}
@@ -83,6 +84,9 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if cfg.AllowUnsignedPlugins != false {
 		t.Errorf("AllowUnsignedPlugins: got %v, want false", cfg.AllowUnsignedPlugins)
+	}
+	if cfg.PluginsDir != "/plugins" {
+		t.Errorf("PluginsDir: got %q, want /plugins", cfg.PluginsDir)
 	}
 }
 
@@ -209,6 +213,15 @@ func TestLoad_Overrides(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "plugins dir override",
+			env:  map[string]string{"GLEIPNIR_PLUGINS_DIR": "/mnt/plugins"},
+			check: func(t *testing.T, cfg Config) {
+				if cfg.PluginsDir != "/mnt/plugins" {
+					t.Errorf("got %q, want /mnt/plugins", cfg.PluginsDir)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -222,7 +235,7 @@ func TestLoad_Overrides(t *testing.T) {
 				"GLEIPNIR_APPROVAL_SCAN_INTERVAL",
 				"GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT", "GLEIPNIR_FEEDBACK_SCAN_INTERVAL",
 				"GLEIPNIR_DRAIN_TIMEOUT", "GLEIPNIR_PID_FILE", "GLEIPNIR_PLUGINS_ENABLED",
-				"GLEIPNIR_ALLOW_UNSIGNED_PLUGINS",
+				"GLEIPNIR_ALLOW_UNSIGNED_PLUGINS", "GLEIPNIR_PLUGINS_DIR",
 			} {
 				t.Setenv(key, "")
 			}

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/infra/config"
+	"github.com/felag-engineering/gleipnir/internal/plugin/loader"
 )
 
 // Loader owns plugin-subsystem initialization. It is the host's entry point
@@ -26,6 +28,7 @@ import (
 // through it (or through types it constructs).
 type Loader struct {
 	verifier *Verifier
+	watcher  *loader.Watcher
 }
 
 func NewLoader() *Loader { return &Loader{} }
@@ -61,4 +64,54 @@ func (l *Loader) Init(_ context.Context, cfg config.Config) error {
 		slog.Default().Info("plugin loader enabled (signature verification active)")
 	}
 	return nil
+}
+
+// StartWatcher wires the fsnotify watcher for the given plugins directory and
+// starts it in a goroutine. It returns immediately; the watcher logs its own
+// exit. q must be non-nil; dir is the watch path (typically cfg.PluginsDir).
+//
+// StartWatcher must be called after Init and after store.Migrate so the DB
+// schema is ready for plugin rows and audit events. It is a no-op when Init
+// was not called (i.e. when GLEIPNIR_PLUGINS_ENABLED=false) — l.verifier will
+// be nil in that case and we return early.
+func (l *Loader) StartWatcher(ctx context.Context, q *db.Queries, dir string) {
+	if l.verifier == nil {
+		return
+	}
+
+	inst := loader.NewInstaller(&verifierAdapter{v: l.verifier}, q)
+	l.watcher = loader.NewWatcher(dir, inst.Install)
+
+	go func() {
+		if err := l.watcher.Run(ctx); err != nil && err != ctx.Err() {
+			slog.Default().Error("plugin watcher exited with error", "dir", dir, "err", err)
+		} else {
+			slog.Default().Debug("plugin watcher stopped", "dir", dir)
+		}
+	}()
+}
+
+// verifierAdapter bridges *Verifier (returns plugin.VerifyResult) to
+// loader.BundleVerifier (returns loader.VerifyResult). The explicit switch
+// insulates callers from any future iota reordering in either type.
+type verifierAdapter struct{ v *Verifier }
+
+func (a *verifierAdapter) VerifyBundle(bundleDir, binaryPath string) loader.VerifyResult {
+	r := a.v.VerifyBundle(bundleDir, binaryPath)
+
+	var outcome loader.VerifyOutcome
+	switch r.Outcome {
+	case OutcomeVerified:
+		outcome = loader.OutcomeVerified
+	case OutcomeUnsignedPermissive:
+		outcome = loader.OutcomeUnsignedPermissive
+	default: // OutcomeRejected or any future value
+		outcome = loader.OutcomeRejected
+	}
+
+	return loader.VerifyResult{
+		Outcome: outcome,
+		Pubkey:  r.Pubkey,
+		Err:     r.Err,
+	}
 }

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -8,10 +8,9 @@
 //     GLEIPNIR_ALLOW_UNSIGNED_PLUGINS toggle and logs a permissive-mode banner
 //     if applicable. The verifier itself (verify.go) is fully wired into
 //     plugin-sdk/signing — single source of truth for the Minisign format.
-//
-// The fsnotify watcher (#187), material-change detection (#189), and the
-// generation manager (#190-impl, #193-impl) land in follow-up PRs and consume
-// the Verifier built here.
+//   - StartWatcher (#187, this PR) sets up the fsnotify watcher and runs the
+//     debounced install loop. Material-change detection (#189) and the
+//     generation/shutdown manager (#190/#193 implementations) are follow-up PRs.
 package plugin
 
 import (
@@ -67,28 +66,40 @@ func (l *Loader) Init(_ context.Context, cfg config.Config) error {
 }
 
 // StartWatcher wires the fsnotify watcher for the given plugins directory and
-// starts it in a goroutine. It returns immediately; the watcher logs its own
-// exit. q must be non-nil; dir is the watch path (typically cfg.PluginsDir).
+// starts the event loop in a goroutine. q must be non-nil; dir is the watch
+// path (typically cfg.PluginsDir).
+//
+// The pre-flight — creating the watch directory and registering it with
+// fsnotify — runs synchronously before spawning any goroutine. If pre-flight
+// fails, StartWatcher returns an error so main.go can treat it as fatal,
+// matching the pattern used by other subsystem starts (scheduler, poller,
+// cronRunner).
 //
 // StartWatcher must be called after Init and after store.Migrate so the DB
-// schema is ready for plugin rows and audit events. It is a no-op when Init
-// was not called (i.e. when GLEIPNIR_PLUGINS_ENABLED=false) — l.verifier will
-// be nil in that case and we return early.
-func (l *Loader) StartWatcher(ctx context.Context, q *db.Queries, dir string) {
+// schema is ready for plugin rows and audit events. It is a no-op (returns nil)
+// when Init was not called (i.e. when GLEIPNIR_PLUGINS_ENABLED=false) —
+// l.verifier will be nil in that case and we return early.
+func (l *Loader) StartWatcher(ctx context.Context, q *db.Queries, dir string) error {
 	if l.verifier == nil {
-		return
+		return nil
 	}
 
 	inst := loader.NewInstaller(&verifierAdapter{v: l.verifier}, q)
 	l.watcher = loader.NewWatcher(dir, inst.Install)
 
+	fw, err := l.watcher.Setup()
+	if err != nil {
+		return err
+	}
+
 	go func() {
-		if err := l.watcher.Run(ctx); err != nil && err != ctx.Err() {
+		if err := l.watcher.Run(ctx, fw); err != nil && err != ctx.Err() {
 			slog.Default().Error("plugin watcher exited with error", "dir", dir, "err", err)
 		} else {
 			slog.Default().Debug("plugin watcher stopped", "dir", dir)
 		}
 	}()
+	return nil
 }
 
 // verifierAdapter bridges *Verifier (returns plugin.VerifyResult) to

--- a/internal/plugin/loader/extract.go
+++ b/internal/plugin/loader/extract.go
@@ -1,0 +1,150 @@
+// Package loader implements the plugin install pipeline: a debounced fsnotify
+// watcher dispatches tarballs through extract → verify → snapshot-into-DB.
+package loader
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExtractTarball extracts a gzip-compressed tarball at tarPath into destDir.
+//
+// Safety guarantees enforced on every entry:
+//   - No path traversal: entries with ".." segments or absolute paths are rejected.
+//   - Only regular files and directories are accepted; symlinks, hard links,
+//     devices, and FIFOs are rejected to prevent privilege escalation.
+//   - Cumulative uncompressed bytes across all entries must not exceed maxBytes.
+//     This defends against gzip-bomb payloads (see plan §100MB cap note).
+//   - File mode is 0755 if the executable bit is set, otherwise 0644.
+func ExtractTarball(tarPath, destDir string, maxBytes int64) error {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return fmt.Errorf("open tarball: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var totalBytes int64
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar entry: %w", err)
+		}
+
+		if err := validateTarEntry(hdr, destDir); err != nil {
+			return fmt.Errorf("unsafe tar entry %q: %w", hdr.Name, err)
+		}
+
+		target := filepath.Join(destDir, filepath.FromSlash(hdr.Name))
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("create directory %q: %w", hdr.Name, err)
+			}
+
+		case tar.TypeReg:
+			// Ensure parent directories exist (some tarballs omit explicit dir entries).
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create parent dirs for %q: %w", hdr.Name, err)
+			}
+
+			remaining := maxBytes - totalBytes
+			// +1 so that an entry exactly at the cap fails with the right error.
+			written, writeErr := writeFile(target, tr, remaining+1, fileMode(hdr.Mode))
+			totalBytes += written
+			if writeErr != nil {
+				return writeErr
+			}
+			if totalBytes > maxBytes {
+				return fmt.Errorf("tarball exceeds %d-byte uncompressed size cap", maxBytes)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateTarEntry rejects entries that would escape destDir or use unsafe types.
+func validateTarEntry(hdr *tar.Header, destDir string) error {
+	name := filepath.FromSlash(hdr.Name)
+
+	if filepath.IsAbs(name) {
+		return errors.New("absolute path")
+	}
+
+	// filepath.Clean removes ".." but we want to detect it explicitly.
+	for _, part := range strings.Split(hdr.Name, "/") {
+		if part == ".." {
+			return errors.New("path traversal via ..")
+		}
+	}
+
+	// Confirm the resolved path is still inside destDir.
+	resolved := filepath.Join(destDir, name)
+	rel, err := filepath.Rel(destDir, resolved)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return errors.New("path escapes destination directory")
+	}
+
+	switch hdr.Typeflag {
+	case tar.TypeReg, tar.TypeDir:
+		// Allowed.
+	default:
+		return fmt.Errorf("unsupported entry type %d (only regular files and directories allowed)", hdr.Typeflag)
+	}
+
+	return nil
+}
+
+// fileMode returns 0755 when the Unix executable bit is set, otherwise 0644.
+func fileMode(mode int64) os.FileMode {
+	if mode&0o111 != 0 {
+		return 0o755
+	}
+	return 0o644
+}
+
+// writeFile copies at most limitBytes from src into a new file at path.
+// It returns the number of bytes written and any error. If the reader contains
+// more than limitBytes the write is interrupted and an error is returned.
+func writeFile(path string, src io.Reader, limitBytes int64, mode os.FileMode) (int64, error) {
+	out, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return 0, fmt.Errorf("create file %q: %w", path, err)
+	}
+	defer out.Close()
+
+	n, err := io.CopyN(out, src, limitBytes)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return n, fmt.Errorf("write file %q: %w", path, err)
+	}
+
+	// If CopyN stopped because it hit limitBytes without EOF, the entry is too large.
+	if n == limitBytes {
+		// Check if there's more data in the stream.
+		buf := make([]byte, 1)
+		extra, _ := src.Read(buf)
+		if extra > 0 {
+			return n, fmt.Errorf("single entry exceeds size cap")
+		}
+	}
+
+	return n, nil
+}

--- a/internal/plugin/loader/extract_test.go
+++ b/internal/plugin/loader/extract_test.go
@@ -1,0 +1,186 @@
+package loader
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeTarball builds an in-memory .tar.gz from the provided entries and writes
+// it to a temp file, returning the file path. Each entry is (name, content,
+// typeflag, mode). An empty typeflag defaults to tar.TypeReg.
+func makeTarball(t *testing.T, entries []tarEntry) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for _, e := range entries {
+		typeflag := e.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: typeflag,
+			Mode:     e.mode,
+			Size:     int64(len(e.content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write tar header %q: %v", e.name, err)
+		}
+		if len(e.content) > 0 {
+			if _, err := tw.Write(e.content); err != nil {
+				t.Fatalf("write tar body %q: %v", e.name, err)
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+
+	tmp := filepath.Join(t.TempDir(), "test.tar.gz")
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+	return tmp
+}
+
+type tarEntry struct {
+	name     string
+	content  []byte
+	typeflag byte
+	mode     int64
+}
+
+func TestExtractTarball_HappyPath(t *testing.T) {
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "manifest.yaml", content: []byte("name: test-plugin\n"), mode: 0o644},
+		{name: "plugin-bin", content: []byte("binary content"), mode: 0o755},
+	})
+
+	destDir := t.TempDir()
+	if err := ExtractTarball(tarPath, destDir, 100<<20); err != nil {
+		t.Fatalf("ExtractTarball: %v", err)
+	}
+
+	// Both files must be present.
+	for _, name := range []string{"manifest.yaml", "plugin-bin"} {
+		if _, err := os.Stat(filepath.Join(destDir, name)); err != nil {
+			t.Errorf("expected %q to exist after extraction: %v", name, err)
+		}
+	}
+
+	// Executable bit preserved.
+	info, err := os.Stat(filepath.Join(destDir, "plugin-bin"))
+	if err != nil {
+		t.Fatalf("stat plugin-bin: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("plugin-bin: mode %v, want executable bit set", info.Mode())
+	}
+}
+
+func TestExtractTarball_AbsolutePathRejected(t *testing.T) {
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "/etc/passwd", content: []byte("should not land here"), mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, t.TempDir(), 100<<20)
+	if err == nil {
+		t.Fatal("expected error for absolute path, got nil")
+	}
+}
+
+func TestExtractTarball_PathTraversalRejected(t *testing.T) {
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "../escape.txt", content: []byte("escaped"), mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, t.TempDir(), 100<<20)
+	if err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+}
+
+func TestExtractTarball_NestedTraversalRejected(t *testing.T) {
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "subdir/../../escape.txt", content: []byte("escaped"), mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, t.TempDir(), 100<<20)
+	if err == nil {
+		t.Fatal("expected error for nested path traversal, got nil")
+	}
+}
+
+func TestExtractTarball_SymlinkRejected(t *testing.T) {
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "link", content: nil, typeflag: tar.TypeSymlink, mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, t.TempDir(), 100<<20)
+	if err == nil {
+		t.Fatal("expected error for symlink entry, got nil")
+	}
+}
+
+func TestExtractTarball_HardLinkRejected(t *testing.T) {
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "hardlink", content: nil, typeflag: tar.TypeLink, mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, t.TempDir(), 100<<20)
+	if err == nil {
+		t.Fatal("expected error for hard link entry, got nil")
+	}
+}
+
+func TestExtractTarball_OversizedTotalRejected(t *testing.T) {
+	// Two 6-byte files; cap at 10 bytes total.
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "a.bin", content: []byte("AAAAAA"), mode: 0o644},
+		{name: "b.bin", content: []byte("BBBBBB"), mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, t.TempDir(), 10)
+	if err == nil {
+		t.Fatal("expected error for oversized total payload, got nil")
+	}
+}
+
+func TestExtractTarball_OversizedSingleEntryRejected(t *testing.T) {
+	// One 20-byte file; cap at 10 bytes total.
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "big.bin", content: bytes.Repeat([]byte("X"), 20), mode: 0o644},
+	})
+
+	err := ExtractTarball(tarPath, t.TempDir(), 10)
+	if err == nil {
+		t.Fatal("expected error for single oversized entry, got nil")
+	}
+}
+
+func TestExtractTarball_SubdirectoryCreated(t *testing.T) {
+	tarPath := makeTarball(t, []tarEntry{
+		{name: "subdir/", content: nil, typeflag: tar.TypeDir, mode: 0o755},
+		{name: "subdir/file.txt", content: []byte("hello"), mode: 0o644},
+	})
+
+	destDir := t.TempDir()
+	if err := ExtractTarball(tarPath, destDir, 100<<20); err != nil {
+		t.Fatalf("ExtractTarball: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, "subdir", "file.txt")); err != nil {
+		t.Errorf("expected subdir/file.txt to exist: %v", err)
+	}
+}

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
@@ -19,9 +20,9 @@ import (
 type VerifyOutcome int
 
 const (
-	OutcomeVerified          VerifyOutcome = iota // bundle signed and valid
-	OutcomeUnsignedPermissive                     // unsigned but host allows it
-	OutcomeRejected                               // verification failed
+	OutcomeVerified           VerifyOutcome = iota // bundle signed and valid
+	OutcomeUnsignedPermissive                      // unsigned but host allows it
+	OutcomeRejected                                // verification failed
 )
 
 func (o VerifyOutcome) String() string {
@@ -48,6 +49,11 @@ type VerifyResult struct {
 // internal/plugin.Verifier satisfies this interface; using an interface here
 // avoids the import cycle between internal/plugin and internal/plugin/loader.
 type BundleVerifier interface {
+	// VerifyBundle verifies the plugin bundle rooted at bundleDir against the
+	// binary at binaryPath. Err must be non-nil when Outcome == OutcomeRejected.
+	// Pubkey must be non-nil and non-empty when Outcome == OutcomeVerified
+	// (TOFU guarantee per ADR-045 — without this, trusted_pubkey could be stored
+	// as empty string and silently break the key-pinning path in #188).
 	VerifyBundle(bundleDir, binaryPath string) VerifyResult
 }
 
@@ -116,6 +122,9 @@ func (in *Installer) Install(ctx context.Context, tarPath string) error {
 	}
 
 	binaryPath := filepath.Join(tmpDir, m.Name)
+	if rel, err := filepath.Rel(tmpDir, binaryPath); err != nil || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("manifest.name %q escapes bundle directory", m.Name)
+	}
 	result := in.verifier.VerifyBundle(tmpDir, binaryPath)
 
 	if result.Outcome == OutcomeRejected {
@@ -142,6 +151,12 @@ func readManifest(bundleDir string) (*manifest.Manifest, []byte, error) {
 	if m.Name == "" {
 		return nil, nil, fmt.Errorf("manifest.name is required")
 	}
+	if strings.ContainsAny(m.Name, `/\`) || m.Name == ".." || m.Name == "." {
+		return nil, nil, fmt.Errorf("manifest.name %q must be a plain filename (no path separators)", m.Name)
+	}
+	if m.Version == "" {
+		return nil, nil, fmt.Errorf("manifest.version is required")
+	}
 
 	return &m, data, nil
 }
@@ -149,10 +164,17 @@ func readManifest(bundleDir string) (*manifest.Manifest, []byte, error) {
 // recordSignatureInvalid inserts a plugin_audit_events row for a failed
 // signature check and returns nil (the event is the operator signal).
 func (in *Installer) recordSignatureInvalid(ctx context.Context, tarPath, pluginName string, verifyErr error) error {
+	// Guard against a BundleVerifier that returns OutcomeRejected with Err==nil,
+	// which would panic on verifyErr.Error(). The interface contract requires
+	// Err to be non-nil, but we defend here regardless.
+	errMsg := "unknown rejection"
+	if verifyErr != nil {
+		errMsg = verifyErr.Error()
+	}
 	payload, _ := json.Marshal(map[string]string{
 		"tarball":       tarPath,
 		"manifest_name": pluginName,
-		"error":         verifyErr.Error(),
+		"error":         errMsg,
 	})
 
 	_, err := in.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
@@ -192,6 +214,10 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 }
 
 // createPlugin inserts a new plugin row with status=pending_review.
+//
+// TODO(plugin): wrap createPlugin + audit insert in a single transaction once
+// Installer takes *sql.DB instead of *db.Queries. Today an audit-insert failure
+// leaves an orphan plugins row; same-version idempotency masks the retry.
 func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, manifestBytes []byte, result VerifyResult, nowStr string) error {
 	_, err := in.q.CreatePlugin(ctx, db.CreatePluginParams{
 		ID:               model.NewULID(),
@@ -229,6 +255,11 @@ func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, man
 
 // updatePlugin updates the manifest snapshot on an existing plugin row when the
 // version has changed. Uses the CAS guard (ADR-038).
+//
+// TODO(plugin): wrap updatePlugin + audit insert in a single transaction once
+// Installer takes *sql.DB instead of *db.Queries. Today an audit-insert failure
+// leaves the plugins row updated but the event unrecorded; same-version
+// idempotency masks the retry.
 func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, nowStr string) error {
 	rows, err := in.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
 		ManifestSnapshot: string(manifestBytes),

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -1,0 +1,273 @@
+package loader
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	manifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+)
+
+// VerifyOutcome mirrors internal/plugin.VerifyOutcome without creating an import cycle.
+type VerifyOutcome int
+
+const (
+	OutcomeVerified          VerifyOutcome = iota // bundle signed and valid
+	OutcomeUnsignedPermissive                     // unsigned but host allows it
+	OutcomeRejected                               // verification failed
+)
+
+func (o VerifyOutcome) String() string {
+	switch o {
+	case OutcomeVerified:
+		return "verified"
+	case OutcomeUnsignedPermissive:
+		return "unsigned_permissive"
+	case OutcomeRejected:
+		return "rejected"
+	default:
+		return "unknown"
+	}
+}
+
+// VerifyResult is the minimal result the installer needs from the verifier.
+type VerifyResult struct {
+	Outcome VerifyOutcome
+	Pubkey  []byte
+	Err     error
+}
+
+// BundleVerifier is the interface the Installer requires from the host verifier.
+// internal/plugin.Verifier satisfies this interface; using an interface here
+// avoids the import cycle between internal/plugin and internal/plugin/loader.
+type BundleVerifier interface {
+	VerifyBundle(bundleDir, binaryPath string) VerifyResult
+}
+
+const (
+	// maxTarballBytes caps cumulative uncompressed bytes extracted from a plugin
+	// tarball. Defends against gzip-bomb payloads (spec §5.1 size guidance).
+	maxTarballBytes = 100 << 20 // 100 MiB
+
+	// Plugin status values that mirror the DB CHECK constraint.
+	statusPendingReview = "pending_review"
+
+	// Audit event types (ADR-046).
+	auditSignatureInvalid = "plugin_signature_invalid"
+	auditPluginInstalled  = "plugin_installed"
+	auditUpdatePending    = "plugin_update_pending"
+
+	// Audit severity levels.
+	severityHigh = "high"
+	severityInfo = "info"
+)
+
+// Installer runs the extract → verify → snapshot-into-DB pipeline for a single
+// plugin tarball. One Installer is shared across all tarballs dispatched by the
+// Watcher; Install is called sequentially (ADR-003 serialization via the
+// watcher's fire channel).
+type Installer struct {
+	verifier BundleVerifier
+	q        *db.Queries
+	// clock is injectable so tests can assert on timestamps without racing real time.
+	clock func() time.Time
+}
+
+// NewInstaller returns an Installer wired to the given verifier and query set.
+func NewInstaller(v BundleVerifier, q *db.Queries) *Installer {
+	return &Installer{verifier: v, q: q, clock: time.Now}
+}
+
+// Install runs the full install pipeline for the tarball at tarPath:
+//  1. Extract to a temp directory.
+//  2. Parse manifest.yaml.
+//  3. Verify the bundle signature.
+//  4. Snapshot into the plugins table with status=pending_review (new plugin),
+//     or update the manifest (version bump), or skip (same version).
+//
+// Failed verification is recorded in plugin_audit_events and Install returns
+// nil — the event is the operator-visible signal (ADR-046). The caller
+// (Watcher) continues after a failed install; nothing is started.
+//
+// NOTE: The schema CHECK constraint on plugins.status only allows
+// pending_review|active|removed. A "signature_invalid" status is not stored
+// on the plugin row — #191 owns the per-instance health state machine.
+func (in *Installer) Install(ctx context.Context, tarPath string) error {
+	tmpDir, err := os.MkdirTemp("", "gleipnir-plugin-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := ExtractTarball(tarPath, tmpDir, maxTarballBytes); err != nil {
+		return fmt.Errorf("extract tarball %q: %w", tarPath, err)
+	}
+
+	m, manifestBytes, err := readManifest(tmpDir)
+	if err != nil {
+		return fmt.Errorf("read manifest from %q: %w", tarPath, err)
+	}
+
+	binaryPath := filepath.Join(tmpDir, m.Name)
+	result := in.verifier.VerifyBundle(tmpDir, binaryPath)
+
+	if result.Outcome == OutcomeRejected {
+		return in.recordSignatureInvalid(ctx, tarPath, m.Name, result.Err)
+	}
+
+	return in.upsertPlugin(ctx, m, manifestBytes, result)
+}
+
+// readManifest parses the manifest.yaml inside the extracted bundle directory.
+// Returns the parsed manifest, the raw YAML bytes, and any error.
+func readManifest(bundleDir string) (*manifest.Manifest, []byte, error) {
+	manifestPath := filepath.Join(bundleDir, "manifest.yaml")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read manifest.yaml: %w", err)
+	}
+
+	var m manifest.Manifest
+	if err := manifest.Unmarshal(data, &m); err != nil {
+		return nil, nil, fmt.Errorf("parse manifest.yaml: %w", err)
+	}
+
+	if m.Name == "" {
+		return nil, nil, fmt.Errorf("manifest.name is required")
+	}
+
+	return &m, data, nil
+}
+
+// recordSignatureInvalid inserts a plugin_audit_events row for a failed
+// signature check and returns nil (the event is the operator signal).
+func (in *Installer) recordSignatureInvalid(ctx context.Context, tarPath, pluginName string, verifyErr error) error {
+	payload, _ := json.Marshal(map[string]string{
+		"tarball":       tarPath,
+		"manifest_name": pluginName,
+		"error":         verifyErr.Error(),
+	})
+
+	_, err := in.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditSignatureInvalid,
+		Severity:         severityHigh,
+		ActorUserID:      nil,
+		PayloadJson:      string(payload),
+		CreatedAt:        in.nowStr(),
+	})
+	if err != nil {
+		return fmt.Errorf("record signature_invalid audit: %w", err)
+	}
+
+	return nil
+}
+
+// upsertPlugin creates or updates the plugin row and emits an audit event.
+func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, manifestBytes []byte, result VerifyResult) error {
+	existing, err := in.q.GetPluginByName(ctx, m.Name)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get plugin %q: %w", m.Name, err)
+	}
+
+	nowStr := in.nowStr()
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return in.createPlugin(ctx, m, manifestBytes, result, nowStr)
+	}
+
+	if existing.PluginVersion == m.Version {
+		// Same version already recorded — idempotent no-op (debounce safety net).
+		return nil
+	}
+
+	return in.updatePlugin(ctx, existing, m, manifestBytes, nowStr)
+}
+
+// createPlugin inserts a new plugin row with status=pending_review.
+func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, manifestBytes []byte, result VerifyResult, nowStr string) error {
+	_, err := in.q.CreatePlugin(ctx, db.CreatePluginParams{
+		ID:               model.NewULID(),
+		Name:             m.Name,
+		PluginVersion:    m.Version,
+		ManifestSnapshot: string(manifestBytes),
+		TrustedPubkey:    string(result.Pubkey),
+		Status:           statusPendingReview,
+		CreatedAt:        nowStr,
+		UpdatedAt:        nowStr,
+	})
+	if err != nil {
+		return fmt.Errorf("create plugin %q: %w", m.Name, err)
+	}
+
+	payload, _ := json.Marshal(map[string]string{
+		"name":    m.Name,
+		"version": m.Version,
+		"outcome": result.Outcome.String(),
+	})
+	_, auditErr := in.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditPluginInstalled,
+		Severity:         severityInfo,
+		ActorUserID:      nil,
+		PayloadJson:      string(payload),
+		CreatedAt:        nowStr,
+	})
+	if auditErr != nil {
+		return fmt.Errorf("record plugin_installed audit: %w", auditErr)
+	}
+
+	return nil
+}
+
+// updatePlugin updates the manifest snapshot on an existing plugin row when the
+// version has changed. Uses the CAS guard (ADR-038).
+func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, nowStr string) error {
+	rows, err := in.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
+		ManifestSnapshot: string(manifestBytes),
+		PluginVersion:    m.Version,
+		Status:           statusPendingReview,
+		UpdatedAt:        nowStr,
+		ID:               existing.ID,
+		ExpectedVersion:  existing.Version,
+	})
+	if err != nil {
+		return fmt.Errorf("update plugin %q manifest: %w", m.Name, err)
+	}
+	if rows == 0 {
+		// CAS miss: a concurrent writer already advanced the version. This is
+		// unlikely in the sequential dispatch model but safe to surface as an error.
+		return fmt.Errorf("update plugin %q: CAS conflict (version mismatch)", m.Name)
+	}
+
+	payload, _ := json.Marshal(map[string]string{
+		"name":        m.Name,
+		"old_version": existing.PluginVersion,
+		"new_version": m.Version,
+	})
+	_, auditErr := in.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditUpdatePending,
+		Severity:         severityInfo,
+		ActorUserID:      nil,
+		PayloadJson:      string(payload),
+		CreatedAt:        nowStr,
+	})
+	if auditErr != nil {
+		return fmt.Errorf("record plugin_update_pending audit: %w", auditErr)
+	}
+
+	return nil
+}
+
+// nowStr returns the current time as an RFC3339Nano string via the injectable clock.
+func (in *Installer) nowStr() string {
+	return in.clock().UTC().Format(time.RFC3339Nano)
+}

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -1,0 +1,407 @@
+package loader
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
+	_ "modernc.org/sqlite"
+)
+
+// realVerifier wraps the signing package to produce a loader.VerifyResult
+// without importing internal/plugin (which would create an import cycle since
+// internal/plugin imports internal/plugin/loader).
+//
+// It reimplements just enough of the verification path for tests: locate
+// signing.pub + *.minisig, parse, and call signing.Verify.
+type realVerifier struct {
+	allowUnsigned bool
+}
+
+func (v *realVerifier) VerifyBundle(bundleDir, binaryPath string) VerifyResult {
+	manifestBytes, err := os.ReadFile(bundleDir + "/manifest.yaml")
+	if err != nil {
+		return VerifyResult{Outcome: OutcomeRejected, Err: err}
+	}
+	binaryBytes, err := os.ReadFile(binaryPath)
+	if err != nil {
+		return VerifyResult{Outcome: OutcomeRejected, Err: err}
+	}
+	pubkeyBytes, pkErr := os.ReadFile(bundleDir + "/signing.pub")
+	matches, _ := filepath.Glob(bundleDir + "/*.minisig")
+	missingSig := len(matches) == 0
+
+	if os.IsNotExist(pkErr) && missingSig {
+		if v.allowUnsigned {
+			return VerifyResult{Outcome: OutcomeUnsignedPermissive}
+		}
+		return VerifyResult{Outcome: OutcomeRejected, Err: errUnsigned}
+	}
+	if pkErr != nil {
+		return VerifyResult{Outcome: OutcomeRejected, Err: pkErr}
+	}
+	if missingSig {
+		return VerifyResult{Outcome: OutcomeRejected, Err: errHalfSigned}
+	}
+
+	pk, _, err := signing.ParsePublicKey(pubkeyBytes)
+	if err != nil {
+		return VerifyResult{Outcome: OutcomeRejected, Err: err}
+	}
+	sigBytes, err := os.ReadFile(matches[0])
+	if err != nil {
+		return VerifyResult{Outcome: OutcomeRejected, Err: err}
+	}
+	sig, _, err := signing.ParseSignature(sigBytes)
+	if err != nil {
+		return VerifyResult{Outcome: OutcomeRejected, Err: err}
+	}
+	payload := signing.PluginPayload(binaryBytes, manifestBytes)
+	if err := signing.Verify(pk, payload, sig, sig.TrustedComment); err != nil {
+		return VerifyResult{Outcome: OutcomeRejected, Err: err}
+	}
+	return VerifyResult{Outcome: OutcomeVerified, Pubkey: pubkeyBytes}
+}
+
+// sentinel errors for the test verifier stubs.
+var (
+	errUnsigned  = os.ErrNotExist // matches expected behaviour for unsigned check
+	errHalfSigned = os.ErrInvalid
+)
+
+// openTestDB opens a temporary SQLite DB, applies the full schema, and returns
+// a *db.Queries ready for use. The store is closed at the end of the test.
+func openTestDB(t *testing.T) *db.Queries {
+	t.Helper()
+	s, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return s.Queries()
+}
+
+// signedPluginTarball builds a fully signed plugin tarball at a temp path and
+// returns the tarball path plus the raw manifest bytes.
+//
+// Uses signing.GenerateKeypair(rand.Reader) for consistency with
+// internal/plugin/verify_test.go.
+func signedPluginTarball(t *testing.T, name, version string) (tarPath string, manifestBytes []byte) {
+	t.Helper()
+
+	manifestBytes = []byte("schema_version: v1\nname: " + name + "\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	binaryBytes := []byte("fake binary content for " + name)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+
+	payload := signing.PluginPayload(binaryBytes, manifestBytes)
+	sig, err := signing.Sign(sk.SecretKey, sk.KeyID, payload, "trusted comment")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+	sigBytes := signing.MarshalSignature(sig, "test sig")
+
+	tarPath = filepath.Join(t.TempDir(), name+".tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: name, content: binaryBytes, mode: 0o755},
+		{name: "signing.pub", content: pubkeyBytes, mode: 0o644},
+		{name: name + ".minisig", content: sigBytes, mode: 0o644},
+	})
+
+	return tarPath, manifestBytes
+}
+
+// unsignedPluginTarball builds a plugin tarball without any signing artifacts.
+func unsignedPluginTarball(t *testing.T, name, version string) string {
+	t.Helper()
+
+	manifestBytes := []byte("schema_version: v1\nname: " + name + "\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	binaryBytes := []byte("fake binary content for " + name)
+
+	tarPath := filepath.Join(t.TempDir(), name+".tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: name, content: binaryBytes, mode: 0o755},
+	})
+	return tarPath
+}
+
+// badSignatureTarball builds a tarball with a signing.pub and .minisig that
+// don't match the binary content.
+func badSignatureTarball(t *testing.T, name, version string) string {
+	t.Helper()
+
+	manifestBytes := []byte("schema_version: v1\nname: " + name + "\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	binaryBytes := []byte("tampered binary content")
+	originalBinaryBytes := []byte("original binary content")
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+
+	// Sign the original bytes, not the tampered bytes — produces an invalid sig.
+	payload := signing.PluginPayload(originalBinaryBytes, manifestBytes)
+	sig, err := signing.Sign(sk.SecretKey, sk.KeyID, payload, "trusted comment")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+	sigBytes := signing.MarshalSignature(sig, "test sig")
+
+	tarPath := filepath.Join(t.TempDir(), name+"-bad.tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: name, content: binaryBytes, mode: 0o755},
+		{name: "signing.pub", content: pubkeyBytes, mode: 0o644},
+		{name: name + ".minisig", content: sigBytes, mode: 0o644},
+	})
+	return tarPath
+}
+
+// oversizedTarball builds a tarball whose uncompressed total exceeds maxTarballBytes.
+func oversizedTarball(t *testing.T, name string) string {
+	t.Helper()
+
+	// Write 101 MiB of content (just over the 100 MiB cap).
+	huge := bytes.Repeat([]byte("X"), 101<<20)
+
+	tarPath := filepath.Join(t.TempDir(), name+"-huge.tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "huge.bin", content: huge, mode: 0o644},
+	})
+	return tarPath
+}
+
+// writeTarball serialises entries into a .tar.gz at path.
+func writeTarball(t *testing.T, path string, entries []tarEntry) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for _, e := range entries {
+		tf := e.typeflag
+		if tf == 0 {
+			tf = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: tf,
+			Mode:     e.mode,
+			Size:     int64(len(e.content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %q: %v", e.name, err)
+		}
+		if len(e.content) > 0 {
+			if _, err := tw.Write(e.content); err != nil {
+				t.Fatalf("write body %q: %v", e.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tarball %q: %v", path, err)
+	}
+}
+
+// newTestInstaller builds an Installer with a fixed clock for timestamp assertions.
+func newTestInstaller(t *testing.T, q *db.Queries, allowUnsigned bool) *Installer {
+	t.Helper()
+	v := &realVerifier{allowUnsigned: allowUnsigned}
+	inst := NewInstaller(v, q)
+	inst.clock = func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
+	return inst
+}
+
+func TestInstall_NewSignedPlugin_PendingReview(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath, _ := signedPluginTarball(t, "test-plugin", "1.0.0")
+
+	if err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "test-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+
+	if row.Status != "pending_review" {
+		t.Errorf("status = %q, want %q", row.Status, "pending_review")
+	}
+	if row.PluginVersion != "1.0.0" {
+		t.Errorf("plugin_version = %q, want %q", row.PluginVersion, "1.0.0")
+	}
+	if row.TrustedPubkey == "" {
+		t.Error("trusted_pubkey: want non-empty (TOFU-captured pubkey)")
+	}
+}
+
+func TestInstall_BadSignature_AuditOnly(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath := badSignatureTarball(t, "bad-plugin", "1.0.0")
+
+	if err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install with bad sig returned unexpected error: %v", err)
+	}
+
+	// No plugin row must exist — only an audit event.
+	_, err := q.GetPluginByName(context.Background(), "bad-plugin")
+	if err == nil {
+		t.Error("expected no plugin row for bad-signature install, got one")
+	}
+
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditSignatureInvalid,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list audit events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Error("expected at least one signature_invalid audit event")
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(events[0].PayloadJson), &payload); err != nil {
+		t.Fatalf("parse audit payload: %v", err)
+	}
+	if payload["manifest_name"] != "bad-plugin" {
+		t.Errorf("audit payload manifest_name = %q, want %q", payload["manifest_name"], "bad-plugin")
+	}
+	if payload["error"] == "" {
+		t.Error("audit payload error: want non-empty")
+	}
+	if events[0].Severity != "high" {
+		t.Errorf("audit severity = %q, want %q", events[0].Severity, "high")
+	}
+}
+
+func TestInstall_VersionBump_PendingReview(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	// First install — v1.0.0.
+	tarPath1, _ := signedPluginTarball(t, "bump-plugin", "1.0.0")
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("initial Install: %v", err)
+	}
+
+	// Second install — v1.1.0 (version bump).
+	tarPath2, _ := signedPluginTarball(t, "bump-plugin", "1.1.0")
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("version-bump Install: %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "bump-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if row.PluginVersion != "1.1.0" {
+		t.Errorf("plugin_version = %q, want %q", row.PluginVersion, "1.1.0")
+	}
+	if row.Status != "pending_review" {
+		t.Errorf("status = %q, want %q", row.Status, "pending_review")
+	}
+
+	// Expect a plugin_update_pending audit event.
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditUpdatePending,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list update_pending events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Error("expected plugin_update_pending audit event after version bump")
+	}
+}
+
+func TestInstall_SameVersion_NoOp(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath, _ := signedPluginTarball(t, "stable-plugin", "2.0.0")
+
+	// Install twice with the same version.
+	if err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("first Install: %v", err)
+	}
+	if err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("second Install (same version): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "stable-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	// Version counter stays at 0 (no update was issued).
+	if row.Version != 0 {
+		t.Errorf("version = %d, want 0 (same-version should be a no-op)", row.Version)
+	}
+}
+
+func TestInstall_TarballTooLarge(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath := oversizedTarball(t, "huge-plugin")
+
+	err := inst.Install(context.Background(), tarPath)
+	if err == nil {
+		t.Fatal("expected error for oversized tarball, got nil")
+	}
+}
+
+func TestInstall_UnsignedPermissive_PendingReview(t *testing.T) {
+	q := openTestDB(t)
+	// AllowUnsigned=true so unsigned bundles are accepted.
+	inst := newTestInstaller(t, q, true)
+
+	tarPath := unsignedPluginTarball(t, "unsigned-plugin", "1.0.0")
+
+	if err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install (unsigned permissive): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "unsigned-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if row.Status != "pending_review" {
+		t.Errorf("status = %q, want pending_review", row.Status)
+	}
+}

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,7 +75,7 @@ func (v *realVerifier) VerifyBundle(bundleDir, binaryPath string) VerifyResult {
 
 // sentinel errors for the test verifier stubs.
 var (
-	errUnsigned  = os.ErrNotExist // matches expected behaviour for unsigned check
+	errUnsigned   = os.ErrNotExist // matches expected behaviour for unsigned check
 	errHalfSigned = os.ErrInvalid
 )
 
@@ -182,7 +183,7 @@ func badSignatureTarball(t *testing.T, name, version string) string {
 func oversizedTarball(t *testing.T, name string) string {
 	t.Helper()
 
-	// Write 101 MiB of content (just over the 100 MiB cap).
+	// 101 MiB is intentional: it sits just over the 100 MiB cumulative cap to exercise that limit.
 	huge := bytes.Repeat([]byte("X"), 101<<20)
 
 	tarPath := filepath.Join(t.TempDir(), name+"-huge.tar.gz")
@@ -403,5 +404,133 @@ func TestInstall_UnsignedPermissive_PendingReview(t *testing.T) {
 	}
 	if row.Status != "pending_review" {
 		t.Errorf("status = %q, want pending_review", row.Status)
+	}
+}
+
+// traversalTarball builds a tarball whose manifest.yaml contains the given name.
+// The tarball itself uses "binary" as the actual file entry to avoid OS-level
+// path issues when creating the archive; the manifest is what triggers the check.
+func traversalTarball(t *testing.T, manifestName string) string {
+	t.Helper()
+
+	manifestBytes := []byte("schema_version: v1\nname: " + manifestName + "\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	binaryBytes := []byte("fake binary")
+
+	tarPath := filepath.Join(t.TempDir(), "traversal.tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: "binary", content: binaryBytes, mode: 0o755},
+	})
+	return tarPath
+}
+
+// TestInstall_ManifestNamePathTraversal_Rejected verifies that a manifest whose
+// name field contains path separators (e.g. "../escape") is rejected before any
+// DB writes occur.
+func TestInstall_ManifestNamePathTraversal_Rejected(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, true) // allowUnsigned so verifier is not the rejection path
+
+	tarPath := traversalTarball(t, "../escape")
+
+	err := inst.Install(context.Background(), tarPath)
+	if err == nil {
+		t.Fatal("Install: expected error for path-traversal manifest name, got nil")
+	}
+
+	// No plugin row must have been created.
+	_, dbErr := q.GetPluginByName(context.Background(), "../escape")
+	if dbErr == nil {
+		t.Error("expected no plugin row for traversal name, but found one")
+	}
+}
+
+// nilErrVerifier is a stub BundleVerifier that returns OutcomeRejected with
+// Err==nil, violating the interface contract, to confirm Install doesn't panic.
+type nilErrVerifier struct{}
+
+func (nilErrVerifier) VerifyBundle(_, _ string) VerifyResult {
+	return VerifyResult{Outcome: OutcomeRejected, Err: nil}
+}
+
+// TestInstall_RejectedWithNilErr_NoPanic confirms that Install does not panic
+// when a BundleVerifier returns OutcomeRejected with Err==nil.
+func TestInstall_RejectedWithNilErr_NoPanic(t *testing.T) {
+	q := openTestDB(t)
+
+	// Build a valid signed tarball so we get past manifest parsing.
+	tarPath, _ := signedPluginTarball(t, "nil-err-plugin", "1.0.0")
+
+	inst := &Installer{verifier: nilErrVerifier{}, q: q, clock: time.Now}
+
+	// Must not panic; Install should record an audit event and return nil.
+	if err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install returned unexpected error: %v", err)
+	}
+
+	// No plugin row — only an audit event.
+	_, dbErr := q.GetPluginByName(context.Background(), "nil-err-plugin")
+	if dbErr == nil {
+		t.Error("expected no plugin row for rejected install, but found one")
+	}
+
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditSignatureInvalid,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list audit events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Error("expected a signature_invalid audit event, got none")
+	}
+}
+
+func TestReadManifest_Validation(t *testing.T) {
+	base := "schema_version: v1\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n"
+
+	cases := []struct {
+		name        string
+		manifest    string
+		wantErrFrag string
+	}{
+		{
+			name:        "empty name",
+			manifest:    base + "version: 1.0.0\n",
+			wantErrFrag: "manifest.name is required",
+		},
+		{
+			name:        "empty version",
+			manifest:    base + "name: my-plugin\n",
+			wantErrFrag: "manifest.version is required",
+		},
+		{
+			name:        "valid manifest",
+			manifest:    base + "name: my-plugin\nversion: 1.0.0\n",
+			wantErrFrag: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte(tc.manifest), 0o644); err != nil {
+				t.Fatalf("write manifest: %v", err)
+			}
+			_, _, err := readManifest(dir)
+			if tc.wantErrFrag == "" {
+				if err != nil {
+					t.Errorf("readManifest: unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("readManifest: expected error containing %q, got nil", tc.wantErrFrag)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrFrag) {
+				t.Errorf("readManifest error = %q, want substring %q", err.Error(), tc.wantErrFrag)
+			}
+		})
 	}
 }

--- a/internal/plugin/loader/watcher.go
+++ b/internal/plugin/loader/watcher.go
@@ -39,6 +39,12 @@ type Watcher struct {
 
 	mu      sync.Mutex
 	pending map[string]*time.Timer
+
+	// ctx and fire are set during Run and used by schedule/AfterFunc callbacks.
+	// They are only written once (at the start of Run) before any goroutines that
+	// read them are spawned, so no additional synchronisation is needed.
+	ctx  context.Context
+	fire chan string
 }
 
 // WatcherOption configures a Watcher.
@@ -66,16 +72,47 @@ func NewWatcher(dir string, install installFunc, opts ...WatcherOption) *Watcher
 	return w
 }
 
-// Run blocks until ctx is cancelled, dispatching settled tarballs to Install.
-// It creates the watch directory if it does not exist, performs an initial sweep
-// of any existing tarballs, then enters the fsnotify event loop.
-func (w *Watcher) Run(ctx context.Context) error {
+// Setup creates the plugins directory if it does not exist, opens the fsnotify
+// watcher, and registers the directory with it. The returned *fsnotify.Watcher
+// must be passed to Run. Separating Setup from Run lets callers (StartWatcher)
+// surface pre-flight errors synchronously before spawning any goroutines.
+func (w *Watcher) Setup() (*fsnotify.Watcher, error) {
 	if err := os.MkdirAll(w.dir, 0o755); err != nil {
-		return fmt.Errorf("ensure plugins dir %q: %w", w.dir, err)
+		return nil, fmt.Errorf("ensure plugins dir %q: %w", w.dir, err)
 	}
 
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create fsnotify watcher: %w", err)
+	}
+
+	if err := fw.Add(w.dir); err != nil {
+		fw.Close()
+		return nil, fmt.Errorf("watch plugins dir %q: %w", w.dir, err)
+	}
+
+	return fw, nil
+}
+
+// Run blocks until ctx is cancelled, dispatching settled tarballs to Install.
+// It takes the fsnotify.Watcher created by Setup, spawns the dispatch goroutine,
+// performs an initial sweep of any existing tarballs, then enters the event loop.
+//
+// Run must not be called more than once on the same Watcher: it writes w.ctx and
+// w.fire at startup, and a second call would stomp those fields while the first
+// call's AfterFunc callbacks are still reading them.
+func (w *Watcher) Run(ctx context.Context, fw *fsnotify.Watcher) error {
+	defer fw.Close()
+
 	// fire receives absolute paths of tarballs that have settled (debounce expired).
+	// Buffer of 16 absorbs an initial sweep burst without blocking schedule callbacks.
 	fire := make(chan string, 16)
+
+	// Store ctx and fire so schedule()'s AfterFunc callbacks can reach them without
+	// capturing the loop variables from Run (which would require passing them through
+	// every call site).
+	w.ctx = ctx
+	w.fire = fire
 
 	// Sequential dispatch goroutine. One Install at a time, mirroring ADR-003.
 	// We select on both fire and ctx.Done() rather than ranging over fire so the
@@ -83,6 +120,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 	// fire after cancelAllTimers() would race: a timer whose AfterFunc callback
 	// already fired but hasn't sent yet would panic writing to a closed channel.
 	// The channel is GC'd once both goroutines drop their references.
+	//
+	// The dispatch goroutine is started AFTER fsnotify is set up so that if
+	// fsnotify setup fails we don't leak a goroutine waiting for a ctx cancel.
 	go func() {
 		for {
 			select {
@@ -97,6 +137,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}()
 
 	// Initial sweep: enqueue tarballs already present before the watcher starts.
+	// The dispatch goroutine is already running so AfterFunc sends will be drained.
 	entries, err := os.ReadDir(w.dir)
 	if err != nil {
 		return fmt.Errorf("read plugins dir %q: %w", w.dir, err)
@@ -104,18 +145,8 @@ func (w *Watcher) Run(ctx context.Context) error {
 	for _, e := range entries {
 		if !e.IsDir() && isTarball(e.Name()) {
 			abs := filepath.Join(w.dir, e.Name())
-			w.schedule(ctx, abs, fire)
+			w.schedule(abs)
 		}
-	}
-
-	fw, err := fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("create fsnotify watcher: %w", err)
-	}
-	defer fw.Close()
-
-	if err := fw.Add(w.dir); err != nil {
-		return fmt.Errorf("watch plugins dir %q: %w", w.dir, err)
 	}
 
 	for {
@@ -134,7 +165,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 			}
 			switch {
 			case event.Has(fsnotify.Create) || event.Has(fsnotify.Write) || event.Has(fsnotify.Rename):
-				w.schedule(ctx, abs, fire)
+				w.schedule(abs)
 			case event.Has(fsnotify.Remove):
 				w.cancelTimer(abs)
 			}
@@ -148,15 +179,16 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 }
 
-// schedule arms (or resets) the debounce timer for the tarball at abs. When
-// the timer fires it posts abs on the fire channel.
-func (w *Watcher) schedule(ctx context.Context, abs string, fire chan<- string) {
+// schedule arms the debounce timer for the tarball at abs. If a timer is
+// already pending it is stopped and replaced with a fresh one to avoid the
+// Reset-after-fire-already-queued race under Go 1.23+ AfterFunc semantics.
+func (w *Watcher) schedule(abs string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if t, ok := w.pending[abs]; ok {
-		t.Reset(w.debounce)
-		return
+	if existing, ok := w.pending[abs]; ok {
+		existing.Stop()
+		delete(w.pending, abs)
 	}
 
 	w.pending[abs] = time.AfterFunc(w.debounce, func() {
@@ -165,8 +197,8 @@ func (w *Watcher) schedule(ctx context.Context, abs string, fire chan<- string) 
 		w.mu.Unlock()
 
 		select {
-		case fire <- abs:
-		case <-ctx.Done():
+		case w.fire <- abs:
+		case <-w.ctx.Done():
 		}
 	})
 }

--- a/internal/plugin/loader/watcher.go
+++ b/internal/plugin/loader/watcher.go
@@ -1,0 +1,198 @@
+package loader
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const defaultDebounce = 250 * time.Millisecond
+
+// installFunc is the install signature accepted by Watcher. Using a function
+// type rather than the concrete Installer keeps watcher_test.go stub-friendly.
+type installFunc func(ctx context.Context, tarPath string) error
+
+// Watcher watches a directory for plugin tarballs using fsnotify and dispatches
+// each settled file through an install function.
+//
+// Design notes:
+//   - Debounce: tarball writes generate many Create/Write events as the file
+//     lands on disk. The watcher waits for a quiet period (default 250ms) before
+//     firing Install, so only one call is made per tarball drop.
+//   - Sequential dispatch: a single goroutine drains the fire channel and runs
+//     Install one at a time, mirroring the ADR-003 audit-write serialization pattern.
+//   - Initial sweep: on Run the watcher enqueues any *.tar.gz / *.tgz files
+//     already present so a server restart picks up tarballs that arrived while down.
+//   - inotify on bind-mounted /plugins is fine on Linux (the default deployment).
+type Watcher struct {
+	dir      string
+	debounce time.Duration
+	install  installFunc
+	logger   *slog.Logger
+
+	mu      sync.Mutex
+	pending map[string]*time.Timer
+}
+
+// WatcherOption configures a Watcher.
+type WatcherOption func(*Watcher)
+
+// WithDebounce overrides the debounce window. Intended for tests where 250ms
+// would make the suite too slow.
+func WithDebounce(d time.Duration) WatcherOption {
+	return func(w *Watcher) { w.debounce = d }
+}
+
+// NewWatcher creates a Watcher for dir. The install function is called once per
+// settled tarball. opts may include WithDebounce.
+func NewWatcher(dir string, install installFunc, opts ...WatcherOption) *Watcher {
+	w := &Watcher{
+		dir:      dir,
+		debounce: defaultDebounce,
+		install:  install,
+		logger:   slog.Default(),
+		pending:  make(map[string]*time.Timer),
+	}
+	for _, o := range opts {
+		o(w)
+	}
+	return w
+}
+
+// Run blocks until ctx is cancelled, dispatching settled tarballs to Install.
+// It creates the watch directory if it does not exist, performs an initial sweep
+// of any existing tarballs, then enters the fsnotify event loop.
+func (w *Watcher) Run(ctx context.Context) error {
+	if err := os.MkdirAll(w.dir, 0o755); err != nil {
+		return fmt.Errorf("ensure plugins dir %q: %w", w.dir, err)
+	}
+
+	// fire receives absolute paths of tarballs that have settled (debounce expired).
+	fire := make(chan string, 16)
+
+	// Sequential dispatch goroutine. One Install at a time, mirroring ADR-003.
+	// We select on both fire and ctx.Done() rather than ranging over fire so the
+	// goroutine exits when ctx is cancelled without requiring close(fire). Closing
+	// fire after cancelAllTimers() would race: a timer whose AfterFunc callback
+	// already fired but hasn't sent yet would panic writing to a closed channel.
+	// The channel is GC'd once both goroutines drop their references.
+	go func() {
+		for {
+			select {
+			case path := <-fire:
+				if err := w.install(ctx, path); err != nil {
+					w.logger.Warn("plugin install failed", "path", path, "err", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Initial sweep: enqueue tarballs already present before the watcher starts.
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		return fmt.Errorf("read plugins dir %q: %w", w.dir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() && isTarball(e.Name()) {
+			abs := filepath.Join(w.dir, e.Name())
+			w.schedule(ctx, abs, fire)
+		}
+	}
+
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("create fsnotify watcher: %w", err)
+	}
+	defer fw.Close()
+
+	if err := fw.Add(w.dir); err != nil {
+		return fmt.Errorf("watch plugins dir %q: %w", w.dir, err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.cancelAllTimers()
+			return ctx.Err()
+
+		case event, ok := <-fw.Events:
+			if !ok {
+				return nil
+			}
+			abs := filepath.Clean(event.Name)
+			if !isTarball(abs) {
+				continue
+			}
+			switch {
+			case event.Has(fsnotify.Create) || event.Has(fsnotify.Write) || event.Has(fsnotify.Rename):
+				w.schedule(ctx, abs, fire)
+			case event.Has(fsnotify.Remove):
+				w.cancelTimer(abs)
+			}
+
+		case err, ok := <-fw.Errors:
+			if !ok {
+				return nil
+			}
+			w.logger.Warn("fsnotify error", "dir", w.dir, "err", err)
+		}
+	}
+}
+
+// schedule arms (or resets) the debounce timer for the tarball at abs. When
+// the timer fires it posts abs on the fire channel.
+func (w *Watcher) schedule(ctx context.Context, abs string, fire chan<- string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if t, ok := w.pending[abs]; ok {
+		t.Reset(w.debounce)
+		return
+	}
+
+	w.pending[abs] = time.AfterFunc(w.debounce, func() {
+		w.mu.Lock()
+		delete(w.pending, abs)
+		w.mu.Unlock()
+
+		select {
+		case fire <- abs:
+		case <-ctx.Done():
+		}
+	})
+}
+
+// cancelTimer stops and removes the pending timer for abs, if any.
+func (w *Watcher) cancelTimer(abs string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if t, ok := w.pending[abs]; ok {
+		t.Stop()
+		delete(w.pending, abs)
+	}
+}
+
+// cancelAllTimers stops all pending debounce timers. Called on ctx cancellation.
+func (w *Watcher) cancelAllTimers() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for abs, t := range w.pending {
+		t.Stop()
+		delete(w.pending, abs)
+	}
+}
+
+// isTarball returns true for filenames ending in .tar.gz or .tgz.
+func isTarball(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz")
+}

--- a/internal/plugin/loader/watcher_test.go
+++ b/internal/plugin/loader/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -44,6 +45,19 @@ func (s *stubInstaller) waitForCount(n int, deadline time.Duration) int {
 
 const testDebounce = 50 * time.Millisecond
 
+// runWatcher calls Setup, starts Run in a goroutine, and returns a done channel.
+// The test is fatally failed if Setup returns an error.
+func runWatcher(t *testing.T, ctx context.Context, w *Watcher) <-chan error {
+	t.Helper()
+	fw, err := w.Setup()
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx, fw) }()
+	return done
+}
+
 func TestWatcher_DebouncesBurstWrites(t *testing.T) {
 	dir := t.TempDir()
 	stub := &stubInstaller{}
@@ -52,9 +66,7 @@ func TestWatcher_DebouncesBurstWrites(t *testing.T) {
 	defer cancel()
 
 	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
-
-	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx) }()
+	done := runWatcher(t, ctx, w)
 
 	// Give the watcher time to register the inotify watch.
 	time.Sleep(20 * time.Millisecond)
@@ -93,9 +105,7 @@ func TestWatcher_InitialSweep(t *testing.T) {
 	defer cancel()
 
 	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
-
-	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx) }()
+	done := runWatcher(t, ctx, w)
 
 	// The initial sweep enqueues the file immediately, then the debounce window fires.
 	n := stub.waitForCount(1, testDebounce*10)
@@ -115,9 +125,7 @@ func TestWatcher_IgnoresNonTarball(t *testing.T) {
 	defer cancel()
 
 	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
-
-	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx) }()
+	done := runWatcher(t, ctx, w)
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -148,9 +156,7 @@ func TestWatcher_ContextCancel_StopsCleanly(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	w := NewWatcher(dir, install, WithDebounce(testDebounce))
-
-	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx) }()
+	done := runWatcher(t, ctx, w)
 
 	time.Sleep(20 * time.Millisecond)
 	cancel()
@@ -177,9 +183,7 @@ func TestWatcher_CancelDuringDebounce_NoRace(t *testing.T) {
 
 	const debounce = 50 * time.Millisecond
 	w := NewWatcher(dir, stub.install, WithDebounce(debounce))
-
-	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx) }()
+	done := runWatcher(t, ctx, w)
 
 	// Give the watcher time to register the inotify watch.
 	time.Sleep(20 * time.Millisecond)
@@ -207,6 +211,40 @@ func TestWatcher_CancelDuringDebounce_NoRace(t *testing.T) {
 	// may not have fired once depending on timing — either is acceptable.
 }
 
+// TestWatcher_FsnotifySetupFailure_NoGoroutineLeak verifies that when Setup
+// fails (os.MkdirAll receives a path that is a regular file rather than a
+// directory, which returns ENOTDIR), it returns an error without leaking the
+// dispatch goroutine. The dispatch goroutine is spawned inside Run, which is
+// never reached when Setup fails.
+func TestWatcher_FsnotifySetupFailure_NoGoroutineLeak(t *testing.T) {
+	// Create a regular file where the watcher expects a directory.
+	// os.MkdirAll on a path that is a regular file returns ENOTDIR.
+	dir := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(dir, []byte("file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubInstaller{}
+	w := NewWatcher(dir, stub.install, WithDebounce(20*time.Millisecond))
+
+	before := runtime.NumGoroutine()
+
+	_, err := w.Setup()
+	if err == nil {
+		t.Fatal("expected Setup to return an error when dir is a regular file")
+	}
+
+	// Give the runtime a moment to clean up any transient goroutines.
+	time.Sleep(50 * time.Millisecond)
+
+	after := runtime.NumGoroutine()
+	// Allow a small delta for unrelated runtime goroutines. The dispatch goroutine
+	// must not have been started, so the count should not have grown.
+	if after > before+2 {
+		t.Errorf("goroutine count grew from %d to %d after failed Setup — possible leak", before, after)
+	}
+}
+
 func TestWatcher_RemoveCancelsPendingTimer(t *testing.T) {
 	dir := t.TempDir()
 	stub := &stubInstaller{}
@@ -215,9 +253,7 @@ func TestWatcher_RemoveCancelsPendingTimer(t *testing.T) {
 	defer cancel()
 
 	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
-
-	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx) }()
+	done := runWatcher(t, ctx, w)
 
 	time.Sleep(20 * time.Millisecond)
 

--- a/internal/plugin/loader/watcher_test.go
+++ b/internal/plugin/loader/watcher_test.go
@@ -1,0 +1,243 @@
+package loader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubInstaller counts Install calls and records which paths were installed.
+type stubInstaller struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (s *stubInstaller) install(ctx context.Context, tarPath string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, tarPath)
+	return nil
+}
+
+func (s *stubInstaller) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+// waitForCount blocks until the stubInstaller has accumulated at least n calls
+// or deadline is reached. Returns the call count at deadline.
+func (s *stubInstaller) waitForCount(n int, deadline time.Duration) int {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if s.count() >= n {
+			return s.count()
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return s.count()
+}
+
+const testDebounce = 50 * time.Millisecond
+
+func TestWatcher_DebouncesBurstWrites(t *testing.T) {
+	dir := t.TempDir()
+	stub := &stubInstaller{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// Give the watcher time to register the inotify watch.
+	time.Sleep(20 * time.Millisecond)
+
+	tarPath := filepath.Join(dir, "test-plugin.tar.gz")
+
+	// Simulate 4 write chunks — the watcher should collapse them to 1 install.
+	for i := 0; i < 4; i++ {
+		if err := os.WriteFile(tarPath, []byte("chunk"), 0o644); err != nil {
+			t.Fatalf("write chunk %d: %v", i, err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Wait for the debounce window to expire and one install to fire.
+	n := stub.waitForCount(1, testDebounce*10)
+	if n != 1 {
+		t.Errorf("install call count = %d, want exactly 1 (debounce should collapse burst)", n)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestWatcher_InitialSweep(t *testing.T) {
+	dir := t.TempDir()
+
+	// Drop the tarball BEFORE the watcher starts.
+	tarPath := filepath.Join(dir, "pre-existing.tar.gz")
+	if err := os.WriteFile(tarPath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write pre-existing tarball: %v", err)
+	}
+
+	stub := &stubInstaller{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// The initial sweep enqueues the file immediately, then the debounce window fires.
+	n := stub.waitForCount(1, testDebounce*10)
+	if n < 1 {
+		t.Errorf("install count = %d after initial sweep, want >= 1", n)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestWatcher_IgnoresNonTarball(t *testing.T) {
+	dir := t.TempDir()
+	stub := &stubInstaller{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Drop a non-tarball file — must not trigger an install.
+	if err := os.WriteFile(filepath.Join(dir, "README.txt"), []byte("notes"), 0o644); err != nil {
+		t.Fatalf("write README.txt: %v", err)
+	}
+
+	// Wait longer than the debounce window and confirm no install fired.
+	time.Sleep(testDebounce * 4)
+	if n := stub.count(); n != 0 {
+		t.Errorf("install count = %d, want 0 (non-tarball should be ignored)", n)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestWatcher_ContextCancel_StopsCleanly(t *testing.T) {
+	dir := t.TempDir()
+
+	var installCount atomic.Int64
+	install := func(ctx context.Context, tarPath string) error {
+		installCount.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	w := NewWatcher(dir, install, WithDebounce(testDebounce))
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel within 2s")
+	}
+}
+
+// TestWatcher_CancelDuringDebounce_NoRace is a regression test for the shutdown
+// race where time.Timer.Stop() returns false (callback already queued), then
+// close(fire) is called before the callback sends on fire — causing a panic.
+// The fix: drop close(fire) and have the dispatch goroutine select on ctx.Done().
+func TestWatcher_CancelDuringDebounce_NoRace(t *testing.T) {
+	dir := t.TempDir()
+	stub := &stubInstaller{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	const debounce = 50 * time.Millisecond
+	w := NewWatcher(dir, stub.install, WithDebounce(debounce))
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// Give the watcher time to register the inotify watch.
+	time.Sleep(20 * time.Millisecond)
+
+	// Drop a tarball to arm the debounce timer.
+	tarPath := filepath.Join(dir, "race-check.tar.gz")
+	if err := os.WriteFile(tarPath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+
+	// Cancel right in the middle of the debounce window, while the timer may
+	// be queued or about to fire. This is the window that previously panicked.
+	time.Sleep(debounce / 2)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after context cancel within 3s")
+	}
+	// If we reach here without panic the race is not triggered. install may or
+	// may not have fired once depending on timing — either is acceptable.
+}
+
+func TestWatcher_RemoveCancelsPendingTimer(t *testing.T) {
+	dir := t.TempDir()
+	stub := &stubInstaller{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	tarPath := filepath.Join(dir, "remove-me.tar.gz")
+	if err := os.WriteFile(tarPath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+
+	// Remove the file before the debounce window expires.
+	time.Sleep(10 * time.Millisecond)
+	if err := os.Remove(tarPath); err != nil {
+		t.Fatalf("remove tarball: %v", err)
+	}
+
+	// Wait for the debounce window; the install should NOT fire (file was removed).
+	time.Sleep(testDebounce * 4)
+	if n := stub.count(); n != 0 {
+		t.Errorf("install count = %d, want 0 (removed file timer should be cancelled)", n)
+	}
+
+	cancel()
+	<-done
+}

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -74,6 +74,18 @@ func TestLoader_Init_Disabled_LeavesVerifierNil(t *testing.T) {
 	}
 }
 
+// TestLoader_StartWatcher_DisabledIsNoOp asserts that StartWatcher is a no-op
+// when GLEIPNIR_PLUGINS_ENABLED=false (i.e. Init was never called, verifier is nil).
+func TestLoader_StartWatcher_DisabledIsNoOp(t *testing.T) {
+	l := NewLoader()
+	if err := l.Init(context.Background(), config.Config{PluginsEnabled: false}); err != nil {
+		t.Fatalf("Init disabled: %v", err)
+	}
+	// StartWatcher must return without panicking or starting anything.
+	// Pass nil for q — the code must not reach any q calls when disabled.
+	l.StartWatcher(context.Background(), nil, t.TempDir())
+}
+
 // captureLogs swaps slog.Default with a buffer-backed handler for the
 // duration of the test and returns the buffer.
 func captureLogs(t *testing.T) *bytes.Buffer {

--- a/main.go
+++ b/main.go
@@ -65,10 +65,11 @@ func run(cfg config.Config) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Plugin loader is a stub today; Init is a no-op when GLEIPNIR_PLUGINS_ENABLED
-	// is false (the default for this release; spec §15.2). Init currently cannot
-	// fail — the error return is for the Phase 3 loader.
-	if err := pluginpkg.NewLoader().Init(ctx, cfg); err != nil {
+	// Plugin loader: Init sets up the Verifier; StartWatcher starts the fsnotify
+	// watcher after the DB is migrated. Both are no-ops when GLEIPNIR_PLUGINS_ENABLED
+	// is false (the default for this release; spec §15.2).
+	loader := pluginpkg.NewLoader()
+	if err := loader.Init(ctx, cfg); err != nil {
 		return fmt.Errorf("init plugin loader: %w", err)
 	}
 
@@ -80,6 +81,12 @@ func run(cfg config.Config) error {
 
 	if err := store.Migrate(ctx); err != nil {
 		return fmt.Errorf("migrate: %w", err)
+	}
+
+	// Start the plugin watcher after migration so the schema is ready.
+	// No-op when GLEIPNIR_PLUGINS_ENABLED=false.
+	if cfg.PluginsEnabled {
+		loader.StartWatcher(ctx, store.Queries(), cfg.PluginsDir)
 	}
 
 	// Mark any in-flight runs as interrupted (ADR-011).

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
 	runpkg "github.com/felag-engineering/gleipnir/internal/execution/run"
-	pluginpkg "github.com/felag-engineering/gleipnir/internal/plugin"
 	"github.com/felag-engineering/gleipnir/internal/http/api"
 	"github.com/felag-engineering/gleipnir/internal/http/auth"
 	"github.com/felag-engineering/gleipnir/internal/http/sse"
@@ -25,6 +24,7 @@ import (
 	llmfactory "github.com/felag-engineering/gleipnir/internal/llm/factory"
 	openaicompatllm "github.com/felag-engineering/gleipnir/internal/llm/openaicompat"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
+	pluginpkg "github.com/felag-engineering/gleipnir/internal/plugin"
 	"github.com/felag-engineering/gleipnir/internal/policy"
 	"github.com/felag-engineering/gleipnir/internal/settings"
 	"github.com/felag-engineering/gleipnir/internal/timeout"
@@ -86,7 +86,9 @@ func run(cfg config.Config) error {
 	// Start the plugin watcher after migration so the schema is ready.
 	// No-op when GLEIPNIR_PLUGINS_ENABLED=false.
 	if cfg.PluginsEnabled {
-		loader.StartWatcher(ctx, store.Queries(), cfg.PluginsDir)
+		if err := loader.StartWatcher(ctx, store.Queries(), cfg.PluginsDir); err != nil {
+			return fmt.Errorf("start plugin watcher: %w", err)
+		}
 	}
 
 	// Mark any in-flight runs as interrupted (ADR-011).


### PR DESCRIPTION
Closes #187

## Summary
Adds the host-side install pipeline for plugin tarballs:

- **`internal/plugin/loader/extract.go`** — safe tarball extraction. Rejects path traversal (`..`, absolute paths, escapes via `filepath.Rel`), symlinks/hardlinks/devices/fifos. Cumulative-byte cap (100MB) defends against gzip bombs.
- **`internal/plugin/loader/install.go`** — extract → parse manifest → `Verifier.VerifyBundle` → snapshot into `plugins` table with status `pending_review` (or update with ADR-038 CAS on version bump). Failed verification → `plugin_audit_events` row only; the `plugins.status` CHECK reserves the health-state machine for #191.
- **`internal/plugin/loader/watcher.go`** — fsnotify watch on `GLEIPNIR_PLUGINS_DIR` (default `/plugins`) with 250ms debounce against burst writes during a tarball drop. Initial directory sweep on startup catches dropins that arrived while the server was down. Sequential install via fire channel (mirrors ADR-003 audit-write serialization).
- **`internal/plugin/loader.go`** — `StartWatcher(ctx, *db.Queries, dir)` second-phase init that runs after `store.Migrate` so the loader stays DB-independent during early startup.
- **`main.go`** — wires `StartWatcher` after migrations, gated on `GLEIPNIR_PLUGINS_ENABLED`.
- **New env var:** `GLEIPNIR_PLUGINS_DIR` (default `/plugins`).

## Test coverage
- `extract_test.go` — 9 cases: happy path, absolute path / `../` / nested traversal / symlink / hardlink rejected, total + entry oversize rejected, subdir creation.
- `install_test.go` — 6 cases: new signed plugin → pending_review, bad sig → audit-only, version bump → pending_review + audit, same version → no-op, oversize tarball, unsigned permissive.
- `watcher_test.go` — 6 cases including the issue's named "burst-of-writes-during-debounce" test, initial sweep, non-tarball ignored, ctx cancel, remove cancels pending timer, and `CancelDuringDebounce_NoRace` regression for a shutdown panic caught in code review.

## Out of scope (explicit)
- Per-instance health-state machine and the `signature_invalid`/`pending_*` states (#191).
- TOFU pubkey capture + Accept-new-key UI (#188).
- Material manifest diff on hot-reload (#189).
- Subprocess spawning + generation refcounts (later phases).

## Plan & review cycles
<details><summary>Architecture plan</summary>

See `.dev-loop/plan.md`. Two-phase loader init keeps DB-independence; sequential install via fire channel mirrors ADR-003; 100MB cumulative cap defends against gzip bombs; signature failures recorded only via `plugin_audit_events` until #191 lands the health-state column.

</details>

- 1 architect pass + adversarial plan review (APPROVE)
- 2 code-review cycles. Cycle 1 caught a shutdown race (`close(fire)` could panic against an in-flight `AfterFunc` send) — fixed by dropping the close and selecting on `<-ctx.Done()` in the dispatch goroutine. Regression test `TestWatcher_CancelDuringDebounce_NoRace` exercises the window with `-race`.
- CLAUDE.md updated: `GLEIPNIR_PLUGINS_DIR` env var row + refreshed `internal/plugin` package description.

🤖 Generated by the agentic dev loop.