### PR TITLE
Fix OpenAI-compat model toggle, whitespace thoughts, and add docker build overlay

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,22 @@
+# Build overlay — builds the gleipnir image from local source instead of
+# pulling felagengineering/gleipnir:latest. Layer this on top of the base
+# compose file so the rest of the service definition (env, volumes, health
+# check, port mapping) is shared.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up --build
+#
+# Combine with the dev overlay to also start the MCP test server:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml -f docker-compose.dev.yml up --build
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: gleipnir:local
+    # host.docker.internal lets the container reach services on the host
+    # (e.g. an LMStudio server bound to 127.0.0.1:1234). Required on Linux
+    # where the alias is not added automatically; harmless on Docker Desktop.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/frontend/src/components/admin/OpenAICompatProvidersSection.module.css
+++ b/frontend/src/components/admin/OpenAICompatProvidersSection.module.css
@@ -66,10 +66,22 @@
   text-align: center;
 }
 
+.tableWrap {
+  overflow-x: auto;
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;
   font-size: var(--text-sm);
+  table-layout: auto;
+}
+
+.table td.url {
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .table th,
@@ -116,6 +128,7 @@
 .actions {
   display: flex;
   gap: var(--space-2);
+  white-space: nowrap;
 }
 
 .actions button {

--- a/frontend/src/components/admin/OpenAICompatProvidersSection.tsx
+++ b/frontend/src/components/admin/OpenAICompatProvidersSection.tsx
@@ -53,6 +53,7 @@ export function OpenAICompatProvidersSection() {
           <p>Add one to use OpenAI, Ollama, vLLM, or any compatible backend.</p>
         </div>
       ) : (
+        <div className={styles.tableWrap}>
         <table className={styles.table}>
           <thead>
             <tr>
@@ -68,13 +69,13 @@ export function OpenAICompatProvidersSection() {
             {rows.map((p) => (
               <tr key={p.id}>
                 <td className={styles.name}>{p.name}</td>
-                <td className={styles.url}>{p.base_url}</td>
+                <td className={styles.url} title={p.base_url}>{p.base_url}</td>
                 <td className={styles.key}>{p.masked_key}</td>
                 <td>
                   {p.models_endpoint_available ? (
                     <span className={styles.badgeOk}>Available</span>
                   ) : (
-                    <span className={styles.badgeWarn}>models endpoint unavailable</span>
+                    <span className={styles.badgeWarn} title="GET /models returned 404 or was unreachable; model-name validation is skipped">Unavailable</span>
                   )}
                 </td>
                 <td>{formatTimestamp(p.updated_at)}</td>
@@ -106,6 +107,7 @@ export function OpenAICompatProvidersSection() {
             ))}
           </tbody>
         </table>
+        </div>
       )}
 
       {modalState !== null && (

--- a/frontend/src/hooks/mutations/admin.ts
+++ b/frontend/src/hooks/mutations/admin.ts
@@ -51,9 +51,9 @@ export function useSetModelEnabled() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: ({ modelId, provider, enabled }: { modelId: string; provider: string; enabled: boolean }) =>
-      apiFetch<{ status: string }>(`/admin/models/${encodeURIComponent(modelId)}/enabled`, {
+      apiFetch<{ status: string }>(`/admin/models/enabled`, {
         method: 'PUT',
-        body: JSON.stringify({ provider, enabled }),
+        body: JSON.stringify({ provider, model_name: modelId, enabled }),
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.admin.models })

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -431,15 +431,24 @@ func (h *Handler) ListAllModels(lister llm.ModelLister) http.HandlerFunc {
 }
 
 // SetModelEnabled enables or disables a model. Disabling the current default model returns 409.
+//
+// Identifier is in the body (not the URL) so model names containing '/'
+// (common for OpenAI-compatible backends like LM Studio: "google/gemma-4-e4b")
+// round-trip cleanly. chi does not URL-decode path params, so a path-based
+// identifier would persist the percent-encoded form and never match the
+// registry-returned name on read.
 func (h *Handler) SetModelEnabled(w http.ResponseWriter, r *http.Request) {
-	modelID := chi.URLParam(r, "id")
-
 	var body struct {
-		Provider string `json:"provider"`
-		Enabled  bool   `json:"enabled"`
+		Provider  string `json:"provider"`
+		ModelName string `json:"model_name"`
+		Enabled   bool   `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON body", "")
+		return
+	}
+	if body.Provider == "" || body.ModelName == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "provider and model_name are required", "")
 		return
 	}
 
@@ -447,7 +456,7 @@ func (h *Handler) SetModelEnabled(w http.ResponseWriter, r *http.Request) {
 		defaultRow, err := h.q.GetSystemSetting(r.Context(), "default_model")
 		if err == nil {
 			defaultVal := defaultRow.Value
-			candidate := body.Provider + ":" + modelID
+			candidate := body.Provider + ":" + body.ModelName
 			if defaultVal == candidate {
 				httputil.WriteError(w, http.StatusConflict, "cannot disable the current default model", "")
 				return
@@ -461,7 +470,7 @@ func (h *Handler) SetModelEnabled(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := h.q.UpsertModelSetting(r.Context(), body.Provider, modelID, enabled, now); err != nil {
+	if err := h.q.UpsertModelSetting(r.Context(), body.Provider, body.ModelName, enabled, now); err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to update model setting", "")
 		return
 	}

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -240,9 +240,8 @@ func TestSetModelEnabled_DisableDefault_Returns409(t *testing.T) {
 		Value: "anthropic:claude-sonnet-4-20250514",
 	}
 
-	body := `{"provider": "anthropic", "enabled": false}`
-	req := httptest.NewRequest(http.MethodPut, "/models/claude-sonnet-4-20250514/enabled", strings.NewReader(body))
-	req = withChiParam(req, "id", "claude-sonnet-4-20250514")
+	body := `{"provider": "anthropic", "model_name": "claude-sonnet-4-20250514", "enabled": false}`
+	req := httptest.NewRequest(http.MethodPut, "/models/enabled", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	h.SetModelEnabled(rec, req)
 
@@ -265,14 +264,60 @@ func TestSetModelEnabled_DisableNonDefault_OK(t *testing.T) {
 		Value: "anthropic:claude-sonnet-4-20250514",
 	}
 
-	body := `{"provider": "openai", "enabled": false}`
-	req := httptest.NewRequest(http.MethodPut, "/models/gpt-4o/enabled", strings.NewReader(body))
-	req = withChiParam(req, "id", "gpt-4o")
+	body := `{"provider": "openai", "model_name": "gpt-4o", "enabled": false}`
+	req := httptest.NewRequest(http.MethodPut, "/models/enabled", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	h.SetModelEnabled(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSetModelEnabled_SlashInName guards the regression that prompted moving
+// the model identifier from the URL path to the request body. chi does not
+// URL-decode path params, so a model name like "google/gemma-4-e4b" used to
+// round-trip as "google%2Fgemma-4-e4b" — written under the encoded key in
+// the DB but compared against the decoded registry name on read, so the
+// toggle silently never took effect.
+func TestSetModelEnabled_SlashInName(t *testing.T) {
+	q := newMockQuerier()
+	h := newTestHandler(q)
+
+	body := `{"provider": "lmstudio", "model_name": "google/gemma-4-e4b", "enabled": true}`
+	req := httptest.NewRequest(http.MethodPut, "/models/enabled", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.SetModelEnabled(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	row, ok := q.models["lmstudio:google/gemma-4-e4b"]
+	if !ok {
+		t.Fatalf("expected row keyed by raw model name, got models: %#v", q.models)
+	}
+	if row.ModelName != "google/gemma-4-e4b" {
+		t.Errorf("model_name = %q, want %q", row.ModelName, "google/gemma-4-e4b")
+	}
+	if row.Enabled != 1 {
+		t.Errorf("enabled = %d, want 1", row.Enabled)
+	}
+}
+
+func TestSetModelEnabled_MissingFields(t *testing.T) {
+	q := newMockQuerier()
+	h := newTestHandler(q)
+
+	for _, body := range []string{
+		`{"provider": "lmstudio", "enabled": true}`,
+		`{"model_name": "x", "enabled": true}`,
+	} {
+		req := httptest.NewRequest(http.MethodPut, "/models/enabled", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		h.SetModelEnabled(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body %s: expected 400, got %d", body, rec.Code)
+		}
 	}
 }
 

--- a/internal/admin/openai_compat_handler.go
+++ b/internal/admin/openai_compat_handler.go
@@ -408,6 +408,13 @@ func (h *OpenAICompatHandler) TestProvider(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	h.modelsAvail[existing.Name] = modelsAvail
+	// The tester runs against a one-shot client; the registry-side client may
+	// still hold a stale model cache from a prior failed fetch. Drop it so the
+	// next /admin/models/all picks up the freshly verified backend state.
+	if err := h.registry.InvalidateModelCache(existing.Name); err != nil {
+		// Provider isn't registered (deleted between save and test). Not fatal.
+		_ = err
+	}
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{
 		"ok":                        true,
 		"models_endpoint_available": modelsAvail,

--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -182,7 +182,7 @@ func BuildRouter(cfg RouterConfig) chi.Router {
 			r.Put("/settings", cfg.Handlers.AdminHandler.UpdateSettings)
 			r.Get("/models", cfg.Handlers.AdminHandler.ListModelsAdmin)
 			r.Get("/models/all", cfg.Handlers.AdminHandler.ListAllModels(cfg.Services.ModelLister))
-			r.Put("/models/{id}/enabled", cfg.Handlers.AdminHandler.SetModelEnabled)
+			r.Put("/models/enabled", cfg.Handlers.AdminHandler.SetModelEnabled)
 			r.Get("/system-info", admin.GetSystemInfo(admin.SystemInfoDeps{
 				Version:   cfg.Metadata.Version,
 				StartTime: cfg.Metadata.StartTime,

--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -88,14 +88,8 @@ func parseSSEStream(ctx context.Context, body io.ReadCloser, out chan<- llm.Mess
 
 		for _, choice := range chunk.Choices {
 			if choice.Delta.Content != nil && *choice.Delta.Content != "" {
-				// Drop deltas whose only content is whitespace. Local models
-				// (LM Studio, Ollama) frequently sprinkle bare "\n" deltas
-				// alongside tool calls; surfacing them creates empty text
-				// blocks downstream.
-				if strings.TrimSpace(*choice.Delta.Content) != "" {
-					text := *choice.Delta.Content
-					out <- llm.MessageChunk{Text: &text}
-				}
+				text := *choice.Delta.Content
+				out <- llm.MessageChunk{Text: &text}
 			}
 			for _, part := range choice.Delta.ToolCalls {
 				p := partials[part.Index]

--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -88,8 +88,14 @@ func parseSSEStream(ctx context.Context, body io.ReadCloser, out chan<- llm.Mess
 
 		for _, choice := range chunk.Choices {
 			if choice.Delta.Content != nil && *choice.Delta.Content != "" {
-				text := *choice.Delta.Content
-				out <- llm.MessageChunk{Text: &text}
+				// Drop deltas whose only content is whitespace. Local models
+				// (LM Studio, Ollama) frequently sprinkle bare "\n" deltas
+				// alongside tool calls; surfacing them creates empty text
+				// blocks downstream.
+				if strings.TrimSpace(*choice.Delta.Content) != "" {
+					text := *choice.Delta.Content
+					out <- llm.MessageChunk{Text: &text}
+				}
 			}
 			for _, part := range choice.Delta.ToolCalls {
 				p := partials[part.Index]

--- a/internal/llm/openaicompat/translate.go
+++ b/internal/llm/openaicompat/translate.go
@@ -179,9 +179,12 @@ func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping) 
 	choice := wire.Choices[0]
 
 	// Content is omitted (nil) when the response is tool-calls-only; an empty
-	// string string also carries no useful text and would create a spurious block
-	// that confuses callers expecting at least one real token.
-	if choice.Message.Content != nil && *choice.Message.Content != "" {
+	// or whitespace-only string also carries no useful text and would create a
+	// spurious block that confuses callers expecting at least one real token.
+	// Local models served via LM Studio / Ollama frequently emit "\n" or "\n\n"
+	// alongside tool calls — we strip those out here rather than every caller
+	// having to filter blank thought steps.
+	if choice.Message.Content != nil && strings.TrimSpace(*choice.Message.Content) != "" {
 		out.Text = []llm.TextBlock{{Text: *choice.Message.Content}}
 	}
 

--- a/internal/llm/openaicompat/translate_test.go
+++ b/internal/llm/openaicompat/translate_test.go
@@ -533,6 +533,40 @@ func TestParseChatCompletionResponse_MalformedToolArguments(t *testing.T) {
 	}
 }
 
+// TestParseChatCompletionResponse_WhitespaceContent guards the regression
+// where local models (LM Studio, Ollama) emit "\n" or "\n\n" in content
+// alongside tool calls. The whitespace string used to slip past the empty
+// check and surface as a thought step containing only newlines.
+func TestParseChatCompletionResponse_WhitespaceContent(t *testing.T) {
+	for _, raw := range []string{"\n", "\n\n", "  ", "\t\n"} {
+		content := raw
+		wire := &chatResponse{
+			Choices: []chatChoice{{
+				Message: chatMessage{
+					Role:    "assistant",
+					Content: &content,
+					ToolCalls: []chatToolCall{{
+						ID:       "c1",
+						Type:     "function",
+						Function: chatToolCallFunc{Name: "t", Arguments: "{}"},
+					}},
+				},
+				FinishReason: "tool_calls",
+			}},
+		}
+		resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{})
+		if err != nil {
+			t.Fatalf("content %q: parse: %v", raw, err)
+		}
+		if len(resp.Text) != 0 {
+			t.Errorf("content %q: expected no text blocks, got %d (%q)", raw, len(resp.Text), resp.Text[0].Text)
+		}
+		if len(resp.ToolCalls) != 1 {
+			t.Errorf("content %q: expected tool call to round-trip, got %d", raw, len(resp.ToolCalls))
+		}
+	}
+}
+
 func TestParseChatCompletionResponse_UnknownFinishReason(t *testing.T) {
 	s := "hi"
 	wire := &chatResponse{


### PR DESCRIPTION
## Summary

Three independent fixes that surfaced while standing up Gleipnir against a local LM Studio backend, plus a docker-compose overlay for building from source.

- **OpenAI-compat model toggle never took effect for names containing `/`.** chi v5 does not URL-decode path params, so a model name like `google/gemma-4-e4b` round-tripped through `PUT /api/v1/admin/models/{id}/enabled` as `google%2Fgemma-4-e4b`, was persisted under the encoded key, and never matched the registry's decoded name on read. Move the identifier to the JSON body — route is now `PUT /api/v1/admin/models/enabled` with `{provider, model_name, enabled}`. Frontend mutation updated to match.
- **Whitespace-only `content` in tool-call responses produced empty thought rows.** LM Studio / Ollama frequently emit `"\n"` or `"\n\n"` alongside tool calls instead of leaving content empty or null. The non-streaming translator's empty-string guard let that whitespace through and surfaced it as a `thought` audit step containing only newlines. Trim before deciding whether to emit. The streaming path is left alone — each delta there is an incremental chunk and a single-space delta is meaningful punctuation between words.
- **`/admin/openai-providers/{id}/test` left the registry's model cache stale.** A user who first saved a provider with a wrong base URL got `models endpoint unavailable`; even after fixing the URL and clicking Test, `/admin/models/all` kept returning an empty list because the registered client cached the failure. Invalidate the registry-side cache after a successful test.
- **OpenAI-compat providers admin table layout.** Long base URLs and the `models endpoint unavailable` badge pushed the Delete button off the right edge. Wrap the table in `overflow-x: auto`, truncate the URL column at 280px with a title tooltip, shorten the badge to `Unavailable` (with a hover tooltip explaining what it means), and pin the actions cell to `nowrap`.
- **`docker-compose.build.yml` overlay** for building the api image from local source instead of pulling `felagengineering/gleipnir:latest`. Adds a `host.docker.internal` host-gateway alias so the container can reach LM Studio / other host-bound services on Linux.

A separate issue (#273) tracks surfacing `reasoning_content` from OpenAI-compatible reasoning models as `thinking` steps — explicitly out of scope for this PR.

## Test plan
- [x] `go test ./...` — admin, openaicompat, http/api packages all green
- [x] New regression tests:
  - `TestSetModelEnabled_SlashInName` — guards the `google/gemma-4-e4b` round-trip
  - `TestSetModelEnabled_MissingFields` — body validation
  - `TestParseChatCompletionResponse_WhitespaceContent` — covers `"\n"`, `"\n\n"`, `"  "`, `"\t\n"`
- [x] Manual verification against LM Studio: model with `/` in name now toggles and persists; tool-call responses no longer produce empty newline thought rows in the run timeline
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.build.yml up --build -d` — image builds, api healthy, mcp-test-server reachable from api container

🤖 Generated with [Claude Code](https://claude.com/claude-code)