### PR TITLE
feat(plugin): TOFU pubkey capture + admin accept-new-key endpoint (#188)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Routes are registered in `internal/http/api/router.go` via `BuildRouter`, which 
 - `/api/v1/runs/*` — list/get runs, steps, cancel, approval, feedback
 - `/api/v1/mcp/servers/*` — MCP server registry, tool discovery; `PUT /:id` updates name/url only; `PUT /:id/headers/:name` and `DELETE /:id/headers/:name` manage individual auth headers (admin|operator only; see ADR-039); `POST /:id/arcade/authorize` and `POST /:id/arcade/authorize/wait` pre-authorize Arcade toolkits (admin|operator only; see ADR-040)
 - `/api/v1/admin/plugins/{id}/instances/{iid}` — per-instance plugin health (state, detail, version) for the admin plugins UI; admin-only
+- `/api/v1/admin/plugins/{id}/accept-new-key` — admin-only TOFU rotation: rotates `plugins.trusted_pubkey` to an operator-supplied candidate pubkey and unblocks instances stuck in `pending_key_approval` (see ADR-045 §5.3)
 - `/api/v1/webhooks/{policyID}` — fires a webhook-triggered run (auth dispatcher per `trigger.auth`: hmac | bearer | none)
 - `/api/v1/policies/{policyID}/trigger` — fires a manual run
 - `/api/v1/policies/{id}/webhook/rotate`, `/api/v1/policies/{id}/webhook/secret` — rotate/reveal the webhook secret (admin|operator only; see ADR-034)

--- a/docs/developer/ADR_Tracker.md
+++ b/docs/developer/ADR_Tracker.md
@@ -248,6 +248,17 @@ The full set of v1 health states (per spec §5.6) is enumerated here so that dow
 
 Each state is rendered as a colored chip on `/admin/plugins`, click-through reveals detail and admin actions (Accept new key / Approve manifest / View error / Revert / Remove pending update). Chip rendering and the action set are owned by issue #191; this ADR fixes the state names and the conditions under which the loader assigns them.
 
+### Audit event types (issue #188)
+
+Two audit event types are emitted by the TOFU trust machinery (both at severity `high`):
+
+| Event type              | When emitted                                                                 | Key payload fields |
+|-------------------------|------------------------------------------------------------------------------|--------------------|
+| `plugin_pubkey_mismatch`| A signed update arrives with a different key than the captured trusted pubkey. The update is blocked; all instances move to `pending_key_approval`. | `plugin_id`, `name`, `old_pubkey_fingerprint`, `new_pubkey_fingerprint`, `new_pubkey_b64` (base64 of the full signing.pub bytes), `version` |
+| `plugin_pubkey_rotated` | An admin accepts the new key via `POST /api/v1/admin/plugins/:id/accept-new-key`. The `trusted_pubkey` column is updated (CAS-guarded); `pending_key_approval` instances transition to `healthy`. | `plugin_id`, `name`, `old_pubkey_fingerprint`, `new_pubkey_fingerprint` |
+
+`PluginInstanceID` is `nil` for both events (plugin-level, not instance-level). `ActorUserID` is set for `plugin_pubkey_rotated` from the authenticated session.
+
 ### Out of scope
 
 - The Minisign Go library implementation itself (ADR-043 covers it from the producer side; the host imports the same `plugin-sdk/signing` package for verification).
@@ -257,6 +268,7 @@ Each state is rendered as a colored chip on `/admin/plugins`, click-through reve
 - Revocation lists. v1 has no revocation channel; admins remove a compromised plugin by uninstalling it. CRL-style infrastructure is deferred.
 - Verifying plugin behavior against the manifest at runtime. Out of scope — that's a sandboxing concern (not v1).
 - The admin UI flows for "Accept new key" and "Approve manifest". Owned by issues #188 (TOFU UI) and #189 (material-change detection); this ADR specifies the conditions, not the screens.
+- Out-of-band pubkey paste at install time (deferred to a follow-up per issue #188 scope-down). The TOFU first-leap plus `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS` is the v1 escape hatch.
 
 ### Consequences
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -393,3 +393,21 @@ export interface ApiPluginInstance {
   version: number
   updated_at: string
 }
+
+// Payload embedded in a plugin_pubkey_mismatch audit event's payload_json field.
+// Sourced by AcceptNewKeyModal to obtain the candidate pubkey and display fingerprints.
+export interface ApiPluginPubkeyMismatchAuditPayload {
+  plugin_id: string
+  name: string
+  old_pubkey_fingerprint: string
+  new_pubkey_fingerprint: string
+  // Base64-encoded Minisign signing.pub bytes — passed as-is to accept-new-key.
+  new_pubkey_b64: string
+  version: string
+}
+
+// Matches internal/admin/plugin_handler.go → acceptNewKeyResponse.
+export interface ApiAcceptNewKeyResponse {
+  accepted_pubkey_fingerprint: string
+  instances_unblocked: number
+}

--- a/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.module.css
+++ b/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.module.css
@@ -1,0 +1,52 @@
+.warning {
+  padding: var(--space-4);
+  border-radius: 4px;
+  background: rgba(240, 85, 69, 0.08); /* --color-red at low opacity */
+  border: 1px solid var(--color-red);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  margin-bottom: var(--space-5);
+}
+
+.keyGrid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.keyRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.keyLabel {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.fingerprint {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: var(--space-2) var(--space-3);
+  word-break: break-all;
+}
+
+.errorBanner {
+  margin-top: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(240, 85, 69, 0.08);
+  border: 1px solid var(--color-red);
+  border-radius: 4px;
+  color: var(--color-red);
+  font-size: var(--text-sm);
+}

--- a/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.stories.tsx
+++ b/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import '@/tokens.css'
+import { AcceptNewKeyModal } from './AcceptNewKeyModal'
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+// Fixture fingerprints — 8-byte hex values matching the Minisign key ID format.
+const OLD_FINGERPRINT = 'a1b2c3d4e5f6a7b8'
+const NEW_FINGERPRINT = 'deadbeef01020304'
+// Minimal valid-looking base64 for story purposes.
+const CANDIDATE_B64 = 'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXkK'
+
+const meta: Meta<typeof AcceptNewKeyModal> = {
+  title: 'Admin/AcceptNewKeyModal',
+  component: AcceptNewKeyModal,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={makeQueryClient()}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof AcceptNewKeyModal>
+
+// Primary — idle state showing both fingerprints and the warning.
+export const Primary: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/accept-new-key', () =>
+          HttpResponse.json({
+            data: { accepted_pubkey_fingerprint: NEW_FINGERPRINT, instances_unblocked: 1 },
+          }),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-abc',
+    oldPubkeyFingerprint: OLD_FINGERPRINT,
+    newPubkeyFingerprint: NEW_FINGERPRINT,
+    candidatePubkeyB64: CANDIDATE_B64,
+    onClose: () => {},
+  },
+}
+
+// Loading — button is in loading state (simulate slow response).
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        // Never resolves — keeps the UI in loading state.
+        http.post('/api/v1/admin/plugins/:id/accept-new-key', () => new Promise(() => {})),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-abc',
+    oldPubkeyFingerprint: OLD_FINGERPRINT,
+    newPubkeyFingerprint: NEW_FINGERPRINT,
+    candidatePubkeyB64: CANDIDATE_B64,
+    onClose: () => {},
+  },
+}
+
+// Error — the backend rejects the candidate pubkey.
+export const WithError: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/accept-new-key', () =>
+          HttpResponse.json(
+            { error: 'Pubkey verification failed', detail: 'Candidate key does not match the expected format.' },
+            { status: 400 },
+          ),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-abc',
+    oldPubkeyFingerprint: OLD_FINGERPRINT,
+    newPubkeyFingerprint: NEW_FINGERPRINT,
+    candidatePubkeyB64: CANDIDATE_B64,
+    onClose: () => {},
+  },
+}
+
+// PreviouslyUnsigned — plugin was unsigned on first install; old fingerprint is empty.
+// The chip → modal wiring in a future /admin/plugins page should handle this gracefully.
+export const PreviouslyUnsigned: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/accept-new-key', () =>
+          HttpResponse.json({
+            data: { accepted_pubkey_fingerprint: NEW_FINGERPRINT, instances_unblocked: 2 },
+          }),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-unsigned',
+    oldPubkeyFingerprint: '',
+    newPubkeyFingerprint: NEW_FINGERPRINT,
+    candidatePubkeyB64: CANDIDATE_B64,
+    onClose: () => {},
+  },
+}

--- a/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.test.tsx
+++ b/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/server'
+import { AcceptNewKeyModal } from './AcceptNewKeyModal'
+
+const OLD_FP = 'a1b2c3d4e5f6a7b8'
+const NEW_FP = 'deadbeef01020304'
+// Minimal base64 string for the candidate pubkey field.
+const CANDIDATE_B64 = 'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXkK'
+
+function makeClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+}
+
+function renderModal(onClose = vi.fn()) {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <AcceptNewKeyModal
+        pluginId="plugin-test"
+        oldPubkeyFingerprint={OLD_FP}
+        newPubkeyFingerprint={NEW_FP}
+        candidatePubkeyB64={CANDIDATE_B64}
+        onClose={onClose}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AcceptNewKeyModal', () => {
+  it('renders both key fingerprints', () => {
+    renderModal()
+    expect(screen.getByText(OLD_FP)).toBeInTheDocument()
+    expect(screen.getByText(NEW_FP)).toBeInTheDocument()
+  })
+
+  it('shows a warning about verifying the key out-of-band', () => {
+    renderModal()
+    expect(screen.getByText(/different signing key/i)).toBeInTheDocument()
+  })
+
+  it('calls mutation with the correct candidate_pubkey on accept', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post('/api/v1/admin/plugins/plugin-test/accept-new-key', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({
+          data: { accepted_pubkey_fingerprint: NEW_FP, instances_unblocked: 1 },
+        })
+      }),
+    )
+
+    const onClose = vi.fn()
+    renderModal(onClose)
+
+    await userEvent.click(screen.getByRole('button', { name: /accept new key/i }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+    expect(capturedBody).toEqual({ candidate_pubkey: CANDIDATE_B64 })
+  })
+
+  it('surfaces error message inline on API failure', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins/plugin-test/accept-new-key', () =>
+        HttpResponse.json(
+          { error: 'Bad request', detail: 'Candidate key is malformed.' },
+          { status: 400 },
+        ),
+      ),
+    )
+
+    renderModal()
+    await userEvent.click(screen.getByRole('button', { name: /accept new key/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Candidate key is malformed.'),
+    )
+  })
+
+  it('calls onClose when Cancel is clicked', async () => {
+    // No API handler needed — cancel never hits the network.
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/accept-new-key', () =>
+        HttpResponse.json({ data: { accepted_pubkey_fingerprint: NEW_FP, instances_unblocked: 0 } }),
+      ),
+    )
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.tsx
+++ b/frontend/src/components/admin/AcceptNewKeyModal/AcceptNewKeyModal.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+import { Modal } from '@/components/Modal'
+import { ModalFooter } from '@/components/ModalFooter'
+import { useAcceptPluginNewKey } from '@/hooks/mutations/plugins'
+import { ApiError } from '@/api/fetch'
+import styles from './AcceptNewKeyModal.module.css'
+
+interface AcceptNewKeyModalProps {
+  pluginId: string
+  /** 8-byte hex key ID of the currently-trusted pubkey. */
+  oldPubkeyFingerprint: string
+  /** 8-byte hex key ID of the new candidate pubkey. */
+  newPubkeyFingerprint: string
+  /** Base64-encoded Minisign signing.pub bytes from the audit event. Passed as-is to the API. */
+  candidatePubkeyB64: string
+  onClose: () => void
+}
+
+// AcceptNewKeyModal lets an admin approve a new signing key for a plugin that
+// is blocked in pending_key_approval state. The modal shows both key fingerprints
+// so the admin can verify the new key out-of-band before accepting.
+//
+// Wire this modal to the PluginHealthChip's onClick when state === 'pending_key_approval'.
+// Source the props from the plugin_pubkey_mismatch audit event payload.
+export function AcceptNewKeyModal({
+  pluginId,
+  oldPubkeyFingerprint,
+  newPubkeyFingerprint,
+  candidatePubkeyB64,
+  onClose,
+}: AcceptNewKeyModalProps) {
+  const [error, setError] = useState<string | null>(null)
+  const mutation = useAcceptPluginNewKey()
+
+  function handleAccept() {
+    setError(null)
+    mutation.mutate(
+      { pluginId, candidatePubkey: candidatePubkeyB64 },
+      {
+        onSuccess: onClose,
+        onError: (err) => {
+          if (err instanceof ApiError) {
+            setError(err.detail ?? err.message)
+          } else if (err instanceof Error) {
+            setError(err.message)
+          } else {
+            setError('Unexpected error — please try again.')
+          }
+        },
+      },
+    )
+  }
+
+  const footer = (
+    <ModalFooter
+      onCancel={onClose}
+      onSubmit={handleAccept}
+      isLoading={mutation.isPending}
+      submitLabel="Accept new key"
+      loadingLabel="Accepting…"
+      submitDisabled={mutation.isPending}
+      variant="danger"
+    />
+  )
+
+  return (
+    <Modal title="Accept new signing key" onClose={onClose} footer={footer}>
+      <div className={styles.warning}>
+        <strong>This plugin was updated with a different signing key.</strong>{' '}
+        Verify the new key fingerprint matches what you expect before accepting.
+        Accepting a key you do not recognise may allow untrusted code to run.
+      </div>
+
+      <div className={styles.keyGrid}>
+        <div className={styles.keyRow}>
+          <span className={styles.keyLabel}>Current trusted key</span>
+          <code className={styles.fingerprint}>{oldPubkeyFingerprint || '(none — previously unsigned)'}</code>
+        </div>
+        <div className={styles.keyRow}>
+          <span className={styles.keyLabel}>New candidate key</span>
+          <code className={styles.fingerprint}>{newPubkeyFingerprint}</code>
+        </div>
+      </div>
+
+      {error != null && (
+        <div className={styles.errorBanner} role="alert">
+          {error}
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/src/hooks/mutations/plugins.ts
+++ b/frontend/src/hooks/mutations/plugins.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/api/fetch'
+import type { ApiAcceptNewKeyResponse } from '@/api/types'
+import { queryKeys } from '../queryKeys'
+
+interface AcceptNewKeyParams {
+  pluginId: string
+  candidatePubkey: string
+}
+
+// useAcceptPluginNewKey posts the candidate pubkey to the backend, which
+// rotates the plugin's trusted_pubkey and unblocks any pending_key_approval
+// instances. On success, the plugin instance query cache is invalidated so
+// health chips refresh automatically.
+export function useAcceptPluginNewKey() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ pluginId, candidatePubkey }: AcceptNewKeyParams) =>
+      apiFetch<ApiAcceptNewKeyResponse>(`/admin/plugins/${encodeURIComponent(pluginId)}/accept-new-key`, {
+        method: 'POST',
+        body: JSON.stringify({ candidate_pubkey: candidatePubkey }),
+      }),
+    onSuccess: (_data, { pluginId }) => {
+      // Invalidate all instance queries for this plugin so health chips reflect
+      // the transition to healthy.
+      void queryClient.invalidateQueries({
+        queryKey: ['admin', 'plugins', pluginId],
+      })
+    },
+  })
+}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -53,4 +53,8 @@ export const queryKeys = {
   config: {
     all: ['config'] as const,
   },
+  plugins: {
+    instance: (pluginId: string, instanceId: string) =>
+      ['admin', 'plugins', pluginId, 'instances', instanceId] as const,
+  },
 } as const

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -2,30 +2,66 @@ package admin
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/http/auth"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
+)
+
+const (
+	// auditPubkeyRotated is the event type emitted when an admin accepts a new
+	// plugin signing key via POST /api/v1/admin/plugins/{id}/accept-new-key.
+	auditPubkeyRotated = "plugin_pubkey_rotated"
 )
 
 // PluginQuerier is the narrow DB interface required by PluginHandler.
 // Accepting an interface (not *db.Queries) keeps the handler testable with
 // a fake querier and mirrors the AdminQuerier pattern in handler.go.
+// It is a superset of pluginstate.Querier so h.q can be passed directly into
+// pluginstate.SetHealthState.
 type PluginQuerier interface {
+	// Instance read (used by GetInstance and state machine).
 	GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error)
+	// Plugin read (used by AcceptNewKey).
+	GetPluginByID(ctx context.Context, id string) (db.Plugin, error)
+	// Plugin write (used by AcceptNewKey to rotate the pinned pubkey).
+	UpdatePluginTrustedPubkey(ctx context.Context, arg db.UpdatePluginTrustedPubkeyParams) (int64, error)
+	// Instance list (used by AcceptNewKey to unblock pending instances).
+	ListPluginInstancesByPlugin(ctx context.Context, pluginID string) ([]db.PluginInstance, error)
+	// Instance health write (required by pluginstate.Querier interface).
+	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
+	// Audit write (used by AcceptNewKey to record the key rotation).
+	InsertPluginAuditEvent(ctx context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error)
 }
 
 // PluginHandler handles plugin-related admin endpoints.
 type PluginHandler struct {
-	q PluginQuerier
+	q         PluginQuerier
+	publisher event.Publisher
+	clock     func() time.Time
 }
 
-// NewPluginHandler returns a PluginHandler backed by the given querier.
-func NewPluginHandler(q PluginQuerier) *PluginHandler {
-	return &PluginHandler{q: q}
+// NewPluginHandler returns a PluginHandler backed by the given querier, event
+// publisher, and clock. publisher may be nil — events are skipped when nil.
+// clock may be nil — time.Now is used as the default.
+func NewPluginHandler(q PluginQuerier, publisher event.Publisher, clock func() time.Time) *PluginHandler {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &PluginHandler{q: q, publisher: publisher, clock: clock}
 }
 
 // instanceResponse is the JSON shape returned by GetInstance.
@@ -74,4 +110,148 @@ func (h *PluginHandler) GetInstance(w http.ResponseWriter, r *http.Request) {
 		Version:      row.Version,
 		UpdatedAt:    row.UpdatedAt,
 	})
+}
+
+// acceptNewKeyRequest is the JSON body for POST /api/v1/admin/plugins/{id}/accept-new-key.
+type acceptNewKeyRequest struct {
+	CandidatePubkey string `json:"candidate_pubkey"`
+}
+
+// acceptNewKeyResponse is the JSON body returned on success.
+type acceptNewKeyResponse struct {
+	AcceptedPubkeyFingerprint string `json:"accepted_pubkey_fingerprint"`
+	InstancesUnblocked        int    `json:"instances_unblocked"`
+}
+
+// AcceptNewKey handles POST /api/v1/admin/plugins/{id}/accept-new-key.
+// It rotates the trusted pubkey on the plugin row (CAS-guarded) and transitions
+// all instances in pending_key_approval to healthy.
+//
+// Request body: { "candidate_pubkey": "<base64-encoded minisign signing.pub bytes>" }
+// The candidate_pubkey is sourced from the plugin_pubkey_mismatch audit event's
+// new_pubkey_b64 field, which contains the full Minisign-formatted signing.pub bytes.
+func (h *PluginHandler) AcceptNewKey(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	pluginID := chi.URLParam(r, "id")
+
+	var body acceptNewKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", "")
+		return
+	}
+	if body.CandidatePubkey == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "candidate_pubkey is required", "")
+		return
+	}
+
+	// Decode the base64 candidate and parse as a Minisign public key to validate format.
+	rawPubkey, err := base64.StdEncoding.DecodeString(body.CandidatePubkey)
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "candidate_pubkey: invalid base64", "")
+		return
+	}
+	newKey, _, err := signing.ParsePublicKey(rawPubkey)
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "candidate_pubkey: not a valid Minisign public key", err.Error())
+		return
+	}
+
+	// Look up the plugin row.
+	plugin, err := h.q.GetPluginByID(ctx, pluginID)
+	if errors.Is(err, ErrNotFound) {
+		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
+		return
+	}
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
+		return
+	}
+
+	now := h.clock().UTC()
+	nowStr := now.Format(time.RFC3339Nano)
+
+	oldFingerprint := fmt.Sprintf("%x", deriveFingerprint([]byte(plugin.TrustedPubkey)))
+	newFingerprint := fmt.Sprintf("%x", newKey.KeyID)
+
+	// CAS-guarded pubkey rotation (ADR-038).
+	rows, err := h.q.UpdatePluginTrustedPubkey(ctx, db.UpdatePluginTrustedPubkeyParams{
+		TrustedPubkey:   string(rawPubkey),
+		UpdatedAt:       nowStr,
+		ID:              pluginID,
+		ExpectedVersion: plugin.Version,
+	})
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update trusted pubkey", "")
+		return
+	}
+	if rows == 0 {
+		// CAS miss — a concurrent writer advanced the version.
+		httputil.WriteError(w, http.StatusConflict, "concurrent modification detected; retry", "")
+		return
+	}
+
+	// Unblock all instances currently in pending_key_approval.
+	instances, err := h.q.ListPluginInstancesByPlugin(ctx, pluginID)
+	if err != nil {
+		// Non-fatal — pubkey is already rotated; log and report 0 unblocked.
+		slog.ErrorContext(ctx, "accept-new-key: list instances failed", "plugin_id", pluginID, "err", err)
+		instances = nil
+	}
+
+	unblocked := 0
+	for _, inst := range instances {
+		if model.PluginHealthState(inst.HealthState) != model.PluginHealthStatePendingKeyApproval {
+			continue
+		}
+		if stateErr := pluginstate.SetHealthState(ctx, h.q, h.publisher, inst.ID, pluginstate.OriginHost, model.PluginHealthStateHealthy, "operator accepted new signing key"); stateErr != nil {
+			if !errors.Is(stateErr, pluginstate.ErrTransitionConflict) {
+				slog.WarnContext(ctx, "accept-new-key: set health state failed", "instance_id", inst.ID, "err", stateErr)
+			}
+			continue
+		}
+		unblocked++
+	}
+
+	// Emit a plugin_pubkey_rotated audit event.
+	caller, _ := auth.UserFromContext(ctx)
+	var actorUserID *string
+	if caller != nil {
+		actorUserID = &caller.ID
+	}
+	auditPayload, _ := json.Marshal(map[string]string{
+		"plugin_id":              pluginID,
+		"name":                   plugin.Name,
+		"old_pubkey_fingerprint": oldFingerprint,
+		"new_pubkey_fingerprint": newFingerprint,
+	})
+	if _, auditErr := h.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditPubkeyRotated,
+		Severity:         "high",
+		ActorUserID:      actorUserID,
+		PayloadJson:      string(auditPayload),
+		CreatedAt:        nowStr,
+	}); auditErr != nil {
+		// Non-fatal — the rotation already succeeded; log the audit failure.
+		slog.ErrorContext(ctx, "accept-new-key: audit event failed", "plugin_id", pluginID, "err", auditErr)
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, acceptNewKeyResponse{
+		AcceptedPubkeyFingerprint: newFingerprint,
+		InstancesUnblocked:        unblocked,
+	})
+}
+
+// deriveFingerprint extracts the 8-byte key ID from a Minisign public key blob.
+// Returns a zero array if the blob is empty or unparseable (e.g. unsigned plugins
+// have an empty trusted_pubkey).
+func deriveFingerprint(pubkeyBytes []byte) [8]byte {
+	if len(pubkeyBytes) == 0 {
+		return [8]byte{}
+	}
+	pk, _, err := signing.ParsePublicKey(pubkeyBytes)
+	if err != nil {
+		return [8]byte{}
+	}
+	return pk.KeyID
 }

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -1,20 +1,48 @@
 package admin
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
 
 // fakePluginQuerier is an in-memory PluginQuerier for tests.
 type fakePluginQuerier struct {
-	instances map[string]db.PluginInstance
+	instances    map[string]db.PluginInstance
+	plugins      map[string]db.Plugin
+	auditEvents  []db.PluginAuditEvent
+	// casFailOn is the plugin ID that should return 0 rows for UpdatePluginTrustedPubkey
+	// to simulate a CAS conflict.
+	casFailOn    string
+	updatePubkey string // last value written by UpdatePluginTrustedPubkey
+}
+
+func newFakePluginQuerier() *fakePluginQuerier {
+	return &fakePluginQuerier{
+		instances: make(map[string]db.PluginInstance),
+		plugins:   make(map[string]db.Plugin),
+	}
+}
+
+func (f *fakePluginQuerier) seed(inst db.PluginInstance) {
+	f.instances[inst.ID] = inst
+}
+
+func (f *fakePluginQuerier) seedPlugin(p db.Plugin) {
+	f.plugins[p.ID] = p
 }
 
 func (f *fakePluginQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
@@ -25,12 +53,63 @@ func (f *fakePluginQuerier) GetPluginInstanceByID(_ context.Context, id string) 
 	return row, nil
 }
 
-func newFakePluginQuerier() *fakePluginQuerier {
-	return &fakePluginQuerier{instances: make(map[string]db.PluginInstance)}
+func (f *fakePluginQuerier) GetPluginByID(_ context.Context, id string) (db.Plugin, error) {
+	row, ok := f.plugins[id]
+	if !ok {
+		return db.Plugin{}, ErrNotFound
+	}
+	return row, nil
 }
 
-func (f *fakePluginQuerier) seed(inst db.PluginInstance) {
-	f.instances[inst.ID] = inst
+func (f *fakePluginQuerier) UpdatePluginTrustedPubkey(_ context.Context, arg db.UpdatePluginTrustedPubkeyParams) (int64, error) {
+	if f.casFailOn == arg.ID {
+		return 0, nil // simulate CAS conflict
+	}
+	p, ok := f.plugins[arg.ID]
+	if !ok {
+		return 0, nil
+	}
+	p.TrustedPubkey = arg.TrustedPubkey
+	p.Version++
+	f.plugins[arg.ID] = p
+	f.updatePubkey = arg.TrustedPubkey
+	return 1, nil
+}
+
+func (f *fakePluginQuerier) ListPluginInstancesByPlugin(_ context.Context, pluginID string) ([]db.PluginInstance, error) {
+	var result []db.PluginInstance
+	for _, inst := range f.instances {
+		if inst.PluginID == pluginID {
+			result = append(result, inst)
+		}
+	}
+	return result, nil
+}
+
+func (f *fakePluginQuerier) UpdatePluginInstanceHealth(_ context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error) {
+	inst, ok := f.instances[arg.ID]
+	if !ok || inst.Version != arg.ExpectedVersion {
+		return 0, nil
+	}
+	inst.HealthState = arg.HealthState
+	inst.HealthDetail = arg.HealthDetail
+	inst.Version++
+	f.instances[arg.ID] = inst
+	return 1, nil
+}
+
+func (f *fakePluginQuerier) InsertPluginAuditEvent(_ context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error) {
+	ev := db.PluginAuditEvent{
+		ID:               int64(len(f.auditEvents)),
+		PluginInstanceID: arg.PluginInstanceID,
+		EventType:        arg.EventType,
+		Severity:         arg.Severity,
+		ActorUserID:      arg.ActorUserID,
+		PayloadJson:      arg.PayloadJson,
+		CreatedAt:        arg.CreatedAt,
+	}
+	f.auditEvents = append(f.auditEvents, ev)
+	return ev, nil
 }
 
 func TestPluginHandler_GetInstance(t *testing.T) {
@@ -91,7 +170,7 @@ func TestPluginHandler_GetInstance(t *testing.T) {
 			if tt.seed != nil {
 				q.seed(*tt.seed)
 			}
-			h := NewPluginHandler(q)
+			h := NewPluginHandler(q, nil, nil)
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins/"+tt.pluginID+"/instances/"+tt.instanceID, nil)
 			req = withChiParams(req, map[string]string{"id": tt.pluginID, "iid": tt.instanceID})
@@ -122,6 +201,182 @@ func TestPluginHandler_GetInstance(t *testing.T) {
 			}
 		})
 	}
+}
+
+// makeTestPubkey generates a valid Minisign public key and returns its bytes
+// and the base64-encoded form suitable for the accept-new-key request body.
+func makeTestPubkey(t *testing.T) (rawBytes []byte, b64 string) {
+	t.Helper()
+	pk, _, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	raw := signing.MarshalPublicKey(pk, "test key")
+	return raw, base64.StdEncoding.EncodeToString(raw)
+}
+
+func TestPluginHandler_AcceptNewKey(t *testing.T) {
+	fixedClock := func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
+
+	t.Run("rotates trusted_pubkey and emits audit event", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		oldPubkey, _ := makeTestPubkey(t)
+		q.seedPlugin(db.Plugin{
+			ID:            "plugin-1",
+			Name:          "my-plugin",
+			TrustedPubkey: string(oldPubkey),
+			Version:       2,
+		})
+
+		_, newB64 := makeTestPubkey(t)
+		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/accept-new-key", bytes.NewBufferString(body))
+		req = withChiParams(req, map[string]string{"id": "plugin-1"})
+		rec := httptest.NewRecorder()
+		h.AcceptNewKey(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+
+		// Check audit event was emitted.
+		if len(q.auditEvents) == 0 {
+			t.Fatal("expected audit event, got none")
+		}
+		if q.auditEvents[0].EventType != "plugin_pubkey_rotated" {
+			t.Errorf("audit event type = %q, want plugin_pubkey_rotated", q.auditEvents[0].EventType)
+		}
+		if q.auditEvents[0].Severity != "high" {
+			t.Errorf("audit severity = %q, want high", q.auditEvents[0].Severity)
+		}
+
+		// Check pubkey was updated.
+		newRaw, _ := base64.StdEncoding.DecodeString(newB64)
+		if q.updatePubkey != string(newRaw) {
+			t.Errorf("updatePubkey mismatch: got %q, want decoded pubkey bytes", q.updatePubkey)
+		}
+	})
+
+	t.Run("transitions pending_key_approval instances to healthy", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		oldPubkey, _ := makeTestPubkey(t)
+		q.seedPlugin(db.Plugin{
+			ID:            "plugin-2",
+			Name:          "blocked-plugin",
+			TrustedPubkey: string(oldPubkey),
+			Version:       1,
+		})
+		q.seed(db.PluginInstance{
+			ID:          "inst-a",
+			PluginID:    "plugin-2",
+			HealthState: string(model.PluginHealthStatePendingKeyApproval),
+			Version:     0,
+		})
+		q.seed(db.PluginInstance{
+			ID:          "inst-b",
+			PluginID:    "plugin-2",
+			HealthState: string(model.PluginHealthStateHealthy), // already healthy — should not be touched
+			Version:     0,
+		})
+
+		_, newB64 := makeTestPubkey(t)
+		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-2/accept-new-key", bytes.NewBufferString(body))
+		req = withChiParams(req, map[string]string{"id": "plugin-2"})
+		rec := httptest.NewRecorder()
+		h.AcceptNewKey(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+
+		data := parseDataResponse(t, rec)
+		var resp acceptNewKeyResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp.InstancesUnblocked != 1 {
+			t.Errorf("instances_unblocked = %d, want 1", resp.InstancesUnblocked)
+		}
+
+		// inst-a should be healthy now.
+		instA := q.instances["inst-a"]
+		if instA.HealthState != string(model.PluginHealthStateHealthy) {
+			t.Errorf("inst-a health_state = %q, want healthy", instA.HealthState)
+		}
+		// inst-b should remain unchanged.
+		instB := q.instances["inst-b"]
+		if instB.HealthState != string(model.PluginHealthStateHealthy) {
+			t.Errorf("inst-b health_state = %q, want healthy (unchanged)", instB.HealthState)
+		}
+	})
+
+	t.Run("rejects malformed candidate_pubkey with 400", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		oldPubkey, _ := makeTestPubkey(t)
+		q.seedPlugin(db.Plugin{ID: "plugin-3", Name: "p", TrustedPubkey: string(oldPubkey), Version: 0})
+
+		h := NewPluginHandler(q, nil, fixedClock)
+
+		// Not valid base64.
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"candidate_pubkey": "not-valid-base64!!!"}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-3"})
+		rec := httptest.NewRecorder()
+		h.AcceptNewKey(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400 for invalid base64", rec.Code)
+		}
+
+		// Valid base64 but not a Minisign pubkey.
+		garbage := base64.StdEncoding.EncodeToString([]byte("not a pubkey"))
+		req2 := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(fmt.Sprintf(`{"candidate_pubkey": %q}`, garbage)))
+		req2 = withChiParams(req2, map[string]string{"id": "plugin-3"})
+		rec2 := httptest.NewRecorder()
+		h.AcceptNewKey(rec2, req2)
+		if rec2.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400 for invalid pubkey format", rec2.Code)
+		}
+	})
+
+	t.Run("returns 404 on unknown plugin id", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		_, newB64 := makeTestPubkey(t)
+		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+		req = withChiParams(req, map[string]string{"id": "nonexistent"})
+		rec := httptest.NewRecorder()
+		h.AcceptNewKey(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404 for unknown plugin", rec.Code)
+		}
+	})
+
+	t.Run("CAS conflict surfaces as 409", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		oldPubkey, _ := makeTestPubkey(t)
+		q.seedPlugin(db.Plugin{ID: "plugin-4", Name: "p", TrustedPubkey: string(oldPubkey), Version: 0})
+		q.casFailOn = "plugin-4" // trigger CAS miss
+
+		_, newB64 := makeTestPubkey(t)
+		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+		req = withChiParams(req, map[string]string{"id": "plugin-4"})
+		rec := httptest.NewRecorder()
+		h.AcceptNewKey(rec, req)
+
+		if rec.Code != http.StatusConflict {
+			t.Errorf("status = %d, want 409 for CAS conflict", rec.Code)
+		}
+	})
 }
 
 // withChiParams sets multiple chi URL params on a request in a single route

--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -218,6 +218,7 @@ func BuildRouter(cfg RouterConfig) chi.Router {
 
 			if cfg.Handlers.PluginAdminHandler != nil {
 				r.Get("/plugins/{id}/instances/{iid}", cfg.Handlers.PluginAdminHandler.GetInstance)
+				r.Post("/plugins/{id}/accept-new-key", cfg.Handlers.PluginAdminHandler.AcceptNewKey)
 			}
 
 			r.Route("/openai-providers", func(r chi.Router) {

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/infra/config"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
 	"github.com/felag-engineering/gleipnir/internal/plugin/loader"
 )
 
@@ -79,12 +80,16 @@ func (l *Loader) Init(_ context.Context, cfg config.Config) error {
 // schema is ready for plugin rows and audit events. It is a no-op (returns nil)
 // when Init was not called (i.e. when GLEIPNIR_PLUGINS_ENABLED=false) —
 // l.verifier will be nil in that case and we return early.
-func (l *Loader) StartWatcher(ctx context.Context, q *db.Queries, dir string) error {
+//
+// publisher is used to emit plugin.health_changed events when a pubkey mismatch
+// transitions instances to pending_key_approval. It may be nil — events are
+// skipped when nil.
+func (l *Loader) StartWatcher(ctx context.Context, q *db.Queries, dir string, publisher event.Publisher) error {
 	if l.verifier == nil {
 		return nil
 	}
 
-	inst := loader.NewInstaller(&verifierAdapter{v: l.verifier}, q)
+	inst := loader.NewInstaller(&verifierAdapter{v: l.verifier}, q, publisher)
 	l.watcher = loader.NewWatcher(dir, inst.Install)
 
 	fw, err := l.watcher.Setup()

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -1,18 +1,24 @@
 package loader
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
 	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 	manifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 )
 
@@ -69,6 +75,7 @@ const (
 	auditSignatureInvalid = "plugin_signature_invalid"
 	auditPluginInstalled  = "plugin_installed"
 	auditUpdatePending    = "plugin_update_pending"
+	auditPubkeyMismatch   = "plugin_pubkey_mismatch"
 
 	// Audit severity levels.
 	severityHigh = "high"
@@ -80,15 +87,17 @@ const (
 // Watcher; Install is called sequentially (ADR-003 serialization via the
 // watcher's fire channel).
 type Installer struct {
-	verifier BundleVerifier
-	q        *db.Queries
+	verifier  BundleVerifier
+	q         *db.Queries
+	publisher event.Publisher
 	// clock is injectable so tests can assert on timestamps without racing real time.
 	clock func() time.Time
 }
 
-// NewInstaller returns an Installer wired to the given verifier and query set.
-func NewInstaller(v BundleVerifier, q *db.Queries) *Installer {
-	return &Installer{verifier: v, q: q, clock: time.Now}
+// NewInstaller returns an Installer wired to the given verifier, query set, and
+// event publisher. publisher may be nil — state change events are skipped when nil.
+func NewInstaller(v BundleVerifier, q *db.Queries, publisher event.Publisher) *Installer {
+	return &Installer{verifier: v, q: q, publisher: publisher, clock: time.Now}
 }
 
 // Install runs the full install pipeline for the tarball at tarPath:
@@ -210,7 +219,107 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 		return nil
 	}
 
+	// TOFU pubkey trust check: only applies to verified (signed) bundles.
+	if result.Outcome == OutcomeVerified {
+		if existing.TrustedPubkey == "" {
+			// Delayed TOFU: plugin was first installed under GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true
+			// and a signed update has now arrived. Capture the pubkey silently — no mismatch event.
+			rows, updateErr := in.q.UpdatePluginTrustedPubkey(ctx, db.UpdatePluginTrustedPubkeyParams{
+				TrustedPubkey:   string(result.Pubkey),
+				UpdatedAt:       nowStr,
+				ID:              existing.ID,
+				ExpectedVersion: existing.Version,
+			})
+			if updateErr != nil {
+				return fmt.Errorf("capture trusted pubkey for %q (delayed TOFU): %w", m.Name, updateErr)
+			}
+			if rows == 0 {
+				return fmt.Errorf("capture trusted pubkey for %q: CAS conflict (version mismatch)", m.Name)
+			}
+			// Re-read so updatePlugin sees the bumped version.
+			existing, err = in.q.GetPluginByName(ctx, m.Name)
+			if err != nil {
+				return fmt.Errorf("re-read plugin %q after TOFU capture: %w", m.Name, err)
+			}
+		} else if !bytes.Equal(result.Pubkey, []byte(existing.TrustedPubkey)) {
+			// Key mismatch: a different signing key was used for this update.
+			// Block the update and transition all instances to pending_key_approval
+			// so admins are alerted. Do not call updatePlugin.
+			return in.handlePubkeyMismatch(ctx, existing, result, m.Version, nowStr)
+		}
+	}
+
 	return in.updatePlugin(ctx, existing, m, manifestBytes, nowStr)
+}
+
+// handlePubkeyMismatch transitions all instances of the plugin to
+// pending_key_approval and emits a plugin_pubkey_mismatch audit event.
+// It returns nil so the watcher continues — the audit event is the operator signal.
+func (in *Installer) handlePubkeyMismatch(ctx context.Context, existing db.Plugin, result VerifyResult, newVersion, nowStr string) error {
+	// Compute fingerprints from old and new pubkeys for the audit payload.
+	oldFingerprint := pubkeyFingerprint([]byte(existing.TrustedPubkey))
+	newFingerprint := pubkeyFingerprint(result.Pubkey)
+
+	// Transition all instances to pending_key_approval. Each uses the state machine
+	// CAS guard. ErrTransitionConflict means another writer already moved the instance;
+	// log and continue rather than failing the whole operation.
+	// If listing instances fails, log the error and fall through to emit the audit event
+	// anyway — the audit row is the operator's only signal that a mismatch happened.
+	instances, listErr := in.q.ListPluginInstancesByPlugin(ctx, existing.ID)
+	if listErr != nil {
+		slog.WarnContext(ctx, "pubkey mismatch: list instances failed; skipping state transitions",
+			"plugin", existing.Name, "err", listErr)
+	}
+	for _, inst := range instances {
+		current := model.PluginHealthState(inst.HealthState)
+		if !pluginstate.IsLegalTransition(current, model.PluginHealthStatePendingKeyApproval) {
+			continue
+		}
+		if stateErr := pluginstate.SetHealthState(ctx, in.q, in.publisher, inst.ID, pluginstate.OriginHost, model.PluginHealthStatePendingKeyApproval, "signing key changed; admin approval required"); stateErr != nil {
+			if !errors.Is(stateErr, pluginstate.ErrTransitionConflict) {
+				slog.WarnContext(ctx, "pubkey mismatch: set pending_key_approval failed",
+					"instance_id", inst.ID, "err", stateErr)
+			}
+		}
+	}
+
+	payload, _ := json.Marshal(map[string]string{
+		"plugin_id":              existing.ID,
+		"name":                   existing.Name,
+		"old_pubkey_fingerprint": oldFingerprint,
+		"new_pubkey_fingerprint": newFingerprint,
+		"new_pubkey_b64":         base64.StdEncoding.EncodeToString(result.Pubkey),
+		"version":                newVersion,
+	})
+	_, auditErr := in.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditPubkeyMismatch,
+		Severity:         severityHigh,
+		ActorUserID:      nil,
+		PayloadJson:      string(payload),
+		CreatedAt:        nowStr,
+	})
+	if auditErr != nil {
+		return fmt.Errorf("record pubkey_mismatch audit for %q: %w", existing.Name, auditErr)
+	}
+
+	return nil
+}
+
+// pubkeyFingerprint derives a short human-readable fingerprint from the
+// Minisign public key bytes. Returns the hex-encoded 8-byte key ID, which is
+// already embedded in the wire format and unique per keypair.
+// If the bytes cannot be parsed (e.g. empty string for an unsigned plugin),
+// a fallback of "(unknown)" is returned.
+func pubkeyFingerprint(pubkeyBytes []byte) string {
+	if len(pubkeyBytes) == 0 {
+		return "(unknown)"
+	}
+	pk, _, err := signing.ParsePublicKey(pubkeyBytes)
+	if err != nil {
+		return "(unparseable)"
+	}
+	return fmt.Sprintf("%x", pk.KeyID)
 }
 
 // createPlugin inserts a new plugin row with status=pending_review.

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 	_ "modernc.org/sqlite"
 )
@@ -236,7 +237,7 @@ func writeTarball(t *testing.T, path string, entries []tarEntry) {
 func newTestInstaller(t *testing.T, q *db.Queries, allowUnsigned bool) *Installer {
 	t.Helper()
 	v := &realVerifier{allowUnsigned: allowUnsigned}
-	inst := NewInstaller(v, q)
+	inst := NewInstaller(v, q, nil)
 	inst.clock = func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
 	return inst
 }
@@ -314,14 +315,42 @@ func TestInstall_VersionBump_PendingReview(t *testing.T) {
 	q := openTestDB(t)
 	inst := newTestInstaller(t, q, false)
 
+	// Generate a single keypair so both installs are signed by the same key.
+	// Using the same key avoids triggering the pubkey-mismatch path.
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	buildVersionedTarball := func(t *testing.T, version string) string {
+		t.Helper()
+		manifestBytes := []byte("schema_version: v1\nname: bump-plugin\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+		binaryBytes := []byte("binary for bump-plugin " + version)
+		payload := signing.PluginPayload(binaryBytes, manifestBytes)
+		sig, err := signing.Sign(sk.SecretKey, sk.KeyID, payload, "trusted comment")
+		if err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+		sigBytes := signing.MarshalSignature(sig, "test sig")
+		tarPath := filepath.Join(t.TempDir(), "bump-plugin-"+version+".tar.gz")
+		writeTarball(t, tarPath, []tarEntry{
+			{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+			{name: "bump-plugin", content: binaryBytes, mode: 0o755},
+			{name: "signing.pub", content: pubkeyBytes, mode: 0o644},
+			{name: "bump-plugin.minisig", content: sigBytes, mode: 0o644},
+		})
+		return tarPath
+	}
+
 	// First install — v1.0.0.
-	tarPath1, _ := signedPluginTarball(t, "bump-plugin", "1.0.0")
+	tarPath1 := buildVersionedTarball(t, "1.0.0")
 	if err := inst.Install(context.Background(), tarPath1); err != nil {
 		t.Fatalf("initial Install: %v", err)
 	}
 
-	// Second install — v1.1.0 (version bump).
-	tarPath2, _ := signedPluginTarball(t, "bump-plugin", "1.1.0")
+	// Second install — v1.1.0 (version bump, same key).
+	tarPath2 := buildVersionedTarball(t, "1.1.0")
 	if err := inst.Install(context.Background(), tarPath2); err != nil {
 		t.Fatalf("version-bump Install: %v", err)
 	}
@@ -407,6 +436,227 @@ func TestInstall_UnsignedPermissive_PendingReview(t *testing.T) {
 	}
 }
 
+// seedPluginInstance creates a plugin_instances row for testing TOFU transitions.
+func seedPluginInstance(t *testing.T, q *db.Queries, pluginID, instanceID string, state model.PluginHealthState) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := q.CreatePluginInstance(context.Background(), db.CreatePluginInstanceParams{
+		ID:                instanceID,
+		PluginID:          pluginID,
+		InstanceName:      "test",
+		ConfigJson:        "{}",
+		HandshakeVersions: "{}",
+		HealthState:       string(state),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	})
+	if err != nil {
+		t.Fatalf("CreatePluginInstance: %v", err)
+	}
+}
+
+func TestInstall_TOFUFirstInstall_CapturesPubkey(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath, _ := signedPluginTarball(t, "tofu-plugin", "1.0.0")
+	if err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "tofu-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if row.TrustedPubkey == "" {
+		t.Error("trusted_pubkey: want non-empty after first install (TOFU capture)")
+	}
+}
+
+func TestInstall_SamePubkeyUpdate_PassesThrough(t *testing.T) {
+	// Install v1 with key A, then install v2 built from the same key A.
+	// The update should proceed without a mismatch event.
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	// Generate one keypair and build two tarballs with it.
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	buildTar := func(t *testing.T, version string) string {
+		t.Helper()
+		manifestBytes := []byte("schema_version: v1\nname: same-key-plugin\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+		binaryBytes := []byte("binary for " + version)
+		payload := signing.PluginPayload(binaryBytes, manifestBytes)
+		sig, err := signing.Sign(sk.SecretKey, sk.KeyID, payload, "trusted comment")
+		if err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+		sigBytes := signing.MarshalSignature(sig, "test sig")
+		tarPath := filepath.Join(t.TempDir(), "same-key-plugin-"+version+".tar.gz")
+		writeTarball(t, tarPath, []tarEntry{
+			{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+			{name: "same-key-plugin", content: binaryBytes, mode: 0o755},
+			{name: "signing.pub", content: pubkeyBytes, mode: 0o644},
+			{name: "same-key-plugin.minisig", content: sigBytes, mode: 0o644},
+		})
+		return tarPath
+	}
+
+	if err := inst.Install(context.Background(), buildTar(t, "1.0.0")); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+	if err := inst.Install(context.Background(), buildTar(t, "1.1.0")); err != nil {
+		t.Fatalf("Install v1.1.0 (same key): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "same-key-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if row.PluginVersion != "1.1.0" {
+		t.Errorf("plugin_version = %q, want 1.1.0", row.PluginVersion)
+	}
+
+	// No mismatch event should have been recorded.
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditPubkeyMismatch,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list audit events: %v", err)
+	}
+	if len(events) > 0 {
+		t.Errorf("got %d pubkey_mismatch events, want 0 (same key update)", len(events))
+	}
+}
+
+func TestInstall_DifferentPubkeyUpdate_BlocksAndAudits(t *testing.T) {
+	// Install v1 with key A, then attempt v2 signed by key B.
+	// Expect: no UpdatePluginManifest call (version stays at v1), mismatch audit event,
+	// and any healthy instance transitions to pending_key_approval.
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	// First install with key A.
+	tarPath1, _ := signedPluginTarball(t, "mismatch-plugin", "1.0.0")
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	pluginRow, err := q.GetPluginByName(context.Background(), "mismatch-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v1: %v", err)
+	}
+
+	// Seed a healthy instance for the plugin.
+	seedPluginInstance(t, q, pluginRow.ID, "inst-1", model.PluginHealthStateHealthy)
+
+	// Second tarball signed by a different key (signedPluginTarball generates a fresh keypair).
+	tarPath2, _ := signedPluginTarball(t, "mismatch-plugin", "2.0.0")
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (different key): %v", err)
+	}
+
+	// Plugin version must remain at 1.0.0 (blocked).
+	pluginRow2, err := q.GetPluginByName(context.Background(), "mismatch-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v2: %v", err)
+	}
+	if pluginRow2.PluginVersion != "1.0.0" {
+		t.Errorf("plugin_version = %q, want 1.0.0 (mismatch should block update)", pluginRow2.PluginVersion)
+	}
+
+	// A plugin_pubkey_mismatch audit event must have been recorded.
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditPubkeyMismatch,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list mismatch events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected a plugin_pubkey_mismatch audit event, got none")
+	}
+	if events[0].Severity != "high" {
+		t.Errorf("audit severity = %q, want high", events[0].Severity)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(events[0].PayloadJson), &payload); err != nil {
+		t.Fatalf("parse mismatch audit payload: %v", err)
+	}
+	if payload["new_pubkey_b64"] == "" {
+		t.Error("mismatch audit payload: new_pubkey_b64 must be non-empty")
+	}
+	if payload["name"] != "mismatch-plugin" {
+		t.Errorf("mismatch audit payload: name = %q, want mismatch-plugin", payload["name"])
+	}
+
+	// The instance must be in pending_key_approval now.
+	inst1, err := q.GetPluginInstanceByID(context.Background(), "inst-1")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", err)
+	}
+	if inst1.HealthState != string(model.PluginHealthStatePendingKeyApproval) {
+		t.Errorf("instance health_state = %q, want pending_key_approval", inst1.HealthState)
+	}
+}
+
+func TestInstall_DelayedTOFU_CapturesSilently(t *testing.T) {
+	// First install unsigned (empty trusted_pubkey), then signed update arrives.
+	// Expect: pubkey is captured via UpdatePluginTrustedPubkey, no mismatch event.
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, true) // allowUnsigned to accept the first install
+
+	tarPath1 := unsignedPluginTarball(t, "delayed-tofu", "1.0.0")
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1 (unsigned): %v", err)
+	}
+
+	row1, err := q.GetPluginByName(context.Background(), "delayed-tofu")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v1: %v", err)
+	}
+	if row1.TrustedPubkey != "" {
+		t.Errorf("trusted_pubkey after unsigned install = %q, want empty", row1.TrustedPubkey)
+	}
+
+	// Install signed v2 — should capture pubkey, not mismatch.
+	tarPath2, _ := signedPluginTarball(t, "delayed-tofu", "2.0.0")
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (signed): %v", err)
+	}
+
+	row2, err := q.GetPluginByName(context.Background(), "delayed-tofu")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v2: %v", err)
+	}
+	if row2.TrustedPubkey == "" {
+		t.Error("trusted_pubkey: want non-empty after delayed TOFU capture")
+	}
+	if row2.PluginVersion != "2.0.0" {
+		t.Errorf("plugin_version = %q, want 2.0.0 after delayed TOFU", row2.PluginVersion)
+	}
+
+	// No mismatch events.
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditPubkeyMismatch,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list mismatch events: %v", err)
+	}
+	if len(events) > 0 {
+		t.Errorf("got %d pubkey_mismatch events after delayed TOFU, want 0", len(events))
+	}
+}
+
 // traversalTarball builds a tarball whose manifest.yaml contains the given name.
 // The tarball itself uses "binary" as the actual file entry to avoid OS-level
 // path issues when creating the archive; the manifest is what triggers the check.
@@ -461,7 +711,7 @@ func TestInstall_RejectedWithNilErr_NoPanic(t *testing.T) {
 	// Build a valid signed tarball so we get past manifest parsing.
 	tarPath, _ := signedPluginTarball(t, "nil-err-plugin", "1.0.0")
 
-	inst := &Installer{verifier: nilErrVerifier{}, q: q, clock: time.Now}
+	inst := &Installer{verifier: nilErrVerifier{}, q: q, publisher: nil, clock: time.Now}
 
 	// Must not panic; Install should record an audit event and return nil.
 	if err := inst.Install(context.Background(), tarPath); err != nil {

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -83,7 +83,7 @@ func TestLoader_StartWatcher_DisabledIsNoOp(t *testing.T) {
 	}
 	// StartWatcher must return without panicking or starting anything.
 	// Pass nil for q — the code must not reach any q calls when disabled.
-	l.StartWatcher(context.Background(), nil, t.TempDir())
+	l.StartWatcher(context.Background(), nil, t.TempDir(), nil)
 }
 
 // captureLogs swaps slog.Default with a buffer-backed handler for the

--- a/internal/plugin/state/pluginstate.go
+++ b/internal/plugin/state/pluginstate.go
@@ -117,26 +117,31 @@ var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
 		model.PluginHealthStateCrashed,
 		model.PluginHealthStateCircuitBroken,
 		model.PluginHealthStatePendingManifestApproval, // hot-reload detects manifest change
+		model.PluginHealthStatePendingKeyApproval,      // new signed update with mismatched key (#188)
 	},
 	model.PluginHealthStateUnsignedPermissive: {
 		model.PluginHealthStateUnhealthy,
 		model.PluginHealthStateCrashed,
 		model.PluginHealthStateCircuitBroken,
 		model.PluginHealthStatePendingManifestApproval,
+		model.PluginHealthStatePendingKeyApproval, // signed update arrives for previously-unsigned plugin (#188)
 	},
 	model.PluginHealthStateUnhealthy: {
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateCrashed,
 		model.PluginHealthStateCircuitBroken,
+		model.PluginHealthStatePendingKeyApproval, // key mismatch detected during unhealthy state (#188)
 	},
 	model.PluginHealthStateCircuitBroken: {
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateUnhealthy,
 		model.PluginHealthStateCrashed,
+		model.PluginHealthStatePendingKeyApproval, // key mismatch detected during circuit-broken state (#188)
 	},
 	model.PluginHealthStateCrashed: {
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateUnhealthy,
+		model.PluginHealthStatePendingKeyApproval, // key mismatch detected after crash (#188)
 	},
 	// signature_invalid and verification_error are terminal — no outgoing edges.
 	// A re-install or admin key-rotation creates a fresh instance row.

--- a/internal/plugin/state/pluginstate_test.go
+++ b/internal/plugin/state/pluginstate_test.go
@@ -90,6 +90,12 @@ func TestIsLegalTransition(t *testing.T) {
 		{model.PluginHealthStateHealthy, model.PluginHealthStateCrashed},
 		{model.PluginHealthStateHealthy, model.PluginHealthStateCircuitBroken},
 		{model.PluginHealthStateHealthy, model.PluginHealthStatePendingManifestApproval},
+		// New edges: pending_key_approval is reachable from non-terminal states (#188).
+		{model.PluginHealthStateHealthy, model.PluginHealthStatePendingKeyApproval},
+		{model.PluginHealthStateUnsignedPermissive, model.PluginHealthStatePendingKeyApproval},
+		{model.PluginHealthStateUnhealthy, model.PluginHealthStatePendingKeyApproval},
+		{model.PluginHealthStateCircuitBroken, model.PluginHealthStatePendingKeyApproval},
+		{model.PluginHealthStateCrashed, model.PluginHealthStatePendingKeyApproval},
 		{model.PluginHealthStateUnsignedPermissive, model.PluginHealthStateUnhealthy},
 		{model.PluginHealthStateUnsignedPermissive, model.PluginHealthStateCrashed},
 		{model.PluginHealthStateUnhealthy, model.PluginHealthStateHealthy},
@@ -110,7 +116,7 @@ func TestIsLegalTransition(t *testing.T) {
 	illegal := [][2]model.PluginHealthState{
 		{model.PluginHealthStateSignatureInvalid, model.PluginHealthStateHealthy},
 		{model.PluginHealthStateVerificationError, model.PluginHealthStateHealthy},
-		{model.PluginHealthStateHealthy, model.PluginHealthStatePendingKeyApproval},
+		// signature_invalid and verification_error are terminal — no outgoing edges.
 		{model.PluginHealthStateCrashed, model.PluginHealthStateSignatureInvalid},
 	}
 	for _, pair := range illegal {

--- a/main.go
+++ b/main.go
@@ -83,13 +83,8 @@ func run(cfg config.Config) error {
 		return fmt.Errorf("migrate: %w", err)
 	}
 
-	// Start the plugin watcher after migration so the schema is ready.
-	// No-op when GLEIPNIR_PLUGINS_ENABLED=false.
-	if cfg.PluginsEnabled {
-		if err := loader.StartWatcher(ctx, store.Queries(), cfg.PluginsDir); err != nil {
-			return fmt.Errorf("start plugin watcher: %w", err)
-		}
-	}
+	// Plugin watcher start is deferred until after broadcaster is initialized;
+	// see below after sse.NewBroadcaster().
 
 	// Mark any in-flight runs as interrupted (ADR-011).
 	if err := store.ScanOrphanedRuns(ctx, slog.Default()); err != nil {
@@ -107,6 +102,15 @@ func run(cfg config.Config) error {
 
 	broadcaster := sse.NewBroadcaster()
 	sseHandler := sse.NewHandler(broadcaster)
+
+	// Start the plugin watcher after broadcaster is initialized so pubkey-mismatch
+	// transitions can emit plugin.health_changed SSE events. Schema is already
+	// migrated at this point. No-op when GLEIPNIR_PLUGINS_ENABLED=false.
+	if cfg.PluginsEnabled {
+		if err := loader.StartWatcher(ctx, store.Queries(), cfg.PluginsDir, broadcaster); err != nil {
+			return fmt.Errorf("start plugin watcher: %w", err)
+		}
+	}
 
 	approvalScanner := timeout.NewApprovalScanner(
 		store,
@@ -288,7 +292,7 @@ func run(cfg config.Config) error {
 		SettingsHandler:      settingsHandler,
 		AdminHandler:         adminHandler,
 		OpenAICompatHandler:  openaiCompatHandler,
-		PluginAdminHandler:   admin.NewPluginHandler(store.Queries()),
+		PluginAdminHandler:   admin.NewPluginHandler(store.Queries(), broadcaster, nil),
 		WebhookHandler:       webhookHandler,
 		SSEHandler:           sseHandler,
 		PolicyWebhookHandler: policyWebhookHandler,


### PR DESCRIPTION
Closes #188

## Summary

Implements TOFU pubkey trust for the plugin signing chain:
- On first verified install, the bundle's `signing.pub` is captured into `plugins.trusted_pubkey`.
- On subsequent updates, a mismatch against the captured pubkey blocks the install, emits a `plugin_pubkey_mismatch` audit event (with the candidate pubkey base64-encoded so the operator can echo it back), and transitions affected instances into `pending_key_approval`.
- Empty `trusted_pubkey` (i.e. plugin first installed under `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true`) is treated as delayed TOFU — the new key is captured silently.
- New admin-only endpoint `POST /api/v1/admin/plugins/{id}/accept-new-key` parses the operator-supplied candidate, CAS-rotates `trusted_pubkey`, transitions every `pending_key_approval` instance for that plugin back to `healthy`, and emits `plugin_pubkey_rotated`.
- Frontend: `AcceptNewKeyModal` (CSS Modules, 4px tokens, Storybook story) + `useAcceptPluginNewKey` mutation hook.

ADR-045 §5.3 gets a new audit-event entry under ADR_Tracker.md.

## Scope-down

The optional out-of-band pubkey paste at initial install is **deferred**. The fsnotify watcher is the only install pathway today; there is no admin-driven HTTP install endpoint to attach a pinned pubkey to. The TOFU first-leap is sufficient given `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS` as the existing escape hatch. Tracking as a follow-up against the eventual admin-install UI.

## Architecture plan

<details>
<summary>Plan (revised once after adversarial review)</summary>

See `.dev-loop/plan.md` on the branch. Five blocking corrections from the plan reviewer were applied before implementation:
- `audit_events` schema has no `plugin_id` column — events are stored with `PluginInstanceID = nil` and the plugin id lives inside `PayloadJson`.
- `state.ErrTransitionConflict` (not `runstate.ErrTransitionConflict`) for plugin-state CAS conflicts.
- `NewInstaller` constructor signature widened to accept `event.Publisher`.
- `fakePluginQuerier` in tests had to be widened to satisfy the broader `PluginQuerier` interface.
- Audit event payload includes `new_pubkey_b64` so the frontend can sourcing the candidate without new server-side staging state.

</details>

## Review cycles

Two cycles. Cycle 1 flagged one blocking issue (silently-discarded `SetHealthState` error) and two minor suggestions (named const for `auditPubkeyRotated`; emit audit event even when the instance list lookup fails). All addressed in cycle 2; cycle 2 returned APPROVE.

## Tests

- Backend: 4 new TOFU tests in `install_test.go`, 5 new `AcceptNewKey` tests in `plugin_handler_test.go`, transition-table assertions in `pluginstate_test.go`. All Go tests pass.
- Frontend: 5 new tests for `AcceptNewKeyModal`. All vitest pass.

## Test plan

- [ ] Bundle a plugin signed with key A, install it, verify `plugins.trusted_pubkey` is populated.
- [ ] Bundle a new version with key A, install, verify version bump succeeds with no audit event.
- [ ] Bundle a new version with key B, drop into `/plugins`, verify `plugin_pubkey_mismatch` audit event row, verify all healthy instances transition to `pending_key_approval`, verify the new manifest is NOT applied.
- [ ] Click the chip → modal opens → "Accept new key" → verify `trusted_pubkey` rotates, instances return to `healthy`, `plugin_pubkey_rotated` audit row appears.
- [ ] CAS conflict (concurrent rotation): verify 409.
- [ ] Malformed `candidate_pubkey`: verify 400.

## Documentation

`CLAUDE.md` updated with the new admin endpoint. `ADR_Tracker.md` updated with the two new audit event types under ADR-045.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop