### PR TITLE
feat(plugin): per-instance health-state machine + admin chip (#191)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ internal/
   mcp/                — MCP HTTP client, tool registry, capability tags
   model/              — domain types (Policy, Run, RunStep, ApprovalRequest, enums, ...)
   plugin/             — host-side plugin loader; gated by GLEIPNIR_PLUGINS_ENABLED. Implements fsnotify watcher, tarball extractor, minisign verifier, and DB installer. Out-of-process subprocess spawning and generation refcounts remain as follow-up work.
+    state/            — per-instance health-state machine; mirrors execution/runstate (transition table + version-CAS, ADR-038). Severity ranking encodes §8.1 "plugin can only mark itself worse" merge rule.
   policy/             — YAML parser, validator, system prompt renderer
   settings/           — read-side accessor for system_settings (default model, public URL); injected into runtime so non-admin packages don't depend on the admin HTTP handler
   testutil/           — shared test helpers
@@ -176,6 +177,7 @@ Routes are registered in `internal/http/api/router.go` via `BuildRouter`, which 
 - `/api/v1/policies/*` — CRUD for policies
 - `/api/v1/runs/*` — list/get runs, steps, cancel, approval, feedback
 - `/api/v1/mcp/servers/*` — MCP server registry, tool discovery; `PUT /:id` updates name/url only; `PUT /:id/headers/:name` and `DELETE /:id/headers/:name` manage individual auth headers (admin|operator only; see ADR-039); `POST /:id/arcade/authorize` and `POST /:id/arcade/authorize/wait` pre-authorize Arcade toolkits (admin|operator only; see ADR-040)
+- `/api/v1/admin/plugins/{id}/instances/{iid}` — per-instance plugin health (state, detail, version) for the admin plugins UI; admin-only
 - `/api/v1/webhooks/{policyID}` — fires a webhook-triggered run (auth dispatcher per `trigger.auth`: hmac | bearer | none)
 - `/api/v1/policies/{policyID}/trigger` — fires a manual run
 - `/api/v1/policies/{id}/webhook/rotate`, `/api/v1/policies/{id}/webhook/secret` — rotate/reveal the webhook secret (admin|operator only; see ADR-034)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -225,7 +225,7 @@ Organized by feature area:
 - **AgentList/** — agent list with folder grouping
 - **RunDetail/** — RunHeader, StepTimeline, FilterBar, MetadataGrid, CapabilitySnapshotCard, ThoughtBlock, ThinkingBlock, ToolBlock, CompleteBlock, ErrorBlock, FeedbackBlock, ApprovalActions, FeedbackActions
 - **MCPPage/** — ServerCard, ToolList, ToolRow, MCPStatsBar, HealthIndicator, AddServerModal, DeleteServerModal, ServerDetailModal (per-header auth editor: existing name fields are read-only, value field is empty with placeholder; save fans out via `useSetMcpServerHeader`/`useDeleteMcpServerHeader`; no sentinel; see ADR-039), ArcadeAuthSection (toolkit-level OAuth pre-authorization for Arcade gateways; renders only when `server.is_arcade_gateway && canManage`; see ADR-040)
-- **admin/** — EncryptionKeyNotice (persistent warning banner on the Models page about encryption key backup requirements)
+- **admin/** — EncryptionKeyNotice (persistent warning banner on the Models page about encryption key backup requirements), PluginHealthChip (colored chip — green/yellow/red — for the 10 plugin-instance health states; pairs with `utils/pluginHealth.ts` for the worst-across-instances aggregate)
 - **form/** — FieldError (inline message under a field), ErrorBanner (top-of-form bulleted summary with scroll-to-field). Shared primitives for surfacing validation/save errors.
 - **Shared** — Button, Modal, ModalFooter, EmptyState, ErrorBoundary, QueryBoundary, CopyBlock, CollapsibleJSON, SkeletonBlock, PageHeader, ApprovalBanner, ConnectionBanner, TriggerRunModal
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -365,3 +365,31 @@ export interface ArcadeAuthorizeWaitRequest {
   toolkit: string
   auth_id: string
 }
+
+// Matches internal/model/plugin_health.go → PluginHealthState.
+// Ten states across three severity tiers:
+//   Green  — healthy
+//   Yellow — degraded but operational
+//   Red    — non-functional
+export type PluginHealthState =
+  | 'healthy'
+  | 'unsigned_permissive'
+  | 'pending_key_approval'
+  | 'pending_manifest_approval'
+  | 'pending_config_migration'
+  | 'unhealthy'
+  | 'circuit_broken'
+  | 'verification_error'
+  | 'signature_invalid'
+  | 'crashed'
+
+// Matches internal/admin/plugin_handler.go → instanceResponse.
+export interface ApiPluginInstance {
+  id: string
+  plugin_id: string
+  instance_name: string
+  state: PluginHealthState
+  detail: string | null
+  version: number
+  updated_at: string
+}

--- a/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.module.css
+++ b/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.module.css
@@ -1,0 +1,42 @@
+.chip {
+  composes: badgeRect from '../../../styles/badges.module.css';
+  font-family: var(--font-mono);
+  cursor: default;
+  border: 1px solid transparent;
+  /* Reset button styles */
+  background: transparent;
+  padding: var(--space-1) var(--space-2);
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+
+.chip:not(:disabled) {
+  cursor: pointer;
+}
+
+.chip:hover:not(:disabled) {
+  opacity: 0.8;
+}
+
+.green {
+  color: var(--color-green);
+  background: color-mix(in srgb, var(--color-green) 8%, transparent);
+  border-color: color-mix(in srgb, var(--color-green) 20%, transparent);
+}
+
+.yellow {
+  color: var(--color-amber);
+  background: color-mix(in srgb, var(--color-amber) 8%, transparent);
+  border-color: color-mix(in srgb, var(--color-amber) 20%, transparent);
+}
+
+.red {
+  color: var(--color-red);
+  background: color-mix(in srgb, var(--color-red) 8%, transparent);
+  border-color: color-mix(in srgb, var(--color-red) 20%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chip {
+    transition: none;
+  }
+}

--- a/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.stories.tsx
+++ b/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import '@/tokens.css'
+import { PluginHealthChip } from './PluginHealthChip'
+
+const meta: Meta<typeof PluginHealthChip> = {
+  title: 'Admin/PluginHealthChip',
+  component: PluginHealthChip,
+  argTypes: {
+    state: {
+      control: 'select',
+      options: [
+        'healthy',
+        'unsigned_permissive',
+        'pending_key_approval',
+        'pending_manifest_approval',
+        'pending_config_migration',
+        'unhealthy',
+        'circuit_broken',
+        'verification_error',
+        'signature_invalid',
+        'crashed',
+      ],
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof PluginHealthChip>
+
+export const Healthy: Story = { args: { state: 'healthy' } }
+export const UnsignedPermissive: Story = { args: { state: 'unsigned_permissive' } }
+export const PendingKeyApproval: Story = { args: { state: 'pending_key_approval' } }
+export const PendingManifestApproval: Story = { args: { state: 'pending_manifest_approval' } }
+export const PendingConfigMigration: Story = { args: { state: 'pending_config_migration' } }
+export const Unhealthy: Story = { args: { state: 'unhealthy' } }
+export const CircuitBroken: Story = { args: { state: 'circuit_broken' } }
+export const VerificationError: Story = { args: { state: 'verification_error' } }
+export const SignatureInvalid: Story = { args: { state: 'signature_invalid' } }
+export const Crashed: Story = { args: { state: 'crashed' } }
+
+export const WithDetail: Story = {
+  args: {
+    state: 'verification_error',
+    detail: 'Manifest hash does not match trusted snapshot',
+    onClick: () => alert('Chip clicked'),
+  },
+}
+
+// AggregateWorst shows a row of all states to validate color mapping at a glance.
+// This is the pattern a future /admin/plugins page would use to show instance health.
+export const AggregateWorst: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+      <PluginHealthChip state="healthy" />
+      <PluginHealthChip state="unsigned_permissive" />
+      <PluginHealthChip state="pending_key_approval" />
+      <PluginHealthChip state="pending_manifest_approval" />
+      <PluginHealthChip state="pending_config_migration" />
+      <PluginHealthChip state="unhealthy" />
+      <PluginHealthChip state="circuit_broken" />
+      <PluginHealthChip state="verification_error" />
+      <PluginHealthChip state="signature_invalid" />
+      <PluginHealthChip state="crashed" />
+    </div>
+  ),
+}

--- a/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.test.tsx
+++ b/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PluginHealthChip } from './PluginHealthChip'
+import type { PluginHealthState } from '@/api/types'
+
+describe('PluginHealthChip', () => {
+  it('renders the label for each state', () => {
+    const cases: Array<[PluginHealthState, string]> = [
+      ['healthy', 'Healthy'],
+      ['unsigned_permissive', 'Unsigned (permissive)'],
+      ['pending_key_approval', 'Pending key approval'],
+      ['pending_manifest_approval', 'Pending manifest approval'],
+      ['pending_config_migration', 'Pending config migration'],
+      ['unhealthy', 'Unhealthy'],
+      ['circuit_broken', 'Circuit broken'],
+      ['verification_error', 'Verification error'],
+      ['signature_invalid', 'Signature invalid'],
+      ['crashed', 'Crashed'],
+    ]
+    for (const [state, label] of cases) {
+      const { unmount } = render(<PluginHealthChip state={state} />)
+      expect(screen.getByText(label)).toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('calls onClick when clicked', async () => {
+    const handler = vi.fn()
+    render(<PluginHealthChip state="healthy" onClick={handler} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Healthy' }))
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('sets the title attribute to the detail prop', () => {
+    const detail = 'Manifest hash mismatch'
+    render(<PluginHealthChip state="verification_error" detail={detail} />)
+    expect(screen.getByRole('button')).toHaveAttribute('title', detail)
+  })
+
+  it('renders a green variant for healthy state', () => {
+    render(<PluginHealthChip state="healthy" />)
+    const btn = screen.getByRole('button')
+    // CSS Modules generate a hashed class name; we verify a class is present.
+    // The exact class name is verified by the green/yellow/red naming convention
+    // in the CSS module — this test confirms the class is applied at all.
+    expect(btn.className).toMatch(/green/)
+  })
+
+  it('renders a yellow variant for pending states', () => {
+    render(<PluginHealthChip state="pending_key_approval" />)
+    expect(screen.getByRole('button').className).toMatch(/yellow/)
+  })
+
+  it('renders a red variant for error states', () => {
+    render(<PluginHealthChip state="crashed" />)
+    expect(screen.getByRole('button').className).toMatch(/red/)
+  })
+})

--- a/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.tsx
+++ b/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.tsx
@@ -1,0 +1,39 @@
+import type { PluginHealthState } from '@/api/types'
+import { pluginHealthLabel } from '@/utils/pluginHealth'
+import styles from './PluginHealthChip.module.css'
+
+interface PluginHealthChipProps {
+  state: PluginHealthState
+  detail?: string
+  onClick?: () => void
+}
+
+// variant maps each state to a CSS module class based on its severity tier.
+//   green  — healthy
+//   yellow — degraded but operational (unsigned_permissive, pending_*, unhealthy)
+//   red    — non-functional (verification_error, signature_invalid, circuit_broken, crashed)
+const VARIANT: Record<PluginHealthState, string> = {
+  healthy:                    styles.green,
+  unsigned_permissive:        styles.yellow,
+  pending_key_approval:       styles.yellow,
+  pending_manifest_approval:  styles.yellow,
+  pending_config_migration:   styles.yellow,
+  unhealthy:                  styles.yellow,
+  circuit_broken:             styles.red,
+  verification_error:         styles.red,
+  signature_invalid:          styles.red,
+  crashed:                    styles.red,
+}
+
+export function PluginHealthChip({ state, detail, onClick }: PluginHealthChipProps) {
+  return (
+    <button
+      type="button"
+      className={`${styles.chip} ${VARIANT[state]}`}
+      title={detail}
+      onClick={onClick}
+    >
+      {pluginHealthLabel(state)}
+    </button>
+  )
+}

--- a/frontend/src/utils/pluginHealth.test.ts
+++ b/frontend/src/utils/pluginHealth.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { worstHealth, pluginHealthLabel } from '@/utils/pluginHealth'
+import type { PluginHealthState } from '@/api/types'
+
+describe('worstHealth', () => {
+  it('returns healthy for an empty array', () => {
+    expect(worstHealth([])).toBe('healthy')
+  })
+
+  it('returns the single state when only one is provided', () => {
+    expect(worstHealth(['unhealthy'])).toBe('unhealthy')
+  })
+
+  it('picks the worst across mixed states', () => {
+    const states: PluginHealthState[] = ['healthy', 'unhealthy', 'crashed']
+    expect(worstHealth(states)).toBe('crashed')
+  })
+
+  it('returns healthy when all states are healthy', () => {
+    expect(worstHealth(['healthy', 'healthy'])).toBe('healthy')
+  })
+
+  it('treats crashed as worse than signature_invalid', () => {
+    // crashed = severity 7, signature_invalid = 6, verification_error = 5
+    const states: PluginHealthState[] = ['signature_invalid', 'verification_error', 'crashed']
+    expect(worstHealth(states)).toBe('crashed')
+  })
+
+  it('treats signature_invalid as worse than verification_error', () => {
+    const states: PluginHealthState[] = ['verification_error', 'signature_invalid']
+    expect(worstHealth(states)).toBe('signature_invalid')
+  })
+
+  it('all pending states have equal severity (returns first encountered)', () => {
+    // All three pending states share severity 2 — worstHealth picks whichever
+    // appears last when tied (iterates in order, replaces on strictly-greater).
+    const states: PluginHealthState[] = [
+      'pending_key_approval',
+      'pending_manifest_approval',
+      'pending_config_migration',
+    ]
+    // None is strictly worse than another; first one stays as worst.
+    expect(worstHealth(states)).toBe('pending_key_approval')
+  })
+})
+
+describe('pluginHealthLabel', () => {
+  const cases: Array<[PluginHealthState, string]> = [
+    ['healthy',                   'Healthy'],
+    ['unsigned_permissive',       'Unsigned (permissive)'],
+    ['pending_key_approval',      'Pending key approval'],
+    ['pending_manifest_approval', 'Pending manifest approval'],
+    ['pending_config_migration',  'Pending config migration'],
+    ['unhealthy',                 'Unhealthy'],
+    ['circuit_broken',            'Circuit broken'],
+    ['verification_error',        'Verification error'],
+    ['signature_invalid',         'Signature invalid'],
+    ['crashed',                   'Crashed'],
+  ]
+
+  for (const [state, label] of cases) {
+    it(`${state} → "${label}"`, () => {
+      expect(pluginHealthLabel(state)).toBe(label)
+    })
+  }
+})

--- a/frontend/src/utils/pluginHealth.ts
+++ b/frontend/src/utils/pluginHealth.ts
@@ -1,0 +1,45 @@
+import type { PluginHealthState } from '@/api/types'
+
+// Severity ranking mirrors internal/plugin/state/pluginstate.go → severity map.
+// Higher rank = worse health. The ranking is a design decision from issue #191;
+// see that package's godoc for the full rationale.
+const SEVERITY: Record<PluginHealthState, number> = {
+  healthy:                    0,
+  unsigned_permissive:        1,
+  pending_key_approval:       2,
+  pending_manifest_approval:  2,
+  pending_config_migration:   2,
+  unhealthy:                  3,
+  circuit_broken:             4,
+  verification_error:         5,
+  signature_invalid:          6,
+  crashed:                    7,
+}
+
+// worstHealth returns the most severe state from the given array.
+// Returns 'healthy' for an empty array.
+export function worstHealth(states: PluginHealthState[]): PluginHealthState {
+  let worst: PluginHealthState = 'healthy'
+  for (const s of states) {
+    if (SEVERITY[s] > SEVERITY[worst]) {
+      worst = s
+    }
+  }
+  return worst
+}
+
+// pluginHealthLabel returns the human-readable display label for a health state.
+export function pluginHealthLabel(state: PluginHealthState): string {
+  switch (state) {
+    case 'healthy':                   return 'Healthy'
+    case 'unsigned_permissive':       return 'Unsigned (permissive)'
+    case 'pending_key_approval':      return 'Pending key approval'
+    case 'pending_manifest_approval': return 'Pending manifest approval'
+    case 'pending_config_migration':  return 'Pending config migration'
+    case 'unhealthy':                 return 'Unhealthy'
+    case 'circuit_broken':            return 'Circuit broken'
+    case 'verification_error':        return 'Verification error'
+    case 'signature_invalid':         return 'Signature invalid'
+    case 'crashed':                   return 'Crashed'
+  }
+}

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -1,0 +1,77 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+)
+
+// PluginQuerier is the narrow DB interface required by PluginHandler.
+// Accepting an interface (not *db.Queries) keeps the handler testable with
+// a fake querier and mirrors the AdminQuerier pattern in handler.go.
+type PluginQuerier interface {
+	GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error)
+}
+
+// PluginHandler handles plugin-related admin endpoints.
+type PluginHandler struct {
+	q PluginQuerier
+}
+
+// NewPluginHandler returns a PluginHandler backed by the given querier.
+func NewPluginHandler(q PluginQuerier) *PluginHandler {
+	return &PluginHandler{q: q}
+}
+
+// instanceResponse is the JSON shape returned by GetInstance.
+// Credentials and other write-only fields are intentionally absent — mirrors
+// the ADR-039 read-restraint pattern for encrypted auth headers.
+type instanceResponse struct {
+	ID           string  `json:"id"`
+	PluginID     string  `json:"plugin_id"`
+	InstanceName string  `json:"instance_name"`
+	State        string  `json:"state"`
+	Detail       *string `json:"detail"`
+	Version      int64   `json:"version"`
+	UpdatedAt    string  `json:"updated_at"`
+}
+
+// GetInstance handles GET /api/v1/admin/plugins/{id}/instances/{iid}.
+// Returns the health state and detail for a single plugin instance. 404 is
+// returned when the instance does not exist or belongs to a different plugin.
+func (h *PluginHandler) GetInstance(w http.ResponseWriter, r *http.Request) {
+	pluginID := chi.URLParam(r, "id")
+	instanceID := chi.URLParam(r, "iid")
+
+	row, err := h.q.GetPluginInstanceByID(r.Context(), instanceID)
+	if errors.Is(err, ErrNotFound) {
+		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
+		return
+	}
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get instance", "")
+		return
+	}
+
+	// Validate that the instance belongs to the requested plugin. Return 404
+	// rather than 403 to avoid leaking instance existence across plugins.
+	if row.PluginID != pluginID {
+		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, instanceResponse{
+		ID:           row.ID,
+		PluginID:     row.PluginID,
+		InstanceName: row.InstanceName,
+		State:        row.HealthState,
+		Detail:       row.HealthDetail,
+		Version:      row.Version,
+		UpdatedAt:    row.UpdatedAt,
+	})
+}

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -1,0 +1,136 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+)
+
+// fakePluginQuerier is an in-memory PluginQuerier for tests.
+type fakePluginQuerier struct {
+	instances map[string]db.PluginInstance
+}
+
+func (f *fakePluginQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
+	row, ok := f.instances[id]
+	if !ok {
+		return db.PluginInstance{}, ErrNotFound
+	}
+	return row, nil
+}
+
+func newFakePluginQuerier() *fakePluginQuerier {
+	return &fakePluginQuerier{instances: make(map[string]db.PluginInstance)}
+}
+
+func (f *fakePluginQuerier) seed(inst db.PluginInstance) {
+	f.instances[inst.ID] = inst
+}
+
+func TestPluginHandler_GetInstance(t *testing.T) {
+	detail := "verified by host"
+
+	tests := []struct {
+		name         string
+		pluginID     string
+		instanceID   string
+		seed         *db.PluginInstance // nil means don't seed
+		wantStatus   int
+		wantState    string
+		wantPluginID string
+	}{
+		{
+			name:       "200 happy path",
+			pluginID:   "plugin-1",
+			instanceID: "inst-1",
+			seed: &db.PluginInstance{
+				ID:           "inst-1",
+				PluginID:     "plugin-1",
+				InstanceName: "prod",
+				HealthState:  "healthy",
+				HealthDetail: &detail,
+				Version:      3,
+				UpdatedAt:    "2024-01-01T00:00:00Z",
+			},
+			wantStatus:   http.StatusOK,
+			wantState:    "healthy",
+			wantPluginID: "plugin-1",
+		},
+		{
+			name:       "404 instance not found",
+			pluginID:   "plugin-1",
+			instanceID: "inst-missing",
+			seed:       nil,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "404 mismatched plugin_id",
+			pluginID:   "plugin-X",
+			instanceID: "inst-1",
+			seed: &db.PluginInstance{
+				ID:           "inst-1",
+				PluginID:     "plugin-1", // belongs to a different plugin
+				InstanceName: "prod",
+				HealthState:  "healthy",
+				Version:      0,
+				UpdatedAt:    "2024-01-01T00:00:00Z",
+			},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := newFakePluginQuerier()
+			if tt.seed != nil {
+				q.seed(*tt.seed)
+			}
+			h := NewPluginHandler(q)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins/"+tt.pluginID+"/instances/"+tt.instanceID, nil)
+			req = withChiParams(req, map[string]string{"id": tt.pluginID, "iid": tt.instanceID})
+			rec := httptest.NewRecorder()
+			h.GetInstance(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body: %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+
+			data := parseDataResponse(t, rec)
+			var resp instanceResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if resp.State != tt.wantState {
+				t.Errorf("state = %q, want %q", resp.State, tt.wantState)
+			}
+			if resp.PluginID != tt.wantPluginID {
+				t.Errorf("plugin_id = %q, want %q", resp.PluginID, tt.wantPluginID)
+			}
+			if resp.ID != tt.instanceID {
+				t.Errorf("id = %q, want %q", resp.ID, tt.instanceID)
+			}
+		})
+	}
+}
+
+// withChiParams sets multiple chi URL params on a request in a single route
+// context so none are lost when chaining (withChiParam creates a new context
+// each time, which would overwrite any previously set params).
+func withChiParams(r *http.Request, params map[string]string) *http.Request {
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}

--- a/internal/db/migrations/0001_initial.sql
+++ b/internal/db/migrations/0001_initial.sql
@@ -395,7 +395,10 @@ CREATE TABLE plugin_instances (
                                          'pending_manifest_approval',
                                          'pending_config_migration',
                                          'verification_error',
-                                         'unsigned_permissive'
+                                         'unsigned_permissive',
+                                         'unhealthy',
+                                         'crashed',
+                                         'circuit_broken'
                                      )),
     health_detail            TEXT,
     last_oauth_callback_url  TEXT,

--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -38,6 +38,7 @@ type HandlerBundle struct {
 	SettingsHandler      *auth.SettingsHandler
 	AdminHandler         *admin.Handler
 	OpenAICompatHandler  *admin.OpenAICompatHandler
+	PluginAdminHandler   *admin.PluginHandler
 	WebhookHandler       *trigger.WebhookHandler
 	SSEHandler           *sse.Handler
 	PolicyWebhookHandler *PolicyWebhookHandler
@@ -214,6 +215,10 @@ func BuildRouter(cfg RouterConfig) chi.Router {
 					return int(n), err
 				},
 			}))
+
+			if cfg.Handlers.PluginAdminHandler != nil {
+				r.Get("/plugins/{id}/instances/{iid}", cfg.Handlers.PluginAdminHandler.GetInstance)
+			}
 
 			r.Route("/openai-providers", func(r chi.Router) {
 				r.Get("/", cfg.Handlers.OpenAICompatHandler.ListProviders)

--- a/internal/model/plugin_health.go
+++ b/internal/model/plugin_health.go
@@ -1,0 +1,25 @@
+package model
+
+// PluginHealthState represents the lifecycle health of a plugin instance.
+// States fall into three severity tiers:
+//
+//	Green  — healthy
+//	Yellow — degraded but operational (unsigned_permissive, pending_*, unhealthy)
+//	Red    — non-functional (verification_error, signature_invalid, circuit_broken, crashed)
+//
+// The transition graph and total severity ordering are defined in
+// internal/plugin/state. See spec §5.6 and issue #191.
+type PluginHealthState string
+
+const (
+	PluginHealthStateHealthy                PluginHealthState = "healthy"
+	PluginHealthStateUnsignedPermissive     PluginHealthState = "unsigned_permissive"
+	PluginHealthStatePendingKeyApproval     PluginHealthState = "pending_key_approval"
+	PluginHealthStatePendingManifestApproval PluginHealthState = "pending_manifest_approval"
+	PluginHealthStatePendingConfigMigration PluginHealthState = "pending_config_migration"
+	PluginHealthStateUnhealthy              PluginHealthState = "unhealthy"
+	PluginHealthStateCircuitBroken          PluginHealthState = "circuit_broken"
+	PluginHealthStateVerificationError      PluginHealthState = "verification_error"
+	PluginHealthStateSignatureInvalid       PluginHealthState = "signature_invalid"
+	PluginHealthStateCrashed                PluginHealthState = "crashed"
+)

--- a/internal/plugin/state/metrics.go
+++ b/internal/plugin/state/metrics.go
@@ -1,0 +1,25 @@
+package state
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// pluginHealthTransitionsTotal counts successful plugin health state machine
+// transitions. Called only on the success path, after the DB write commits, so
+// the counter accurately reflects durable transitions.
+var pluginHealthTransitionsTotal = promauto.With(metrics.Registry()).NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "gleipnir_plugin_health_transitions_total",
+		Help: "Count of plugin instance health state machine transitions.",
+	},
+	[]string{metrics.LabelFrom, metrics.LabelTo},
+)
+
+// RecordTransition increments the plugin health transition counter for from→to.
+func RecordTransition(from, to model.PluginHealthState) {
+	pluginHealthTransitionsTotal.WithLabelValues(string(from), string(to)).Inc()
+}

--- a/internal/plugin/state/pluginstate.go
+++ b/internal/plugin/state/pluginstate.go
@@ -1,0 +1,236 @@
+// Package state provides the plugin instance health-state machine and CAS
+// transition helpers. It mirrors the shape of internal/execution/runstate
+// (ADR-038 atomic transitions) for consistency.
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// ErrIllegalTransition is returned when a requested health-state transition is
+// not permitted by the plugin health state machine graph.
+var ErrIllegalTransition = errors.New("illegal plugin health state transition")
+
+// ErrTransitionConflict is returned when a CAS update finds that another writer
+// already advanced the instance's version. The instance is in a valid state in
+// the DB — the caller must not treat this as fatal, only as a signal that its
+// write was lost.
+var ErrTransitionConflict = errors.New("plugin health state transition lost to concurrent writer")
+
+// Origin identifies who is reporting a health-state change. The §8.1 rule
+// ("plugin can only mark itself worse than host-detected state") is encoded
+// inside SetHealthState based on this value.
+type Origin int
+
+const (
+	// OriginHost means the Gleipnir host runtime is reporting the state.
+	OriginHost Origin = iota
+	// OriginPluginSelf means the plugin process itself reported the state via
+	// the host RPC SetHealthState call.
+	OriginPluginSelf
+)
+
+// Querier is the narrow DB interface required by this package. Accepting an
+// interface (not *db.Queries) keeps the package testable with a fake querier
+// and mirrors the admin.Handler pattern.
+type Querier interface {
+	GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error)
+	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
+}
+
+// severity maps each health state to a numeric rank used to compare states.
+// Higher rank = worse health. The total ordering is required by the §8.1 merge
+// rule ("plugin-self can only worsen; worst across plugin-self and host wins").
+//
+// This ordering is a design decision introduced in issue #191: the spec §8.1
+// specifies the merge rule but not the full total ordering across all 10 states.
+// The ranking here reflects the operational impact of each state:
+//
+//	0 = fully operational
+//	1 = degraded-but-allowed (unsigned is intentional operator choice)
+//	2 = waiting for operator action (pending states)
+//	3 = runtime auth/availability problem (unhealthy)
+//	4 = circuit breaker tripped (requests not routed)
+//	5 = cryptographic verification failed
+//	6 = manifest signature rejected
+//	7 = process crash
+var severity = map[model.PluginHealthState]int{
+	model.PluginHealthStateHealthy:                 0,
+	model.PluginHealthStateUnsignedPermissive:      1,
+	model.PluginHealthStatePendingKeyApproval:      2,
+	model.PluginHealthStatePendingManifestApproval: 2,
+	model.PluginHealthStatePendingConfigMigration:  2,
+	model.PluginHealthStateUnhealthy:               3,
+	model.PluginHealthStateCircuitBroken:           4,
+	model.PluginHealthStateVerificationError:       5,
+	model.PluginHealthStateSignatureInvalid:        6,
+	model.PluginHealthStateCrashed:                 7,
+}
+
+// Severity returns the numeric severity rank for a state. Lower is better.
+// Unknown states return -1 so callers can detect them if needed.
+func Severity(s model.PluginHealthState) int {
+	v, ok := severity[s]
+	if !ok {
+		return -1
+	}
+	return v
+}
+
+// legalTransitions defines the plugin health state machine graph. Each key is
+// a state that may transition; its value lists every state it may move to.
+//
+// The graph encodes the operational lifecycle:
+//   - Startup states (pending_*) resolve toward healthy or an error state.
+//   - healthy/unsigned_permissive may degrade at runtime (unhealthy, crashed,
+//     circuit_broken) and can recover back to healthy.
+//   - Error states (signature_invalid, verification_error) are terminal from the
+//     plugin's own perspective; only the host can re-install / re-approve.
+var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
+	model.PluginHealthStatePendingKeyApproval: {
+		model.PluginHealthStateHealthy,
+		model.PluginHealthStateUnsignedPermissive,
+		model.PluginHealthStateSignatureInvalid,
+		model.PluginHealthStateVerificationError,
+		model.PluginHealthStatePendingManifestApproval,
+	},
+	model.PluginHealthStatePendingManifestApproval: {
+		model.PluginHealthStateHealthy,
+		model.PluginHealthStateVerificationError,
+		model.PluginHealthStatePendingConfigMigration,
+	},
+	model.PluginHealthStatePendingConfigMigration: {
+		model.PluginHealthStateHealthy,
+		model.PluginHealthStateVerificationError,
+	},
+	model.PluginHealthStateHealthy: {
+		model.PluginHealthStateUnhealthy,
+		model.PluginHealthStateCrashed,
+		model.PluginHealthStateCircuitBroken,
+		model.PluginHealthStatePendingManifestApproval, // hot-reload detects manifest change
+	},
+	model.PluginHealthStateUnsignedPermissive: {
+		model.PluginHealthStateUnhealthy,
+		model.PluginHealthStateCrashed,
+		model.PluginHealthStateCircuitBroken,
+		model.PluginHealthStatePendingManifestApproval,
+	},
+	model.PluginHealthStateUnhealthy: {
+		model.PluginHealthStateHealthy,
+		model.PluginHealthStateCrashed,
+		model.PluginHealthStateCircuitBroken,
+	},
+	model.PluginHealthStateCircuitBroken: {
+		model.PluginHealthStateHealthy,
+		model.PluginHealthStateUnhealthy,
+		model.PluginHealthStateCrashed,
+	},
+	model.PluginHealthStateCrashed: {
+		model.PluginHealthStateHealthy,
+		model.PluginHealthStateUnhealthy,
+	},
+	// signature_invalid and verification_error are terminal — no outgoing edges.
+	// A re-install or admin key-rotation creates a fresh instance row.
+}
+
+// IsLegalTransition reports whether transitioning from → to is permitted by the
+// plugin health state machine graph.
+func IsLegalTransition(from, to model.PluginHealthState) bool {
+	for _, allowed := range legalTransitions[from] {
+		if allowed == to {
+			return true
+		}
+	}
+	return false
+}
+
+// SetHealthState transitions a plugin instance to a new health state, enforcing:
+//  1. §8.1 plugin-self merge rule: if origin is OriginPluginSelf and the
+//     reported state is not worse than the current state, the call is a no-op.
+//  2. The state machine graph (legalTransitions): an illegal edge returns
+//     ErrIllegalTransition.
+//  3. ADR-038 CAS guard: if another writer advanced the version concurrently,
+//     returns ErrTransitionConflict.
+//
+// On success, the transition is recorded as a metric, logged, and published as
+// a "plugin.health_changed" event (if publisher is non-nil).
+func SetHealthState(ctx context.Context, q Querier, publisher event.Publisher, instanceID string, origin Origin, reported model.PluginHealthState, detail string) error {
+	row, err := q.GetPluginInstanceByID(ctx, instanceID)
+	if err != nil {
+		return fmt.Errorf("get plugin instance: %w", err)
+	}
+
+	current := model.PluginHealthState(row.HealthState)
+
+	// §8.1: plugin-self reports are dropped when they do not worsen the current
+	// state. The host is never restricted — it may improve or worsen freely.
+	if origin == OriginPluginSelf && Severity(reported) <= Severity(current) {
+		return nil
+	}
+
+	if !IsLegalTransition(current, reported) {
+		return fmt.Errorf("%w: %s → %s", ErrIllegalTransition, current, reported)
+	}
+
+	detailPtr := (*string)(nil)
+	if detail != "" {
+		detailPtr = &detail
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	rows, err := q.UpdatePluginInstanceHealth(ctx, db.UpdatePluginInstanceHealthParams{
+		HealthState:     string(reported),
+		HealthDetail:    detailPtr,
+		UpdatedAt:       now,
+		ID:              instanceID,
+		ExpectedVersion: row.Version,
+	})
+	if err != nil {
+		return fmt.Errorf("update plugin instance health: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("%w: instance %s", ErrTransitionConflict, instanceID)
+	}
+
+	RecordTransition(current, reported)
+
+	logctx.Logger(ctx).InfoContext(ctx, "plugin health state transition",
+		"instance_id", instanceID,
+		"plugin_id", row.PluginID,
+		"from", string(current),
+		"to", string(reported),
+	)
+
+	if publisher != nil {
+		if data, err := json.Marshal(map[string]string{
+			"instance_id": instanceID,
+			"plugin_id":   row.PluginID,
+			"state":       string(reported),
+		}); err == nil {
+			publisher.Publish("plugin.health_changed", data)
+		}
+	}
+
+	return nil
+}
+
+// WorstHealth returns the most severe PluginHealthState from the given slice.
+// If the slice is empty, it returns PluginHealthStateHealthy.
+func WorstHealth(states []model.PluginHealthState) model.PluginHealthState {
+	worst := model.PluginHealthStateHealthy
+	for _, s := range states {
+		if Severity(s) > Severity(worst) {
+			worst = s
+		}
+	}
+	return worst
+}

--- a/internal/plugin/state/pluginstate_test.go
+++ b/internal/plugin/state/pluginstate_test.go
@@ -1,0 +1,381 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+)
+
+// capturePublisher records every Publish call for assertion in tests.
+type capturePublisher struct {
+	mu     sync.Mutex
+	events []capturedEvent
+}
+
+type capturedEvent struct {
+	eventType string
+	data      json.RawMessage
+}
+
+func (p *capturePublisher) Publish(eventType string, data json.RawMessage) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, capturedEvent{eventType: eventType, data: data})
+}
+
+func (p *capturePublisher) all() []capturedEvent {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]capturedEvent, len(p.events))
+	copy(out, p.events)
+	return out
+}
+
+// seedInstance inserts a plugin + plugin_instance row and returns the instance ID.
+func seedInstance(tb testing.TB, s *db.Store, instanceID string, state model.PluginHealthState) {
+	tb.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	pluginID := instanceID + "-plugin"
+	_, err := s.Queries().CreatePlugin(ctx, db.CreatePluginParams{
+		ID:               pluginID,
+		Name:             pluginID,
+		PluginVersion:    "1.0.0",
+		ManifestSnapshot: "{}",
+		TrustedPubkey:    "pubkey",
+		Status:           "active",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	})
+	if err != nil {
+		tb.Fatalf("CreatePlugin: %v", err)
+	}
+
+	_, err = s.Queries().CreatePluginInstance(ctx, db.CreatePluginInstanceParams{
+		ID:                instanceID,
+		PluginID:          pluginID,
+		InstanceName:      "test-instance",
+		ConfigJson:        "{}",
+		HandshakeVersions: "{}",
+		HealthState:       string(state),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	})
+	if err != nil {
+		tb.Fatalf("CreatePluginInstance: %v", err)
+	}
+}
+
+func TestIsLegalTransition(t *testing.T) {
+	legal := [][2]model.PluginHealthState{
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStateHealthy},
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStateUnsignedPermissive},
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStateSignatureInvalid},
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStateVerificationError},
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStatePendingManifestApproval},
+		{model.PluginHealthStatePendingManifestApproval, model.PluginHealthStateHealthy},
+		{model.PluginHealthStatePendingManifestApproval, model.PluginHealthStateVerificationError},
+		{model.PluginHealthStatePendingManifestApproval, model.PluginHealthStatePendingConfigMigration},
+		{model.PluginHealthStatePendingConfigMigration, model.PluginHealthStateHealthy},
+		{model.PluginHealthStatePendingConfigMigration, model.PluginHealthStateVerificationError},
+		{model.PluginHealthStateHealthy, model.PluginHealthStateUnhealthy},
+		{model.PluginHealthStateHealthy, model.PluginHealthStateCrashed},
+		{model.PluginHealthStateHealthy, model.PluginHealthStateCircuitBroken},
+		{model.PluginHealthStateHealthy, model.PluginHealthStatePendingManifestApproval},
+		{model.PluginHealthStateUnsignedPermissive, model.PluginHealthStateUnhealthy},
+		{model.PluginHealthStateUnsignedPermissive, model.PluginHealthStateCrashed},
+		{model.PluginHealthStateUnhealthy, model.PluginHealthStateHealthy},
+		{model.PluginHealthStateUnhealthy, model.PluginHealthStateCrashed},
+		{model.PluginHealthStateUnhealthy, model.PluginHealthStateCircuitBroken},
+		{model.PluginHealthStateCircuitBroken, model.PluginHealthStateHealthy},
+		{model.PluginHealthStateCircuitBroken, model.PluginHealthStateUnhealthy},
+		{model.PluginHealthStateCircuitBroken, model.PluginHealthStateCrashed},
+		{model.PluginHealthStateCrashed, model.PluginHealthStateHealthy},
+		{model.PluginHealthStateCrashed, model.PluginHealthStateUnhealthy},
+	}
+	for _, pair := range legal {
+		if !IsLegalTransition(pair[0], pair[1]) {
+			t.Errorf("IsLegalTransition(%s, %s) = false, want true", pair[0], pair[1])
+		}
+	}
+
+	illegal := [][2]model.PluginHealthState{
+		{model.PluginHealthStateSignatureInvalid, model.PluginHealthStateHealthy},
+		{model.PluginHealthStateVerificationError, model.PluginHealthStateHealthy},
+		{model.PluginHealthStateHealthy, model.PluginHealthStatePendingKeyApproval},
+		{model.PluginHealthStateCrashed, model.PluginHealthStateSignatureInvalid},
+	}
+	for _, pair := range illegal {
+		if IsLegalTransition(pair[0], pair[1]) {
+			t.Errorf("IsLegalTransition(%s, %s) = true, want false", pair[0], pair[1])
+		}
+	}
+}
+
+func TestSetHealthState_LegalTransitions(t *testing.T) {
+	legal := [][2]model.PluginHealthState{
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStateHealthy},
+		{model.PluginHealthStateHealthy, model.PluginHealthStateUnhealthy},
+		{model.PluginHealthStateUnhealthy, model.PluginHealthStateCrashed},
+		{model.PluginHealthStateCrashed, model.PluginHealthStateHealthy},
+	}
+
+	for _, pair := range legal {
+		from, to := pair[0], pair[1]
+		t.Run(string(from)+"→"+string(to), func(t *testing.T) {
+			s := testutil.NewTestStore(t)
+			iid := "inst-" + string(from)
+			seedInstance(t, s, iid, from)
+
+			if err := SetHealthState(context.Background(), s.Queries(), nil, iid, OriginHost, to, ""); err != nil {
+				t.Fatalf("SetHealthState(%s → %s): unexpected error: %v", from, to, err)
+			}
+
+			row, err := s.Queries().GetPluginInstanceByID(context.Background(), iid)
+			if err != nil {
+				t.Fatalf("GetPluginInstanceByID: %v", err)
+			}
+			if row.HealthState != string(to) {
+				t.Errorf("health_state = %q, want %q", row.HealthState, to)
+			}
+		})
+	}
+}
+
+func TestSetHealthState_IllegalTransition(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedInstance(t, s, "inst1", model.PluginHealthStateSignatureInvalid)
+
+	err := SetHealthState(context.Background(), s.Queries(), nil, "inst1", OriginHost, model.PluginHealthStateHealthy, "")
+	if err == nil {
+		t.Fatal("expected error for illegal transition, got nil")
+	}
+	if !errors.Is(err, ErrIllegalTransition) {
+		t.Errorf("error = %v, want errors.Is(err, ErrIllegalTransition)", err)
+	}
+
+	// State must remain unchanged.
+	row, err := s.Queries().GetPluginInstanceByID(context.Background(), "inst1")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", err)
+	}
+	if row.HealthState != string(model.PluginHealthStateSignatureInvalid) {
+		t.Errorf("health_state changed to %q after illegal transition", row.HealthState)
+	}
+}
+
+func TestSetHealthState_PluginSelfDroppedWhenNotWorse(t *testing.T) {
+	// Plugin self-reporting healthy when already healthy → dropped (no write).
+	s := testutil.NewTestStore(t)
+	seedInstance(t, s, "inst1", model.PluginHealthStateUnhealthy)
+
+	// Plugin reports a less-severe state — should be silently dropped.
+	err := SetHealthState(context.Background(), s.Queries(), nil, "inst1", OriginPluginSelf, model.PluginHealthStateHealthy, "")
+	if err != nil {
+		t.Fatalf("SetHealthState: unexpected error: %v", err)
+	}
+
+	row, err := s.Queries().GetPluginInstanceByID(context.Background(), "inst1")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", err)
+	}
+	if row.HealthState != string(model.PluginHealthStateUnhealthy) {
+		t.Errorf("health_state = %q, want unhealthy (plugin-self improvement must be dropped)", row.HealthState)
+	}
+	if row.Version != 0 {
+		t.Errorf("version = %d, want 0 (no DB write expected)", row.Version)
+	}
+}
+
+func TestSetHealthState_PluginSelfCanWorsen(t *testing.T) {
+	// Plugin self-reporting crashed when currently healthy → allowed (worsens).
+	s := testutil.NewTestStore(t)
+	seedInstance(t, s, "inst1", model.PluginHealthStateHealthy)
+
+	err := SetHealthState(context.Background(), s.Queries(), nil, "inst1", OriginPluginSelf, model.PluginHealthStateCrashed, "OOM")
+	if err != nil {
+		t.Fatalf("SetHealthState: unexpected error: %v", err)
+	}
+
+	row, err := s.Queries().GetPluginInstanceByID(context.Background(), "inst1")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", err)
+	}
+	if row.HealthState != string(model.PluginHealthStateCrashed) {
+		t.Errorf("health_state = %q, want crashed", row.HealthState)
+	}
+}
+
+func TestSetHealthState_HostCanImprove(t *testing.T) {
+	// Host reporting healthy when currently unhealthy → allowed (host not restricted).
+	s := testutil.NewTestStore(t)
+	seedInstance(t, s, "inst1", model.PluginHealthStateUnhealthy)
+
+	err := SetHealthState(context.Background(), s.Queries(), nil, "inst1", OriginHost, model.PluginHealthStateHealthy, "")
+	if err != nil {
+		t.Fatalf("SetHealthState: unexpected error: %v", err)
+	}
+
+	row, err := s.Queries().GetPluginInstanceByID(context.Background(), "inst1")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", err)
+	}
+	if row.HealthState != string(model.PluginHealthStateHealthy) {
+		t.Errorf("health_state = %q, want healthy", row.HealthState)
+	}
+}
+
+func TestSetHealthState_PublishesEvent(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedInstance(t, s, "inst1", model.PluginHealthStatePendingKeyApproval)
+
+	pub := &capturePublisher{}
+	if err := SetHealthState(context.Background(), s.Queries(), pub, "inst1", OriginHost, model.PluginHealthStateHealthy, "verified"); err != nil {
+		t.Fatalf("SetHealthState: %v", err)
+	}
+
+	events := pub.all()
+	if len(events) != 1 {
+		t.Fatalf("got %d published events, want 1", len(events))
+	}
+	if events[0].eventType != "plugin.health_changed" {
+		t.Errorf("event type = %q, want plugin.health_changed", events[0].eventType)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(events[0].data, &payload); err != nil {
+		t.Fatalf("unmarshal event data: %v", err)
+	}
+	if payload["instance_id"] != "inst1" {
+		t.Errorf("instance_id = %q, want inst1", payload["instance_id"])
+	}
+	if payload["state"] != "healthy" {
+		t.Errorf("state = %q, want healthy", payload["state"])
+	}
+}
+
+func TestSetHealthState_NilPublisher(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedInstance(t, s, "inst1", model.PluginHealthStatePendingKeyApproval)
+
+	// nil publisher must not panic.
+	if err := SetHealthState(context.Background(), s.Queries(), nil, "inst1", OriginHost, model.PluginHealthStateHealthy, ""); err != nil {
+		t.Fatalf("SetHealthState with nil publisher: %v", err)
+	}
+}
+
+func TestSetHealthState_CASConflict(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedInstance(t, s, "inst1", model.PluginHealthStatePendingKeyApproval)
+
+	// Bump the version externally to simulate a concurrent write.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.DB().Exec(
+		`UPDATE plugin_instances SET version = 5, updated_at = ? WHERE id = 'inst1'`,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("bump version: %v", err)
+	}
+
+	// A SetHealthState that reads version=5 and writes with expected_version=5 should succeed.
+	if err := SetHealthState(context.Background(), s.Queries(), nil, "inst1", OriginHost, model.PluginHealthStateHealthy, ""); err != nil {
+		t.Fatalf("SetHealthState after version bump: unexpected error: %v", err)
+	}
+
+	// Now use UpdatePluginInstanceHealth directly with a stale expected_version to
+	// verify the CAS semantics work — mirrors the runstate CAS test pattern.
+	reason := "stale"
+	rows, updateErr := s.Queries().UpdatePluginInstanceHealth(context.Background(), db.UpdatePluginInstanceHealthParams{
+		HealthState:     string(model.PluginHealthStateUnhealthy),
+		HealthDetail:    &reason,
+		UpdatedAt:       now,
+		ID:              "inst1",
+		ExpectedVersion: 3, // stale — real version is now 6
+	})
+	if updateErr != nil {
+		t.Fatalf("UpdatePluginInstanceHealth: %v", updateErr)
+	}
+	if rows != 0 {
+		t.Errorf("rows = %d for stale version CAS, want 0", rows)
+	}
+
+	row, err := s.Queries().GetPluginInstanceByID(context.Background(), "inst1")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID after CAS miss: %v", err)
+	}
+	if row.HealthState != string(model.PluginHealthStateHealthy) {
+		t.Errorf("health_state = %q after CAS miss, want healthy (unchanged)", row.HealthState)
+	}
+}
+
+func TestSetHealthState_InstanceNotFound(t *testing.T) {
+	s := testutil.NewTestStore(t)
+
+	err := SetHealthState(context.Background(), s.Queries(), nil, "nonexistent-instance", OriginHost, model.PluginHealthStateHealthy, "")
+	if err == nil {
+		t.Fatal("expected error for nonexistent instance, got nil")
+	}
+}
+
+func TestWorstHealth(t *testing.T) {
+	tests := []struct {
+		name   string
+		states []model.PluginHealthState
+		want   model.PluginHealthState
+	}{
+		{
+			name:   "empty returns healthy",
+			states: nil,
+			want:   model.PluginHealthStateHealthy,
+		},
+		{
+			name:   "single healthy",
+			states: []model.PluginHealthState{model.PluginHealthStateHealthy},
+			want:   model.PluginHealthStateHealthy,
+		},
+		{
+			name: "picks worst",
+			states: []model.PluginHealthState{
+				model.PluginHealthStateHealthy,
+				model.PluginHealthStateUnhealthy,
+				model.PluginHealthStateCrashed,
+			},
+			want: model.PluginHealthStateCrashed,
+		},
+		{
+			name: "all equal",
+			states: []model.PluginHealthState{
+				model.PluginHealthStateUnhealthy,
+				model.PluginHealthStateUnhealthy,
+			},
+			want: model.PluginHealthStateUnhealthy,
+		},
+		{
+			name: "signature_invalid is worst",
+			states: []model.PluginHealthState{
+				model.PluginHealthStateCrashed,
+				model.PluginHealthStateSignatureInvalid,
+				model.PluginHealthStateVerificationError,
+			},
+			want: model.PluginHealthStateCrashed, // severity 7 > 6 > 5
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WorstHealth(tt.states)
+			if got != tt.want {
+				t.Errorf("WorstHealth(%v) = %q, want %q", tt.states, got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -288,6 +288,7 @@ func run(cfg config.Config) error {
 		SettingsHandler:      settingsHandler,
 		AdminHandler:         adminHandler,
 		OpenAICompatHandler:  openaiCompatHandler,
+		PluginAdminHandler:   admin.NewPluginHandler(store.Queries()),
 		WebhookHandler:       webhookHandler,
 		SSEHandler:           sseHandler,
 		PolicyWebhookHandler: policyWebhookHandler,

--- a/schemas/sql_schemas.sql
+++ b/schemas/sql_schemas.sql
@@ -425,8 +425,11 @@ CREATE TABLE plugin_instances (
                                          'pending_manifest_approval',
                                          'pending_config_migration',
                                          'verification_error',
-                                         'unsigned_permissive'
-                                     )),                                                  -- ADR-045 §7
+                                         'unsigned_permissive',
+                                         'unhealthy',
+                                         'crashed',
+                                         'circuit_broken'
+                                     )),                                                  -- ADR-038, ADR-045 §7, issue #191
     health_detail            TEXT,                                                        -- nullable; operator-facing reason for non-healthy state
     last_oauth_callback_url  TEXT,                                                        -- nullable; OAuth-flow plumbing (#230)
     version                  INTEGER NOT NULL DEFAULT 0,                                  -- ADR-038 CAS counter


### PR DESCRIPTION
Closes #191

## Summary
Lands the per-instance plugin health-state machine and the colored chip primitive the future admin plugins page will consume.

- **`internal/plugin/state/`** — mirrors `internal/execution/runstate/` (transition table + version-CAS per ADR-038). 10 states: §5.6 startup (`healthy`, `unsigned_permissive`, `pending_key_approval`, `pending_manifest_approval`, `pending_config_migration`, `verification_error`, `signature_invalid`) plus runtime (`unhealthy`, `crashed`, `circuit_broken`).
- **`SetHealthState(ctx, q, publisher, instanceID, origin, reported, detail)`** encodes §8.1: \"plugin can only mark itself worse than host-detected; worst across plugin-self and host-detected wins.\" Plugin-self reports of equal or better severity are silently dropped. CAS conflicts surface as `ErrTransitionConflict`.
- **Severity ranking** is a new design decision documented inline (`healthy=0` … `crashed=7`) — §8.1 specifies the merge rule but not the total ordering.
- **`GET /api/v1/admin/plugins/{id}/instances/{iid}`** returns `{ state, detail, version, ... }` for the admin UI. Admin-only via existing `RequireRole` middleware. 404 on plugin/instance mismatch (avoids leaking existence).
- **`PluginHealthChip`** (`frontend/src/components/admin/PluginHealthChip/`) — green/yellow/red colored chip with hover tooltip + onClick handler. Storybook story per state plus `AggregateWorst` row.
- **`pluginHealth.ts`** ships `worstHealth(states)` mirroring the Go-side severity ranking, ready for the future plugins page's per-plugin rollup.

## Schema
The `plugin_instances.health_state` CHECK constraint was widened in BOTH `schemas/sql_schemas.sql` AND `internal/db/migrations/0001_initial.sql` to include the 3 runtime states. No data migration — every existing value remains valid. No new sqlc queries; `ListPluginInstancesByPlugin` already returns full rows.

## Out of scope (explicit, deferred)
- Host gRPC `SetHealthState` handler — proto exists in `plugin-sdk/`, but no host server is wired yet (Phase 3 loader work). The Go `SetHealthState` function is structured so a future RPC handler calls it directly; the merge rule lives once, inside the package.
- The loader's TODO to write `signature_invalid` into `plugin_instances` on bad-sig install — today's loader never creates instance rows, so there's nothing to target. Loader keeps emitting only the audit event.

## Plan + reviews
<details><summary>Architecture plan</summary>

See `.dev-loop/plan.md`. Plan-review caught 4 blocking corrections folded in before implementation: HandlerBundle field placement (not RouterConfig directly), narrow Querier interfaces (not `*db.Queries`), schema widening must hit BOTH SQL files, no spurious GetWorstHealth query. Code-review APPROVE on cycle 1.

</details>

- 1 architect pass + 1 plan-review (REVISE → 4 corrections folded in)
- 1 code-review cycle (APPROVE)
- CLAUDE.md + frontend/CLAUDE.md updated (new `internal/plugin/state/` package; new admin endpoint; new chip + utility)

🤖 Generated by the agentic dev loop.