### PR TITLE
feat(plugin): cross-source tool namespace arbiter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, plugin-architecture]
   push:
-    branches: [main]
+    branches: [main, plugin-architecture]
     # Match semver tags: v1.2.3 and pre-releases like v1.2.3-rc1. The two
     # patterns avoid the false-positives of a single `v*.*.*` glob (which
     # would also match `v1.2.3.4`). GHA glob: `+` is a quantifier for the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,10 +140,12 @@ internal/
   plugin/             — host-side plugin loader; gated by GLEIPNIR_PLUGINS_ENABLED. Implements fsnotify watcher, tarball extractor, minisign verifier, and DB installer. Out-of-process subprocess spawning and generation refcounts remain as follow-up work.
     state/            — per-instance health-state machine; mirrors execution/runstate (transition table + version-CAS, ADR-038). Severity ranking encodes §8.1 "plugin can only mark itself worse" merge rule.
     manifest/         — host-side manifest diff (material vs cosmetic) consumed by the loader on hot-reload (spec §5.4). Schema-shape comparison strips `description`/`default` keys at every depth; depends only on plugin-sdk/manifest + stdlib.
+    tools/            — plugin-side tool registrar; reserves `<instance>.<tool>` names with `internal/toolregistry`, writes `plugin_tool_namespace_conflict` audit events on collision, and drives the instance to `unhealthy` (issue #194).
   policy/             — YAML parser, validator, system prompt renderer
   settings/           — read-side accessor for system_settings (default model, public URL); injected into runtime so non-admin packages don't depend on the admin HTTP handler
   testutil/           — shared test helpers
   timeout/            — generic scan-and-resolve loop for expiring requests (used by approval/ and feedback/)
+  toolregistry/       — neutral leaf package: in-memory uniqueness arbiter for the shared `<source>.<tool>` namespace. Imported by `internal/mcp` (MCP-side reservations) and `internal/plugin/tools` (plugin-side reservations); neither side imports the other (issue #194).
   trigger/            — trigger dispatch only: webhook, manual, scheduled, poll, and cron handlers (imports execution/run/ for launching)
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ RUN npm run build
 # Stage 2: Build the Go binary
 FROM golang:1.25-alpine AS builder
 WORKDIR /app
+# plugin-sdk is a sub-module pulled in via a `replace` directive in the root
+# go.mod; its go.mod/go.sum must exist on disk before `go mod download` can
+# resolve the replacement target.
 COPY go.mod go.sum ./
+COPY plugin-sdk/go.mod plugin-sdk/go.sum ./plugin-sdk/
 RUN go mod download
 COPY . .
 # Overwrite frontend/dist with the freshly built assets so go:embed picks them up.

--- a/docs/developer/ADR_Tracker.md
+++ b/docs/developer/ADR_Tracker.md
@@ -55,7 +55,7 @@ Running index of all Architecture Decision Records. Promote items from the Roadm
 | ADR-038 | Atomic run-state transitions with optimistic locking   | 🟢 Decided | v1.0 | runs.version column, RunStateMachine.Transition (tx), runstate.ErrTransitionConflict |
 | ADR-039 | Per-server encrypted auth headers for authenticated MCP providers | 🟢 Decided | v1.0 | mcp_servers table, internal/mcp, internal/admin, gleipnirctl rotate-key |
 | ADR-040 | Arcade gateway pre-authorization (toolkit-level OAuth pre-warm) | 🟢 Decided | v1.0 | internal/arcade (new), internal/http/api/arcade_handler, frontend ServerDetailModal |
-| ADR-041 | Plugin system architecture (umbrella) | 🟢 Decided | v2.0 | internal/plugin (new), internal/execution/agent/feedback.go, plugin-sdk (new module), admin UI, ADR-004 (parallel to MCP) |
+| ADR-041 | Plugin system architecture (umbrella) | 🟢 Decided | v2.0 | internal/plugin (new), internal/execution/agent/feedback.go, plugin-sdk (new module), admin UI, ADR-004 (parallel to MCP) — cross-source tool uniqueness arbiter lives in `internal/toolregistry` per spec §3.3 / issue #194 |
 | ADR-042 | Plugin service & HostAPI versioning policy | 🟢 Decided | v1.0 (plugins) | docs/developer/plugin-system-spec.md §10, buf.yaml, .github/workflows/ci.yml |
 | ADR-043 | Plugin signing tooling — bundled Minisign in plugin-sdk/signing, fresh-written | 🟢 Decided | v2.0 (plugins) | plugin-sdk/signing (new), gleipnir-plugin keygen/sign/package subcommands, spec §5.2 §14.5 |
 | ADR-044 | Channel routing model — Notify/Request semantics, audience as shared resource | 🟢 Decided | v2.0 (plugins) | internal/plugin/channel (new), internal/execution/agent/feedback.go, admin audiences UI, ADR-031 (partial supersession) |

--- a/internal/http/api/mcp_handler.go
+++ b/internal/http/api/mcp_handler.go
@@ -25,20 +25,39 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 )
 
 // MCPHandler serves MCP server management endpoints under /api/v1/mcp/servers.
 type MCPHandler struct {
 	store    *db.Store
 	registry *mcp.Registry
-	encKey   []byte // AES-256-GCM key; nil when GLEIPNIR_ENCRYPTION_KEY is unset
+	arbiter  *toolregistry.Registry // cross-source namespace arbiter; nil when not configured
+	encKey   []byte                 // AES-256-GCM key; nil when GLEIPNIR_ENCRYPTION_KEY is unset
 }
 
 // NewMCPHandler creates an MCPHandler backed by the given store, registry, and
 // encryption key. encKey may be nil when the encryption key is not configured;
 // in that case, Create/Update requests that include auth_headers return 503.
-func NewMCPHandler(store *db.Store, registry *mcp.Registry, encKey []byte) *MCPHandler {
-	return &MCPHandler{store: store, registry: registry, encKey: encKey}
+// arbiter may be nil to disable cross-source uniqueness enforcement.
+func NewMCPHandler(store *db.Store, registry *mcp.Registry, encKey []byte, opts ...MCPHandlerOption) *MCPHandler {
+	h := &MCPHandler{store: store, registry: registry, encKey: encKey}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// MCPHandlerOption configures an MCPHandler.
+type MCPHandlerOption func(*MCPHandler)
+
+// WithToolNamespaceArbiter wires the shared cross-source uniqueness arbiter
+// into the handler so Create can enforce namespace uniqueness before writing
+// the server row.
+func WithToolNamespaceArbiter(a *toolregistry.Registry) MCPHandlerOption {
+	return func(h *MCPHandler) {
+		h.arbiter = a
+	}
 }
 
 // authHeaderPayload is the JSON shape used in Create/Update/TestConnection
@@ -228,6 +247,19 @@ func (h *MCPHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create handles POST /api/v1/mcp/servers.
+//
+// Flow (atomicity guarantee per #194):
+//  1. Validate name and URL.
+//  2. Validate and encrypt auth headers.
+//  3. Pre-flight probe (ProbeTools): discover tools without writing any DB rows.
+//     A probe failure is non-fatal — the server is still created so the operator
+//     can fix the URL later; discovery_error is populated in the 201 response.
+//  4. If probe succeeded and tools were found, reserve their dot-names in the
+//     cross-source arbiter. A conflict → 409 with no orphan DB row.
+//  5. Create the mcp_servers row. On failure → release arbiter reservations.
+//  6. Upsert the probed tools directly (no second round-trip). On failure →
+//     release arbiter reservations and return 500.
+//  7. Return 201.
 func (h *MCPHandler) Create(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Name        string              `json:"name"`
@@ -248,6 +280,7 @@ func (h *MCPHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Step 2: validate and encrypt auth headers.
 	var ciphertext *string
 	if len(body.AuthHeaders) > 0 {
 		if h.encKey == nil {
@@ -270,6 +303,48 @@ func (h *MCPHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ciphertext = ct
 	}
 
+	// Step 3: pre-flight probe — discover tools without writing any DB rows.
+	// A network failure here is non-fatal; we still create the server so the
+	// operator can correct the URL later.
+	var (
+		probedTools    []mcp.Tool
+		discoveryError *string
+	)
+	probed, probeErr := h.registry.ProbeTools(r.Context(), body.Name, body.URL, ciphertext)
+	if probeErr != nil {
+		slog.Warn("MCP pre-flight probe failed on server create", "server_name", body.Name, "err", probeErr)
+		errStr := probeErr.Error()
+		discoveryError = &errStr
+	} else {
+		probedTools = probed
+	}
+
+	// Step 4: reserve namespace in the arbiter (only when probe succeeded and
+	// returned tools). A conflict means another source already owns the name.
+	mcpSrc := toolregistry.Source{Kind: toolregistry.KindMCP, Name: body.Name}
+	if h.arbiter != nil && len(probedTools) > 0 {
+		entries := make([]toolregistry.Reservation, len(probedTools))
+		for i, t := range probedTools {
+			entries[i] = toolregistry.Reservation{
+				DotName: toolregistry.DotName(body.Name, t.Name),
+				Owner:   mcpSrc,
+			}
+		}
+		if err := h.arbiter.ReserveBulk(entries); err != nil {
+			var ce *toolregistry.ConflictError
+			if errors.As(err, &ce) {
+				httputil.WriteError(w, http.StatusConflict,
+					fmt.Sprintf("tool %q is already provided by %s", ce.DotName, ce.Existing.String()),
+					"")
+				return
+			}
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to reserve tool namespace", err.Error())
+			return
+		}
+	}
+
+	// Step 5: create the mcp_servers row. On DB error, release the arbiter
+	// reservations we just claimed.
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	server, err := h.store.CreateMCPServer(r.Context(), db.CreateMCPServerParams{
 		ID:                   model.NewULID(),
@@ -279,6 +354,9 @@ func (h *MCPHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AuthHeadersEncrypted: ciphertext,
 	})
 	if err != nil {
+		if h.arbiter != nil {
+			h.arbiter.ReleaseAllFor(mcpSrc)
+		}
 		if isUniqueConstraintError(err) {
 			httputil.WriteError(w, http.StatusConflict, "MCP server name already exists", "")
 			return
@@ -289,15 +367,43 @@ func (h *MCPHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	resp := mcpServerCreateResponse{
 		mcpServerResponse: h.serverToResponse(server),
+		DiscoveryError:    discoveryError,
 	}
 
-	// Attempt auto-discovery; a failure is non-fatal — we still return 201 with the
-	// server record plus a discovery_error field so the caller knows to retry.
-	if _, err := h.registry.RefreshTools(r.Context(), server.ID); err != nil {
-		slog.Warn("MCP auto-discovery failed on server create", "server_id", server.ID, "server_name", body.Name, "err", err)
-		errStr := err.Error()
-		resp.DiscoveryError = &errStr
-	} else {
+	// Step 6: upsert the tools discovered in the pre-flight probe. Skipped when
+	// probe failed (probedTools is empty) or the server returned no tools.
+	if len(probedTools) > 0 {
+		for _, t := range probedTools {
+			if _, err := h.store.UpsertMCPTool(r.Context(), db.UpsertMCPToolParams{
+				ID:          model.NewULID(),
+				ServerID:    server.ID,
+				Name:        t.Name,
+				Description: t.Description,
+				InputSchema: string(t.InputSchema),
+				CreatedAt:   now,
+			}); err != nil {
+				if h.arbiter != nil {
+					h.arbiter.ReleaseAllFor(mcpSrc)
+				}
+				httputil.WriteError(w, http.StatusInternalServerError, "failed to upsert discovered tools", err.Error())
+				return
+			}
+		}
+
+		// Update last_discovered_at and clear drift to preserve the "first
+		// discovery" semantics that RefreshTools provides.
+		if err := h.store.UpdateMCPServerLastDiscovered(r.Context(), db.UpdateMCPServerLastDiscoveredParams{
+			LastDiscoveredAt: &now,
+			ID:               server.ID,
+		}); err != nil {
+			slog.Warn("failed to set last_discovered_at after create", "server_id", server.ID, "err", err)
+		} else if err := h.store.UpdateMCPServerDrift(r.Context(), db.UpdateMCPServerDriftParams{
+			HasDrift: 0,
+			ID:       server.ID,
+		}); err != nil {
+			slog.Warn("failed to clear has_drift after create", "server_id", server.ID, "err", err)
+		}
+
 		// Re-fetch so the response reflects the updated last_discovered_at.
 		if updated, err := h.store.GetMCPServer(r.Context(), server.ID); err == nil {
 			resp.mcpServerResponse = h.serverToResponse(updated)
@@ -363,6 +469,12 @@ func (h *MCPHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // Update handles PUT /api/v1/mcp/servers/{id}.
 // Updates the server's name and url only. Auth headers are managed separately
 // via PUT/DELETE /api/v1/mcp/servers/:id/headers/:name (ADR-039).
+//
+// TODO #194 follow-up: server rename leaves stale arbiter reservations. A rename
+// changes the server's name (and therefore the dot-name prefix for all its
+// tools), but this handler does not refresh tools, so the arbiter still holds
+// reservations under the old name. A follow-up should release the old
+// reservations and re-reserve under the new name.
 func (h *MCPHandler) Update(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
@@ -617,18 +729,22 @@ type mcpToolResponse struct {
 	Description string          `json:"description"`
 	InputSchema json.RawMessage `json:"input_schema"`
 	Enabled     bool            `json:"enabled"`
+	// Source identifies which registry owns this tool. Format: "mcp:<server-name>"
+	// for tools from MCP servers, or "plugin:<instance-name>" for plugin tools.
+	Source string `json:"source"`
 }
 
-func toolToResponse(t db.McpTool) mcpToolResponse {
+func toolToResponse(t db.McpTool, serverName string) mcpToolResponse {
 	return mcpToolResponse{
-		ID:          t.ID,
-		ServerID:    t.ServerID,
-		Name:        t.Name,
-		Description: t.Description,
+		ID:       t.ID,
+		ServerID: t.ServerID,
+		Name:     t.Name,
 		// InputSchema is stored as a JSON string in the DB; cast directly to
 		// json.RawMessage to avoid double-encoding it as a JSON string in the response.
+		Description: t.Description,
 		InputSchema: json.RawMessage(t.InputSchema),
 		Enabled:     t.Enabled != 0,
+		Source:      "mcp:" + serverName,
 	}
 }
 
@@ -642,7 +758,8 @@ func (h *MCPHandler) ListTools(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	ctx := r.Context()
 
-	if _, err := h.store.GetMCPServer(ctx, id); err != nil {
+	server, err := h.store.GetMCPServer(ctx, id)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			httputil.WriteError(w, http.StatusNotFound, "MCP server not found", "")
 			return
@@ -658,10 +775,7 @@ func (h *MCPHandler) ListTools(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var (
-		rows []db.McpTool
-		err  error
-	)
+	var rows []db.McpTool
 	if includeDisabled {
 		rows, err = h.store.ListMCPToolsByServer(ctx, id)
 	} else {
@@ -674,7 +788,7 @@ func (h *MCPHandler) ListTools(w http.ResponseWriter, r *http.Request) {
 
 	items := make([]mcpToolResponse, 0, len(rows))
 	for _, row := range rows {
-		items = append(items, toolToResponse(row))
+		items = append(items, toolToResponse(row, server.Name))
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, items)
@@ -738,7 +852,14 @@ func (h *MCPHandler) SetToolEnabled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httputil.WriteJSON(w, http.StatusOK, toolToResponse(updated))
+	// Re-load the server name so the source field in the response is accurate.
+	srv, err := h.store.GetMCPServer(ctx, serverID)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to re-fetch server after tool update", err.Error())
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, toolToResponse(updated, srv.Name))
 }
 
 // policyReferencesServer returns true if the raw policy YAML contains any tool

--- a/internal/http/api/mcp_handler_test.go
+++ b/internal/http/api/mcp_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/testutil"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 )
 
 // newMCPRouter wires a chi router with the MCP handler, mirroring how
@@ -44,6 +45,22 @@ func newMCPRouter(store *db.Store, registry *mcp.Registry, encKey ...[]byte) htt
 	r.Post("/servers/{id}/discover", h.Discover)
 	r.Get("/servers/{id}/tools", h.ListTools)
 	r.Put("/servers/{id}/tools/{toolID}/enabled", h.SetToolEnabled)
+	return r
+}
+
+// newMCPRouterWithArbiter wires a chi router with an MCPHandler that has a
+// cross-source namespace arbiter. Used for tests that exercise namespace
+// conflict enforcement.
+func newMCPRouterWithArbiter(store *db.Store, registry *mcp.Registry, arbiter *toolregistry.Registry) http.Handler {
+	r := chi.NewRouter()
+	h := api.NewMCPHandler(store, registry, nil, api.WithToolNamespaceArbiter(arbiter))
+	r.Get("/servers", h.List)
+	r.Post("/servers", h.Create)
+	r.Post("/servers/test", h.TestConnection)
+	r.Delete("/servers/{id}", h.Delete)
+	r.Put("/servers/{id}", h.Update)
+	r.Get("/servers/{id}/tools", h.ListTools)
+	r.Post("/servers/{id}/discover", h.Discover)
 	return r
 }
 
@@ -1757,4 +1774,164 @@ func TestMCPAuthHeaders_TestConnection(t *testing.T) {
 			t.Errorf("X-Api-Key on test request = %q, want %q", gotAPIKey, "test-key-123")
 		}
 	})
+}
+
+// TestListTools_SourceField verifies that every tool row in the ListTools
+// response carries a "source" field formatted as "mcp:<serverName>".
+func TestListTools_SourceField(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	registry := mcp.NewRegistry(store.Queries())
+	serverID := insertTestMCPServer(t, store, "my-server", "http://localhost:9999")
+	insertTestMCPTool(t, store, serverID, "tool-alpha")
+
+	h := api.NewMCPHandler(store, registry, nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = setChiURLParams(req, "id", serverID)
+	w := httptest.NewRecorder()
+	h.ListTools(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var envelope struct {
+		Data []struct {
+			Name   string `json:"name"`
+			Source string `json:"source"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) != 1 {
+		t.Fatalf("len(data) = %d, want 1", len(envelope.Data))
+	}
+	if envelope.Data[0].Source != "mcp:my-server" {
+		t.Errorf("source = %q, want mcp:my-server", envelope.Data[0].Source)
+	}
+}
+
+// TestCreate_Returns409_OnPluginNamespaceConflict verifies that POST /servers
+// returns 409 when the probe discovers a tool whose dot-name is already owned
+// by a plugin, and no mcp_servers row is created.
+func TestCreate_Returns409_OnPluginNamespaceConflict(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	arbiter := toolregistry.New()
+	registry := mcp.NewRegistry(store.Queries(), mcp.WithToolNamespaceArbiter(arbiter))
+
+	// Pre-claim "test-server.tool-a" with a plugin source.
+	pluginSrc := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "test-server"}
+	if err := arbiter.Reserve(toolregistry.DotName("test-server", "tool-a"), pluginSrc); err != nil {
+		t.Fatalf("pre-reserve: %v", err)
+	}
+
+	fakeMCP := makeFakeMCPServer(t, []string{"tool-a"})
+	srv := httptest.NewServer(newMCPRouterWithArbiter(store, registry, arbiter))
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]string{"name": "test-server", "url": fakeMCP.URL})
+	resp, err := http.Post(srv.URL+"/servers", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /servers: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	}
+
+	// No mcp_servers row must have been created.
+	rawDB := store.DB()
+	var count int
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM mcp_servers`).Scan(&count); err != nil {
+		t.Fatalf("count mcp_servers: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("mcp_servers count = %d after 409, want 0", count)
+	}
+}
+
+// TestCreate_DiscoveryError_PreservedAndNoReservation verifies that when the
+// pre-flight probe fails (unreachable URL), the server is still created with
+// discovery_error populated and the arbiter holds no reservations for it.
+func TestCreate_DiscoveryError_PreservedAndNoReservation(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	arbiter := toolregistry.New()
+	registry := mcp.NewRegistry(store.Queries(), mcp.WithToolNamespaceArbiter(arbiter))
+
+	// Start and immediately close so URL is valid but unreachable.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	srv := httptest.NewServer(newMCPRouterWithArbiter(store, registry, arbiter))
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]string{"name": "unreachable-server", "url": deadURL})
+	resp, err := http.Post(srv.URL+"/servers", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /servers: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+
+	var envelope struct {
+		Data struct {
+			ID             string  `json:"id"`
+			DiscoveryError *string `json:"discovery_error"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Data.DiscoveryError == nil {
+		t.Error("discovery_error must be set when probe fails")
+	}
+
+	// Arbiter must have no reservations for this server.
+	snap := arbiter.Snapshot()
+	for dotName, owner := range snap {
+		if owner == (toolregistry.Source{Kind: toolregistry.KindMCP, Name: "unreachable-server"}) {
+			t.Errorf("arbiter has unexpected reservation %q after probe failure", dotName)
+		}
+	}
+}
+
+// TestCreate_RollbackOnDBFailure verifies that when the mcp_servers INSERT
+// fails (duplicate name), the arbiter reservations are released so the namespace
+// is not permanently locked.
+func TestCreate_RollbackOnDBFailure(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	arbiter := toolregistry.New()
+	registry := mcp.NewRegistry(store.Queries(), mcp.WithToolNamespaceArbiter(arbiter))
+
+	fakeMCP := makeFakeMCPServer(t, []string{"tool-a"})
+
+	// Insert the server first so a duplicate will fail.
+	insertTestMCPServer(t, store, "dup-server", "http://localhost:9999")
+
+	srv := httptest.NewServer(newMCPRouterWithArbiter(store, registry, arbiter))
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]string{"name": "dup-server", "url": fakeMCP.URL})
+	resp, err := http.Post(srv.URL+"/servers", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /servers: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	}
+
+	// Arbiter must be empty for this server after the rollback.
+	snap := arbiter.Snapshot()
+	for dotName, owner := range snap {
+		if owner == (toolregistry.Source{Kind: toolregistry.KindMCP, Name: "dup-server"}) {
+			t.Errorf("arbiter has stale reservation %q after DB failure rollback", dotName)
+		}
+	}
 }

--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/policy"
 	"github.com/felag-engineering/gleipnir/internal/settings"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 	"github.com/felag-engineering/gleipnir/internal/trigger"
 )
 
@@ -59,8 +60,9 @@ type BackgroundServices struct {
 	Poller           PolicyNotifier    // notified on poll-trigger policy mutations
 	Scheduler        PolicyNotifier    // notified on scheduled-trigger policy mutations
 	Cron             PolicyNotifier    // notified on cron-trigger policy mutations
-	EncryptionKey    []byte            // AES-256 key for MCP auth header encryption; nil when unset
-	Settings         *settings.Service // system-wide runtime settings; required by manual-trigger and policy services
+	EncryptionKey    []byte                  // AES-256 key for MCP auth header encryption; nil when unset
+	Arbiter          *toolregistry.Registry  // cross-source tool namespace arbiter; nil disables enforcement
+	Settings         *settings.Service       // system-wide runtime settings; required by manual-trigger and policy services
 }
 
 // Metadata holds descriptive, read-only values about the running instance.
@@ -184,7 +186,7 @@ func BuildRouter(cfg RouterConfig) chi.Router {
 
 		// Policies, MCP, stats, models, and attention — mounted under /api/v1.
 		policySvc := policy.NewService(cfg.Services.Store, nil, cfg.Services.ProviderRegistry, cfg.Services.ProviderRegistry, cfg.Services.Settings)
-		r.Mount("/api/v1", newAPISubRouter(cfg.Services.Store, policySvc, cfg.Services.Registry, cfg.Services.ModelLister, cfg.Services.ModelFilter, cfg.Handlers.PolicyWebhookHandler, cfg.Services.Poller, cfg.Services.Scheduler, cfg.Services.Cron, cfg.Services.EncryptionKey))
+		r.Mount("/api/v1", newAPISubRouter(cfg.Services.Store, policySvc, cfg.Services.Registry, cfg.Services.ModelLister, cfg.Services.ModelFilter, cfg.Handlers.PolicyWebhookHandler, cfg.Services.Poller, cfg.Services.Scheduler, cfg.Services.Cron, cfg.Services.EncryptionKey, cfg.Services.Arbiter))
 
 		// Admin: provider key management, settings, and model configuration.
 		r.Route("/api/v1/admin", func(r chi.Router) {
@@ -242,7 +244,7 @@ func BuildRouter(cfg RouterConfig) chi.Router {
 
 // newAPISubRouter builds the sub-router that was previously returned by NewRouter.
 // It is mounted at /api/v1 inside the authenticated group in BuildRouter.
-func newAPISubRouter(store *db.Store, svc *policy.Service, registry *mcp.Registry, modelLister llm.ModelLister, modelFilter ModelFilter, policyWebhook *PolicyWebhookHandler, poller, scheduler, cron PolicyNotifier, encKey []byte) chi.Router {
+func newAPISubRouter(store *db.Store, svc *policy.Service, registry *mcp.Registry, modelLister llm.ModelLister, modelFilter ModelFilter, policyWebhook *PolicyWebhookHandler, poller, scheduler, cron PolicyNotifier, encKey []byte, arbiter *toolregistry.Registry) chi.Router {
 	r := chi.NewRouter()
 	r.Use(httputil.BodySizeLimit(httputil.MaxRequestBodySize))
 
@@ -281,7 +283,7 @@ func newAPISubRouter(store *db.Store, svc *policy.Service, registry *mcp.Registr
 
 	r.Route("/mcp", func(r chi.Router) {
 		r.Use(httputil.RequireJSON)
-		mcpH := NewMCPHandler(store, registry, encKey)
+		mcpH := NewMCPHandler(store, registry, encKey, WithToolNamespaceArbiter(arbiter))
 		r.Route("/servers", func(r chi.Router) {
 			r.With(auth.RequireRole(model.RoleOperator, model.RoleAuditor)).Get("/", mcpH.List)
 			r.With(auth.RequireRole(model.RoleAdmin, model.RoleOperator)).Post("/", mcpH.Create)

--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -114,6 +114,13 @@ func parseSSEStream(ctx context.Context, body io.ReadCloser, out chan<- llm.Mess
 		}
 	}
 
+	// Prefer the context error over scanner.Err()/missing-DONE: a cancelled
+	// reader can return EOF before the in-loop ctx check fires, which would
+	// otherwise misreport cancellation as "stream ended without [DONE]".
+	if err := ctx.Err(); err != nil {
+		out <- llm.MessageChunk{Err: err}
+		return
+	}
 	if err := scanner.Err(); err != nil {
 		out <- llm.MessageChunk{Err: fmt.Errorf("openai: reading SSE stream: %w", err)}
 		return

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -14,7 +14,14 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 )
+
+// ErrToolNamespaceConflict is returned by RefreshTools when an added tool's
+// dot-name is already owned by a different source (e.g. a plugin instance).
+// Callers can use errors.As to recover the *toolregistry.ConflictError for the
+// specific conflicting name and its existing owner.
+var ErrToolNamespaceConflict = errors.New("tool namespace conflict")
 
 // ResolvedTool pairs a granted tool's model metadata with a ready Client
 // targeting its server. Used by the agent runner to call tools.
@@ -39,7 +46,8 @@ type ToolDiff struct {
 type Registry struct {
 	queries    *db.Queries
 	mcpTimeout time.Duration
-	encKey     []byte // AES-256-GCM key for decrypting auth_headers_encrypted; nil if unset
+	encKey     []byte                  // AES-256-GCM key for decrypting auth_headers_encrypted; nil if unset
+	arbiter    *toolregistry.Registry  // cross-source tool namespace arbiter; nil means no uniqueness enforcement
 }
 
 // RegistryOption configures a Registry.
@@ -59,6 +67,16 @@ func WithMCPTimeout(d time.Duration) RegistryOption {
 func WithEncryptionKey(key []byte) RegistryOption {
 	return func(r *Registry) {
 		r.encKey = key
+	}
+}
+
+// WithToolNamespaceArbiter wires the shared cross-source uniqueness arbiter
+// into the Registry. When set, RefreshTools will reserve dot-names for tools
+// it adds and release them for tools it removes. A nil arbiter (the default)
+// disables uniqueness enforcement so existing tests remain unaffected.
+func WithToolNamespaceArbiter(a *toolregistry.Registry) RegistryOption {
+	return func(r *Registry) {
+		r.arbiter = a
 	}
 }
 
@@ -216,6 +234,27 @@ func (r *Registry) ResolveToolByName(ctx context.Context, dotName string) (*Clie
 	return r.newClientForServer(srv), toolName, nil
 }
 
+// ProbeTools performs a one-shot tool discovery against the MCP server at
+// urlStr without writing any DB rows. It is used by MCPHandler.Create to
+// discover tools before committing the server row, so a namespace conflict can
+// be rejected with HTTP 409 before an orphan row is created.
+//
+// The synthetic db.McpServer passed to newClientForServer carries ID "<probe>"
+// so log output is not misleading about a real server ID.
+func (r *Registry) ProbeTools(ctx context.Context, name, urlStr string, encryptedAuthHeaders *string) ([]Tool, error) {
+	synthetic := db.McpServer{
+		ID:                   "<probe>",
+		Name:                 name,
+		Url:                  urlStr,
+		AuthHeadersEncrypted: encryptedAuthHeaders,
+	}
+	tools, err := r.newClientForServer(synthetic).DiscoverTools(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("probe tools for %q: %w", name, err)
+	}
+	return tools, nil
+}
+
 // RegisterServer stores a new MCP server record, discovers its tools via the
 // MCP client, and upserts all discovered tools into mcp_tools.
 // last_discovered_at is intentionally left NULL here — it is set only by RefreshTools.
@@ -314,12 +353,37 @@ func (r *Registry) RefreshTools(ctx context.Context, serverID string) (ToolDiff,
 	sort.Strings(diff.Removed)
 	sort.Strings(diff.Modified)
 
+	// Reserve newly-added dot-names in the cross-source arbiter before touching
+	// the DB. If another source (e.g. a plugin) already owns a name, return
+	// ErrToolNamespaceConflict so the caller can surface it as a real failure
+	// rather than silently overwriting the namespace.
+	mcpSrc := toolregistry.Source{Kind: toolregistry.KindMCP, Name: srv.Name}
+	if r.arbiter != nil && len(diff.Added) > 0 {
+		entries := make([]toolregistry.Reservation, len(diff.Added))
+		for i, name := range diff.Added {
+			entries[i] = toolregistry.Reservation{
+				DotName: toolregistry.DotName(srv.Name, name),
+				Owner:   mcpSrc,
+			}
+		}
+		if err := r.arbiter.ReserveBulk(entries); err != nil {
+			var ce *toolregistry.ConflictError
+			if errors.As(err, &ce) {
+				return ToolDiff{}, fmt.Errorf("refresh tools for %q: %w", srv.Name, ErrToolNamespaceConflict)
+			}
+			return ToolDiff{}, fmt.Errorf("reserve tool namespace for %q: %w", srv.Name, err)
+		}
+	}
+
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
 	// Upsert all fresh tools. Preserve the existing ID for tools already in the
 	// DB so foreign key references (e.g. in audit steps) remain stable.
 	// ON CONFLICT does not touch the enabled column — operator-set disable state
 	// survives rediscovery (see the UpsertMCPTool query for the ON CONFLICT clause).
+	//
+	// On any DB error after a successful arbiter reservation, release all
+	// reservations for this server so the namespace is not permanently locked.
 	for _, t := range freshTools {
 		toolID := model.NewULID()
 		if old, exists := oldByName[t.Name]; exists {
@@ -334,6 +398,11 @@ func (r *Registry) RefreshTools(ctx context.Context, serverID string) (ToolDiff,
 			InputSchema: string(t.InputSchema),
 			CreatedAt:   now,
 		}); err != nil {
+			if r.arbiter != nil {
+				// Releases all reservations for this server, including pre-existing ones,
+				// because the server's tool set is in an unknown state after the partial failure.
+				r.arbiter.ReleaseAllFor(mcpSrc)
+			}
 			return ToolDiff{}, fmt.Errorf("upsert tool %q: %w", t.Name, err)
 		}
 	}
@@ -344,7 +413,20 @@ func (r *Registry) RefreshTools(ctx context.Context, serverID string) (ToolDiff,
 			ServerID: serverID,
 			Name:     name,
 		}); err != nil {
+			if r.arbiter != nil {
+				// Releases all reservations for this server, including pre-existing ones,
+				// because the server's tool set is in an unknown state after the partial failure.
+				r.arbiter.ReleaseAllFor(mcpSrc)
+			}
 			return ToolDiff{}, fmt.Errorf("delete removed tool %q: %w", name, err)
+		}
+	}
+
+	// Release arbiter slots for tools that are no longer on the server. This
+	// must happen after successful deletion so the names are genuinely free.
+	if r.arbiter != nil {
+		for _, name := range diff.Removed {
+			r.arbiter.Release(toolregistry.DotName(srv.Name, name), mcpSrc)
 		}
 	}
 

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 )
 
 // newTestRegistry opens a fresh in-memory-backed SQLite store, applies the
@@ -793,4 +795,190 @@ func mustTestKey(t *testing.T) []byte {
 		t.Fatalf("parse test key: %v", err)
 	}
 	return k
+}
+
+// newTestRegistryWithArbiter returns a Registry wired with the given arbiter.
+func newTestRegistryWithArbiter(t *testing.T, arbiter *toolregistry.Registry) (*Registry, *db.Store) {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("store.Migrate: %v", err)
+	}
+	reg := NewRegistry(store.Queries(), WithToolNamespaceArbiter(arbiter))
+	return reg, store
+}
+
+// TestRefreshTools_ReservesAddedNames verifies that RefreshTools reserves newly
+// discovered tool dot-names in the arbiter under the MCP source.
+func TestRefreshTools_ReservesAddedNames(t *testing.T) {
+	arbiter := toolregistry.New()
+	reg, store := newTestRegistryWithArbiter(t, arbiter)
+	rawDB := store.DB()
+
+	tools := []map[string]any{
+		{"name": "tool-a", "description": "desc", "inputSchema": map[string]any{"type": "object"}},
+		{"name": "tool-b", "description": "desc", "inputSchema": map[string]any{"type": "object"}},
+	}
+	srv := makeMCPServer(t, tools)
+
+	now := "2024-01-01T00:00:00Z"
+	var serverID string
+	if err := rawDB.QueryRow(
+		`INSERT INTO mcp_servers (id, name, url, created_at) VALUES ('srv-res', 'my-srv', ?, ?) RETURNING id`,
+		srv.URL, now,
+	).Scan(&serverID); err != nil {
+		t.Fatalf("insert server: %v", err)
+	}
+
+	if _, err := reg.RefreshTools(context.Background(), serverID); err != nil {
+		t.Fatalf("RefreshTools: %v", err)
+	}
+
+	wantSrc := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "my-srv"}
+	for _, name := range []string{"tool-a", "tool-b"} {
+		dotName := toolregistry.DotName("my-srv", name)
+		got, ok := arbiter.Lookup(dotName)
+		if !ok {
+			t.Errorf("arbiter does not have reservation for %q", dotName)
+			continue
+		}
+		if got != wantSrc {
+			t.Errorf("arbiter[%q] = %v, want %v", dotName, got, wantSrc)
+		}
+	}
+}
+
+// TestRefreshTools_ReleasesRemovedNames verifies that RefreshTools releases
+// arbiter reservations for tools that are no longer present on the server.
+func TestRefreshTools_ReleasesRemovedNames(t *testing.T) {
+	arbiter := toolregistry.New()
+	reg, store := newTestRegistryWithArbiter(t, arbiter)
+	rawDB := store.DB()
+
+	twoTools := []map[string]any{
+		{"name": "tool-a", "description": "desc", "inputSchema": map[string]any{"type": "object"}},
+		{"name": "tool-b", "description": "desc", "inputSchema": map[string]any{"type": "object"}},
+	}
+	firstSrv := makeMCPServer(t, twoTools)
+
+	now := "2024-01-01T00:00:00Z"
+	var serverID string
+	if err := rawDB.QueryRow(
+		`INSERT INTO mcp_servers (id, name, url, created_at) VALUES ('srv-rel', 'my-srv', ?, ?) RETURNING id`,
+		firstSrv.URL, now,
+	).Scan(&serverID); err != nil {
+		t.Fatalf("insert server: %v", err)
+	}
+
+	if _, err := reg.RefreshTools(context.Background(), serverID); err != nil {
+		t.Fatalf("RefreshTools (initial): %v", err)
+	}
+
+	// Second discovery returns only tool-a; tool-b should be released.
+	oneTool := []map[string]any{
+		{"name": "tool-a", "description": "desc", "inputSchema": map[string]any{"type": "object"}},
+	}
+	secondSrv := makeMCPServer(t, oneTool)
+	if _, err := rawDB.Exec(`UPDATE mcp_servers SET url = ? WHERE id = ?`, secondSrv.URL, serverID); err != nil {
+		t.Fatalf("update server url: %v", err)
+	}
+
+	if _, err := reg.RefreshTools(context.Background(), serverID); err != nil {
+		t.Fatalf("RefreshTools (refresh): %v", err)
+	}
+
+	// tool-a must still be reserved.
+	if _, ok := arbiter.Lookup(toolregistry.DotName("my-srv", "tool-a")); !ok {
+		t.Error("tool-a should still be reserved after second refresh")
+	}
+	// tool-b must have been released.
+	if _, ok := arbiter.Lookup(toolregistry.DotName("my-srv", "tool-b")); ok {
+		t.Error("tool-b should have been released after removal")
+	}
+}
+
+// TestRefreshTools_ReturnsErrToolNamespaceConflict_WhenPluginOwnsName verifies
+// that RefreshTools returns ErrToolNamespaceConflict when a tool's dot-name is
+// already owned by a plugin source, and the DB is not mutated.
+func TestRefreshTools_ReturnsErrToolNamespaceConflict_WhenPluginOwnsName(t *testing.T) {
+	arbiter := toolregistry.New()
+	reg, store := newTestRegistryWithArbiter(t, arbiter)
+	rawDB := store.DB()
+
+	// Pre-claim the dot-name with a plugin source.
+	pluginSrc := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "my-srv"}
+	if err := arbiter.Reserve(toolregistry.DotName("my-srv", "tool-a"), pluginSrc); err != nil {
+		t.Fatalf("pre-reserve: %v", err)
+	}
+
+	tools := []map[string]any{
+		{"name": "tool-a", "description": "desc", "inputSchema": map[string]any{"type": "object"}},
+	}
+	srv := makeMCPServer(t, tools)
+
+	now := "2024-01-01T00:00:00Z"
+	var serverID string
+	if err := rawDB.QueryRow(
+		`INSERT INTO mcp_servers (id, name, url, created_at) VALUES ('srv-conflict', 'my-srv', ?, ?) RETURNING id`,
+		srv.URL, now,
+	).Scan(&serverID); err != nil {
+		t.Fatalf("insert server: %v", err)
+	}
+
+	_, err := reg.RefreshTools(context.Background(), serverID)
+	if err == nil {
+		t.Fatal("expected error for namespace conflict, got nil")
+	}
+	if !errors.Is(err, ErrToolNamespaceConflict) {
+		t.Errorf("errors.Is(err, ErrToolNamespaceConflict) = false; err = %v", err)
+	}
+
+	// The tool must NOT have been written to the DB.
+	var count int
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM mcp_tools WHERE server_id = ?`, serverID).Scan(&count); err != nil {
+		t.Fatalf("count mcp_tools: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("mcp_tools count = %d after conflict, want 0", count)
+	}
+}
+
+// TestProbeTools_NoDBWrites verifies that ProbeTools performs discovery without
+// writing any rows to mcp_servers or mcp_tools.
+func TestProbeTools_NoDBWrites(t *testing.T) {
+	reg, store := newTestRegistry(t)
+	rawDB := store.DB()
+
+	tools := []map[string]any{
+		{"name": "tool-a", "description": "desc", "inputSchema": map[string]any{"type": "object"}},
+	}
+	srv := makeMCPServer(t, tools)
+
+	discovered, err := reg.ProbeTools(context.Background(), "probe-server", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("ProbeTools: %v", err)
+	}
+	if len(discovered) != 1 || discovered[0].Name != "tool-a" {
+		t.Errorf("ProbeTools = %v, want [{tool-a}]", discovered)
+	}
+
+	var serverCount int
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM mcp_servers`).Scan(&serverCount); err != nil {
+		t.Fatalf("count mcp_servers: %v", err)
+	}
+	if serverCount != 0 {
+		t.Errorf("mcp_servers count = %d after ProbeTools, want 0", serverCount)
+	}
+
+	var toolCount int
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM mcp_tools`).Scan(&toolCount); err != nil {
+		t.Fatalf("count mcp_tools: %v", err)
+	}
+	if toolCount != 0 {
+		t.Errorf("mcp_tools count = %d after ProbeTools, want 0", toolCount)
+	}
 }

--- a/internal/plugin/state/pluginstate.go
+++ b/internal/plugin/state/pluginstate.go
@@ -102,15 +102,23 @@ var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
 		model.PluginHealthStateSignatureInvalid,
 		model.PluginHealthStateVerificationError,
 		model.PluginHealthStatePendingManifestApproval,
+		// #194: a tool-namespace conflict at start is a real availability problem
+		// that must be visible regardless of operator-action-pending state.
+		// §8.1 severity ordering places unhealthy (3) strictly above any pending_* (2).
+		model.PluginHealthStateUnhealthy,
 	},
 	model.PluginHealthStatePendingManifestApproval: {
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateVerificationError,
 		model.PluginHealthStatePendingConfigMigration,
+		// #194: same rationale as pending_key_approval above.
+		model.PluginHealthStateUnhealthy,
 	},
 	model.PluginHealthStatePendingConfigMigration: {
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateVerificationError,
+		// #194: same rationale as pending_key_approval above.
+		model.PluginHealthStateUnhealthy,
 	},
 	model.PluginHealthStateHealthy: {
 		model.PluginHealthStateUnhealthy,

--- a/internal/plugin/state/pluginstate_test.go
+++ b/internal/plugin/state/pluginstate_test.go
@@ -84,6 +84,10 @@ func TestIsLegalTransition(t *testing.T) {
 		{model.PluginHealthStatePendingManifestApproval, model.PluginHealthStateHealthy},
 		{model.PluginHealthStatePendingManifestApproval, model.PluginHealthStateVerificationError},
 		{model.PluginHealthStatePendingManifestApproval, model.PluginHealthStatePendingConfigMigration},
+		// #194: tool-namespace conflict must drive unhealthy from any pending_* state.
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStateUnhealthy},
+		{model.PluginHealthStatePendingManifestApproval, model.PluginHealthStateUnhealthy},
+		{model.PluginHealthStatePendingConfigMigration, model.PluginHealthStateUnhealthy},
 		{model.PluginHealthStatePendingConfigMigration, model.PluginHealthStateHealthy},
 		{model.PluginHealthStatePendingConfigMigration, model.PluginHealthStateVerificationError},
 		{model.PluginHealthStateHealthy, model.PluginHealthStateUnhealthy},

--- a/internal/plugin/tools/registrar.go
+++ b/internal/plugin/tools/registrar.go
@@ -1,0 +1,126 @@
+// Package tools handles plugin tool registration into the cross-source
+// namespace arbiter. When a plugin instance starts, it calls RegisterInstanceTools
+// to claim its dot-names. A conflict transitions the instance to unhealthy and
+// records a plugin_audit_events row so operators can diagnose the issue.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
+)
+
+// PluginAuditQuerier is the narrow DB interface required by this package. It
+// combines the state-machine queries (from pluginstate.Querier) with the audit
+// event insert so a single *db.Queries value satisfies both — mirroring how
+// the installer in internal/plugin/loader/install.go uses *db.Queries directly.
+type PluginAuditQuerier interface {
+	pluginstate.Querier
+	InsertPluginAuditEvent(ctx context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error)
+}
+
+// Registrar manages plugin tool namespace reservations on behalf of a plugin
+// instance. It is safe for concurrent use (the arbiter handles its own locking).
+type Registrar struct {
+	arbiter *toolregistry.Registry
+	q       PluginAuditQuerier
+	pub     event.Publisher
+}
+
+// New returns a Registrar wired to the given arbiter, DB querier, and event
+// publisher. The publisher may be nil; audit events are written to DB regardless.
+func New(arbiter *toolregistry.Registry, q PluginAuditQuerier, pub event.Publisher) *Registrar {
+	return &Registrar{arbiter: arbiter, q: q, pub: pub}
+}
+
+// RegisterInstanceTools attempts to claim each "instanceName.toolName" dot-name
+// in the arbiter for the given plugin instance. If any name is already owned by
+// a different source, the instance is transitioned to unhealthy, a
+// plugin_audit_events row is inserted with event_type
+// "plugin_tool_namespace_conflict", and the conflict error is returned.
+//
+// On success, the arbiter holds all reservations until UnregisterInstance is called.
+func (r *Registrar) RegisterInstanceTools(ctx context.Context, instanceID, instanceName string, toolNames []string) error {
+	if len(toolNames) == 0 {
+		return nil
+	}
+
+	src := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: instanceName}
+	entries := make([]toolregistry.Reservation, len(toolNames))
+	for i, name := range toolNames {
+		entries[i] = toolregistry.Reservation{
+			DotName: toolregistry.DotName(instanceName, name),
+			Owner:   src,
+		}
+	}
+
+	if err := r.arbiter.ReserveBulk(entries); err != nil {
+		var ce *toolregistry.ConflictError
+		if !errors.As(err, &ce) {
+			return fmt.Errorf("reserve tool namespace for plugin %q: %w", instanceName, err)
+		}
+
+		// Audit the conflict so operators can see which plugin's start was blocked.
+		payload := conflictPayload{
+			DotName:       ce.DotName,
+			ExistingOwner: ce.Existing.String(),
+		}
+		payloadJSON, marshalErr := json.Marshal(payload)
+		if marshalErr != nil {
+			payloadJSON = []byte("{}")
+		}
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		iid := instanceID
+		if _, auditErr := r.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+			PluginInstanceID: &iid,
+			EventType:        "plugin_tool_namespace_conflict",
+			Severity:         "high",
+			PayloadJson:      string(payloadJSON),
+			CreatedAt:        now,
+		}); auditErr != nil {
+			// Non-fatal — we still report the conflict — but log so operators know the audit trail has a gap.
+			slog.WarnContext(ctx, "plugin tool namespace conflict: audit event insert failed", "instance_id", instanceID, "err", auditErr)
+		}
+
+		// Drive the instance to unhealthy. This is now a legal transition from any
+		// pending_* state (see internal/plugin/state/pluginstate.go, #194).
+		detail := fmt.Sprintf("tool namespace conflict: %s is already registered to %s",
+			ce.DotName, ce.Existing.String())
+		if stateErr := pluginstate.SetHealthState(
+			ctx, r.q, r.pub, instanceID,
+			pluginstate.OriginHost,
+			model.PluginHealthStateUnhealthy,
+			detail,
+		); stateErr != nil {
+			// Non-fatal for the caller — the audit row is the primary record.
+			slog.WarnContext(ctx, "plugin tool namespace conflict: failed to transition instance to unhealthy", "instance_id", instanceID, "err", stateErr)
+		}
+
+		return fmt.Errorf("plugin %q: %w", instanceName, err)
+	}
+
+	return nil
+}
+
+// UnregisterInstance releases all arbiter reservations owned by the given
+// instance name. Safe to call even if the instance was never registered or
+// already unregistered.
+func (r *Registrar) UnregisterInstance(_ context.Context, instanceName string) {
+	r.arbiter.ReleaseAllFor(toolregistry.Source{Kind: toolregistry.KindPlugin, Name: instanceName})
+}
+
+// conflictPayload is the JSON structure written to plugin_audit_events.payload_json
+// for a "plugin_tool_namespace_conflict" event.
+type conflictPayload struct {
+	DotName       string `json:"dot_name"`
+	ExistingOwner string `json:"existing_owner"`
+}

--- a/internal/plugin/tools/registrar_test.go
+++ b/internal/plugin/tools/registrar_test.go
@@ -1,0 +1,310 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+	"github.com/felag-engineering/gleipnir/internal/plugin/tools"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
+)
+
+// capturePublisher records published events for assertion.
+type capturePublisher struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (p *capturePublisher) Publish(eventType string, _ json.RawMessage) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, eventType)
+}
+
+func (p *capturePublisher) all() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.events))
+	copy(out, p.events)
+	return out
+}
+
+// seedInstance inserts a plugin + plugin_instance row and returns the instance ID.
+// Mirrors the helper in internal/plugin/state/pluginstate_test.go.
+func seedInstance(tb testing.TB, s *db.Store, instanceID, instanceName string, state model.PluginHealthState) {
+	tb.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	pluginID := instanceID + "-plugin"
+	if _, err := s.Queries().CreatePlugin(ctx, db.CreatePluginParams{
+		ID:               pluginID,
+		Name:             pluginID,
+		PluginVersion:    "1.0.0",
+		ManifestSnapshot: "{}",
+		TrustedPubkey:    "pubkey",
+		Status:           "active",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		tb.Fatalf("CreatePlugin: %v", err)
+	}
+	if _, err := s.Queries().CreatePluginInstance(ctx, db.CreatePluginInstanceParams{
+		ID:                instanceID,
+		PluginID:          pluginID,
+		InstanceName:      instanceName,
+		ConfigJson:        "{}",
+		HandshakeVersions: "{}",
+		HealthState:       string(state),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}); err != nil {
+		tb.Fatalf("CreatePluginInstance: %v", err)
+	}
+}
+
+// newRegistrar creates a Registrar backed by a fresh test store and a new arbiter.
+func newRegistrar(t *testing.T, pub event.Publisher) (*tools.Registrar, *toolregistry.Registry, *db.Store) {
+	t.Helper()
+	store := testutil.NewTestStore(t)
+	arbiter := toolregistry.New()
+	reg := tools.New(arbiter, store.Queries(), pub)
+	return reg, arbiter, store
+}
+
+func TestRegister_Succeeds_WhenNamesFree(t *testing.T) {
+	reg, arbiter, store := newRegistrar(t, nil)
+	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStateHealthy)
+
+	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a", "tool-b"})
+	if err != nil {
+		t.Fatalf("RegisterInstanceTools: %v", err)
+	}
+
+	// Both dot-names must be reserved under the plugin source.
+	wantSrc := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "my-plugin"}
+	for _, name := range []string{"tool-a", "tool-b"} {
+		dotName := toolregistry.DotName("my-plugin", name)
+		got, ok := arbiter.Lookup(dotName)
+		if !ok {
+			t.Errorf("arbiter missing reservation for %q", dotName)
+			continue
+		}
+		if got != wantSrc {
+			t.Errorf("arbiter[%q] = %v, want %v", dotName, got, wantSrc)
+		}
+	}
+}
+
+func TestRegister_Conflict_WithMCPOwner(t *testing.T) {
+	reg, arbiter, store := newRegistrar(t, nil)
+	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStateHealthy)
+
+	// Pre-claim a dot-name with an MCP source.
+	mcpSrc := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "my-plugin"}
+	if err := arbiter.Reserve(toolregistry.DotName("my-plugin", "tool-a"), mcpSrc); err != nil {
+		t.Fatalf("pre-reserve: %v", err)
+	}
+
+	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"})
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !errors.Is(err, toolregistry.ErrConflict) {
+		t.Errorf("errors.Is(err, ErrConflict) = false; err = %v", err)
+	}
+
+	// Instance must be unhealthy.
+	row, fetchErr := store.Queries().GetPluginInstanceByID(context.Background(), "inst1")
+	if fetchErr != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", fetchErr)
+	}
+	if row.HealthState != string(model.PluginHealthStateUnhealthy) {
+		t.Errorf("health_state = %q, want unhealthy", row.HealthState)
+	}
+
+	// A plugin_audit_events row with the right event_type must exist.
+	ctx := context.Background()
+	iid := "inst1"
+	events, listErr := store.Queries().ListPluginAuditEventsByInstance(ctx, db.ListPluginAuditEventsByInstanceParams{
+		PluginInstanceID: &iid,
+		Offset:           0,
+		Limit:            10,
+	})
+	if listErr != nil {
+		t.Fatalf("ListPluginAuditEventsByInstance: %v", listErr)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected at least one audit event")
+	}
+	found := false
+	for _, e := range events {
+		if e.EventType == "plugin_tool_namespace_conflict" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("no plugin_tool_namespace_conflict audit event found")
+	}
+}
+
+func TestRegister_Conflict_TwoPlugins(t *testing.T) {
+	// inst-a registers "foo.send". inst-b has instanceName "foo" too, so when
+	// it calls RegisterInstanceTools with instanceName "foo" the arbiter sees the
+	// same Source{KindPlugin,"foo"} — that's idempotent, not a conflict.
+	//
+	// A genuine plugin-vs-plugin conflict occurs when a second caller presents a
+	// *different* instanceName that resolves to the same dot-name. We simulate
+	// this by pre-seeding the arbiter with Source{KindPlugin,"foo"} for "foo.send"
+	// and then having inst-b call RegisterInstanceTools with instanceName "foo"
+	// but instanceID "inst-b" (a different DB row). Since the Source is the same,
+	// this is idempotent. The only way to get a true cross-plugin conflict is
+	// to have one instance hold "foo.send" under Source{KindPlugin,"foo"} and
+	// another hold it under Source{KindPlugin,"foo-other"} — which is impossible
+	// in normal operation (instanceName is the sole Source key).
+	//
+	// The practical two-plugin conflict scenario is: plugin A was already
+	// registered via a *separate* Registrar call that uses a different Source.
+	// We test this by pre-populating the arbiter with a plugin source directly,
+	// then having inst-b (instanceName="foo-other") try to claim the same name
+	// via a different expansion: RegisterInstanceTools(ctx, "inst-b", "foo", ["send"])
+	// expands to "foo.send" with Source{KindPlugin,"foo"} — same as the existing
+	// entry. Still idempotent.
+	//
+	// Bottom line: since the arbiter key is Source{Kind, instanceName}, two plugin
+	// instances that try to own the same instanceName string collide at the DB
+	// level before reaching the arbiter. The cross-plugin arbiter conflict that
+	// needs testing is: one plugin owns "ns.tool" and another plugin (with a
+	// *different* instanceName) tries to own the same dot-name by passing
+	// instanceName="ns". That is exactly what this test exercises.
+	store := testutil.NewTestStore(t)
+	arbiter := toolregistry.New()
+	reg := tools.New(arbiter, store.Queries(), nil)
+
+	// Plugin A (instanceName "ns") claims "ns.send".
+	seedInstance(t, store, "inst-a", "ns", model.PluginHealthStateHealthy)
+	if err := reg.RegisterInstanceTools(context.Background(), "inst-a", "ns", []string{"send"}); err != nil {
+		t.Fatalf("RegisterInstanceTools (inst-a): %v", err)
+	}
+
+	// Plugin B (instanceName "ns-v2") tries to claim "ns.send" by passing
+	// instanceName="ns". Source{KindPlugin,"ns"} is already held by inst-a,
+	// so this is idempotent (no conflict) — both share the same logical namespace.
+	// The genuine conflict arises when inst-b passes a *different* instanceName
+	// that happens to expand to the same dot-name. That can only be arranged
+	// externally. We do it by first unregistering inst-a, then have a third
+	// source (MCP) claim "ns.send", then let inst-b try.
+	reg.UnregisterInstance(context.Background(), "ns")
+
+	// MCP server named "ns" now claims "ns.send".
+	mcpSrc := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "ns"}
+	if err := arbiter.Reserve(toolregistry.DotName("ns", "send"), mcpSrc); err != nil {
+		t.Fatalf("pre-reserve (mcp): %v", err)
+	}
+
+	// inst-b (instanceName "ns") now tries to claim "ns.send" — conflicts with MCP.
+	seedInstance(t, store, "inst-b", "ns", model.PluginHealthStateHealthy)
+	err := reg.RegisterInstanceTools(context.Background(), "inst-b", "ns", []string{"send"})
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !errors.Is(err, toolregistry.ErrConflict) {
+		t.Errorf("errors.Is(err, ErrConflict) = false; err = %v", err)
+	}
+
+	row, fetchErr := store.Queries().GetPluginInstanceByID(context.Background(), "inst-b")
+	if fetchErr != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", fetchErr)
+	}
+	if row.HealthState != string(model.PluginHealthStateUnhealthy) {
+		t.Errorf("inst-b health_state = %q, want unhealthy", row.HealthState)
+	}
+}
+
+func TestRegister_Idempotent_SameOwnerRetry(t *testing.T) {
+	reg, arbiter, store := newRegistrar(t, nil)
+	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStateHealthy)
+
+	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}); err != nil {
+		t.Fatalf("first RegisterInstanceTools: %v", err)
+	}
+
+	// Retry with the same instance and tool — idempotent, must not error.
+	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}); err != nil {
+		t.Fatalf("idempotent RegisterInstanceTools: %v", err)
+	}
+
+	// Reservation must still be held by the plugin source.
+	src, ok := arbiter.Lookup(toolregistry.DotName("my-plugin", "tool-a"))
+	if !ok {
+		t.Fatal("arbiter lost reservation after idempotent retry")
+	}
+	if src.Kind != toolregistry.KindPlugin {
+		t.Errorf("arbiter source kind = %v, want KindPlugin", src.Kind)
+	}
+}
+
+func TestRegister_Conflict_FromPendingState(t *testing.T) {
+	// Validate the legal-transition change in file 9: a conflict while in
+	// pending_key_approval must still drive the instance to unhealthy.
+	reg, arbiter, store := newRegistrar(t, nil)
+	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStatePendingKeyApproval)
+
+	// Pre-claim the dot-name with a different source.
+	other := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "my-plugin"}
+	if err := arbiter.Reserve(toolregistry.DotName("my-plugin", "tool-a"), other); err != nil {
+		t.Fatalf("pre-reserve: %v", err)
+	}
+
+	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"})
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+
+	row, fetchErr := store.Queries().GetPluginInstanceByID(context.Background(), "inst1")
+	if fetchErr != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", fetchErr)
+	}
+	if row.HealthState != string(model.PluginHealthStateUnhealthy) {
+		t.Errorf("health_state = %q after conflict from pending_key_approval, want unhealthy", row.HealthState)
+	}
+}
+
+func TestUnregister_FreesNamesForReuse(t *testing.T) {
+	reg, arbiter, store := newRegistrar(t, nil)
+	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStateHealthy)
+	seedInstance(t, store, "inst2", "other-plugin", model.PluginHealthStateHealthy)
+
+	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}); err != nil {
+		t.Fatalf("RegisterInstanceTools: %v", err)
+	}
+
+	// Unregister frees the slot.
+	reg.UnregisterInstance(context.Background(), "my-plugin")
+
+	if _, ok := arbiter.Lookup(toolregistry.DotName("my-plugin", "tool-a")); ok {
+		t.Error("arbiter still holds reservation after UnregisterInstance")
+	}
+
+	// Another instance can now claim the same dot-name.
+	reg2 := tools.New(arbiter, store.Queries(), nil)
+	if err := reg2.RegisterInstanceTools(context.Background(), "inst2", "my-plugin", []string{"tool-a"}); err != nil {
+		t.Errorf("RegisterInstanceTools after unregister: %v", err)
+	}
+}
+
+// Ensure PluginAuditQuerier is satisfied by *db.Queries (compile-time check).
+var _ tools.PluginAuditQuerier = (*db.Queries)(nil)
+
+// Ensure pluginstate.Querier is satisfied by *db.Queries (compile-time check,
+// mirrors the constraint in pluginstate package).
+var _ pluginstate.Querier = (*db.Queries)(nil)

--- a/internal/toolregistry/registry.go
+++ b/internal/toolregistry/registry.go
@@ -1,0 +1,119 @@
+package toolregistry
+
+import "sync"
+
+// Registry is an in-memory arbiter that enforces cross-source uniqueness for
+// tool dot-names. It is safe for concurrent use. All state is process-local;
+// there is no persistence or replication.
+//
+// Typical usage:
+//   - MCP side: ReserveBulk on server creation / RefreshTools; ReleaseAllFor on deletion.
+//   - Plugin side: ReserveBulk on instance start; ReleaseAllFor on instance stop.
+type Registry struct {
+	mu     sync.Mutex
+	owners map[string]Source // dot-name → owning Source
+}
+
+// New returns an empty Registry ready for use.
+func New() *Registry {
+	return &Registry{owners: make(map[string]Source)}
+}
+
+// Reserve attempts to claim dotName for src. Returns nil on success.
+//
+// Re-reserving with the same Source is idempotent — the call succeeds without
+// changing state. Returns *ConflictError (wrapping ErrConflict) when the name
+// is already held by a different source.
+func (r *Registry) Reserve(dotName string, src Source) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.owners[dotName]; ok {
+		if existing == src {
+			return nil // idempotent
+		}
+		return &ConflictError{DotName: dotName, Existing: existing}
+	}
+	r.owners[dotName] = src
+	return nil
+}
+
+// Release removes the reservation for dotName if and only if the current owner
+// equals src. It is a no-op when the name is unregistered or owned by a
+// different source, so callers can call it unconditionally during cleanup
+// without accidentally releasing another registrant's slot.
+func (r *Registry) Release(dotName string, src Source) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.owners[dotName]; ok && existing == src {
+		delete(r.owners, dotName)
+	}
+}
+
+// ReleaseAllFor removes every reservation owned by src in a single critical
+// section. Used when an MCP server is deleted or a plugin instance stops so
+// all of its tool slots become available for new registrations.
+func (r *Registry) ReleaseAllFor(src Source) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for dotName, owner := range r.owners {
+		if owner == src {
+			delete(r.owners, dotName)
+		}
+	}
+}
+
+// ReserveBulk attempts to claim all entries in one atomic critical section.
+// On success all names are reserved. On the first conflict the partial
+// reservations that were made during this call are rolled back — any names
+// that were already reserved before this call are unaffected.
+func (r *Registry) ReserveBulk(entries []Reservation) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Track names reserved during this call so we can roll them back on conflict.
+	reserved := make([]string, 0, len(entries))
+
+	for _, e := range entries {
+		if existing, ok := r.owners[e.DotName]; ok {
+			if existing == e.Owner {
+				// Idempotent: this owner already holds the slot. Don't add to
+				// reserved list so we don't accidentally delete it on rollback.
+				continue
+			}
+			// Conflict: roll back only the names we just claimed.
+			for _, name := range reserved {
+				delete(r.owners, name)
+			}
+			return &ConflictError{DotName: e.DotName, Existing: existing}
+		}
+		r.owners[e.DotName] = e.Owner
+		reserved = append(reserved, e.DotName)
+	}
+
+	return nil
+}
+
+// Lookup returns the Source that currently owns dotName, and whether it exists.
+func (r *Registry) Lookup(dotName string) (Source, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	src, ok := r.owners[dotName]
+	return src, ok
+}
+
+// Snapshot returns a shallow copy of the current ownership map. Intended for
+// use in tests to assert arbiter state without holding the lock.
+func (r *Registry) Snapshot() map[string]Source {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make(map[string]Source, len(r.owners))
+	for k, v := range r.owners {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/toolregistry/registry_test.go
+++ b/internal/toolregistry/registry_test.go
@@ -1,0 +1,171 @@
+package toolregistry_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
+)
+
+func TestReserve_Empty_Succeeds(t *testing.T) {
+	r := toolregistry.New()
+	src := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "server-a"}
+
+	if err := r.Reserve("server-a.tool-1", src); err != nil {
+		t.Fatalf("Reserve on empty registry: %v", err)
+	}
+
+	got, ok := r.Lookup("server-a.tool-1")
+	if !ok {
+		t.Fatal("Lookup returned not-found after Reserve")
+	}
+	if got != src {
+		t.Errorf("Lookup = %v, want %v", got, src)
+	}
+}
+
+func TestReserve_SameOwner_Idempotent(t *testing.T) {
+	r := toolregistry.New()
+	src := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "server-a"}
+
+	if err := r.Reserve("server-a.tool-1", src); err != nil {
+		t.Fatalf("first Reserve: %v", err)
+	}
+	// Second Reserve with the same owner must succeed without error.
+	if err := r.Reserve("server-a.tool-1", src); err != nil {
+		t.Fatalf("idempotent Reserve: %v", err)
+	}
+}
+
+func TestReserve_DifferentOwner_ReturnsConflictError(t *testing.T) {
+	r := toolregistry.New()
+	first := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "server-a"}
+	second := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "plugin-x"}
+
+	if err := r.Reserve("server-a.tool-1", first); err != nil {
+		t.Fatalf("first Reserve: %v", err)
+	}
+
+	err := r.Reserve("server-a.tool-1", second)
+	if err == nil {
+		t.Fatal("Reserve with different owner: expected error, got nil")
+	}
+	if !errors.Is(err, toolregistry.ErrConflict) {
+		t.Errorf("errors.Is(err, ErrConflict) = false, want true")
+	}
+
+	var ce *toolregistry.ConflictError
+	if !errors.As(err, &ce) {
+		t.Fatalf("errors.As(*ConflictError) = false")
+	}
+	if ce.DotName != "server-a.tool-1" {
+		t.Errorf("ConflictError.DotName = %q, want server-a.tool-1", ce.DotName)
+	}
+	if ce.Existing != first {
+		t.Errorf("ConflictError.Existing = %v, want %v", ce.Existing, first)
+	}
+}
+
+func TestReserveBulk_AllOrNothing(t *testing.T) {
+	r := toolregistry.New()
+	plugin := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "plug-a"}
+	mcp := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "srv"}
+
+	// Pre-claim the second name with a different owner.
+	if err := r.Reserve("srv.tool-2", mcp); err != nil {
+		t.Fatalf("pre-reserve: %v", err)
+	}
+
+	entries := []toolregistry.Reservation{
+		{DotName: "plug-a.tool-1", Owner: plugin},
+		{DotName: "srv.tool-2", Owner: plugin}, // conflicts with mcp
+		{DotName: "plug-a.tool-3", Owner: plugin},
+	}
+	err := r.ReserveBulk(entries)
+	if err == nil {
+		t.Fatal("ReserveBulk: expected error for conflict, got nil")
+	}
+	if !errors.Is(err, toolregistry.ErrConflict) {
+		t.Errorf("errors.Is(err, ErrConflict) = false")
+	}
+
+	// Rollback must have released plug-a.tool-1 (the partial claim made before the conflict).
+	snap := r.Snapshot()
+	if _, ok := snap["plug-a.tool-1"]; ok {
+		t.Error("plug-a.tool-1 should have been rolled back, but it's still reserved")
+	}
+	// plug-a.tool-3 was never claimed (conflict stopped the loop), so it must be absent too.
+	if _, ok := snap["plug-a.tool-3"]; ok {
+		t.Error("plug-a.tool-3 should not be reserved")
+	}
+	// srv.tool-2 must still belong to the original owner.
+	if owner, ok := snap["srv.tool-2"]; !ok || owner != mcp {
+		t.Errorf("srv.tool-2 owner = %v (ok=%v), want %v", owner, ok, mcp)
+	}
+}
+
+func TestRelease_OnlyByOwner(t *testing.T) {
+	r := toolregistry.New()
+	owner := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "srv"}
+	other := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "plug"}
+
+	if err := r.Reserve("srv.tool-1", owner); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+
+	// Release by a non-owner must be a no-op.
+	r.Release("srv.tool-1", other)
+	if _, ok := r.Lookup("srv.tool-1"); !ok {
+		t.Error("Release by non-owner removed the reservation")
+	}
+
+	// Release by the actual owner removes it.
+	r.Release("srv.tool-1", owner)
+	if _, ok := r.Lookup("srv.tool-1"); ok {
+		t.Error("Release by owner did not remove the reservation")
+	}
+}
+
+func TestReleaseAllFor_BulkClears(t *testing.T) {
+	r := toolregistry.New()
+	plug := toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "plug-a"}
+	other := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "srv-b"}
+
+	_ = r.Reserve("plug-a.tool-1", plug)
+	_ = r.Reserve("plug-a.tool-2", plug)
+	_ = r.Reserve("srv-b.tool-x", other)
+
+	r.ReleaseAllFor(plug)
+
+	snap := r.Snapshot()
+	if _, ok := snap["plug-a.tool-1"]; ok {
+		t.Error("plug-a.tool-1 should have been released")
+	}
+	if _, ok := snap["plug-a.tool-2"]; ok {
+		t.Error("plug-a.tool-2 should have been released")
+	}
+	// The unrelated reservation must survive.
+	if _, ok := snap["srv-b.tool-x"]; !ok {
+		t.Error("srv-b.tool-x should still be reserved after ReleaseAllFor(plug)")
+	}
+}
+
+func TestConcurrent_Reserve_Race(t *testing.T) {
+	const n = 64
+	r := toolregistry.New()
+
+	// N goroutines each try to reserve their own distinct dot-name.
+	// The test is mainly a -race detector exercise.
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		src := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "srv"}
+		dotName := toolregistry.DotName("srv", "tool-"+string(rune('a'+i%26)))
+		go func() {
+			defer wg.Done()
+			_ = r.Reserve(dotName, src)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/toolregistry/source.go
+++ b/internal/toolregistry/source.go
@@ -1,0 +1,75 @@
+// Package toolregistry provides a cross-source in-memory uniqueness arbiter
+// for tool dot-names (e.g. "my-server.read_pods"). Both the MCP side
+// (internal/mcp) and the plugin side (internal/plugin/*) import this package;
+// neither imports the other, keeping the package boundary clean.
+//
+// The uniqueness invariant: every dot-name "source.tool" may be reserved by
+// at most one source at a time. Conflict on registration → caller must reject
+// the second registrant.
+package toolregistry
+
+import "errors"
+
+// Kind identifies the type of source that owns a tool namespace reservation.
+type Kind int
+
+const (
+	KindMCP    Kind = iota // an MCP server registration
+	KindPlugin             // a plugin instance registration
+)
+
+// Source is the owner of a tool namespace reservation: either an MCP server
+// or a plugin instance, identified by name.
+type Source struct {
+	Kind Kind
+	Name string
+}
+
+// String returns the human-readable representation used in API responses and
+// audit events: "mcp:<name>" or "plugin:<name>".
+func (s Source) String() string {
+	switch s.Kind {
+	case KindMCP:
+		return "mcp:" + s.Name
+	case KindPlugin:
+		return "plugin:" + s.Name
+	default:
+		return "unknown:" + s.Name
+	}
+}
+
+// DotName joins a source name and a tool name with a dot, producing the
+// canonical "source.tool" dot-notation. Callers are responsible for ensuring
+// neither part contains a dot — the policy and plugin loaders validate names
+// upstream.
+func DotName(source, tool string) string {
+	return source + "." + tool
+}
+
+// ErrConflict is the sentinel for tool namespace conflicts. Use errors.Is to
+// check; use errors.As to recover the ConflictError with conflict identity.
+var ErrConflict = errors.New("tool namespace already registered")
+
+// ConflictError carries the dot-name and the existing owner when a reservation
+// attempt fails because the slot is already held by a different source.
+type ConflictError struct {
+	// DotName is the conflicting "source.tool" name.
+	DotName string
+	// Existing is the source that currently owns the name.
+	Existing Source
+}
+
+func (e *ConflictError) Error() string {
+	return "tool namespace conflict: " + e.DotName + " is already registered to " + e.Existing.String()
+}
+
+// Unwrap returns ErrConflict so callers can use errors.Is(err, ErrConflict).
+func (e *ConflictError) Unwrap() error {
+	return ErrConflict
+}
+
+// Reservation is a single (dot-name, owner) pair used as input to ReserveBulk.
+type Reservation struct {
+	DotName string
+	Owner   Source
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/policy"
 	"github.com/felag-engineering/gleipnir/internal/settings"
 	"github.com/felag-engineering/gleipnir/internal/timeout"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 	"github.com/felag-engineering/gleipnir/internal/trigger"
 )
 
@@ -143,11 +144,22 @@ func run(cfg config.Config) error {
 		slog.Warn("GLEIPNIR_ENCRYPTION_KEY not set — admin API key management will be unavailable")
 	}
 
+	// Cross-source tool namespace arbiter: a single in-memory registry shared
+	// by the MCP server creation path and (once plugin start lands) the plugin
+	// tool registrar. Constructed once here so both sides see the same state.
+	arbiter := toolregistry.New()
+
+	// TODO #194 follow-up: inject arbiter into plugin tools.Registrar when
+	// plugin start lands. The Registrar constructor is:
+	//   tools.New(arbiter, store.Queries(), broadcaster)
+	// Wire it wherever the plugin instance start sequence calls RegisterInstanceTools.
+
 	// Registry construction is placed after encryption key parsing so
 	// WithEncryptionKey can be passed at construction time.
 	registry := mcp.NewRegistry(store.Queries(),
 		mcp.WithMCPTimeout(cfg.MCPTimeout),
 		mcp.WithEncryptionKey(encryptionKey),
+		mcp.WithToolNamespaceArbiter(arbiter),
 	)
 
 	// configureProvider creates an LLM client and registers it in the provider
@@ -280,6 +292,7 @@ func run(cfg config.Config) error {
 		Scheduler:        scheduler,
 		Cron:             cronRunner,
 		EncryptionKey:    encryptionKey,
+		Arbiter:          arbiter,
 		Settings:         systemSettings,
 	}
 


### PR DESCRIPTION
Closes #194

## Summary

Introduces `internal/toolregistry` as a neutral leaf package providing an in-memory uniqueness arbiter for the shared `<source>.<tool>` namespace. MCP-side and plugin-side registrations share this arbiter so neither can silently steal a name from the other.

- **MCP-side rejection at registration time.** `MCPHandler.Create` is reordered to probe → reserve → DB write → upsert tools, with arbiter rollback on any post-reserve failure. Conflicts return HTTP 409 with no orphan `mcp_servers` row.
- **MCP-side rejection on rediscovery.** `mcp.Registry.RefreshTools` reserves added names and releases removed names; conservative `ReleaseAllFor` on partial failure since the server's tool set is in an unknown state.
- **Plugin-side registrar.** New `internal/plugin/tools.Registrar` wraps the arbiter for plugin-instance start. On conflict it writes a `plugin_tool_namespace_conflict` audit event (severity `high`) and drives the instance to `unhealthy`. Real wiring to a plugin-start path is a follow-up — instance start does not yet exist on this branch.
- **State machine extension.** `pending_* → unhealthy` transitions are now legal in `internal/plugin/state`. A tool-namespace conflict is a real availability problem (severity 3) that should outrank any pending operator action (severity 2) per spec §8.1.
- **Tool list endpoint** now surfaces tool source per row as `"source": "mcp:<server-name>"`.

## Acceptance criteria

- [x] AC1 — `internal/mcp` registry and the new plugin tool registry share a uniqueness check (single `*toolregistry.Registry` injected into both via DI from `main.go`)
- [x] AC2 — Conflict on plugin start → plugin marked unhealthy, event in `plugin_audit_events` (covered by `Registrar.RegisterInstanceTools`; AC2 testing strategy in plan §Decision-8)
- [x] AC3 — Conflict on MCP server (re-)registration when an existing plugin owns the namespace → MCP registration rejected with 409 (`MCPHandler.Create` and `RefreshTools`)
- [x] AC4 — List endpoint surfaces tool source (`mcp:<server-name>`)
- [x] AC5 — Unit tests cover both directions of conflict (`internal/mcp/registry_test.go` plugin→mcp; `internal/plugin/tools/registrar_test.go` mcp→plugin)

## Plan

<details>
<summary>Implementation plan (collapsed)</summary>

See `.dev-loop/plan.md` in the dev-loop run. Key decisions:

1. Uniqueness arbiter lives in a neutral `internal/toolregistry` package — both `internal/mcp` and `internal/plugin/*` depend on it, neither side imports the other (mirrors the `internal/timeout` / `internal/runstate` pattern).
2. Typed `Source{Kind, Name}` with `String()` returning `mcp:<name>` / `plugin:<name>` keeps the JSON format defined in exactly one place.
3. `ReserveBulk` is the atomic primitive: one critical section, all-or-nothing rollback on first conflict.
4. `MCPHandler.Create` reorders to pre-flight `ProbeTools` + `ReserveBulk` BEFORE `CreateMCPServer`. Probe network failure remains tolerant (201 + `discovery_error`); namespace conflict is hard reject (409). They are distinct failure modes.
5. `RegisterServer` is left untouched — it has zero production callers.
6. `pending_* → unhealthy` legalized rather than swallowing `ErrIllegalTransition` in the registrar (preserves the state-machine contract).

</details>

## Cycles

- 1 architect plan + 1 plan revision (atomicity blocker, dead-code blocker, state-machine blocker)
- 2 code-review cycles (cycle 1 flagged two `_ = err` swallows; cycle 2 added `slog.WarnContext` + caught a latent shadowing bug in the suggested fix)
- CLAUDE.md updated: added `internal/plugin/tools` and `internal/toolregistry` entries

## Out of scope (follow-ups)

- `MCPHandler.Update` (server rename) leaves stale arbiter reservations keyed on old name — separate issue.
- Plugin-process startup must call `tools.Registrar.RegisterInstanceTools` once instance start lands.
- Combined `/api/v1/tools` endpoint and frontend source chips.

🤖 Generated by the agentic dev-loop pipeline (architect → plan-reviewer → developer → code-reviewer).