### PR TITLE
feat(plugin): material manifest change detection on hot-reload (#189)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ internal/
   model/              — domain types (Policy, Run, RunStep, ApprovalRequest, enums, ...)
   plugin/             — host-side plugin loader; gated by GLEIPNIR_PLUGINS_ENABLED. Implements fsnotify watcher, tarball extractor, minisign verifier, and DB installer. Out-of-process subprocess spawning and generation refcounts remain as follow-up work.
     state/            — per-instance health-state machine; mirrors execution/runstate (transition table + version-CAS, ADR-038). Severity ranking encodes §8.1 "plugin can only mark itself worse" merge rule.
+    manifest/         — host-side manifest diff (material vs cosmetic) consumed by the loader on hot-reload (spec §5.4). Schema-shape comparison strips `description`/`default` keys at every depth; depends only on plugin-sdk/manifest + stdlib.
   policy/             — YAML parser, validator, system prompt renderer
   settings/           — read-side accessor for system_settings (default model, public URL); injected into runtime so non-admin packages don't depend on the admin HTTP handler
   testutil/           — shared test helpers
@@ -179,6 +180,7 @@ Routes are registered in `internal/http/api/router.go` via `BuildRouter`, which 
 - `/api/v1/mcp/servers/*` — MCP server registry, tool discovery; `PUT /:id` updates name/url only; `PUT /:id/headers/:name` and `DELETE /:id/headers/:name` manage individual auth headers (admin|operator only; see ADR-039); `POST /:id/arcade/authorize` and `POST /:id/arcade/authorize/wait` pre-authorize Arcade toolkits (admin|operator only; see ADR-040)
 - `/api/v1/admin/plugins/{id}/instances/{iid}` — per-instance plugin health (state, detail, version) for the admin plugins UI; admin-only
 - `/api/v1/admin/plugins/{id}/accept-new-key` — admin-only TOFU rotation: rotates `plugins.trusted_pubkey` to an operator-supplied candidate pubkey and unblocks instances stuck in `pending_key_approval` (see ADR-045 §5.3)
+- `/api/v1/admin/plugins/{id}/accept-manifest` — admin-only: commits a hot-reload's blocked candidate manifest (sourced from the latest `plugin_manifest_material_change` audit event), updates `plugins.manifest_snapshot`, and either unblocks instances to `healthy` or transitions them to `pending_config_migration` when the new schema introduces newly-required fields (spec §5.4)
 - `/api/v1/webhooks/{policyID}` — fires a webhook-triggered run (auth dispatcher per `trigger.auth`: hmac | bearer | none)
 - `/api/v1/policies/{policyID}/trigger` — fires a manual run
 - `/api/v1/policies/{id}/webhook/rotate`, `/api/v1/policies/{id}/webhook/secret` — rotate/reveal the webhook secret (admin|operator only; see ADR-034)

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -17,7 +17,9 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
 	"github.com/felag-engineering/gleipnir/internal/infra/event"
 	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginmanifest "github.com/felag-engineering/gleipnir/internal/plugin/manifest"
 	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
 
@@ -25,6 +27,10 @@ const (
 	// auditPubkeyRotated is the event type emitted when an admin accepts a new
 	// plugin signing key via POST /api/v1/admin/plugins/{id}/accept-new-key.
 	auditPubkeyRotated = "plugin_pubkey_rotated"
+
+	// auditManifestAccepted is the event type emitted when an admin accepts a
+	// material manifest change via POST /api/v1/admin/plugins/{id}/accept-manifest.
+	auditManifestAccepted = "plugin_manifest_accepted"
 )
 
 // PluginQuerier is the narrow DB interface required by PluginHandler.
@@ -45,6 +51,10 @@ type PluginQuerier interface {
 	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
 	// Audit write (used by AcceptNewKey to record the key rotation).
 	InsertPluginAuditEvent(ctx context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error)
+	// Audit read (used by AcceptManifest to find the pending candidate).
+	ListPluginAuditEventsByType(ctx context.Context, arg db.ListPluginAuditEventsByTypeParams) ([]db.PluginAuditEvent, error)
+	// Plugin manifest write (used by AcceptManifest to commit the candidate snapshot).
+	UpdatePluginManifest(ctx context.Context, arg db.UpdatePluginManifestParams) (int64, error)
 }
 
 // PluginHandler handles plugin-related admin endpoints.
@@ -239,6 +249,183 @@ func (h *PluginHandler) AcceptNewKey(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, acceptNewKeyResponse{
 		AcceptedPubkeyFingerprint: newFingerprint,
 		InstancesUnblocked:        unblocked,
+	})
+}
+
+// acceptManifestResponse is the JSON body returned on success.
+type acceptManifestResponse struct {
+	AcceptedManifestVersion string `json:"accepted_manifest_version"`
+	InstancesUnblocked      int    `json:"instances_unblocked"`
+	InstancesPendingConfig  int    `json:"instances_pending_config"`
+}
+
+// AcceptManifest handles POST /api/v1/admin/plugins/{id}/accept-manifest.
+// It commits the candidate manifest (stored in the most recent
+// plugin_manifest_material_change audit event) as the new snapshot, then
+// transitions instances out of pending_manifest_approval.
+//
+// Instances with no newly-required config fields move to healthy.
+// Instances for which new required config fields appear move to pending_config_migration.
+func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	pluginID := chi.URLParam(r, "id")
+
+	plugin, err := h.q.GetPluginByID(ctx, pluginID)
+	if errors.Is(err, ErrNotFound) {
+		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
+		return
+	}
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
+		return
+	}
+
+	// Find the most recent unaccepted plugin_manifest_material_change event for
+	// this plugin. plugin_audit_events has no dedicated plugin_id column, so we
+	// fetch by event type with a generous limit and filter in Go.
+	// TODO(v2): add a plugin-scoped query to avoid this in-Go filter on busy installs.
+	allEvents, err := h.q.ListPluginAuditEventsByType(ctx, db.ListPluginAuditEventsByTypeParams{
+		EventType: "plugin_manifest_material_change",
+		Offset:    0,
+		Limit:     200,
+	})
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list audit events", "")
+		return
+	}
+
+	var candidateEvent *db.PluginAuditEvent
+	for i := range allEvents {
+		ev := &allEvents[i]
+		var payload map[string]any
+		if jsonErr := json.Unmarshal([]byte(ev.PayloadJson), &payload); jsonErr != nil {
+			continue
+		}
+		if payload["plugin_id"] == pluginID {
+			candidateEvent = ev
+			break // events are ordered DESC by created_at; first match is newest
+		}
+	}
+	if candidateEvent == nil {
+		httputil.WriteError(w, http.StatusConflict, "no pending manifest change found for this plugin", "")
+		return
+	}
+
+	var candidatePayload map[string]any
+	if err := json.Unmarshal([]byte(candidateEvent.PayloadJson), &candidatePayload); err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to parse candidate audit event", "")
+		return
+	}
+	candidateB64, _ := candidatePayload["candidate_manifest_b64"].(string)
+	if candidateB64 == "" {
+		httputil.WriteError(w, http.StatusUnprocessableEntity, "candidate manifest not found in audit event", "")
+		return
+	}
+
+	candidateBytes, err := base64.StdEncoding.DecodeString(candidateB64)
+	if err != nil {
+		httputil.WriteError(w, http.StatusUnprocessableEntity, "candidate manifest: invalid base64", "")
+		return
+	}
+
+	var newManifest sdkmanifest.Manifest
+	if parseErr := sdkmanifest.Unmarshal(candidateBytes, &newManifest); parseErr != nil {
+		httputil.WriteError(w, http.StatusUnprocessableEntity, "candidate manifest: parse failed", parseErr.Error())
+		return
+	}
+
+	// Determine which config fields are newly required so we can branch each instance.
+	var oldManifest sdkmanifest.Manifest
+	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &oldManifest); parseErr != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "corrupt manifest snapshot", parseErr.Error())
+		return
+	}
+	newlyRequired := pluginmanifest.ConfigSchemaNewlyRequiredFields(&oldManifest, &newManifest)
+
+	now := h.clock().UTC()
+	nowStr := now.Format(time.RFC3339Nano)
+
+	// CAS-guarded manifest commit (ADR-038). Verify rows-affected before touching instances.
+	rows, err := h.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
+		ManifestSnapshot: string(candidateBytes),
+		PluginVersion:    newManifest.Version,
+		Status:           "pending_review",
+		UpdatedAt:        nowStr,
+		ID:               pluginID,
+		ExpectedVersion:  plugin.Version,
+	})
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update manifest", "")
+		return
+	}
+	if rows == 0 {
+		httputil.WriteError(w, http.StatusConflict, "concurrent modification detected; retry", "")
+		return
+	}
+
+	// Unblock instances currently in pending_manifest_approval.
+	instances, err := h.q.ListPluginInstancesByPlugin(ctx, pluginID)
+	if err != nil {
+		slog.ErrorContext(ctx, "accept-manifest: list instances failed", "plugin_id", pluginID, "err", err)
+		instances = nil
+	}
+
+	unblocked := 0
+	pendingConfig := 0
+	for _, inst := range instances {
+		if model.PluginHealthState(inst.HealthState) != model.PluginHealthStatePendingManifestApproval {
+			continue
+		}
+		var targetState model.PluginHealthState
+		if len(newlyRequired) == 0 {
+			targetState = model.PluginHealthStateHealthy
+		} else {
+			targetState = model.PluginHealthStatePendingConfigMigration
+		}
+		detail := "admin accepted manifest change"
+		if stateErr := pluginstate.SetHealthState(ctx, h.q, h.publisher, inst.ID, pluginstate.OriginHost, targetState, detail); stateErr != nil {
+			if !errors.Is(stateErr, pluginstate.ErrTransitionConflict) {
+				slog.WarnContext(ctx, "accept-manifest: set health state failed", "instance_id", inst.ID, "err", stateErr)
+			}
+			continue
+		}
+		if targetState == model.PluginHealthStateHealthy {
+			unblocked++
+		} else {
+			pendingConfig++
+		}
+	}
+
+	caller, _ := auth.UserFromContext(ctx)
+	var actorUserID *string
+	if caller != nil {
+		actorUserID = &caller.ID
+	}
+
+	oldVersion, _ := candidatePayload["old_version"].(string)
+	auditPayload, _ := json.Marshal(map[string]any{
+		"plugin_id":                pluginID,
+		"name":                     plugin.Name,
+		"old_version":              oldVersion,
+		"new_version":              newManifest.Version,
+		"instances_unblocked":      unblocked,
+		"instances_pending_config": pendingConfig,
+	})
+	if _, auditErr := h.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditManifestAccepted,
+		Severity:         "info",
+		ActorUserID:      actorUserID,
+		PayloadJson:      string(auditPayload),
+		CreatedAt:        nowStr,
+	}); auditErr != nil {
+		slog.ErrorContext(ctx, "accept-manifest: audit event failed", "plugin_id", pluginID, "err", auditErr)
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, acceptManifestResponse{
+		AcceptedManifestVersion: newManifest.Version,
+		InstancesUnblocked:      unblocked,
+		InstancesPendingConfig:  pendingConfig,
 	})
 }
 

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -15,17 +15,18 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/http/auth"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
 
 // fakePluginQuerier is an in-memory PluginQuerier for tests.
 type fakePluginQuerier struct {
-	instances    map[string]db.PluginInstance
-	plugins      map[string]db.Plugin
-	auditEvents  []db.PluginAuditEvent
+	instances   map[string]db.PluginInstance
+	plugins     map[string]db.Plugin
+	auditEvents []db.PluginAuditEvent
 	// casFailOn is the plugin ID that should return 0 rows for UpdatePluginTrustedPubkey
-	// to simulate a CAS conflict.
+	// or UpdatePluginManifest to simulate a CAS conflict.
 	casFailOn    string
 	updatePubkey string // last value written by UpdatePluginTrustedPubkey
 }
@@ -110,6 +111,36 @@ func (f *fakePluginQuerier) InsertPluginAuditEvent(_ context.Context, arg db.Ins
 	}
 	f.auditEvents = append(f.auditEvents, ev)
 	return ev, nil
+}
+
+func (f *fakePluginQuerier) ListPluginAuditEventsByType(_ context.Context, arg db.ListPluginAuditEventsByTypeParams) ([]db.PluginAuditEvent, error) {
+	var result []db.PluginAuditEvent
+	for i := len(f.auditEvents) - 1; i >= 0; i-- {
+		ev := f.auditEvents[i]
+		if ev.EventType == arg.EventType {
+			result = append(result, ev)
+		}
+		if int64(len(result)) >= arg.Limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func (f *fakePluginQuerier) UpdatePluginManifest(_ context.Context, arg db.UpdatePluginManifestParams) (int64, error) {
+	if f.casFailOn == arg.ID {
+		return 0, nil // simulate CAS conflict
+	}
+	p, ok := f.plugins[arg.ID]
+	if !ok || p.Version != arg.ExpectedVersion {
+		return 0, nil
+	}
+	p.ManifestSnapshot = arg.ManifestSnapshot
+	p.PluginVersion = arg.PluginVersion
+	p.Status = arg.Status
+	p.Version++
+	f.plugins[arg.ID] = p
+	return 1, nil
 }
 
 func TestPluginHandler_GetInstance(t *testing.T) {
@@ -388,4 +419,234 @@ func withChiParams(r *http.Request, params map[string]string) *http.Request {
 		rctx.URLParams.Add(k, v)
 	}
 	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// candidateManifestAuditEvent builds a fake plugin_manifest_material_change audit
+// event payload containing the given candidate manifest bytes for the given plugin.
+func candidateManifestAuditEvent(pluginID string, candidateManifest []byte) db.PluginAuditEvent {
+	payload, _ := json.Marshal(map[string]any{
+		"plugin_id":                    pluginID,
+		"name":                         "test-plugin",
+		"old_version":                  "1.0.0",
+		"new_version":                  "2.0.0",
+		"material_fields":              []string{"services.tool"},
+		"cosmetic_fields":              []string{},
+		"candidate_manifest_b64":       base64.StdEncoding.EncodeToString(candidateManifest),
+		"newly_required_config_fields": []string{},
+	})
+	return db.PluginAuditEvent{
+		EventType:   "plugin_manifest_material_change",
+		Severity:    "high",
+		PayloadJson: string(payload),
+		CreatedAt:   "2026-05-05T00:00:00Z",
+	}
+}
+
+const (
+	// v1 manifest for accept-manifest tests.
+	v1ManifestYAML = "schema_version: v1\nname: test-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n"
+	// v2 manifest for accept-manifest tests (material change: services.tool v1→v2).
+	v2ManifestYAML = "schema_version: v1\nname: test-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\n"
+	// v2 manifest with a newly required config field.
+	v2ManifestWithRequiredField = "schema_version: v1\nname: test-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\nconfig_schema:\n  type: object\n  properties:\n    api_key:\n      type: string\n  required:\n    - api_key\n"
+)
+
+func TestPluginHandler_AcceptManifest(t *testing.T) {
+	fixedClock := func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
+
+	t.Run("happy path: updates snapshot and unblocks instances", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-1",
+			Name:             "test-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			PluginVersion:    "1.0.0",
+			Status:           "pending_review",
+			Version:          1,
+		})
+		q.seed(db.PluginInstance{
+			ID:          "inst-a",
+			PluginID:    "plugin-1",
+			HealthState: string(model.PluginHealthStatePendingManifestApproval),
+			Version:     0,
+		})
+		// Seed the audit event as if a material change was previously detected.
+		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-1", []byte(v2ManifestYAML)))
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/accept-manifest", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-1"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+
+		data := parseDataResponse(t, rec)
+		var resp acceptManifestResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp.AcceptedManifestVersion != "2.0.0" {
+			t.Errorf("accepted_manifest_version = %q, want 2.0.0", resp.AcceptedManifestVersion)
+		}
+		if resp.InstancesUnblocked != 1 {
+			t.Errorf("instances_unblocked = %d, want 1", resp.InstancesUnblocked)
+		}
+		if resp.InstancesPendingConfig != 0 {
+			t.Errorf("instances_pending_config = %d, want 0", resp.InstancesPendingConfig)
+		}
+
+		// Instance must now be healthy.
+		instA := q.instances["inst-a"]
+		if instA.HealthState != string(model.PluginHealthStateHealthy) {
+			t.Errorf("inst-a health_state = %q, want healthy", instA.HealthState)
+		}
+		// Snapshot must be updated.
+		if q.plugins["plugin-1"].ManifestSnapshot != v2ManifestYAML {
+			t.Error("manifest_snapshot must be updated to v2 on accept")
+		}
+	})
+
+	t.Run("newly required config field transitions to pending_config_migration", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-2",
+			Name:             "test-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			PluginVersion:    "1.0.0",
+			Status:           "pending_review",
+			Version:          1,
+		})
+		q.seed(db.PluginInstance{
+			ID:          "inst-b",
+			PluginID:    "plugin-2",
+			HealthState: string(model.PluginHealthStatePendingManifestApproval),
+			Version:     0,
+		})
+		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-2", []byte(v2ManifestWithRequiredField)))
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-2/accept-manifest", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-2"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+
+		data := parseDataResponse(t, rec)
+		var resp acceptManifestResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp.InstancesPendingConfig != 1 {
+			t.Errorf("instances_pending_config = %d, want 1", resp.InstancesPendingConfig)
+		}
+		if resp.InstancesUnblocked != 0 {
+			t.Errorf("instances_unblocked = %d, want 0", resp.InstancesUnblocked)
+		}
+
+		instB := q.instances["inst-b"]
+		if instB.HealthState != string(model.PluginHealthStatePendingConfigMigration) {
+			t.Errorf("inst-b health_state = %q, want pending_config_migration", instB.HealthState)
+		}
+	})
+
+	t.Run("no pending change returns 409", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-3", Name: "test-plugin", ManifestSnapshot: v1ManifestYAML, Version: 0})
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-3/accept-manifest", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-3"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusConflict {
+			t.Errorf("status = %d, want 409 when no pending change", rec.Code)
+		}
+	})
+
+	t.Run("plugin not found returns 404", func(t *testing.T) {
+		q := newFakePluginQuerier()
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/nonexistent/accept-manifest", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "nonexistent"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404 for unknown plugin", rec.Code)
+		}
+	})
+
+	t.Run("CAS conflict on UpdatePluginManifest returns 409", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-4",
+			Name:             "test-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			PluginVersion:    "1.0.0",
+			Version:          0,
+		})
+		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-4", []byte(v2ManifestYAML)))
+		q.casFailOn = "plugin-4" // trigger CAS miss on UpdatePluginManifest
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-4/accept-manifest", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-4"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusConflict {
+			t.Errorf("status = %d, want 409 for CAS conflict", rec.Code)
+		}
+	})
+
+	t.Run("emits plugin_manifest_accepted audit event with actor", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-5",
+			Name:             "test-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			PluginVersion:    "1.0.0",
+			Status:           "pending_review",
+			Version:          1,
+		})
+		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-5", []byte(v2ManifestYAML)))
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-5/accept-manifest", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-5"})
+		// Inject an authenticated user so AcceptManifest can record actor_user_id.
+		req = req.WithContext(auth.WithUserContext(req.Context(), "user-admin-1", "admin", []string{"admin"}))
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+
+		var found *db.PluginAuditEvent
+		for i := range q.auditEvents {
+			if q.auditEvents[i].EventType == "plugin_manifest_accepted" {
+				found = &q.auditEvents[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("expected a plugin_manifest_accepted audit event, got none")
+		}
+		if found.Severity != "info" {
+			t.Errorf("audit severity = %q, want info", found.Severity)
+		}
+		wantActorID := "user-admin-1"
+		if found.ActorUserID == nil || *found.ActorUserID != wantActorID {
+			t.Errorf("actor_user_id = %v, want %q", found.ActorUserID, wantActorID)
+		}
+	})
 }

--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -219,6 +219,7 @@ func BuildRouter(cfg RouterConfig) chi.Router {
 			if cfg.Handlers.PluginAdminHandler != nil {
 				r.Get("/plugins/{id}/instances/{iid}", cfg.Handlers.PluginAdminHandler.GetInstance)
 				r.Post("/plugins/{id}/accept-new-key", cfg.Handlers.PluginAdminHandler.AcceptNewKey)
+				r.Post("/plugins/{id}/accept-manifest", cfg.Handlers.PluginAdminHandler.AcceptManifest)
 			}
 
 			r.Route("/openai-providers", func(r chi.Router) {

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -17,9 +17,10 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/infra/event"
 	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginmanifest "github.com/felag-engineering/gleipnir/internal/plugin/manifest"
 	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 	manifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
 
 // VerifyOutcome mirrors internal/plugin.VerifyOutcome without creating an import cycle.
@@ -72,10 +73,12 @@ const (
 	statusPendingReview = "pending_review"
 
 	// Audit event types (ADR-046).
-	auditSignatureInvalid = "plugin_signature_invalid"
-	auditPluginInstalled  = "plugin_installed"
-	auditUpdatePending    = "plugin_update_pending"
-	auditPubkeyMismatch   = "plugin_pubkey_mismatch"
+	auditSignatureInvalid       = "plugin_signature_invalid"
+	auditPluginInstalled        = "plugin_installed"
+	auditUpdatePending          = "plugin_update_pending"
+	auditPubkeyMismatch         = "plugin_pubkey_mismatch"
+	auditManifestMaterialChange = "plugin_manifest_material_change"
+	auditManifestCosmeticChange = "plugin_manifest_cosmetic_change"
 
 	// Audit severity levels.
 	severityHigh = "high"
@@ -249,6 +252,21 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 		}
 	}
 
+	// Diff the incoming manifest against the stored snapshot before calling
+	// updatePlugin. Material changes block the update and enter pending_manifest_approval.
+	// Cosmetic-only changes update the snapshot silently.
+	var oldManifest manifest.Manifest
+	if parseErr := manifest.Unmarshal([]byte(existing.ManifestSnapshot), &oldManifest); parseErr != nil {
+		return fmt.Errorf("parse stored manifest snapshot for %q: %w", m.Name, parseErr)
+	}
+	changes := pluginmanifest.Diff(&oldManifest, m)
+	if pluginmanifest.HasMaterial(changes) {
+		return in.handleManifestMaterialChange(ctx, existing, &oldManifest, m, manifestBytes, changes, nowStr)
+	}
+	if len(changes) > 0 {
+		return in.updatePluginCosmetic(ctx, existing, m, manifestBytes, changes, nowStr)
+	}
+
 	return in.updatePlugin(ctx, existing, m, manifestBytes, nowStr)
 }
 
@@ -301,6 +319,101 @@ func (in *Installer) handlePubkeyMismatch(ctx context.Context, existing db.Plugi
 	})
 	if auditErr != nil {
 		return fmt.Errorf("record pubkey_mismatch audit for %q: %w", existing.Name, auditErr)
+	}
+
+	return nil
+}
+
+// handleManifestMaterialChange blocks the manifest update and transitions all
+// eligible instances to pending_manifest_approval. The candidate manifest is
+// persisted in the audit-event payload (as base64) rather than the plugins row;
+// the running generation continues serving the existing snapshot until an admin
+// calls POST /api/v1/admin/plugins/{id}/accept-manifest.
+//
+// oldManifest is the already-parsed existing snapshot — passed in to avoid a
+// second parse of the same bytes that upsertPlugin already completed.
+func (in *Installer) handleManifestMaterialChange(ctx context.Context, existing db.Plugin, oldManifest *manifest.Manifest, m *manifest.Manifest, candidateBytes []byte, changes []pluginmanifest.Change, nowStr string) error {
+	instances, listErr := in.q.ListPluginInstancesByPlugin(ctx, existing.ID)
+	if listErr != nil {
+		slog.WarnContext(ctx, "manifest material change: list instances failed; skipping state transitions",
+			"plugin", existing.Name, "err", listErr)
+	}
+	for _, inst := range instances {
+		current := model.PluginHealthState(inst.HealthState)
+		if !pluginstate.IsLegalTransition(current, model.PluginHealthStatePendingManifestApproval) {
+			continue
+		}
+		if stateErr := pluginstate.SetHealthState(ctx, in.q, in.publisher, inst.ID, pluginstate.OriginHost, model.PluginHealthStatePendingManifestApproval, "manifest changed materially; admin re-approval required"); stateErr != nil {
+			if !errors.Is(stateErr, pluginstate.ErrTransitionConflict) {
+				slog.WarnContext(ctx, "manifest material change: set pending_manifest_approval failed",
+					"instance_id", inst.ID, "err", stateErr)
+			}
+		}
+	}
+
+	newlyRequired := pluginmanifest.ConfigSchemaNewlyRequiredFields(oldManifest, m)
+
+	payload, _ := json.Marshal(map[string]any{
+		"plugin_id":                    existing.ID,
+		"name":                         existing.Name,
+		"old_version":                  existing.PluginVersion,
+		"new_version":                  m.Version,
+		"material_fields":              pluginmanifest.MaterialFields(changes),
+		"cosmetic_fields":              pluginmanifest.CosmeticFields(changes),
+		"candidate_manifest_b64":       base64.StdEncoding.EncodeToString(candidateBytes),
+		"newly_required_config_fields": newlyRequired,
+	})
+	_, auditErr := in.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditManifestMaterialChange,
+		Severity:         severityHigh,
+		ActorUserID:      nil,
+		PayloadJson:      string(payload),
+		CreatedAt:        nowStr,
+	})
+	if auditErr != nil {
+		return fmt.Errorf("record manifest_material_change audit for %q: %w", existing.Name, auditErr)
+	}
+
+	return nil
+}
+
+// updatePluginCosmetic updates the manifest snapshot for a cosmetic-only change,
+// preserving the current plugin status so an already-active plugin is not
+// regressed to pending_review for a description tweak.
+func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, changes []pluginmanifest.Change, nowStr string) error {
+	rows, err := in.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
+		ManifestSnapshot: string(manifestBytes),
+		PluginVersion:    m.Version,
+		Status:           existing.Status, // preserve current status — cosmetic change must not regress an active plugin
+		UpdatedAt:        nowStr,
+		ID:               existing.ID,
+		ExpectedVersion:  existing.Version,
+	})
+	if err != nil {
+		return fmt.Errorf("update plugin %q manifest (cosmetic): %w", m.Name, err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("update plugin %q manifest (cosmetic): CAS conflict (version mismatch)", m.Name)
+	}
+
+	payload, _ := json.Marshal(map[string]any{
+		"plugin_id":       existing.ID,
+		"name":            existing.Name,
+		"old_version":     existing.PluginVersion,
+		"new_version":     m.Version,
+		"cosmetic_fields": pluginmanifest.CosmeticFields(changes),
+	})
+	_, auditErr := in.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        auditManifestCosmeticChange,
+		Severity:         severityInfo,
+		ActorUserID:      nil,
+		PayloadJson:      string(payload),
+		CreatedAt:        nowStr,
+	})
+	if auditErr != nil {
+		return fmt.Errorf("record manifest_cosmetic_change audit for %q: %w", existing.Name, auditErr)
 	}
 
 	return nil

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -366,17 +366,18 @@ func TestInstall_VersionBump_PendingReview(t *testing.T) {
 		t.Errorf("status = %q, want %q", row.Status, "pending_review")
 	}
 
-	// Expect a plugin_update_pending audit event.
+	// A version-string-only bump produces a cosmetic diff (version is a cosmetic field),
+	// so we now expect plugin_manifest_cosmetic_change rather than plugin_update_pending.
 	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
-		EventType: auditUpdatePending,
+		EventType: auditManifestCosmeticChange,
 		Offset:    0,
 		Limit:     10,
 	})
 	if err != nil {
-		t.Fatalf("list update_pending events: %v", err)
+		t.Fatalf("list cosmetic_change events: %v", err)
 	}
 	if len(events) == 0 {
-		t.Error("expected plugin_update_pending audit event after version bump")
+		t.Error("expected plugin_manifest_cosmetic_change audit event after version-only bump")
 	}
 }
 
@@ -436,14 +437,23 @@ func TestInstall_UnsignedPermissive_PendingReview(t *testing.T) {
 	}
 }
 
-// seedPluginInstance creates a plugin_instances row for testing TOFU transitions.
+// seedPluginInstance creates a plugin_instances row with instance_name="test".
+// Use seedPluginInstanceNamed when seeding multiple instances for the same plugin.
 func seedPluginInstance(t *testing.T, q *db.Queries, pluginID, instanceID string, state model.PluginHealthState) {
+	t.Helper()
+	seedPluginInstanceNamed(t, q, pluginID, instanceID, "test", state)
+}
+
+// seedPluginInstanceNamed creates a plugin_instances row with a specified instance name.
+// Required when seeding multiple instances for the same plugin to satisfy the
+// (plugin_id, instance_name) UNIQUE constraint.
+func seedPluginInstanceNamed(t *testing.T, q *db.Queries, pluginID, instanceID, instanceName string, state model.PluginHealthState) {
 	t.Helper()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	_, err := q.CreatePluginInstance(context.Background(), db.CreatePluginInstanceParams{
 		ID:                instanceID,
 		PluginID:          pluginID,
-		InstanceName:      "test",
+		InstanceName:      instanceName,
 		ConfigJson:        "{}",
 		HandshakeVersions: "{}",
 		HealthState:       string(state),
@@ -782,5 +792,318 @@ func TestReadManifest_Validation(t *testing.T) {
 				t.Errorf("readManifest error = %q, want substring %q", err.Error(), tc.wantErrFrag)
 			}
 		})
+	}
+}
+
+// buildSignedTarWithContent builds a tarball signed by a given keypair with specific
+// manifest content and binary content. Returns the tarball path.
+func buildSignedTarWithContent(t *testing.T, name string, manifestContent, binaryContent, pubkeyBytes []byte, skSecret [64]byte, skKeyID [8]byte) string {
+	t.Helper()
+
+	payload := signing.PluginPayload(binaryContent, manifestContent)
+	sig, err := signing.Sign(skSecret, skKeyID, payload, "trusted comment")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sigBytes := signing.MarshalSignature(sig, "test sig")
+	tarPath := filepath.Join(t.TempDir(), name+".tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "manifest.yaml", content: manifestContent, mode: 0o644},
+		{name: name, content: binaryContent, mode: 0o755},
+		{name: "signing.pub", content: pubkeyBytes, mode: 0o644},
+		{name: name + ".minisig", content: sigBytes, mode: 0o644},
+	})
+	return tarPath
+}
+
+// TestInstall_HotReload_MaterialChange_DoesNotUpdateSnapshot verifies that a hot-reload
+// tarball with a material manifest change does not update the plugin row's manifest_snapshot.
+func TestInstall_HotReload_MaterialChange_DoesNotUpdateSnapshot(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	v1Manifest := []byte("schema_version: v1\nname: mat-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "mat-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	row1, err := q.GetPluginByName(context.Background(), "mat-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v1: %v", err)
+	}
+
+	// v2 adds a new tool — material change.
+	v2Manifest := []byte("schema_version: v1\nname: mat-plugin\nversion: 2.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\ntools:\n- name: my_tool\n  description: a tool\n")
+	tarPath2 := buildSignedTarWithContent(t, "mat-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (material change): %v", err)
+	}
+
+	row2, err := q.GetPluginByName(context.Background(), "mat-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v2: %v", err)
+	}
+	// Snapshot must remain at v1 — material change must NOT update the row.
+	if row2.ManifestSnapshot != row1.ManifestSnapshot {
+		t.Errorf("manifest_snapshot was updated despite material change; want unchanged v1 snapshot")
+	}
+	if row2.PluginVersion != "1.0.0" {
+		t.Errorf("plugin_version = %q, want 1.0.0 (blocked by material change)", row2.PluginVersion)
+	}
+}
+
+// TestInstall_HotReload_MaterialChange_TransitionsInstancesToPendingManifestApproval
+// verifies that healthy and unsigned_permissive instances are transitioned to
+// pending_manifest_approval on a material change; terminal-state instances are skipped.
+func TestInstall_HotReload_MaterialChange_TransitionsInstancesToPendingManifestApproval(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	v1Manifest := []byte("schema_version: v1\nname: trans-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "trans-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	pluginRow, err := q.GetPluginByName(context.Background(), "trans-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+
+	// Use the instanceID as the instance_name to satisfy the (plugin_id, instance_name) UNIQUE constraint.
+	seedPluginInstanceNamed(t, q, pluginRow.ID, "inst-healthy", "inst-healthy", model.PluginHealthStateHealthy)
+	seedPluginInstanceNamed(t, q, pluginRow.ID, "inst-crashed", "inst-crashed", model.PluginHealthStateCrashed) // terminal — should be skipped
+
+	v2Manifest := []byte("schema_version: v1\nname: trans-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath2 := buildSignedTarWithContent(t, "trans-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (material change): %v", err)
+	}
+
+	instHealthy, err := q.GetPluginInstanceByID(context.Background(), "inst-healthy")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID inst-healthy: %v", err)
+	}
+	if instHealthy.HealthState != string(model.PluginHealthStatePendingManifestApproval) {
+		t.Errorf("inst-healthy health_state = %q, want pending_manifest_approval", instHealthy.HealthState)
+	}
+
+	instCrashed, err := q.GetPluginInstanceByID(context.Background(), "inst-crashed")
+	if err != nil {
+		t.Fatalf("GetPluginInstanceByID inst-crashed: %v", err)
+	}
+	if instCrashed.HealthState != string(model.PluginHealthStateCrashed) {
+		t.Errorf("inst-crashed health_state = %q, want crashed (unchanged)", instCrashed.HealthState)
+	}
+}
+
+// TestInstall_HotReload_MaterialChange_EmitsHighSeverityAuditEvent verifies that a
+// plugin_manifest_material_change audit event with high severity is emitted.
+func TestInstall_HotReload_MaterialChange_EmitsHighSeverityAuditEvent(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	v1Manifest := []byte("schema_version: v1\nname: audit-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "audit-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	v2Manifest := []byte("schema_version: v1\nname: audit-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath2 := buildSignedTarWithContent(t, "audit-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (material change): %v", err)
+	}
+
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditManifestMaterialChange,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list audit events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected a plugin_manifest_material_change audit event, got none")
+	}
+	if events[0].Severity != "high" {
+		t.Errorf("audit severity = %q, want high", events[0].Severity)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(events[0].PayloadJson), &payload); err != nil {
+		t.Fatalf("parse audit payload: %v", err)
+	}
+	if payload["candidate_manifest_b64"] == "" {
+		t.Error("audit payload: candidate_manifest_b64 must be non-empty")
+	}
+	materialFields, ok := payload["material_fields"].([]any)
+	if !ok || len(materialFields) == 0 {
+		t.Errorf("audit payload: material_fields must be non-empty, got %v", payload["material_fields"])
+	}
+}
+
+// TestInstall_HotReload_MaterialChange_NewlyRequiredConfigField_PayloadIncludesField
+// verifies that the audit event payload includes newly-required config fields when
+// the new manifest's config_schema gains a required property.
+func TestInstall_HotReload_MaterialChange_NewlyRequiredConfigField_PayloadIncludesField(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	// v1 has no config_schema.
+	v1Manifest := []byte("schema_version: v1\nname: config-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "config-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	// v2 adds a required config field AND changes services (to ensure it's material).
+	v2Manifest := []byte("schema_version: v1\nname: config-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\nconfig_schema:\n  type: object\n  properties:\n    api_key:\n      type: string\n  required:\n    - api_key\n")
+	tarPath2 := buildSignedTarWithContent(t, "config-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (with newly required config field): %v", err)
+	}
+
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditManifestMaterialChange,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list audit events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected a plugin_manifest_material_change audit event, got none")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(events[0].PayloadJson), &payload); err != nil {
+		t.Fatalf("parse audit payload: %v", err)
+	}
+	newlyRequired, ok := payload["newly_required_config_fields"].([]any)
+	if !ok || len(newlyRequired) == 0 {
+		t.Errorf("expected newly_required_config_fields to contain api_key, got %v", payload["newly_required_config_fields"])
+		return
+	}
+	if newlyRequired[0] != "api_key" {
+		t.Errorf("newly_required_config_fields[0] = %v, want api_key", newlyRequired[0])
+	}
+}
+
+// TestInstall_HotReload_CosmeticChange_UpdatesSnapshot_EmitsInfoAuditEvent verifies
+// that a cosmetic-only change (description update) updates the snapshot and emits
+// a plugin_manifest_cosmetic_change info-severity audit event.
+func TestInstall_HotReload_CosmeticChange_UpdatesSnapshot_EmitsInfoAuditEvent(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	v1Manifest := []byte("schema_version: v1\nname: cosm-plugin\nversion: 1.0.0\ndescription: old description\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "cosm-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	// v2 changes only the description and version — both cosmetic.
+	v2Manifest := []byte("schema_version: v1\nname: cosm-plugin\nversion: 1.0.1\ndescription: new description\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath2 := buildSignedTarWithContent(t, "cosm-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (cosmetic change): %v", err)
+	}
+
+	row2, err := q.GetPluginByName(context.Background(), "cosm-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v2: %v", err)
+	}
+	if row2.PluginVersion != "1.0.1" {
+		t.Errorf("plugin_version = %q, want 1.0.1 (cosmetic update must advance version)", row2.PluginVersion)
+	}
+	if !strings.Contains(row2.ManifestSnapshot, "new description") {
+		t.Error("manifest_snapshot must be updated to v2 content on cosmetic change")
+	}
+
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditManifestCosmeticChange,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list cosmetic audit events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected a plugin_manifest_cosmetic_change audit event, got none")
+	}
+	if events[0].Severity != "info" {
+		t.Errorf("audit severity = %q, want info", events[0].Severity)
+	}
+}
+
+// TestInstall_HotReload_NoChange_NoOp verifies that a tarball with a new version but
+// structurally identical manifest content (differing only in version field) uses the
+// cosmetic path and does not emit a material-change event.
+func TestInstall_HotReload_NoChange_NoOp(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	v1Manifest := []byte("schema_version: v1\nname: noop-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "noop-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	// v2 only bumps the version — cosmetic, no structural change.
+	v2Manifest := []byte("schema_version: v1\nname: noop-plugin\nversion: 2.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath2 := buildSignedTarWithContent(t, "noop-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (version-only bump): %v", err)
+	}
+
+	// No material-change event must have been emitted.
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditManifestMaterialChange,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list material events: %v", err)
+	}
+	if len(events) > 0 {
+		t.Errorf("got %d material-change events for version-only bump, want 0", len(events))
 	}
 }

--- a/internal/plugin/manifest/diff.go
+++ b/internal/plugin/manifest/diff.go
@@ -1,0 +1,413 @@
+// Package manifest provides material-vs-cosmetic diff logic for plugin manifests.
+// It operates on parsed *manifest.Manifest values from plugin-sdk/manifest and
+// depends only on that package and the Go standard library.
+//
+// Pubkey-claim diffing (spec §5.4 bullet 1) is intentionally absent here;
+// key-mismatch detection is owned by issue #188 (internal/plugin/loader install.go,
+// handlePubkeyMismatch). Only the remaining material categories are handled:
+// services, tier-2 capabilities, OAuth, tools, config_schema shape, event_kinds.
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+// Change records a single detected difference between two manifest versions.
+type Change struct {
+	Field    string
+	Material bool
+	From     string
+	To       string
+}
+
+// Diff returns the list of differences between old and new. Material differences
+// block reload; cosmetic differences update the snapshot silently.
+func Diff(old, new *sdkmanifest.Manifest) []Change {
+	var changes []Change
+
+	changes = append(changes, diffServices(old, new)...)
+	changes = append(changes, diffTier2(old, new)...)
+	changes = append(changes, diffAuth(old, new)...)
+	changes = append(changes, diffTools(old, new)...)
+	changes = append(changes, diffConfigSchema(old, new)...)
+	changes = append(changes, diffEventKinds(old, new)...)
+
+	// Cosmetic fields: description, version, author, license, sbom.
+	if old.Description != new.Description {
+		changes = append(changes, Change{Field: "description", Material: false, From: old.Description, To: new.Description})
+	}
+	if old.Version != new.Version {
+		changes = append(changes, Change{Field: "version", Material: false, From: old.Version, To: new.Version})
+	}
+	if old.Author != new.Author {
+		changes = append(changes, Change{Field: "author", Material: false, From: old.Author, To: new.Author})
+	}
+	if old.License != new.License {
+		changes = append(changes, Change{Field: "license", Material: false, From: old.License, To: new.License})
+	}
+	if old.SBOM != new.SBOM {
+		changes = append(changes, Change{Field: "sbom", Material: false, From: old.SBOM, To: new.SBOM})
+	}
+
+	return changes
+}
+
+// HasMaterial reports whether any change in the slice is material.
+func HasMaterial(changes []Change) bool {
+	for _, c := range changes {
+		if c.Material {
+			return true
+		}
+	}
+	return false
+}
+
+// MaterialFields returns the Field values of all material changes.
+func MaterialFields(changes []Change) []string {
+	var out []string
+	for _, c := range changes {
+		if c.Material {
+			out = append(out, c.Field)
+		}
+	}
+	return out
+}
+
+// CosmeticFields returns the Field values of all cosmetic (non-material) changes.
+func CosmeticFields(changes []Change) []string {
+	var out []string
+	for _, c := range changes {
+		if !c.Material {
+			out = append(out, c.Field)
+		}
+	}
+	return out
+}
+
+// ConfigSchemaNewlyRequiredFields returns the names of JSON Schema properties
+// that are required in new.ConfigSchema but absent from (or not required in)
+// old.ConfigSchema. This drives the pending_config_migration transition when
+// an admin accepts a material manifest change.
+//
+// "Newly required" means: a property name appears in new's "required" array
+// but did not appear in old's "required" array. Plugin-wide granularity (not
+// per-instance) per the v1 design decision.
+func ConfigSchemaNewlyRequiredFields(old, new *sdkmanifest.Manifest) []string {
+	oldRequired := requiredFieldSet(old.ConfigSchema)
+	newRequired := requiredFieldSet(new.ConfigSchema)
+
+	var added []string
+	for field := range newRequired {
+		if !oldRequired[field] {
+			added = append(added, field)
+		}
+	}
+	sort.Strings(added)
+	return added
+}
+
+// requiredFieldSet extracts the set of names from a JSON Schema's "required"
+// array. Returns an empty map when the node is nil or has no "required" key.
+func requiredFieldSet(node *yaml.Node) map[string]bool {
+	if node == nil {
+		return nil
+	}
+	// Decode the node into a generic map to extract "required".
+	raw, err := yaml.Marshal(node)
+	if err != nil {
+		return nil
+	}
+	var schema map[string]any
+	if err := yaml.Unmarshal(raw, &schema); err != nil {
+		return nil
+	}
+	req, ok := schema["required"]
+	if !ok {
+		return nil
+	}
+	slice, ok := req.([]any)
+	if !ok {
+		return nil
+	}
+	set := make(map[string]bool, len(slice))
+	for _, v := range slice {
+		if s, ok := v.(string); ok {
+			set[s] = true
+		}
+	}
+	return set
+}
+
+// diffServices emits material changes for each service version field.
+func diffServices(old, new *sdkmanifest.Manifest) []Change {
+	var changes []Change
+	if old.Services.Tool != new.Services.Tool {
+		changes = append(changes, Change{Field: "services.tool", Material: true, From: old.Services.Tool, To: new.Services.Tool})
+	}
+	if old.Services.Channel != new.Services.Channel {
+		changes = append(changes, Change{Field: "services.channel", Material: true, From: old.Services.Channel, To: new.Services.Channel})
+	}
+	if old.Services.Trigger != new.Services.Trigger {
+		changes = append(changes, Change{Field: "services.trigger", Material: true, From: old.Services.Trigger, To: new.Services.Trigger})
+	}
+	return changes
+}
+
+// diffTier2 emits a single material change when the sorted set of tier-2
+// capability declarations changes.
+func diffTier2(old, new *sdkmanifest.Manifest) []Change {
+	oldSet := sortedJoin(old.Tier2)
+	newSet := sortedJoin(new.Tier2)
+	if oldSet == newSet {
+		return nil
+	}
+	return []Change{{Field: "tier2", Material: true, From: oldSet, To: newSet}}
+}
+
+// sortedJoin sorts a string slice, deduplicates, and joins with commas for
+// comparison and display.
+func sortedJoin(ss []string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	cp := make([]string, len(ss))
+	copy(cp, ss)
+	sort.Strings(cp)
+	// Deduplicate.
+	out := cp[:0]
+	for i, s := range cp {
+		if i == 0 || s != cp[i-1] {
+			out = append(out, s)
+		}
+	}
+	b, _ := json.Marshal(out)
+	return string(b)
+}
+
+// diffAuth compares auth mode, strategy, and OAuth defaults. All are material.
+func diffAuth(old, new *sdkmanifest.Manifest) []Change {
+	var changes []Change
+	if old.Auth.Mode != new.Auth.Mode {
+		changes = append(changes, Change{Field: "auth.mode", Material: true, From: old.Auth.Mode, To: new.Auth.Mode})
+	}
+	if old.Auth.Strategy != new.Auth.Strategy {
+		changes = append(changes, Change{Field: "auth.strategy", Material: true, From: old.Auth.Strategy, To: new.Auth.Strategy})
+	}
+	changes = append(changes, diffOAuthDefaults(old.Auth.OAuthDefaults, new.Auth.OAuthDefaults)...)
+	return changes
+}
+
+// diffOAuthDefaults compares OAuthDefaultsDecl presence and fields.
+func diffOAuthDefaults(old, new *sdkmanifest.OAuthDefaultsDecl) []Change {
+	if old == nil && new == nil {
+		return nil
+	}
+	if (old == nil) != (new == nil) {
+		from, to := "nil", "set"
+		if old != nil {
+			from, to = "set", "nil"
+		}
+		return []Change{{Field: "auth.oauth_defaults", Material: true, From: from, To: to}}
+	}
+	var changes []Change
+	if old.AuthorizationURL != new.AuthorizationURL {
+		changes = append(changes, Change{Field: "auth.oauth_defaults.authorization_url", Material: true, From: old.AuthorizationURL, To: new.AuthorizationURL})
+	}
+	if old.TokenURL != new.TokenURL {
+		changes = append(changes, Change{Field: "auth.oauth_defaults.token_url", Material: true, From: old.TokenURL, To: new.TokenURL})
+	}
+	oldScopes := sortedJoin(old.Scopes)
+	newScopes := sortedJoin(new.Scopes)
+	if oldScopes != newScopes {
+		changes = append(changes, Change{Field: "auth.oauth_defaults.scopes", Material: true, From: oldScopes, To: newScopes})
+	}
+	if old.HasClientID != new.HasClientID {
+		changes = append(changes, Change{Field: "auth.oauth_defaults.has_client_id", Material: true,
+			From: fmt.Sprintf("%v", old.HasClientID), To: fmt.Sprintf("%v", new.HasClientID)})
+	}
+	if old.HasClientSecret != new.HasClientSecret {
+		changes = append(changes, Change{Field: "auth.oauth_defaults.has_client_secret", Material: true,
+			From: fmt.Sprintf("%v", old.HasClientSecret), To: fmt.Sprintf("%v", new.HasClientSecret)})
+	}
+	return changes
+}
+
+// diffTools compares the declared tool list keyed by Name.
+// Added or removed tools are material. For existing names: ApprovalRequired
+// flip and InputSchema/OutputSchema canonical-bytes change are material;
+// Description change is cosmetic.
+func diffTools(old, new *sdkmanifest.Manifest) []Change {
+	oldMap := toolDeclMap(old.Tools)
+	newMap := toolDeclMap(new.Tools)
+
+	var changes []Change
+
+	for name := range oldMap {
+		if _, ok := newMap[name]; !ok {
+			changes = append(changes, Change{Field: "tools." + name, Material: true, From: name, To: ""})
+		}
+	}
+	for name := range newMap {
+		if _, ok := oldMap[name]; !ok {
+			changes = append(changes, Change{Field: "tools." + name, Material: true, From: "", To: name})
+		}
+	}
+	for name, oldTool := range oldMap {
+		newTool, ok := newMap[name]
+		if !ok {
+			continue
+		}
+		if oldTool.ApprovalRequired != newTool.ApprovalRequired {
+			changes = append(changes, Change{
+				Field:    "tools." + name + ".approval_required",
+				Material: true,
+				From:     fmt.Sprintf("%v", oldTool.ApprovalRequired),
+				To:       fmt.Sprintf("%v", newTool.ApprovalRequired),
+			})
+		}
+		oldIn := canonicalSchemaBytes(oldTool.InputSchema)
+		newIn := canonicalSchemaBytes(newTool.InputSchema)
+		if !bytes.Equal(oldIn, newIn) {
+			changes = append(changes, Change{Field: "tools." + name + ".input_schema", Material: true, From: string(oldIn), To: string(newIn)})
+		}
+		oldOut := canonicalSchemaBytes(oldTool.OutputSchema)
+		newOut := canonicalSchemaBytes(newTool.OutputSchema)
+		if !bytes.Equal(oldOut, newOut) {
+			changes = append(changes, Change{Field: "tools." + name + ".output_schema", Material: true, From: string(oldOut), To: string(newOut)})
+		}
+		if oldTool.Description != newTool.Description {
+			changes = append(changes, Change{Field: "tools." + name + ".description", Material: false, From: oldTool.Description, To: newTool.Description})
+		}
+	}
+	return changes
+}
+
+func toolDeclMap(tools []sdkmanifest.ToolDecl) map[string]sdkmanifest.ToolDecl {
+	m := make(map[string]sdkmanifest.ToolDecl, len(tools))
+	for _, t := range tools {
+		m[t.Name] = t
+	}
+	return m
+}
+
+// diffConfigSchema compares the instance config_schema after stripping cosmetic keys.
+func diffConfigSchema(old, new *sdkmanifest.Manifest) []Change {
+	oldBytes := canonicalSchemaBytes(old.ConfigSchema)
+	newBytes := canonicalSchemaBytes(new.ConfigSchema)
+	if bytes.Equal(oldBytes, newBytes) {
+		return nil
+	}
+	return []Change{{Field: "config_schema", Material: true, From: string(oldBytes), To: string(newBytes)}}
+}
+
+// diffEventKinds compares event_kinds keyed by Kind. Added/removed kinds are
+// material. For existing kinds: BindingSchema and PayloadSchema canonical bytes
+// are material; Description and Examples are cosmetic.
+func diffEventKinds(old, new *sdkmanifest.Manifest) []Change {
+	oldMap := eventKindMap(old.EventKinds)
+	newMap := eventKindMap(new.EventKinds)
+
+	var changes []Change
+	for kind := range oldMap {
+		if _, ok := newMap[kind]; !ok {
+			changes = append(changes, Change{Field: "event_kinds." + kind, Material: true, From: kind, To: ""})
+		}
+	}
+	for kind := range newMap {
+		if _, ok := oldMap[kind]; !ok {
+			changes = append(changes, Change{Field: "event_kinds." + kind, Material: true, From: "", To: kind})
+		}
+	}
+	for kind, oldEK := range oldMap {
+		newEK, ok := newMap[kind]
+		if !ok {
+			continue
+		}
+		oldBinding := canonicalSchemaBytes(oldEK.BindingSchema)
+		newBinding := canonicalSchemaBytes(newEK.BindingSchema)
+		if !bytes.Equal(oldBinding, newBinding) {
+			changes = append(changes, Change{Field: "event_kinds." + kind + ".binding_schema", Material: true, From: string(oldBinding), To: string(newBinding)})
+		}
+		oldPayload := canonicalSchemaBytes(oldEK.PayloadSchema)
+		newPayload := canonicalSchemaBytes(newEK.PayloadSchema)
+		if !bytes.Equal(oldPayload, newPayload) {
+			changes = append(changes, Change{Field: "event_kinds." + kind + ".payload_schema", Material: true, From: string(oldPayload), To: string(newPayload)})
+		}
+		if oldEK.Description != newEK.Description {
+			changes = append(changes, Change{Field: "event_kinds." + kind + ".description", Material: false, From: oldEK.Description, To: newEK.Description})
+		}
+	}
+	return changes
+}
+
+func eventKindMap(kinds []sdkmanifest.EventKindDecl) map[string]sdkmanifest.EventKindDecl {
+	m := make(map[string]sdkmanifest.EventKindDecl, len(kinds))
+	for _, ek := range kinds {
+		m[ek.Kind] = ek
+	}
+	return m
+}
+
+// canonicalSchemaBytes produces a deterministic JSON byte representation of a
+// *yaml.Node JSON Schema suitable for material comparison. Two schemas are
+// materially equal if and only if their canonical bytes are equal.
+//
+// Strategy:
+//  1. nil node → nil (nil ↔ nil compares as equal, nil ↔ non-nil as different).
+//  2. YAML-marshal the node to bytes via yaml.v3.
+//  3. Unmarshal those bytes into map[string]any (generic tree).
+//  4. Recursively strip "description" and "default" keys at every depth; sort map keys.
+//  5. json.Marshal the cleaned tree — Go's json package emits map keys alphabetically.
+//
+// Errors in marshal/unmarshal are treated as an empty schema (nil return) so
+// a parse failure on one side always differs from a valid schema on the other.
+func canonicalSchemaBytes(node *yaml.Node) []byte {
+	if node == nil {
+		return nil
+	}
+	raw, err := yaml.Marshal(node)
+	if err != nil {
+		return nil
+	}
+	var tree any
+	if err := yaml.Unmarshal(raw, &tree); err != nil {
+		return nil
+	}
+	cleaned := stripCosmeticKeys(tree)
+	out, err := json.Marshal(cleaned)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// stripCosmeticKeys recursively removes "description" and "default" keys from
+// every map node in the tree. Map keys are sorted for determinism (json.Marshal
+// already sorts map[string]any keys, but we make it explicit).
+func stripCosmeticKeys(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, child := range val {
+			if k == "description" || k == "default" {
+				continue
+			}
+			out[k] = stripCosmeticKeys(child)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = stripCosmeticKeys(elem)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/internal/plugin/manifest/diff_test.go
+++ b/internal/plugin/manifest/diff_test.go
@@ -1,0 +1,317 @@
+package manifest_test
+
+import (
+	"testing"
+
+	pluginmanifest "github.com/felag-engineering/gleipnir/internal/plugin/manifest"
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+// baseManifest returns a minimal valid manifest to use as the baseline for diff tests.
+func baseManifest() *sdkmanifest.Manifest {
+	return &sdkmanifest.Manifest{
+		SchemaVersion: "v1",
+		Name:          "test-plugin",
+		Version:       "1.0.0",
+		Description:   "A plugin",
+		Services:      sdkmanifest.Services{Tool: "v1"},
+		Auth:          sdkmanifest.AuthDecl{Mode: "instance_credentials", Strategy: "none"},
+	}
+}
+
+// parseNode builds a *yaml.Node from inline YAML text. Panics on parse error
+// (tests call this only with valid YAML literals).
+func parseNode(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("parseNode: %v", err)
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return &doc
+}
+
+func TestDiff_MaterialServiceVersionChange(t *testing.T) {
+	old := baseManifest()
+	new := baseManifest()
+	new.Services.Tool = "v2"
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change for services.tool version bump")
+	}
+	fields := pluginmanifest.MaterialFields(changes)
+	if len(fields) != 1 || fields[0] != "services.tool" {
+		t.Errorf("material fields = %v, want [services.tool]", fields)
+	}
+}
+
+func TestDiff_MaterialTier2Added(t *testing.T) {
+	old := baseManifest()
+	new := baseManifest()
+	new.Tier2 = []string{"host.exec"}
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when tier2 capability is added")
+	}
+	fields := pluginmanifest.MaterialFields(changes)
+	if len(fields) != 1 || fields[0] != "tier2" {
+		t.Errorf("material fields = %v, want [tier2]", fields)
+	}
+}
+
+func TestDiff_MaterialOAuthScopesChanged(t *testing.T) {
+	old := baseManifest()
+	old.Auth.Strategy = "oauth_authcode"
+	old.Auth.OAuthDefaults = &sdkmanifest.OAuthDefaultsDecl{
+		AuthorizationURL: "https://example.com/auth",
+		TokenURL:         "https://example.com/token",
+		Scopes:           []string{"read"},
+	}
+
+	new := baseManifest()
+	new.Auth.Strategy = "oauth_authcode"
+	new.Auth.OAuthDefaults = &sdkmanifest.OAuthDefaultsDecl{
+		AuthorizationURL: "https://example.com/auth",
+		TokenURL:         "https://example.com/token",
+		Scopes:           []string{"read", "write"},
+	}
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change for OAuth scope addition")
+	}
+	mf := pluginmanifest.MaterialFields(changes)
+	found := false
+	for _, f := range mf {
+		if f == "auth.oauth_defaults.scopes" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected auth.oauth_defaults.scopes in material fields, got %v", mf)
+	}
+}
+
+func TestDiff_MaterialOAuthStrategyChanged(t *testing.T) {
+	old := baseManifest()
+	old.Auth.Strategy = "static_key"
+
+	new := baseManifest()
+	new.Auth.Strategy = "oauth_authcode"
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change for auth.strategy change")
+	}
+}
+
+func TestDiff_MaterialToolAdded(t *testing.T) {
+	old := baseManifest()
+	new := baseManifest()
+	new.Tools = []sdkmanifest.ToolDecl{{Name: "new_tool"}}
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when a tool is added")
+	}
+	for _, c := range changes {
+		if c.Field == "tools.new_tool" && c.Material {
+			return
+		}
+	}
+	t.Errorf("expected change for tools.new_tool, got %v", changes)
+}
+
+func TestDiff_MaterialToolRemoved(t *testing.T) {
+	old := baseManifest()
+	old.Tools = []sdkmanifest.ToolDecl{{Name: "old_tool"}}
+
+	new := baseManifest()
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when a tool is removed")
+	}
+	for _, c := range changes {
+		if c.Field == "tools.old_tool" && c.Material {
+			return
+		}
+	}
+	t.Errorf("expected change for tools.old_tool, got %v", changes)
+}
+
+func TestDiff_MaterialToolApprovalFlipped(t *testing.T) {
+	old := baseManifest()
+	old.Tools = []sdkmanifest.ToolDecl{{Name: "risky_tool", ApprovalRequired: false}}
+
+	new := baseManifest()
+	new.Tools = []sdkmanifest.ToolDecl{{Name: "risky_tool", ApprovalRequired: true}}
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when approval_required is flipped")
+	}
+	for _, c := range changes {
+		if c.Field == "tools.risky_tool.approval_required" && c.Material {
+			return
+		}
+	}
+	t.Errorf("expected change for tools.risky_tool.approval_required, got %v", changes)
+}
+
+func TestDiff_MaterialToolInputSchemaChanged(t *testing.T) {
+	schemaA := parseNode(t, `{"type":"object","properties":{"x":{"type":"string"}}}`)
+	schemaB := parseNode(t, `{"type":"object","properties":{"x":{"type":"integer"}}}`)
+
+	old := baseManifest()
+	old.Tools = []sdkmanifest.ToolDecl{{Name: "my_tool", InputSchema: schemaA}}
+
+	new := baseManifest()
+	new.Tools = []sdkmanifest.ToolDecl{{Name: "my_tool", InputSchema: schemaB}}
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when tool input_schema type changes")
+	}
+	for _, c := range changes {
+		if c.Field == "tools.my_tool.input_schema" && c.Material {
+			return
+		}
+	}
+	t.Errorf("expected change for tools.my_tool.input_schema, got %v", changes)
+}
+
+func TestDiff_MaterialConfigSchemaShapeChanged(t *testing.T) {
+	schemaA := parseNode(t, `{"type":"object","properties":{"token":{"type":"string"}}}`)
+	schemaB := parseNode(t, `{"type":"object","properties":{"token":{"type":"string"},"endpoint":{"type":"string"}}}`)
+
+	old := baseManifest()
+	old.ConfigSchema = schemaA
+
+	new := baseManifest()
+	new.ConfigSchema = schemaB
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when config_schema gains a property")
+	}
+	for _, c := range changes {
+		if c.Field == "config_schema" && c.Material {
+			return
+		}
+	}
+	t.Errorf("expected change for config_schema, got %v", changes)
+}
+
+func TestDiff_MaterialEventKindBindingSchemaChanged(t *testing.T) {
+	schemaA := parseNode(t, `{"type":"object","properties":{"channel":{"type":"string"}}}`)
+	schemaB := parseNode(t, `{"type":"object","properties":{"channel":{"type":"string"},"topic":{"type":"string"}}}`)
+
+	old := baseManifest()
+	old.EventKinds = []sdkmanifest.EventKindDecl{{Kind: "message", BindingSchema: schemaA}}
+
+	new := baseManifest()
+	new.EventKinds = []sdkmanifest.EventKindDecl{{Kind: "message", BindingSchema: schemaB}}
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when event_kind binding_schema changes")
+	}
+	for _, c := range changes {
+		if c.Field == "event_kinds.message.binding_schema" && c.Material {
+			return
+		}
+	}
+	t.Errorf("expected change for event_kinds.message.binding_schema, got %v", changes)
+}
+
+func TestDiff_MaterialEventKindAdded(t *testing.T) {
+	old := baseManifest()
+	new := baseManifest()
+	new.EventKinds = []sdkmanifest.EventKindDecl{{Kind: "alert"}}
+
+	changes := pluginmanifest.Diff(old, new)
+	if !pluginmanifest.HasMaterial(changes) {
+		t.Error("expected material change when an event_kind is added")
+	}
+	for _, c := range changes {
+		if c.Field == "event_kinds.alert" && c.Material {
+			return
+		}
+	}
+	t.Errorf("expected change for event_kinds.alert, got %v", changes)
+}
+
+func TestDiff_CosmeticDescriptionOnly_NoMaterial(t *testing.T) {
+	old := baseManifest()
+	new := baseManifest()
+	new.Description = "An updated description"
+
+	changes := pluginmanifest.Diff(old, new)
+	if pluginmanifest.HasMaterial(changes) {
+		t.Errorf("expected no material changes for description-only diff, got %v", pluginmanifest.MaterialFields(changes))
+	}
+	if len(changes) != 1 || changes[0].Field != "description" {
+		t.Errorf("expected exactly one cosmetic change (description), got %v", changes)
+	}
+}
+
+func TestDiff_CosmeticSchemaDescriptionAndDefault_NoMaterial(t *testing.T) {
+	// Schemas that differ only in "description" and "default" values must not
+	// produce a material change — those keys are stripped before comparison.
+	schemaA := parseNode(t, `{"type":"object","properties":{"token":{"type":"string","description":"old desc","default":"x"}}}`)
+	schemaB := parseNode(t, `{"type":"object","properties":{"token":{"type":"string","description":"new desc","default":"y"}}}`)
+
+	old := baseManifest()
+	old.ConfigSchema = schemaA
+
+	new := baseManifest()
+	new.ConfigSchema = schemaB
+
+	changes := pluginmanifest.Diff(old, new)
+	if pluginmanifest.HasMaterial(changes) {
+		t.Errorf("expected no material changes for schema-description-only diff, got %v", pluginmanifest.MaterialFields(changes))
+	}
+}
+
+func TestDiff_ConfigSchemaNewlyRequiredFields_ReturnsAddedNames(t *testing.T) {
+	schemaOld := parseNode(t, `{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"string"}},"required":["a"]}`)
+	schemaNew := parseNode(t, `{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"string"}},"required":["a","b"]}`)
+
+	old := baseManifest()
+	old.ConfigSchema = schemaOld
+
+	new := baseManifest()
+	new.ConfigSchema = schemaNew
+
+	added := pluginmanifest.ConfigSchemaNewlyRequiredFields(old, new)
+	if len(added) != 1 || added[0] != "b" {
+		t.Errorf("newly required fields = %v, want [b]", added)
+	}
+}
+
+func TestDiff_ConfigSchemaNewlyRequiredFields_NilOld(t *testing.T) {
+	schemaNew := parseNode(t, `{"type":"object","properties":{"token":{"type":"string"}},"required":["token"]}`)
+
+	old := baseManifest()
+	new := baseManifest()
+	new.ConfigSchema = schemaNew
+
+	added := pluginmanifest.ConfigSchemaNewlyRequiredFields(old, new)
+	if len(added) != 1 || added[0] != "token" {
+		t.Errorf("newly required fields = %v, want [token]", added)
+	}
+}
+
+func TestDiff_NoChange_Empty(t *testing.T) {
+	m := baseManifest()
+	changes := pluginmanifest.Diff(m, m)
+	if len(changes) != 0 {
+		t.Errorf("expected no changes for identical manifests, got %v", changes)
+	}
+}


### PR DESCRIPTION
Closes #189

## Summary

Implements hot-reload manifest diffing per ADR-045 §5.4:

- New `internal/plugin/manifest` package: `Diff`, `HasMaterial`, `MaterialFields`, `CosmeticFields`, `ConfigSchemaNewlyRequiredFields`. JSON-Schema "shape" comparison strips `description`/`default` keys at every depth before byte-comparing `*yaml.Node`s, so cosmetic schema churn doesn't trigger material classification.
- Install pipeline: material changes block the reload, transition every eligible instance to `pending_manifest_approval` (guarded by `IsLegalTransition`), and emit `plugin_manifest_material_change` (severity high) with the candidate manifest base64-encoded in the payload. Cosmetic-only changes update the snapshot silently and preserve `existing.Status` (so active plugins aren't demoted to `pending_review` for a description tweak).
- New admin endpoint `POST /api/v1/admin/plugins/{id}/accept-manifest`: looks up the most recent unaccepted material change for the plugin, validates the candidate, CAS-rotates `plugins.manifest_snapshot`, then either unblocks instances to `healthy` or transitions them to `pending_config_migration` when the new schema introduces newly-required fields. Emits `plugin_manifest_accepted` with the actor user id.

## Material categories

services, Tier-2 capability declarations, OAuth mode/strategy/scopes, declared tool list (add/remove/approval flip, input/output schema shape), config_schema shape, event_kinds binding_schema/payload_schema. Tool and event-kind descriptions are explicitly cosmetic.

## Scope-down

Frontend is deferred. The `PluginHealthChip` already supports `pending_manifest_approval` clicks; a categorized diff modal that reads `material_fields`/`cosmetic_fields` from the audit payload is tracked as a separate UI follow-up. None of the issue's acceptance criteria are frontend-shaped.

## Architecture plan

<details>
<summary>Plan (revised once after adversarial review)</summary>

See `.dev-loop/plan.md` on the branch. Plan reviewer caught: wrong `manifest.Unmarshal` signature, missing `IsLegalTransition` guard, incorrect schema-canonicalization strategy (`*yaml.Node` not `json.RawMessage`), unscoped audit-event lookup (cross-plugin collision risk), forced `pending_review` status on cosmetic, and missing `fakePluginQuerier` extension. All addressed before implementation.

</details>

## Review cycles

Two cycles. Cycle 1 flagged 2 BLOCKING (unused `acceptManifestRequest` type; silently swallowed parse error in `AcceptManifest`) + 3 SUGGESTIONS (re-parse in `handleManifestMaterialChange`; "actor" test that didn't actually verify actor; etc.). All addressed in cycle 2; cycle 2 returned APPROVE.

## Tests

- `internal/plugin/manifest/diff_test.go` — 14 tests covering every material category and cosmetic edge case.
- `internal/plugin/loader/install_test.go` — 6 new hot-reload tests; updated `TestInstall_VersionBump_PendingReview` because version-only bumps are now correctly classified cosmetic.
- `internal/admin/plugin_handler_test.go` — `TestPluginHandler_AcceptManifest` with 5 subtests including CAS conflict, 404, 409 (no pending change), pending-config-migration branch, and actor-user assertion.
- All Go tests pass.

## Test plan

- [ ] Install a plugin v1, drop a v2 with a cosmetic-only change (description tweak) — verify `plugin_manifest_cosmetic_change` audit row, `manifest_snapshot` updated, instances stay healthy.
- [ ] Drop a v2 with a material change (e.g. removed tool) — verify `plugin_manifest_material_change` row with `material_fields`, instances transition to `pending_manifest_approval`, `manifest_snapshot` is unchanged.
- [ ] `POST /api/v1/admin/plugins/{id}/accept-manifest` — verify snapshot rotates, instances return to `healthy`, `plugin_manifest_accepted` row appears.
- [ ] Material change adding a newly-required config field — verify `accept-manifest` transitions instances to `pending_config_migration` instead of `healthy`.
- [ ] Concurrent rotation: trigger CAS conflict on `accept-manifest` — verify 409.

## Documentation

`CLAUDE.md` updated: new `internal/plugin/manifest/` sub-package and the new admin endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop