### PR TITLE
feat(agent): capability snapshot includes plugin-source tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ internal/
   plugin/             — host-side plugin loader; gated by GLEIPNIR_PLUGINS_ENABLED. Implements fsnotify watcher, tarball extractor, minisign verifier, and DB installer. Out-of-process subprocess spawning and generation refcounts remain as follow-up work.
     state/            — per-instance health-state machine; mirrors execution/runstate (transition table + version-CAS, ADR-038). Severity ranking encodes §8.1 "plugin can only mark itself worse" merge rule.
     manifest/         — host-side manifest diff (material vs cosmetic) consumed by the loader on hot-reload (spec §5.4). Schema-shape comparison strips `description`/`default` keys at every depth; depends only on plugin-sdk/manifest + stdlib.
-    tools/            — plugin-side tool registrar; reserves `<instance>.<tool>` names with `internal/toolregistry`, writes `plugin_tool_namespace_conflict` audit events on collision, and drives the instance to `unhealthy` (issue #194).
+    tools/            — plugin-side tool registrar; reserves `<instance>.<tool>` names with `internal/toolregistry`, writes `plugin_tool_namespace_conflict` audit events on collision, drives the instance to `unhealthy` (issue #194), and tracks per-instance generation consulted by `internal/execution/agent` to fail tool calls bound to a replaced generation with a structural error (issue #195, ADR-018).
   policy/             — YAML parser, validator, system prompt renderer
   settings/           — read-side accessor for system_settings (default model, public URL); injected into runtime so non-admin packages don't depend on the admin HTTP handler
   testutil/           — shared test helpers

--- a/internal/execution/agent/agent.go
+++ b/internal/execution/agent/agent.go
@@ -19,24 +19,49 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/policy"
 )
 
+// PluginGenerationLookup is the narrow interface the agent uses to verify a
+// plugin tool's generation is still active at call time. *tools.Registrar from
+// internal/plugin/tools satisfies this interface structurally — the agent does
+// NOT import that package to preserve the package boundary.
+type PluginGenerationLookup interface {
+	Generation(instanceName string) (int64, bool)
+}
+
+// PluginToolEntry describes a single plugin-backed tool to expose to the agent.
+// New() derives both the dispatch-side toolsByName entry and the snapshot-side
+// pluginGrantedTools slice from this single input (decision (f) in plan).
+type PluginToolEntry struct {
+	InstanceName string
+	ToolName     string
+	Generation   int64
+	Description  string
+	Schema       map[string]any
+	Approval     model.ApprovalMode
+	Params       map[string]any // narrowed schema per ADR-017
+}
+
 // BoundAgent executes a single policy run. It owns the LLM API loop,
 // dispatches tool calls to MCP clients, intercepts approval-gated tools,
 // and writes every step to the audit trail via AuditWriter.
 type BoundAgent struct {
-	policy      *model.ParsedPolicy
-	tools       []mcp.ResolvedTool
-	toolsByName map[string]resolvedToolEntry
-	llmClient   llm.LLMClient
-	audit       *AuditWriter
-	sm          *RunStateMachine
-	approvals   *ApprovalHandler
-	feedback    *FeedbackHandler
+	policy             *model.ParsedPolicy
+	tools              []mcp.ResolvedTool
+	toolsByName        map[string]resolvedToolEntry
+	pluginGrantedTools []model.GrantedTool // snapshot entries for plugin-source tools
+	pluginRegistrar    PluginGenerationLookup
+	llmClient          llm.LLMClient
+	audit              *AuditWriter
+	sm                 *RunStateMachine
+	approvals          *ApprovalHandler
+	feedback           *FeedbackHandler
 }
 
 // Config holds the dependencies needed to construct a BoundAgent.
 type Config struct {
 	Policy                 *model.ParsedPolicy
 	Tools                  []mcp.ResolvedTool
+	PluginTools            []PluginToolEntry      // plugin-backed tools; requires PluginRegistrar when non-empty
+	PluginRegistrar        PluginGenerationLookup // may be nil when PluginTools is empty
 	LLMClient              llm.LLMClient
 	Audit                  *AuditWriter
 	ApprovalCh             <-chan bool
@@ -45,10 +70,16 @@ type Config struct {
 }
 
 // New returns a BoundAgent ready to run, or an error if schema narrowing fails
-// for any of the provided tools.
+// for any of the provided tools. Panics if PluginTools is non-empty but
+// PluginRegistrar is nil — this invariant simplifies handleToolCall (when
+// entry.pluginSource != nil, the registrar is guaranteed non-nil).
 func New(cfg Config) (*BoundAgent, error) {
 	if cfg.StateMachine == nil {
 		return nil, fmt.Errorf("config.StateMachine is required")
+	}
+
+	if len(cfg.PluginTools) > 0 && cfg.PluginRegistrar == nil {
+		panic("agent.Config: PluginTools is non-empty but PluginRegistrar is nil — provide a PluginGenerationLookup")
 	}
 
 	toolsByName, err := buildResolvedToolMap(cfg.Tools)
@@ -56,15 +87,56 @@ func New(cfg Config) (*BoundAgent, error) {
 		return nil, err
 	}
 
+	// Derive dispatch-side entries and snapshot-side granted tools from plugin
+	// tool configs in a single pass (plan decision (f)).
+	pluginGrantedTools := make([]model.GrantedTool, 0, len(cfg.PluginTools))
+	for _, pt := range cfg.PluginTools {
+		dotName := pt.InstanceName + "." + pt.ToolName
+
+		schemaJSON, err := json.Marshal(pt.Schema)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling schema for plugin tool %s: %w", dotName, err)
+		}
+
+		toolsByName[dotName] = resolvedToolEntry{
+			tool: mcp.ResolvedTool{
+				GrantedTool: model.GrantedTool{
+					ServerName: "", // no MCP server; plugin dispatch is via pluginSource
+					ToolName:   pt.ToolName,
+					Approval:   pt.Approval,
+					Params:     pt.Params,
+				},
+				Client:      nil, // real dispatch wired in #198
+				Description: pt.Description,
+				InputSchema: schemaJSON,
+			},
+			narrowedSchema: schemaJSON,
+			pluginSource: &pluginToolSource{
+				InstanceName: pt.InstanceName,
+				Generation:   pt.Generation,
+			},
+		}
+
+		pluginGrantedTools = append(pluginGrantedTools, model.GrantedTool{
+			ServerName: "",
+			ToolName:   pt.ToolName,
+			Approval:   pt.Approval,
+			Params:     pt.Params,
+			Source:     sourceString(toolsByName[dotName]),
+		})
+	}
+
 	return &BoundAgent{
-		policy:      cfg.Policy,
-		tools:       cfg.Tools,
-		toolsByName: toolsByName,
-		llmClient:   cfg.LLMClient,
-		audit:       cfg.Audit,
-		sm:          cfg.StateMachine,
-		approvals:   NewApprovalHandler(cfg.Audit, cfg.StateMachine, cfg.ApprovalCh),
-		feedback:    NewFeedbackHandler(cfg.Audit, cfg.StateMachine, cfg.DefaultFeedbackTimeout),
+		policy:             cfg.Policy,
+		tools:              cfg.Tools,
+		toolsByName:        toolsByName,
+		pluginGrantedTools: pluginGrantedTools,
+		pluginRegistrar:    cfg.PluginRegistrar,
+		llmClient:          cfg.LLMClient,
+		audit:              cfg.Audit,
+		sm:                 cfg.StateMachine,
+		approvals:          NewApprovalHandler(cfg.Audit, cfg.StateMachine, cfg.ApprovalCh),
+		feedback:           NewFeedbackHandler(cfg.Audit, cfg.StateMachine, cfg.DefaultFeedbackTimeout),
 	}, nil
 }
 
@@ -371,20 +443,26 @@ func (a *BoundAgent) Run(ctx context.Context, runID string, triggerPayload strin
 		return fmt.Errorf("transitioning run to running: %w", err)
 	}
 
-	// Extract granted tools for system prompt rendering.
+	// Extract granted tools for system prompt rendering, populating the Source
+	// field so the capability snapshot identifies each tool's origin.
 	grantedTools := make([]model.GrantedTool, len(a.tools))
 	for i, rt := range a.tools {
-		grantedTools[i] = rt.GrantedTool
+		gt := rt.GrantedTool // copy: GrantedTool is a value type
+		gt.Source = sourceString(resolvedToolEntry{tool: rt})
+		grantedTools[i] = gt
 	}
 	// Include the synthetic ask_operator tool in the capability snapshot when
 	// feedback is enabled, so the audit trail reflects the full set of tools
-	// available to the agent at run start.
+	// available to the agent at run start. Source is intentionally empty for
+	// synthetic tools (they have no MCP server or plugin instance).
 	if a.policy.Capabilities.Feedback.Enabled {
 		grantedTools = append(grantedTools, model.GrantedTool{
 			ServerName: "gleipnir",
 			ToolName:   "ask_operator",
 		})
 	}
+	// Append plugin-source tools; their Source strings were set at New() time.
+	grantedTools = append(grantedTools, a.pluginGrantedTools...)
 
 	// Render system prompt (ADR-001: only granted tools are visible to the agent).
 	systemPrompt := policy.RenderSystemPrompt(a.policy, grantedTools, time.Now().UTC())
@@ -454,6 +532,37 @@ func (a *BoundAgent) handleToolCall(ctx context.Context, runID, toolName string,
 		return "", false, err
 	}
 
+	// Plugin generation guard: verify the plugin instance that provided this tool
+	// is still active and on the same generation captured in the snapshot. If not,
+	// write a tool_result structural error (same shape as MCP transport failures)
+	// so the agent can reason about it. No tool_call step is written first —
+	// the call never reached a server.
+	//
+	// The registrar is guaranteed non-nil when entry.pluginSource != nil because
+	// New() panics if PluginTools is non-empty without a PluginRegistrar.
+	if entry.pluginSource != nil {
+		active, registered := a.pluginRegistrar.Generation(entry.pluginSource.InstanceName)
+		if !registered || active != entry.pluginSource.Generation {
+			msg := fmt.Sprintf("plugin generation %d for instance %q is no longer active",
+				entry.pluginSource.Generation, entry.pluginSource.InstanceName)
+			if writeErr := a.audit.Write(ctx, Step{
+				RunID: runID,
+				Type:  model.StepTypeToolResult,
+				Content: map[string]any{
+					"tool_name": toolName,
+					"output":    msg,
+					"is_error":  true,
+				},
+			}); writeErr != nil {
+				return "", false, fmt.Errorf("writing plugin generation mismatch tool_result: %w", writeErr)
+			}
+			return msg, true, nil
+		}
+		// Generation matches — real dispatch is not yet wired (#198).
+		// server_id would be empty for plugin entries (no MCP server).
+		return "", false, errPluginDispatchUnimplemented
+	}
+
 	// Validate input against narrowed schema.
 	if err := mcp.ValidateCall(entry.narrowedSchema, input); err != nil {
 		a.logAuditError(ctx, runID, err.Error(), model.ErrorCodeSchemaViolation)
@@ -469,7 +578,9 @@ func (a *BoundAgent) handleToolCall(ctx context.Context, runID, toolName string,
 		}
 	}
 
-	// Write tool_call step.
+	// Write tool_call step. server_id is the MCP ServerName for MCP-source tools;
+	// it would be empty for plugin entries — but plugin tools are intercepted above
+	// before this point, so only MCP tools reach here (#198 will wire plugin dispatch).
 	if err := a.audit.Write(ctx, Step{
 		RunID: runID,
 		Type:  model.StepTypeToolCall,

--- a/internal/execution/agent/agent_test.go
+++ b/internal/execution/agent/agent_test.go
@@ -717,10 +717,14 @@ func TestRun_CapabilitySnapshotFirst(t *testing.T) {
 	pol.Agent.ModelConfig.Provider = "anthropic"
 	pol.Agent.ModelConfig.Name = "claude-sonnet-4-6"
 
+	// Use an MCP tool so we can assert its source is "mcp:<server>".
+	fakeSrv := makeToolCallServer(t, json.RawMessage(`[{"type":"text","text":"ok"}]`), false)
+	mcpTool := makeResolvedTool(fakeSrv.URL, "my-server", "read_data")
+
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
 		LLMClient:    testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 5)),
-		Tools:        nil,
+		Tools:        []mcp.ResolvedTool{mcpTool},
 		Policy:       pol,
 		Audit:        w,
 		StateMachine: NewRunStateMachine("r1", model.RunStatusPending, s.DB(), s.Queries()),
@@ -748,10 +752,11 @@ func TestRun_CapabilitySnapshotFirst(t *testing.T) {
 		t.Errorf("capability snapshot token cost = %d, want 0", first.TokenCost)
 	}
 
-	// Verify provider and model are recorded in the snapshot content JSON.
+	// Verify provider, model, and MCP tool source are recorded in the snapshot.
 	type snapshotContent struct {
-		Provider string `json:"provider"`
-		Model    string `json:"model"`
+		Provider string              `json:"provider"`
+		Model    string              `json:"model"`
+		Tools    []model.GrantedTool `json:"tools"`
 	}
 	var snap snapshotContent
 	if err := json.Unmarshal([]byte(first.Content), &snap); err != nil {
@@ -762,6 +767,16 @@ func TestRun_CapabilitySnapshotFirst(t *testing.T) {
 	}
 	if snap.Model != "claude-sonnet-4-6" {
 		t.Errorf("snapshot model = %q, want %q", snap.Model, "claude-sonnet-4-6")
+	}
+	// Every MCP-source tool must carry source = "mcp:<serverName>".
+	for _, gt := range snap.Tools {
+		if gt.ServerName == "" {
+			continue // synthetic tools have empty server name; skip
+		}
+		wantSource := "mcp:" + gt.ServerName
+		if gt.Source != wantSource {
+			t.Errorf("tool %q source = %q, want %q", gt.ToolName, gt.Source, wantSource)
+		}
 	}
 }
 
@@ -2206,6 +2221,10 @@ func TestCapabilitySnapshot_IncludesAskOperator(t *testing.T) {
 	for _, gt := range snap.Tools {
 		if gt.ServerName == "gleipnir" && gt.ToolName == "ask_operator" {
 			found = true
+			// Synthetic tools must have empty Source — they have no MCP server or plugin instance.
+			if gt.Source != "" {
+				t.Errorf("gleipnir.ask_operator source = %q, want empty string", gt.Source)
+			}
 		}
 	}
 	if !found {
@@ -2882,5 +2901,252 @@ func TestRun_MCPTransportError_BecomesToolResult(t *testing.T) {
 	}
 	if foundErrorStep {
 		t.Error("transport error should NOT produce an error step — it should be a tool_result")
+	}
+}
+
+// fakePluginRegistrar is a test double for PluginGenerationLookup.
+type fakePluginRegistrar struct {
+	activeGen  int64
+	registered bool
+}
+
+func (f *fakePluginRegistrar) Generation(_ string) (int64, bool) {
+	return f.activeGen, f.registered
+}
+
+func TestNew_PanicsWhenPluginToolsWithoutRegistrar(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when PluginTools is non-empty and PluginRegistrar is nil")
+		}
+	}()
+	s := testutil.NewTestStore(t)
+	_, _ = New(Config{
+		Policy:       minimalPolicy(),
+		Tools:        nil,
+		PluginTools:  []PluginToolEntry{{InstanceName: "my-plugin", ToolName: "do-thing", Generation: 1}},
+		PluginRegistrar: nil, // intentionally nil — must panic
+		LLMClient:    testutil.NewNoopLLMClient(),
+		Audit:        NewAuditWriter(s.Queries()),
+		StateMachine: NewRunStateMachine("r1", model.RunStatusPending, s.DB(), s.Queries()),
+	})
+}
+
+func TestCapabilitySnapshot_IncludesPluginSourceTools(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusPending)
+
+	fakeSrv := makeToolCallServer(t, json.RawMessage(`[{"type":"text","text":"ok"}]`), false)
+	mcpTool := makeResolvedTool(fakeSrv.URL, "mcp-server", "mcp-tool")
+
+	registrar := &fakePluginRegistrar{activeGen: 1, registered: true}
+
+	w := NewAuditWriter(s.Queries())
+	ba, err := New(Config{
+		LLMClient: testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 5, 5)),
+		Tools:     []mcp.ResolvedTool{mcpTool},
+		PluginTools: []PluginToolEntry{
+			{InstanceName: "my-plugin", ToolName: "do-thing", Generation: 1, Description: "a plugin tool"},
+		},
+		PluginRegistrar: registrar,
+		Policy:          minimalPolicy(),
+		Audit:           w,
+		StateMachine:    NewRunStateMachine("r1", model.RunStatusPending, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := ba.Run(context.Background(), "r1", "trigger"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	if len(steps) == 0 {
+		t.Fatal("no steps written")
+	}
+	if steps[0].Type != string(model.StepTypeCapabilitySnapshot) {
+		t.Fatalf("first step type = %q, want capability_snapshot", steps[0].Type)
+	}
+
+	type snapshotContent struct {
+		Tools []model.GrantedTool `json:"tools"`
+	}
+	var snap snapshotContent
+	if err := json.Unmarshal([]byte(steps[0].Content), &snap); err != nil {
+		t.Fatalf("unmarshal snapshot content: %v", err)
+	}
+
+	var foundMCP, foundPlugin bool
+	for _, gt := range snap.Tools {
+		switch gt.Source {
+		case "mcp:mcp-server":
+			foundMCP = true
+		case "plugin:my-plugin@1":
+			foundPlugin = true
+		}
+	}
+	if !foundMCP {
+		t.Errorf("MCP tool source not found in snapshot; tools = %v", snap.Tools)
+	}
+	if !foundPlugin {
+		t.Errorf("plugin tool source not found in snapshot; tools = %v", snap.Tools)
+	}
+}
+
+func TestHandleToolCall_PluginGenerationMismatch_StructuralError(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusRunning)
+
+	// Registrar reports generation 2 is active; snapshot captured generation 1.
+	registrar := &fakePluginRegistrar{activeGen: 2, registered: true}
+
+	w := NewAuditWriter(s.Queries())
+	ba, err := New(Config{
+		Policy: minimalPolicy(),
+		PluginTools: []PluginToolEntry{
+			{InstanceName: "my-plugin", ToolName: "do-thing", Generation: 1},
+		},
+		PluginRegistrar: registrar,
+		LLMClient:       testutil.NewNoopLLMClient(),
+		Audit:           w,
+		StateMachine:    NewRunStateMachine("r1", model.RunStatusRunning, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	output, isErr, err := ba.handleToolCall(context.Background(), "r1", "my-plugin.do-thing", map[string]any{})
+	if err != nil {
+		t.Fatalf("handleToolCall returned unexpected error: %v", err)
+	}
+	if !isErr {
+		t.Error("expected isErr=true for generation mismatch")
+	}
+	if !strings.Contains(output, "no longer active") {
+		t.Errorf("output = %q; want it to contain 'no longer active'", output)
+	}
+
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+
+	var toolResultFound, toolCallFound bool
+	for _, step := range steps {
+		switch step.Type {
+		case string(model.StepTypeToolResult):
+			var content map[string]any
+			if jsonErr := json.Unmarshal([]byte(step.Content), &content); jsonErr != nil {
+				t.Fatalf("unmarshal tool_result: %v", jsonErr)
+			}
+			if isErrFlag, _ := content["is_error"].(bool); isErrFlag {
+				toolResultFound = true
+			}
+		case string(model.StepTypeToolCall):
+			toolCallFound = true
+		}
+	}
+	if !toolResultFound {
+		t.Error("expected tool_result step with is_error=true")
+	}
+	if toolCallFound {
+		t.Error("tool_call step must NOT be written for a generation mismatch")
+	}
+}
+
+func TestHandleToolCall_PluginGenerationUnregistered_StructuralError(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusRunning)
+
+	// Registrar reports instance is not registered.
+	registrar := &fakePluginRegistrar{activeGen: 0, registered: false}
+
+	w := NewAuditWriter(s.Queries())
+	ba, err := New(Config{
+		Policy: minimalPolicy(),
+		PluginTools: []PluginToolEntry{
+			{InstanceName: "my-plugin", ToolName: "do-thing", Generation: 1},
+		},
+		PluginRegistrar: registrar,
+		LLMClient:       testutil.NewNoopLLMClient(),
+		Audit:           w,
+		StateMachine:    NewRunStateMachine("r1", model.RunStatusRunning, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	output, isErr, err := ba.handleToolCall(context.Background(), "r1", "my-plugin.do-thing", map[string]any{})
+	if err != nil {
+		t.Fatalf("handleToolCall returned unexpected error: %v", err)
+	}
+	if !isErr {
+		t.Error("expected isErr=true for unregistered instance")
+	}
+	if !strings.Contains(output, "no longer active") {
+		t.Errorf("output = %q; want it to contain 'no longer active'", output)
+	}
+
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+
+	var toolResultFound, toolCallFound bool
+	for _, step := range steps {
+		switch step.Type {
+		case string(model.StepTypeToolResult):
+			var content map[string]any
+			if jsonErr := json.Unmarshal([]byte(step.Content), &content); jsonErr != nil {
+				t.Fatalf("unmarshal tool_result: %v", jsonErr)
+			}
+			if isErrFlag, _ := content["is_error"].(bool); isErrFlag {
+				toolResultFound = true
+			}
+		case string(model.StepTypeToolCall):
+			toolCallFound = true
+		}
+	}
+	if !toolResultFound {
+		t.Error("expected tool_result step with is_error=true")
+	}
+	if toolCallFound {
+		t.Error("tool_call step must NOT be written for an unregistered instance")
+	}
+}
+
+func TestHandleToolCall_PluginGenerationMatch_ReachesPlaceholderDispatch(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusRunning)
+
+	// Registrar reports the same generation as captured — generation check passes.
+	registrar := &fakePluginRegistrar{activeGen: 1, registered: true}
+
+	w := NewAuditWriter(s.Queries())
+	ba, err := New(Config{
+		Policy: minimalPolicy(),
+		PluginTools: []PluginToolEntry{
+			{InstanceName: "my-plugin", ToolName: "do-thing", Generation: 1},
+		},
+		PluginRegistrar: registrar,
+		LLMClient:       testutil.NewNoopLLMClient(),
+		Audit:           w,
+		StateMachine:    NewRunStateMachine("r1", model.RunStatusRunning, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, _, err = ba.handleToolCall(context.Background(), "r1", "my-plugin.do-thing", map[string]any{})
+	if !errors.Is(err, errPluginDispatchUnimplemented) {
+		t.Errorf("handleToolCall error = %v; want errPluginDispatchUnimplemented", err)
 	}
 }

--- a/internal/execution/agent/errors.go
+++ b/internal/execution/agent/errors.go
@@ -11,6 +11,11 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/model"
 )
 
+// errPluginDispatchUnimplemented is returned by handleToolCall when a plugin
+// tool's generation matches the captured snapshot but real gRPC dispatch is not
+// yet wired (#198). Exercised by tests; not reachable in production until #198.
+var errPluginDispatchUnimplemented = errors.New("plugin tool dispatch is not yet implemented (#198)")
+
 // failRun transitions the run to failed status and returns the original error.
 // If the context is already cancelled, a background context is used so the DB
 // write still lands.

--- a/internal/execution/agent/tools.go
+++ b/internal/execution/agent/tools.go
@@ -10,10 +10,28 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 )
 
+// pluginToolSource identifies the plugin instance and generation captured at run
+// start. Used by handleToolCall to detect when the plugin has been replaced.
+type pluginToolSource struct {
+	InstanceName string
+	Generation   int64
+}
+
 // resolvedToolEntry holds a ResolvedTool paired with its narrowed JSON schema.
+// pluginSource is non-nil for plugin-backed tools; nil for MCP-source tools.
 type resolvedToolEntry struct {
 	tool           mcp.ResolvedTool
 	narrowedSchema json.RawMessage
+	pluginSource   *pluginToolSource // nil for MCP-source tools
+}
+
+// sourceString returns the source identifier for the tool: "plugin:<name>@<gen>"
+// for plugin-source tools, or "mcp:<ServerName>" for MCP-source tools.
+func sourceString(entry resolvedToolEntry) string {
+	if entry.pluginSource != nil {
+		return fmt.Sprintf("plugin:%s@%d", entry.pluginSource.InstanceName, entry.pluginSource.Generation)
+	}
+	return "mcp:" + entry.tool.ServerName
 }
 
 // buildResolvedToolMap constructs the name→entry map used at runtime to dispatch
@@ -45,6 +63,10 @@ func (a *BoundAgent) checkCapabilities() error {
 	// time. The feedback channel (FeedbackConfig) is not an MCP tool and
 	// requires no registry check — it is injected by the runtime when Enabled
 	// is true.
+	//
+	// Note: plugin tools come from Config.PluginTools (loaded into toolsByName by
+	// New()), NOT from policy capabilities — so they are correctly exempt from this
+	// check. A plugin tool that fails namespace reservation never reaches toolsByName.
 	for _, t := range a.policy.Capabilities.Tools {
 		if _, ok := a.toolsByName[t.Tool]; !ok {
 			return fmt.Errorf("capability '%s' not found in MCP registry — verify the MCP server is registered and the tool exists", t.Tool)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -397,7 +397,8 @@ type GrantedTool struct {
 	Approval   ApprovalMode   `json:"approval"`
 	Timeout    time.Duration  `json:"timeout"` // zero means no timeout; serializes as nanoseconds
 	OnTimeout  OnTimeout      `json:"on_timeout"`
-	Params     map[string]any `json:"params,omitempty"` // policy-level parameter scoping (ADR-017)
+	Params     map[string]any `json:"params,omitempty"`  // policy-level parameter scoping (ADR-017)
+	Source     string         `json:"source,omitempty"` // "mcp:<server>", "plugin:<instance>@<generation>", or empty for synthetic tools
 }
 
 // MCPServer represents a registered MCP tool server.

--- a/internal/plugin/tools/registrar.go
+++ b/internal/plugin/tools/registrar.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
@@ -29,17 +30,25 @@ type PluginAuditQuerier interface {
 }
 
 // Registrar manages plugin tool namespace reservations on behalf of a plugin
-// instance. It is safe for concurrent use (the arbiter handles its own locking).
+// instance. It is safe for concurrent use (the arbiter handles its own locking;
+// generation tracking uses its own mu).
 type Registrar struct {
-	arbiter *toolregistry.Registry
-	q       PluginAuditQuerier
-	pub     event.Publisher
+	arbiter     *toolregistry.Registry
+	q           PluginAuditQuerier
+	pub         event.Publisher
+	mu          sync.Mutex
+	generations map[string]int64 // keyed by instanceName; process-local (not persisted)
 }
 
 // New returns a Registrar wired to the given arbiter, DB querier, and event
 // publisher. The publisher may be nil; audit events are written to DB regardless.
 func New(arbiter *toolregistry.Registry, q PluginAuditQuerier, pub event.Publisher) *Registrar {
-	return &Registrar{arbiter: arbiter, q: q, pub: pub}
+	return &Registrar{
+		arbiter:     arbiter,
+		q:           q,
+		pub:         pub,
+		generations: make(map[string]int64),
+	}
 }
 
 // RegisterInstanceTools attempts to claim each "instanceName.toolName" dot-name
@@ -48,8 +57,10 @@ func New(arbiter *toolregistry.Registry, q PluginAuditQuerier, pub event.Publish
 // plugin_audit_events row is inserted with event_type
 // "plugin_tool_namespace_conflict", and the conflict error is returned.
 //
-// On success, the arbiter holds all reservations until UnregisterInstance is called.
-func (r *Registrar) RegisterInstanceTools(ctx context.Context, instanceID, instanceName string, toolNames []string) error {
+// On success, the arbiter holds all reservations until UnregisterInstance is called,
+// and the provided generation is recorded so agent runners can detect stale captures
+// via Generation().
+func (r *Registrar) RegisterInstanceTools(ctx context.Context, instanceID, instanceName string, toolNames []string, generation int64) error {
 	if len(toolNames) == 0 {
 		return nil
 	}
@@ -108,14 +119,33 @@ func (r *Registrar) RegisterInstanceTools(ctx context.Context, instanceID, insta
 		return fmt.Errorf("plugin %q: %w", instanceName, err)
 	}
 
+	r.mu.Lock()
+	r.generations[instanceName] = generation
+	r.mu.Unlock()
+
 	return nil
 }
 
+// Generation returns the active generation for the named plugin instance, or
+// (0, false) if the instance is not currently registered. Agent runners call
+// this at tool-call time to detect when a plugin has been replaced since the
+// capability snapshot was taken.
+func (r *Registrar) Generation(instanceName string) (int64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	gen, ok := r.generations[instanceName]
+	return gen, ok
+}
+
 // UnregisterInstance releases all arbiter reservations owned by the given
-// instance name. Safe to call even if the instance was never registered or
-// already unregistered.
+// instance name and removes its generation record. Safe to call even if the
+// instance was never registered or already unregistered.
 func (r *Registrar) UnregisterInstance(_ context.Context, instanceName string) {
 	r.arbiter.ReleaseAllFor(toolregistry.Source{Kind: toolregistry.KindPlugin, Name: instanceName})
+
+	r.mu.Lock()
+	delete(r.generations, instanceName)
+	r.mu.Unlock()
 }
 
 // conflictPayload is the JSON structure written to plugin_audit_events.payload_json

--- a/internal/plugin/tools/registrar_test.go
+++ b/internal/plugin/tools/registrar_test.go
@@ -84,7 +84,7 @@ func TestRegister_Succeeds_WhenNamesFree(t *testing.T) {
 	reg, arbiter, store := newRegistrar(t, nil)
 	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStateHealthy)
 
-	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a", "tool-b"})
+	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a", "tool-b"}, 1)
 	if err != nil {
 		t.Fatalf("RegisterInstanceTools: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestRegister_Conflict_WithMCPOwner(t *testing.T) {
 		t.Fatalf("pre-reserve: %v", err)
 	}
 
-	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"})
+	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}, 1)
 	if err == nil {
 		t.Fatal("expected conflict error, got nil")
 	}
@@ -192,7 +192,7 @@ func TestRegister_Conflict_TwoPlugins(t *testing.T) {
 
 	// Plugin A (instanceName "ns") claims "ns.send".
 	seedInstance(t, store, "inst-a", "ns", model.PluginHealthStateHealthy)
-	if err := reg.RegisterInstanceTools(context.Background(), "inst-a", "ns", []string{"send"}); err != nil {
+	if err := reg.RegisterInstanceTools(context.Background(), "inst-a", "ns", []string{"send"}, 1); err != nil {
 		t.Fatalf("RegisterInstanceTools (inst-a): %v", err)
 	}
 
@@ -213,7 +213,7 @@ func TestRegister_Conflict_TwoPlugins(t *testing.T) {
 
 	// inst-b (instanceName "ns") now tries to claim "ns.send" — conflicts with MCP.
 	seedInstance(t, store, "inst-b", "ns", model.PluginHealthStateHealthy)
-	err := reg.RegisterInstanceTools(context.Background(), "inst-b", "ns", []string{"send"})
+	err := reg.RegisterInstanceTools(context.Background(), "inst-b", "ns", []string{"send"}, 1)
 	if err == nil {
 		t.Fatal("expected conflict error, got nil")
 	}
@@ -234,12 +234,12 @@ func TestRegister_Idempotent_SameOwnerRetry(t *testing.T) {
 	reg, arbiter, store := newRegistrar(t, nil)
 	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStateHealthy)
 
-	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}); err != nil {
+	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}, 1); err != nil {
 		t.Fatalf("first RegisterInstanceTools: %v", err)
 	}
 
 	// Retry with the same instance and tool — idempotent, must not error.
-	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}); err != nil {
+	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}, 1); err != nil {
 		t.Fatalf("idempotent RegisterInstanceTools: %v", err)
 	}
 
@@ -265,7 +265,7 @@ func TestRegister_Conflict_FromPendingState(t *testing.T) {
 		t.Fatalf("pre-reserve: %v", err)
 	}
 
-	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"})
+	err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}, 1)
 	if err == nil {
 		t.Fatal("expected conflict error, got nil")
 	}
@@ -284,7 +284,7 @@ func TestUnregister_FreesNamesForReuse(t *testing.T) {
 	seedInstance(t, store, "inst1", "my-plugin", model.PluginHealthStateHealthy)
 	seedInstance(t, store, "inst2", "other-plugin", model.PluginHealthStateHealthy)
 
-	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}); err != nil {
+	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "my-plugin", []string{"tool-a"}, 1); err != nil {
 		t.Fatalf("RegisterInstanceTools: %v", err)
 	}
 
@@ -297,8 +297,41 @@ func TestUnregister_FreesNamesForReuse(t *testing.T) {
 
 	// Another instance can now claim the same dot-name.
 	reg2 := tools.New(arbiter, store.Queries(), nil)
-	if err := reg2.RegisterInstanceTools(context.Background(), "inst2", "my-plugin", []string{"tool-a"}); err != nil {
+	if err := reg2.RegisterInstanceTools(context.Background(), "inst2", "my-plugin", []string{"tool-a"}, 2); err != nil {
 		t.Errorf("RegisterInstanceTools after unregister: %v", err)
+	}
+}
+
+func TestRegistrar_Generation_TracksAndReplaces(t *testing.T) {
+	reg, _, store := newRegistrar(t, nil)
+	seedInstance(t, store, "inst1", "foo", model.PluginHealthStateHealthy)
+
+	// Before registration, no generation is recorded.
+	if gen, ok := reg.Generation("foo"); ok {
+		t.Errorf("Generation before register = (%d, true), want (0, false)", gen)
+	}
+
+	// Register generation 1.
+	if err := reg.RegisterInstanceTools(context.Background(), "inst1", "foo", []string{"bar"}, 1); err != nil {
+		t.Fatalf("RegisterInstanceTools gen=1: %v", err)
+	}
+	if gen, ok := reg.Generation("foo"); !ok || gen != 1 {
+		t.Errorf("Generation after gen=1 register = (%d, %v), want (1, true)", gen, ok)
+	}
+
+	// Unregister removes the generation entry.
+	reg.UnregisterInstance(context.Background(), "foo")
+	if gen, ok := reg.Generation("foo"); ok {
+		t.Errorf("Generation after unregister = (%d, true), want (0, false)", gen)
+	}
+
+	// Re-register with generation 2.
+	seedInstance(t, store, "inst2", "foo", model.PluginHealthStateHealthy)
+	if err := reg.RegisterInstanceTools(context.Background(), "inst2", "foo", []string{"bar"}, 2); err != nil {
+		t.Fatalf("RegisterInstanceTools gen=2: %v", err)
+	}
+	if gen, ok := reg.Generation("foo"); !ok || gen != 2 {
+		t.Errorf("Generation after gen=2 register = (%d, %v), want (2, true)", gen, ok)
 	}
 }
 


### PR DESCRIPTION
Closes #195

## Summary

Extends the ADR-018 capability snapshot to record per-tool source identifiers as `mcp:<server>` or `plugin:<instance>@<generation>`, plus the existing parameter scope. Adds a generation-aware guard at tool-call dispatch: calls against a plugin tool whose generation has been replaced fail with a structural `tool_result is_error: true` step, mirroring the MCP-transport-failure pattern.

- **`internal/plugin/tools.Registrar`** tracks per-instance generation in process-local memory. `RegisterInstanceTools` gains a `generation int64` parameter; new `Generation(instanceName)` getter is consulted at dispatch time.
- **`internal/execution/agent`** defines `PluginGenerationLookup` (one method, satisfied structurally by `*tools.Registrar`) — keeps the agent package's no-plugin-import boundary intact.
- **`Config.PluginTools`** is the new seam by which plugin tools enter the agent. `New()` builds both `toolsByName` (dispatch) and `pluginGrantedTools` (snapshot) from a single iteration.
- **Construction-time invariant:** `New()` panics when `PluginTools` is non-empty but `PluginRegistrar` is nil — surfaces the config mistake immediately rather than as a confusing runtime guard fail.
- **Real plugin dispatch is out of scope** (#198/#200). When generation matches, the placeholder branch returns `errPluginDispatchUnimplemented` without writing a `tool_call` step.

## Acceptance criteria

- [x] AC1 — Snapshot records tool name + source (`plugin:instance@generation` or `mcp:server`) + parameter scope. New `Source` field on `model.GrantedTool` with `omitempty` for backwards compat.
- [x] AC2 — Calls to a plugin tool whose generation has been replaced produce a `tool_result is_error: true` step (NOT a tool error). Guard sits before `mcp.ValidateCall`, before approval, before any `tool_call` step write.
- [x] AC3 — Existing capability-snapshot tests extended (`TestRun_CapabilitySnapshotFirst`, `TestCapabilitySnapshot_IncludesAskOperator`).
- [x] AC4 — No MCP-source regression (existing tests pass; `Source = "mcp:<server>"` is additive).

## Plan

<details>
<summary>Implementation plan (collapsed)</summary>

Key decisions:
1. Generation lives process-local on `Registrar` — no DB column. #190/#193 own persistence; promoting later requires no contract change.
2. Snapshot serialization uses a string-encoded `Source` field with `omitempty` — additive, no JSON shape break.
3. Generation check fires live in `handleToolCall`, not at construction time (matches MCP-transport-failure detection model).
4. Structural error reuses the existing `tool_result is_error: true` shape — no new step type, no new error code.
5. `New()` panics on `PluginTools` set but `PluginRegistrar` nil — turns a config mistake into a startup failure.
6. Single `Config.PluginTools` input populates both `toolsByName` and `pluginGrantedTools` in one pass.
7. `sourceString` helper centralizes the format — used at both call sites.

</details>

## Cycles

- 1 architect plan + 1 plan revision (4 blockers: dead loader caller, missing dispatch insertion point, unspecified `New()` seam, contradictory guard position)
- 2 code-review cycles (cycle 1 flagged dead `sourceString` helper; cycle 2 wired it into both call sites)
- CLAUDE.md updated: `internal/plugin/tools/` description expanded with generation-tracking note

## Out of scope (follow-ups)

- Real plugin tool dispatch over gRPC — issues #198 and #200.
- DB persistence of generation — when in-flight runs need to survive restarts (#190/#193).
- Promoting plugin tools to first-class policy capabilities (#196 will revisit).

🤖 Generated by the agentic dev-loop pipeline.