### PR TITLE
feat: approval gating (ADR-008) for plugin tools

### DIFF
--- a/docs/developer/plugin-system-spec.md
+++ b/docs/developer/plugin-system-spec.md
@@ -76,7 +76,7 @@ Hard capability enforcement (ADR-001) is preserved:
 - Plugin tools and MCP tools live in **one namespace**: `<source>.<tool>`, where `<source>` is either an MCP server name or a plugin instance name. Uniqueness is enforced across both registries at registration time.
 - Agents only see the tools their policy grants. Tools not granted are never registered with the LLM.
 - Capability snapshot (ADR-018) records all granted tools at run start, regardless of source.
-- Per-policy parameter scoping (ADR-017) and approval gating (ADR-008) apply to plugin tools identically.
+- Per-policy parameter scoping (ADR-017) and approval gating (ADR-008) apply to plugin tools identically. Implementation invariant: the approval interceptor in `handleToolCall` runs BEFORE source-specific dispatch (MCP transport or plugin generation guard); there is exactly one approval chokepoint.
 - The agent never sees `gleipnir.ask_operator` directly. Internally it sees a synthetic `request_feedback` tool; the runtime resolves the audience and routes to the appropriate Channel implementation. From the agent's perspective, who gets paged is not its concern.
 
 ## 4. Plugin model

--- a/internal/execution/agent/agent.go
+++ b/internal/execution/agent/agent.go
@@ -37,6 +37,7 @@ type PluginToolEntry struct {
 	Description  string
 	Schema       map[string]any
 	Approval     model.ApprovalMode
+	Timeout      time.Duration  // approval timeout; zero means no timeout (same semantics as GrantedTool.Timeout)
 	Params       map[string]any // narrowed schema per ADR-017
 }
 
@@ -112,6 +113,7 @@ func New(cfg Config) (*BoundAgent, error) {
 					ServerName: "", // no MCP server; plugin dispatch is via pluginSource
 					ToolName:   pt.ToolName,
 					Approval:   pt.Approval,
+					Timeout:    pt.Timeout,
 					Params:     pt.Params,
 				},
 				Client:      nil, // real dispatch wired in #198
@@ -514,7 +516,9 @@ func (a *BoundAgent) Run(ctx context.Context, runID string, triggerPayload strin
 
 // handleToolCall dispatches a single tool call from the agent.
 // For approval-gated tools it suspends the run and waits for a decision
-// before proceeding. This is the hard runtime guarantee (ADR-001).
+// before any source-specific dispatch. This is the hard runtime guarantee
+// (ADR-008): the approval interceptor runs unconditionally regardless of
+// whether the tool is MCP- or plugin-backed.
 // On error, it writes an error step and returns the error.
 //
 // toolName is the original MCP dot-separated name (e.g. "myserver.read_data"),
@@ -549,11 +553,26 @@ func (a *BoundAgent) handleToolCall(ctx context.Context, runID, toolName string,
 		return "", false, fmt.Errorf("schema validation for %s: %w", toolName, err)
 	}
 
+	// Approval gating for tools with approval: required (ADR-008).
+	// This interceptor is source-agnostic and runs BEFORE any source-specific
+	// dispatch (plugin generation guard, MCP transport). A single chokepoint
+	// here mirrors how ValidateCall is structured — it is impossible for any
+	// future dispatch path to accidentally bypass it.
+	//
+	// Note: an operator who approves a call for a plugin with a stale generation
+	// will still receive a structural tool_result error below. Approval is
+	// unconditional per ADR-008's "no bypass based on tool source".
+	if entry.tool.Approval == model.ApprovalModeRequired {
+		if err := a.approvals.Wait(ctx, runID, entry, toolName, input); err != nil {
+			return "", false, err
+		}
+	}
+
 	// Plugin generation guard: verify the plugin instance that provided this tool
 	// is still active and on the same generation captured in the snapshot. If not,
 	// write a tool_result structural error (same shape as MCP transport failures)
-	// so the agent can reason about it. Schema validation has already passed above;
-	// this block only handles generation/dispatch routing.
+	// so the agent can reason about it. Schema validation and approval gating have
+	// already run above; this block only handles generation/dispatch routing.
 	//
 	// The registrar is guaranteed non-nil when entry.pluginSource != nil because
 	// New() panics if PluginTools is non-empty without a PluginRegistrar.
@@ -580,18 +599,8 @@ func (a *BoundAgent) handleToolCall(ctx context.Context, runID, toolName string,
 		return "", false, errPluginDispatchUnimplemented
 	}
 
-	// Approval gating for tools with approval: required (ADR-008).
-	// This interception must remain BEFORE the tool_call step is written and
-	// BEFORE MCP dispatch — it is the hard runtime guarantee.
-	if entry.tool.Approval == model.ApprovalModeRequired {
-		if err := a.approvals.Wait(ctx, runID, entry, toolName, input); err != nil {
-			return "", false, err
-		}
-	}
-
 	// Write tool_call step. server_id is the MCP ServerName for MCP-source tools;
-	// it would be empty for plugin entries — but plugin tools are intercepted above
-	// before this point, so only MCP tools reach here (#198 will wire plugin dispatch).
+	// plugin tools return before reaching this point (#198 will wire plugin dispatch).
 	if err := a.audit.Write(ctx, Step{
 		RunID: runID,
 		Type:  model.StepTypeToolCall,

--- a/internal/execution/agent/agent_test.go
+++ b/internal/execution/agent/agent_test.go
@@ -3382,6 +3382,284 @@ func TestNew_PluginSchemaCannotBypassScoping(t *testing.T) {
 	assertSchemaProperties(t, pluginDef.InputSchema, []string{"namespace"})
 }
 
+// TestHandleToolCall_PluginTool_ApprovalGated verifies that the approval
+// interceptor in handleToolCall runs BEFORE the plugin generation guard —
+// i.e. there is exactly one approval chokepoint regardless of tool source
+// (ADR-008, ADR-029).
+func TestHandleToolCall_PluginTool_ApprovalGated(t *testing.T) {
+	tests := []struct {
+		name string
+
+		// approvalRequired controls whether the plugin tool is registered with
+		// ApprovalModeRequired and whether approvalCh is wired in the harness.
+		approvalRequired bool
+
+		// approvalCh configuration.
+		approvalChSend *bool  // nil = don't send, pointer to false = reject, pointer to true = approve
+		toolTimeout    time.Duration
+		cancelCtx      bool // cancel the context before calling handleToolCall
+
+		// Plugin configuration.
+		generation       int64
+		activeGeneration int64
+		registered       bool
+
+		// Expected outcomes.
+		wantErr             string  // substring expected in returned error (empty = no error)
+		wantApprovalRequest bool    // expect approval_request step written
+		wantToolResult      bool    // expect tool_result step written
+		wantApprovalErrCode *string // expected ErrorCode in error step (nil = any/none)
+	}{
+		{
+			// Approved + generation match → proceeds to placeholder dispatch.
+			// Returning errPluginDispatchUnimplemented here confirms the gate
+			// fired before dispatch was attempted.
+			name:             "approved",
+			approvalRequired: true,
+			approvalChSend:   boolPtr(true),
+			generation:       1,
+			activeGeneration: 1,
+			registered:       true,
+			wantErr:          "plugin tool dispatch is not yet implemented",
+			wantApprovalRequest: true,
+		},
+		{
+			// Operator rejects → approval_request written, error returned, no tool_result.
+			name:             "rejected",
+			approvalRequired: true,
+			approvalChSend:   boolPtr(false),
+			generation:       1,
+			activeGeneration: 1,
+			registered:       true,
+			wantErr:          "rejected by operator",
+			wantApprovalRequest: true,
+			wantApprovalErrCode: strPtr(string(model.ErrorCodeApprovalRejected)),
+		},
+		{
+			// Approval times out before a decision arrives.
+			name:             "timeout",
+			approvalRequired: true,
+			approvalChSend:   nil,   // no send → select falls through to timeout
+			toolTimeout:      20 * time.Millisecond,
+			generation:       1,
+			activeGeneration: 1,
+			registered:       true,
+			wantErr:          "approval timeout",
+			wantApprovalRequest: true,
+			wantApprovalErrCode: strPtr(string(model.ErrorCodeApprovalRejected)),
+		},
+		{
+			// Context is cancelled before handleToolCall is even entered.
+			name:             "ctx_cancelled",
+			approvalRequired: true,
+			approvalChSend:   nil,
+			cancelCtx:        true,
+			generation:       1,
+			activeGeneration: 1,
+			registered:       true,
+			wantErr:          "context cancelled",
+			wantApprovalRequest: false,
+		},
+		{
+			// Sanity case: approval NOT required + generation mismatch → generation
+			// guard produces a structural tool_result error, no approval gate involved.
+			name:             "approval_not_required_generation_mismatch_returns_structural_error",
+			approvalRequired: false,
+			approvalChSend:   nil,
+			generation:       1,
+			activeGeneration: 2, // mismatch
+			registered:       true,
+			wantErr:          "",  // no error returned
+			wantApprovalRequest: false,
+			wantToolResult:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testutil.NewTestStore(t)
+			testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+			testutil.InsertRun(t, s, "r1", "p1", model.RunStatusRunning)
+
+			registrar := &fakePluginRegistrar{
+				activeGen:  tc.activeGeneration,
+				registered: tc.registered,
+			}
+
+			// Wire ApprovalCh only for cases that need approval gating.
+			var approvalCh chan bool
+			approval := model.ApprovalModeNone
+			if tc.approvalRequired {
+				approval = model.ApprovalModeRequired
+				approvalCh = make(chan bool, 1)
+				if tc.approvalChSend != nil {
+					approvalCh <- *tc.approvalChSend
+				}
+			}
+
+			w := NewAuditWriter(s.Queries())
+			ba, err := New(Config{
+				Policy: minimalPolicy(),
+				PluginTools: []PluginToolEntry{
+					{
+						InstanceName: "my-plugin",
+						ToolName:     "do-thing",
+						Generation:   tc.generation,
+						Approval:     approval,
+						Timeout:      tc.toolTimeout,
+					},
+				},
+				PluginRegistrar: registrar,
+				LLMClient:       testutil.NewNoopLLMClient(),
+				Audit:           w,
+				ApprovalCh:      approvalCh,
+				StateMachine:    NewRunStateMachine("r1", model.RunStatusRunning, s.DB(), s.Queries()),
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			ctx := context.Background()
+			if tc.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			_, _, callErr := ba.handleToolCall(ctx, "r1", "my-plugin.do-thing", map[string]any{})
+
+			if tc.wantErr != "" {
+				if callErr == nil {
+					t.Fatalf("handleToolCall returned nil; want error containing %q", tc.wantErr)
+				}
+				if !strings.Contains(callErr.Error(), tc.wantErr) {
+					t.Errorf("handleToolCall error = %q; want it to contain %q", callErr.Error(), tc.wantErr)
+				}
+			} else if callErr != nil {
+				t.Fatalf("handleToolCall returned unexpected error: %v", callErr)
+			}
+
+			steps, listErr := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
+			if listErr != nil {
+				t.Fatalf("ListRunSteps: %v", listErr)
+			}
+
+			var approvalRequestFound, toolResultFound bool
+			var foundErrCode string
+			for _, step := range steps {
+				switch step.Type {
+				case string(model.StepTypeApprovalRequest):
+					approvalRequestFound = true
+				case string(model.StepTypeToolResult):
+					toolResultFound = true
+				case string(model.StepTypeError):
+					var content map[string]string
+					if jsonErr := json.Unmarshal([]byte(step.Content), &content); jsonErr == nil {
+						foundErrCode = content["code"]
+					}
+				}
+			}
+
+			if tc.wantApprovalRequest && !approvalRequestFound {
+				t.Error("expected approval_request step to be written; none found")
+			}
+			if !tc.wantApprovalRequest && approvalRequestFound {
+				t.Error("approval_request step written unexpectedly")
+			}
+			if tc.wantToolResult && !toolResultFound {
+				t.Error("expected tool_result step to be written; none found")
+			}
+			if tc.wantApprovalErrCode != nil && foundErrCode != *tc.wantApprovalErrCode {
+				t.Errorf("error step code = %q; want %q", foundErrCode, *tc.wantApprovalErrCode)
+			}
+		})
+	}
+}
+
+// boolPtr returns a pointer to a bool literal.
+func boolPtr(b bool) *bool { return &b }
+
+// strPtr returns a pointer to a string literal.
+func strPtr(s string) *string { return &s }
+
+// TestHandleToolCall_PluginTool_ApprovalGated_GateFiredBeforeGenerationGuard
+// verifies the specific invariant: when a plugin tool has Approval: required AND
+// the generation is mismatched, the approval gate fires FIRST (approval_request
+// step is written and the run waits), and only after approval does the generation
+// guard produce the structural tool_result error.
+func TestHandleToolCall_PluginTool_ApprovalGated_GateFiredBeforeGenerationGuard(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusRunning)
+
+	// Generation mismatch: snapshot captured generation 1, registrar says 2 is active.
+	registrar := &fakePluginRegistrar{activeGen: 2, registered: true}
+
+	// Operator approves — we want to confirm approval runs before the guard.
+	approvalCh := make(chan bool, 1)
+	approvalCh <- true
+
+	w := NewAuditWriter(s.Queries())
+	ba, err := New(Config{
+		Policy: minimalPolicy(),
+		PluginTools: []PluginToolEntry{
+			{
+				InstanceName: "my-plugin",
+				ToolName:     "do-thing",
+				Generation:   1, // stale generation
+				Approval:     model.ApprovalModeRequired,
+			},
+		},
+		PluginRegistrar: registrar,
+		LLMClient:       testutil.NewNoopLLMClient(),
+		Audit:           w,
+		ApprovalCh:      approvalCh,
+		StateMachine:    NewRunStateMachine("r1", model.RunStatusRunning, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// The call should succeed at the handleToolCall level (structural tool_result, no error).
+	output, isErr, callErr := ba.handleToolCall(context.Background(), "r1", "my-plugin.do-thing", map[string]any{})
+	if callErr != nil {
+		t.Fatalf("handleToolCall returned unexpected error: %v", callErr)
+	}
+	if !isErr {
+		t.Error("expected isErr=true for generation mismatch after approval")
+	}
+	if !strings.Contains(output, "no longer active") {
+		t.Errorf("output = %q; want it to contain 'no longer active'", output)
+	}
+
+	steps, listErr := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
+	if listErr != nil {
+		t.Fatalf("ListRunSteps: %v", listErr)
+	}
+
+	var approvalRequestFound, toolResultFound bool
+	for _, step := range steps {
+		switch step.Type {
+		case string(model.StepTypeApprovalRequest):
+			approvalRequestFound = true
+		case string(model.StepTypeToolResult):
+			var content map[string]any
+			if jsonErr := json.Unmarshal([]byte(step.Content), &content); jsonErr == nil {
+				if isErrFlag, _ := content["is_error"].(bool); isErrFlag {
+					toolResultFound = true
+				}
+			}
+		}
+	}
+
+	if !approvalRequestFound {
+		t.Error("approval_request step not written — gate must fire before generation guard")
+	}
+	if !toolResultFound {
+		t.Error("expected tool_result step with is_error=true for generation mismatch")
+	}
+}
+
 // TestNew_PluginToolValidateCallRejectsUndeclared verifies that handleToolCall
 // runs ValidateCall against the narrowed plugin schema before reaching the plugin
 // generation guard or dispatch placeholder. The reorder in agent.go ensures


### PR DESCRIPTION
Closes #197

## Summary
Hoists the approval interceptor in `BoundAgent.handleToolCall` above the plugin source branch so a single source-agnostic chokepoint enforces ADR-008 for both MCP and plugin tools. Previously, plugin tools fell through `errPluginDispatchUnimplemented` *before* `ApprovalHandler.Wait` was called — a bypass forbidden by the issue's "no code path bypasses approval based on tool source" criterion.

The fix is a structural reorder, not new logic. `ApprovalHandler.Wait` was already source-agnostic; the bug was purely in dispatch ordering inside `handleToolCall`.

## Changes
- `internal/execution/agent/agent.go` — moved approval block above the plugin generation guard; added `Timeout time.Duration` to `PluginToolEntry` (mirrors `GrantedTool.Timeout` for MCP); ADR-008 reference + ordering rationale in comments.
- `internal/execution/agent/agent_test.go` — added `TestHandleToolCall_PluginTool_ApprovalGated` (5 subcases: approved / rejected / timeout / ctx_cancelled / sanity) and `TestHandleToolCall_PluginTool_ApprovalGated_GateFiredBeforeGenerationGuard` (proves approval fires first even when the generation guard would otherwise short-circuit).
- `docs/developer/plugin-system-spec.md` — §3.3 implementation invariant note.

## Architecture plan
<details>
<summary>Plan (architect → plan-reviewer approved)</summary>

The approval interceptor in `handleToolCall` was structurally placed *after* the plugin source guard. For an approval-gated plugin tool, control returned at `errPluginDispatchUnimplemented` without ever reaching `a.approvals.Wait`. ADR-008 makes approval a runtime guarantee that should sit above transport routing — same shape as `mcp.ValidateCall`, which already runs before source routing.

Resulting order in `handleToolCall`:
1. ctx.Err() bail
2. Synthetic gleipnir.* routing
3. toolsByName lookup
4. ValidateCall on narrowed schema
5. **Approval gate (single chokepoint)**
6. Plugin generation guard / dispatch
7. tool_call step + MCP dispatch
</details>

## Pipeline
- Brainstorming triggered: no (issue was well-specified)
- Architect → plan-reviewer: APPROVE with 3 non-blocking refinements (all folded in)
- Code review cycles: 2 (cycle 1 flagged a misleading test comment + a fragile `tc.name` string compare; both fixed in cycle 2)
- CLAUDE.md updates: not needed
- 🤖 Generated by the agentic dev loop