### PR TITLE
feat(plugin): per-policy parameter scoping (ADR-017) for plugin tools

### DIFF
--- a/internal/execution/agent/agent.go
+++ b/internal/execution/agent/agent.go
@@ -98,6 +98,14 @@ func New(cfg Config) (*BoundAgent, error) {
 			return nil, fmt.Errorf("marshaling schema for plugin tool %s: %w", dotName, err)
 		}
 
+		// Apply policy-level parameter scoping (ADR-017) to plugin tools, exactly
+		// as buildResolvedToolMap does for MCP tools. narrowedSchema feeds the LLM;
+		// InputSchema is the raw schema of record.
+		narrowed, err := mcp.NarrowSchema(schemaJSON, pt.Params)
+		if err != nil {
+			return nil, fmt.Errorf("narrowing schema for plugin tool %s: %w", dotName, err)
+		}
+
 		toolsByName[dotName] = resolvedToolEntry{
 			tool: mcp.ResolvedTool{
 				GrantedTool: model.GrantedTool{
@@ -110,7 +118,7 @@ func New(cfg Config) (*BoundAgent, error) {
 				Description: pt.Description,
 				InputSchema: schemaJSON,
 			},
-			narrowedSchema: schemaJSON,
+			narrowedSchema: narrowed,
 			pluginSource: &pluginToolSource{
 				InstanceName: pt.InstanceName,
 				Generation:   pt.Generation,
@@ -532,11 +540,20 @@ func (a *BoundAgent) handleToolCall(ctx context.Context, runID, toolName string,
 		return "", false, err
 	}
 
+	// Validate input against narrowed schema. This runs for both MCP and plugin
+	// tools — schema enforcement is source-agnostic (ADR-017). Running it before
+	// source-specific routing means a call with a bad parameter shape surfaces a
+	// schema error regardless of whether the plugin is also stale.
+	if err := mcp.ValidateCall(entry.narrowedSchema, input); err != nil {
+		a.logAuditError(ctx, runID, err.Error(), model.ErrorCodeSchemaViolation)
+		return "", false, fmt.Errorf("schema validation for %s: %w", toolName, err)
+	}
+
 	// Plugin generation guard: verify the plugin instance that provided this tool
 	// is still active and on the same generation captured in the snapshot. If not,
 	// write a tool_result structural error (same shape as MCP transport failures)
-	// so the agent can reason about it. No tool_call step is written first —
-	// the call never reached a server.
+	// so the agent can reason about it. Schema validation has already passed above;
+	// this block only handles generation/dispatch routing.
 	//
 	// The registrar is guaranteed non-nil when entry.pluginSource != nil because
 	// New() panics if PluginTools is non-empty without a PluginRegistrar.
@@ -561,12 +578,6 @@ func (a *BoundAgent) handleToolCall(ctx context.Context, runID, toolName string,
 		// Generation matches — real dispatch is not yet wired (#198).
 		// server_id would be empty for plugin entries (no MCP server).
 		return "", false, errPluginDispatchUnimplemented
-	}
-
-	// Validate input against narrowed schema.
-	if err := mcp.ValidateCall(entry.narrowedSchema, input); err != nil {
-		a.logAuditError(ctx, runID, err.Error(), model.ErrorCodeSchemaViolation)
-		return "", false, fmt.Errorf("schema validation for %s: %w", toolName, err)
 	}
 
 	// Approval gating for tools with approval: required (ADR-008).

--- a/internal/execution/agent/agent_test.go
+++ b/internal/execution/agent/agent_test.go
@@ -3150,3 +3150,292 @@ func TestHandleToolCall_PluginGenerationMatch_ReachesPlaceholderDispatch(t *test
 		t.Errorf("handleToolCall error = %v; want errPluginDispatchUnimplemented", err)
 	}
 }
+
+// assertSchemaProperties unmarshals schema and checks that the keys in the
+// properties map exactly match wantKeys (order-independent). Mirrors the helper
+// in internal/mcp/narrow_test.go — copied here to avoid a cross-package export.
+func assertSchemaProperties(t *testing.T, schema json.RawMessage, wantKeys []string) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("assertSchemaProperties: unmarshal: %v", err)
+	}
+
+	propsRaw, ok := m["properties"]
+	if !ok {
+		if len(wantKeys) > 0 {
+			t.Errorf("schema has no 'properties', want keys %v", wantKeys)
+		}
+		return
+	}
+	propsMap, ok := propsRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("assertSchemaProperties: 'properties' is not map[string]any")
+	}
+
+	var gotKeys []string
+	for k := range propsMap {
+		gotKeys = append(gotKeys, k)
+	}
+	sortStrings(gotKeys)
+
+	want := make([]string, len(wantKeys))
+	copy(want, wantKeys)
+	sortStrings(want)
+
+	if len(gotKeys) != len(want) {
+		t.Errorf("property keys = %v, want %v", gotKeys, want)
+		return
+	}
+	for i := range gotKeys {
+		if gotKeys[i] != want[i] {
+			t.Errorf("property keys = %v, want %v", gotKeys, want)
+			return
+		}
+	}
+}
+
+// sortStrings sorts a string slice in-place; avoids importing sort at the top level.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
+// pluginSchemaWith builds a simple JSON Schema object for use in plugin tool tests.
+func pluginSchemaWith(keys ...string) map[string]any {
+	props := make(map[string]any, len(keys))
+	for _, k := range keys {
+		props[k] = map[string]any{"type": "string"}
+	}
+	return map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+}
+
+// TestNew_NarrowsPluginToolSchema verifies that New() applies ADR-017 parameter
+// scoping to plugin tools: narrowedSchema is set to the policy-constrained view,
+// while tool.InputSchema retains the full raw schema. Mirrors TestNarrowSchema in
+// internal/mcp/narrow_test.go for parity across all v1 ADR-017 operations.
+func TestNew_NarrowsPluginToolSchema(t *testing.T) {
+	baseSchema := pluginSchemaWith("namespace", "pod", "force")
+	noPropsSchema := map[string]any{"type": "object"} // no "properties" key
+
+	tests := []struct {
+		name          string
+		schema        map[string]any
+		params        map[string]any
+		wantKeys      []string // nil means don't check properties
+		wantUnchanged bool     // narrowedSchema must equal marshaled schema
+	}{
+		{
+			name:          "nil Params — schema unchanged",
+			schema:        baseSchema,
+			params:        nil,
+			wantUnchanged: true,
+		},
+		{
+			name:          "empty Params — schema unchanged",
+			schema:        baseSchema,
+			params:        map[string]any{},
+			wantUnchanged: true,
+		},
+		{
+			name:     "single key in Params — only that property survives",
+			schema:   baseSchema,
+			params:   map[string]any{"namespace": "x"},
+			wantKeys: []string{"namespace"},
+		},
+		{
+			name:     "multiple keys in Params — only listed properties survive",
+			schema:   baseSchema,
+			params:   map[string]any{"namespace": "x", "pod": "y"},
+			wantKeys: []string{"namespace", "pod"},
+		},
+		{
+			name:     "Params key not in schema — silently dropped",
+			schema:   baseSchema,
+			params:   map[string]any{"namespace": "x", "nonexistent": "y"},
+			wantKeys: []string{"namespace"},
+		},
+		{
+			name:     "Params drops a required key — required entry removed",
+			schema:   baseSchema,
+			params:   map[string]any{"force": true},
+			wantKeys: []string{"force"},
+		},
+		{
+			name:          "schema with no properties — returned unchanged",
+			schema:        noPropsSchema,
+			params:        map[string]any{"namespace": "x"},
+			wantUnchanged: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testutil.NewTestStore(t)
+			registrar := &fakePluginRegistrar{activeGen: 1, registered: true}
+
+			ba, err := New(Config{
+				Policy: minimalPolicy(),
+				PluginTools: []PluginToolEntry{
+					{
+						InstanceName: "my-plugin",
+						ToolName:     "do-thing",
+						Generation:   1,
+						Schema:       tc.schema,
+						Params:       tc.params,
+					},
+				},
+				PluginRegistrar: registrar,
+				LLMClient:       testutil.NewNoopLLMClient(),
+				Audit:           NewAuditWriter(s.Queries()),
+				StateMachine:    NewRunStateMachine("r1", model.RunStatusPending, s.DB(), s.Queries()),
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			entry, ok := ba.toolsByName["my-plugin.do-thing"]
+			if !ok {
+				t.Fatal("tool entry not found in toolsByName")
+			}
+
+			rawSchema, err := json.Marshal(tc.schema)
+			if err != nil {
+				t.Fatalf("marshal base schema: %v", err)
+			}
+
+			if tc.wantUnchanged {
+				if string(entry.narrowedSchema) != string(rawSchema) {
+					t.Errorf("narrowedSchema = %s, want unchanged %s", entry.narrowedSchema, rawSchema)
+				}
+				return
+			}
+
+			assertSchemaProperties(t, entry.narrowedSchema, tc.wantKeys)
+
+			// Raw InputSchema must always be the full original schema.
+			if string(entry.tool.InputSchema) != string(rawSchema) {
+				t.Errorf("InputSchema modified; got %s, want %s", entry.tool.InputSchema, rawSchema)
+			}
+		})
+	}
+}
+
+// TestNew_PluginSchemaCannotBypassScoping verifies that a plugin tool's Params
+// field restricts what the LLM sees (via buildToolDefinitions), closing the
+// "no escape hatch" acceptance criterion in issue #197.
+func TestNew_PluginSchemaCannotBypassScoping(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	registrar := &fakePluginRegistrar{activeGen: 1, registered: true}
+
+	// Plugin declares both "namespace" and "secret", but policy only permits "namespace".
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"namespace": map[string]any{"type": "string"},
+			"secret":    map[string]any{"type": "string"},
+		},
+	}
+
+	ba, err := New(Config{
+		Policy: minimalPolicy(),
+		PluginTools: []PluginToolEntry{
+			{
+				InstanceName: "my-plugin",
+				ToolName:     "do-thing",
+				Generation:   1,
+				Schema:       schema,
+				Params:       map[string]any{"namespace": "x"},
+			},
+		},
+		PluginRegistrar: registrar,
+		LLMClient:       testutil.NewNoopLLMClient(),
+		Audit:           NewAuditWriter(s.Queries()),
+		StateMachine:    NewRunStateMachine("r1", model.RunStatusPending, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// narrowedSchema must expose only "namespace".
+	entry := ba.toolsByName["my-plugin.do-thing"]
+	assertSchemaProperties(t, entry.narrowedSchema, []string{"namespace"})
+
+	// buildToolDefinitions feeds the narrowedSchema to the LLM — check that too.
+	defs := ba.buildToolDefinitions()
+	var pluginDef *llm.ToolDefinition
+	for i, d := range defs {
+		if d.Name == "my-plugin.do-thing" {
+			pluginDef = &defs[i]
+			break
+		}
+	}
+	if pluginDef == nil {
+		t.Fatal("plugin tool definition not found in buildToolDefinitions output")
+	}
+	assertSchemaProperties(t, pluginDef.InputSchema, []string{"namespace"})
+}
+
+// TestNew_PluginToolValidateCallRejectsUndeclared verifies that handleToolCall
+// runs ValidateCall against the narrowed plugin schema before reaching the plugin
+// generation guard or dispatch placeholder. The reorder in agent.go ensures
+// schema errors surface even for plugin tools.
+func TestNew_PluginToolValidateCallRejectsUndeclared(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusRunning)
+
+	// Generation matches — if ValidateCall were absent, execution would reach errPluginDispatchUnimplemented.
+	registrar := &fakePluginRegistrar{activeGen: 1, registered: true}
+
+	ba, err := New(Config{
+		Policy: minimalPolicy(),
+		PluginTools: []PluginToolEntry{
+			{
+				InstanceName: "my-plugin",
+				ToolName:     "do-thing",
+				Generation:   1,
+				Schema:       pluginSchemaWith("a"),
+				Params:       map[string]any{"a": "x"}, // narrows schema to only "a"
+			},
+		},
+		PluginRegistrar: registrar,
+		LLMClient:       testutil.NewNoopLLMClient(),
+		Audit:           NewAuditWriter(s.Queries()),
+		StateMachine:    NewRunStateMachine("r1", model.RunStatusRunning, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Call with undeclared key "b" — ValidateCall must reject it before dispatch.
+	_, _, err = ba.handleToolCall(context.Background(), "r1", "my-plugin.do-thing", map[string]any{"b": 1})
+
+	if err == nil {
+		t.Fatal("handleToolCall returned nil; want schema validation error")
+	}
+	if !strings.Contains(err.Error(), "b") {
+		t.Errorf("error %q should reference the rejected key %q", err.Error(), "b")
+	}
+	// Must NOT be the dispatch placeholder — schema validation ran first.
+	if errors.Is(err, errPluginDispatchUnimplemented) {
+		t.Error("got errPluginDispatchUnimplemented; schema validation should have fired before dispatch")
+	}
+
+	// No tool_call step should have been written (validation precedes audit writes).
+	steps, err2 := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
+	if err2 != nil {
+		t.Fatalf("ListRunSteps: %v", err2)
+	}
+	for _, step := range steps {
+		if step.Type == string(model.StepTypeToolCall) {
+			t.Error("tool_call step must NOT be written when schema validation fails")
+		}
+	}
+}

--- a/internal/execution/agent/tools.go
+++ b/internal/execution/agent/tools.go
@@ -18,6 +18,8 @@ type pluginToolSource struct {
 }
 
 // resolvedToolEntry holds a ResolvedTool paired with its narrowed JSON schema.
+// narrowedSchema is the policy-scoped view of the tool's input schema (ADR-017)
+// and is what the LLM sees; tool.InputSchema is the raw schema of record.
 // pluginSource is non-nil for plugin-backed tools; nil for MCP-source tools.
 type resolvedToolEntry struct {
 	tool           mcp.ResolvedTool
@@ -34,9 +36,11 @@ func sourceString(entry resolvedToolEntry) string {
 	return "mcp:" + entry.tool.ServerName
 }
 
-// buildResolvedToolMap constructs the name→entry map used at runtime to dispatch
-// tool calls. It applies policy-level parameter scoping (ADR-017) by narrowing
-// each tool's input schema.
+// buildResolvedToolMap constructs the name→entry map for MCP-source tools. It
+// applies policy-level parameter scoping (ADR-017) by narrowing each tool's
+// input schema. Plugin-source tools are added by New() in a separate loop
+// because they carry different fields (pluginSource pointer, schema from
+// map[string]any vs json.RawMessage, snapshot side-effects).
 func buildResolvedToolMap(tools []mcp.ResolvedTool) (map[string]resolvedToolEntry, error) {
 	toolsByName := make(map[string]resolvedToolEntry, len(tools))
 	for _, rt := range tools {


### PR DESCRIPTION
Closes #196

## Summary

Plugin-source tools now obey ADR-017 parameter scoping identically to MCP tools.

- **Registration-time narrowing:** `agent.New()` calls `mcp.NarrowSchema(schemaJSON, pt.Params)` for each `PluginToolEntry`, so the LLM-facing `InputSchema` (via `buildToolDefinitions`) only contains policy-permitted properties.
- **Dispatch-time enforcement:** `mcp.ValidateCall` was reordered to run *above* the `pluginSource != nil` block in `handleToolCall`, making schema validation source-agnostic. A plugin tool called with an undeclared key now surfaces the schema error before any source-specific dispatch routing.
- **No escape hatch:** structurally enforced — verified by `TestNew_PluginSchemaCannotBypassScoping` which asserts both `narrowedSchema` and `buildToolDefinitions()` output are filtered.

Issue #12 (value-level scoping) remains out of scope; v1 ADR-017 is key-level only and the same hook point will pick up plugin tools when value-level lands.

<details>
<summary>Architecture plan</summary>

```
1. internal/execution/agent/agent.go
   a. New(): NarrowSchema(schemaJSON, pt.Params) → narrowedSchema
   b. handleToolCall: move ValidateCall above the pluginSource != nil block
2. internal/execution/agent/tools.go: comment-only updates (resolvedToolEntry, buildResolvedToolMap)
3. internal/execution/agent/agent_test.go:
   - TestNew_NarrowsPluginToolSchema (7-case table parity with mcp/narrow_test.go)
   - TestNew_PluginSchemaCannotBypassScoping (LLM-facing assertion)
   - TestNew_PluginToolValidateCallRejectsUndeclared (dispatch-time)
```

Reuses `mcp.NarrowSchema` and `mcp.ValidateCall` as-is (source-agnostic on `json.RawMessage`). No DB, API, or frontend changes. Existing #195 generation-mismatch tests continue to pass — they use schema-valid empty input.
</details>

## Pipeline

- 1 review cycle (APPROVE on first pass)
- Plan revised once after adversarial review caught an ordering bug (ValidateCall was below the plugin early-return)
- Brainstorming: not triggered (issue was well-specified)
- CLAUDE.md: no updates required

## Test plan

- [x] `go test ./internal/execution/agent/... ./internal/mcp/...`
- [x] `go build ./...`
- [x] Existing #195 plugin-generation tests still pass

🤖 Generated with the agentic dev loop