### PR TITLE
feat: ChannelService.Notify + Request RPC dispatcher

### DIFF
--- a/internal/plugin/dispatch/channel.go
+++ b/internal/plugin/dispatch/channel.go
@@ -1,0 +1,514 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
+)
+
+// RouteContext carries the run/policy/tool identifiers that accompany a
+// channel dispatch.  It maps to the commonv1.RequestContext that is sent to
+// the plugin with every RPC.
+type RouteContext struct {
+	RunID    string
+	PolicyID string
+	ToolName string
+}
+
+// DispatcherConfig holds all tunable parameters for a Dispatcher.
+type DispatcherConfig struct {
+	// Queries is the sqlc query layer used for audience lookup and request persistence.
+	Queries *db.Queries
+
+	// Connect returns a gRPC connection to the named plugin instance.
+	// Reuses the ConnFactory alias defined in pool.go.
+	// Not called when NewChannelClient is set.
+	Connect ConnFactory
+
+	// Publisher, if non-nil, receives audit events on Notify failures.
+	Publisher event.Publisher
+
+	// NotifyTimeout is the per-Notify-call deadline.  Defaults to 10s if zero.
+	NotifyTimeout time.Duration
+
+	// PreAckTimeout is the deadline given to the plugin to return its
+	// synchronous pre-ack from a Request RPC.  Defaults to 5s if zero.
+	PreAckTimeout time.Duration
+
+	// WriteRunStep persists a run step into the audit log.  The signature is
+	// intentionally narrow so this package never needs to import
+	// internal/execution/agent (ADR package-boundary constraint).
+	//
+	//   ctx      — caller's context
+	//   runID    — run to attach the step to
+	//   stepType — e.g. "feedback_dispatch_error", "plugin_request_timeout"
+	//   payload  — arbitrary JSON-serialisable map
+	WriteRunStep func(ctx context.Context, runID, stepType string, payload map[string]interface{}) error
+
+	// NewChannelClient is an injectable factory for the gRPC channel client.
+	// nil means use Connect + channelv1.NewChannelServiceClient (production).
+	// Tests set this to inject a fake without standing up a real gRPC server.
+	NewChannelClient func(instanceName string) channelv1.ChannelServiceClient
+}
+
+// Dispatcher routes ChannelService.Notify and ChannelService.Request calls to
+// plugin instances.
+//
+// Package boundary: internal/plugin must not import internal/execution/agent.
+// WriteRunStep is injected via DispatcherConfig to preserve that boundary.
+//
+// KNOWN DEPENDENCY / DEAD-CODE WINDOW: Dispatcher.Resolve is currently dead
+// code in production.  At the time this was written, WriteAuditStep in
+// internal/plugin/hostsvc/handlers.go dispatches feedback_response payloads
+// exclusively via q.GetFeedbackRequest.  It does NOT consult
+// plugin_pending_requests and does NOT call Dispatcher.Resolve.  Resolve
+// becomes reachable once a follow-up issue extends WriteAuditStep to also look
+// up plugin_pending_requests and invoke Dispatcher.Resolve.  Until then, the
+// unit tests exercise Resolve directly.
+type Dispatcher struct {
+	cfg DispatcherConfig
+
+	// waitersMu guards the waiters map.
+	waitersMu sync.Mutex
+	// waiters maps requestID → buffered channel that carries the resolved
+	// response JSON string.  The channel has capacity 1 so Resolve never
+	// blocks even when the caller has already timed out.
+	waiters map[string]chan string
+}
+
+// NewDispatcher creates a Dispatcher ready to use.
+func NewDispatcher(cfg DispatcherConfig) *Dispatcher {
+	if cfg.NotifyTimeout == 0 {
+		cfg.NotifyTimeout = 10 * time.Second
+	}
+	if cfg.PreAckTimeout == 0 {
+		cfg.PreAckTimeout = 5 * time.Second
+	}
+	return &Dispatcher{
+		cfg:     cfg,
+		waiters: make(map[string]chan string),
+	}
+}
+
+// channelClient returns a ChannelServiceClient for the given instance.
+// When NewChannelClient is set (e.g. in tests), the factory is called directly
+// without going through Connect.  In production, Connect is used to obtain a
+// gRPC connection which is then wrapped with channelv1.NewChannelServiceClient.
+func (d *Dispatcher) channelClient(instanceName string) (channelv1.ChannelServiceClient, error) {
+	if d.cfg.NewChannelClient != nil {
+		return d.cfg.NewChannelClient(instanceName), nil
+	}
+	conn, err := d.cfg.Connect(instanceName)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to plugin instance %q: %w", instanceName, err)
+	}
+	return channelv1.NewChannelServiceClient(conn), nil
+}
+
+// Notify dispatches a fire-and-forget notification to every audience entry
+// that has notify: true.  Failures are logged and metric-counted but never
+// propagated — the run is unaffected regardless of how many entries fail.
+// Worst-case wall-clock is bounded by cfg.NotifyTimeout.
+func (d *Dispatcher) Notify(ctx context.Context, audienceID string, rc RouteContext, eventType, payloadJSON string) error {
+	entries, err := d.cfg.Queries.GetPluginAudienceWithEntries(ctx, audienceID)
+	if err != nil {
+		return fmt.Errorf("get audience %s: %w", audienceID, err)
+	}
+
+	// Collect the entries that are eligible for Notify dispatch.
+	type target struct {
+		entryID      string
+		instanceName string
+		instanceID   string
+		pluginID     string
+		configJSON   string
+	}
+	var targets []target
+	for _, ae := range entries {
+		// LEFT JOIN rows where the audience has no entries have nil EntryID.
+		if ae.EntryID == nil || ae.PluginInstanceID == nil {
+			continue
+		}
+		// Notify is an *int64 from SQLite's integer boolean column.
+		if ae.Notify == nil || *ae.Notify == 0 {
+			continue
+		}
+		inst, err := d.cfg.Queries.GetPluginInstanceByID(ctx, *ae.PluginInstanceID)
+		if err != nil {
+			slog.Warn("notify: could not load plugin instance",
+				"entry_id", *ae.EntryID,
+				"instance_id", *ae.PluginInstanceID,
+				"err", err,
+			)
+			continue
+		}
+		configJSON := ""
+		if ae.ConfigJson != nil {
+			configJSON = *ae.ConfigJson
+		}
+		targets = append(targets, target{
+			entryID:      *ae.EntryID,
+			instanceName: inst.InstanceName,
+			instanceID:   inst.ID,
+			pluginID:     inst.PluginID,
+			configJSON:   configJSON,
+		})
+	}
+
+	if len(targets) == 0 {
+		return nil
+	}
+
+	// All goroutines share a single NotifyTimeout-bounded context so the
+	// worst-case wall clock is bounded regardless of fan-out width.
+	notifyCtx, cancel := context.WithTimeout(ctx, d.cfg.NotifyTimeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, t := range targets {
+		t := t // capture loop variable
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.notifyOne(notifyCtx, rc, t.instanceName, t.instanceID, t.pluginID, t.configJSON, eventType, payloadJSON)
+		}()
+	}
+	wg.Wait()
+	return nil
+}
+
+// notifyOne performs the Notify RPC for a single audience entry.  Any failure
+// is logged and metric-counted but never returned; the caller (Notify) ignores
+// per-entry errors per spec §6.2.
+func (d *Dispatcher) notifyOne(ctx context.Context, rc RouteContext, instanceName, instanceID, pluginID, configJSON, eventType, payloadJSON string) {
+	client, err := d.channelClient(instanceName)
+	if err != nil {
+		slog.Warn("notify: connect failed",
+			"instance", instanceName,
+			"run_id", rc.RunID,
+			"err", err,
+		)
+		incRPCError("Notify", pluginID, instanceID)
+		d.publishAuditEvent(rc.RunID, instanceName, "notify_failed", err.Error())
+		return
+	}
+
+	start := time.Now()
+	resp, rpcErr := client.Notify(ctx, &channelv1.NotifyRequest{
+		Context: &commonv1.RequestContext{
+			RunId:    rc.RunID,
+			PolicyId: rc.PolicyID,
+			CallId:   model.NewULID(), // unique call ID per notify invocation
+		},
+		EventType:         eventType,
+		PayloadJson:       payloadJSON,
+		ChannelConfigJson: configJSON,
+	})
+	observeRPC("Notify", pluginID, instanceID, start)
+
+	// Treat any of: gRPC error, ok==false, non-nil error envelope as failure.
+	var failureMsg string
+	switch {
+	case rpcErr != nil:
+		failureMsg = rpcErr.Error()
+	case resp != nil && !resp.GetOk():
+		failureMsg = "plugin returned ok=false"
+		if resp.GetError() != nil {
+			failureMsg = fmt.Sprintf("plugin returned ok=false: %s", resp.GetError().GetMessage())
+		}
+	case resp != nil && resp.GetError() != nil:
+		failureMsg = fmt.Sprintf("plugin returned error: %s", resp.GetError().GetMessage())
+	}
+
+	if failureMsg != "" {
+		slog.Warn("notify: RPC failed",
+			"instance", instanceName,
+			"run_id", rc.RunID,
+			"event_type", eventType,
+			"err", failureMsg,
+		)
+		incRPCError("Notify", pluginID, instanceID)
+		d.publishAuditEvent(rc.RunID, instanceName, "notify_failed", failureMsg)
+	}
+}
+
+// Request dispatches a channel request to the first audience entry with
+// request: true (in position order).  It applies a 5s pre-ack deadline; on
+// pre-ack success it inserts a plugin_pending_requests row and returns the
+// requestID so the caller can block on Wait.
+//
+// On pre-ack failure, it calls WriteRunStep with a "feedback_dispatch_error"
+// step and returns ErrPreAckFailed.  The caller should map this to
+// runstate.TransitionRunFailed.
+func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteContext, prompt string, expiresAt *time.Time) (requestID string, err error) {
+	entries, err := d.cfg.Queries.GetPluginAudienceWithEntries(ctx, audienceID)
+	if err != nil {
+		return "", fmt.Errorf("get audience %s: %w", audienceID, err)
+	}
+
+	// Find the first entry with request capability.
+	var (
+		targetEntry    *db.GetPluginAudienceWithEntriesRow
+		targetInstance db.PluginInstance
+	)
+	for i := range entries {
+		ae := &entries[i]
+		if ae.EntryID == nil || ae.PluginInstanceID == nil {
+			continue
+		}
+		// Request is an *int64 from SQLite's integer boolean column.
+		if ae.Request == nil || *ae.Request == 0 {
+			continue
+		}
+		inst, lookupErr := d.cfg.Queries.GetPluginInstanceByID(ctx, *ae.PluginInstanceID)
+		if lookupErr != nil {
+			slog.Warn("request: could not load plugin instance",
+				"entry_id", *ae.EntryID,
+				"instance_id", *ae.PluginInstanceID,
+				"err", lookupErr,
+			)
+			continue
+		}
+		targetEntry = ae
+		targetInstance = inst
+		break
+	}
+
+	if targetEntry == nil {
+		return "", ErrNoRequestCapableEntry
+	}
+
+	client, err := d.channelClient(targetInstance.InstanceName)
+	if err != nil {
+		return "", fmt.Errorf("connecting to plugin instance %q: %w", targetInstance.InstanceName, err)
+	}
+
+	// §4.2: request_id is instance-scoped, NOT generation-scoped. Never append a
+	// generation counter here — the ID must survive plugin hot-reloads so that
+	// callbacks from the plugin (WriteAuditStep) can match across generations.
+	reqID := model.NewULID()
+
+	// Register the waiter BEFORE the gRPC call so that a very fast Resolve
+	// (or a test that calls Resolve synchronously) does not miss the channel.
+	// Capacity 1 ensures Resolve never blocks even if Wait has already timed out.
+	waiter := make(chan string, 1)
+	d.waitersMu.Lock()
+	d.waiters[reqID] = waiter
+	d.waitersMu.Unlock()
+
+	configJSON := ""
+	if targetEntry.ConfigJson != nil {
+		configJSON = *targetEntry.ConfigJson
+	}
+
+	preCtx, cancelPre := context.WithTimeout(ctx, d.cfg.PreAckTimeout)
+	defer cancelPre()
+
+	start := time.Now()
+	resp, rpcErr := client.Request(preCtx, &channelv1.RequestRequest{
+		Context: &commonv1.RequestContext{
+			RunId:    rc.RunID,
+			PolicyId: rc.PolicyID,
+			CallId:   model.NewULID(),
+		},
+		RequestId:         reqID,
+		Prompt:            prompt,
+		ChannelConfigJson: configJSON,
+	})
+	observeRPC("Request", targetInstance.PluginID, targetInstance.ID, start)
+
+	// Classify pre-ack failure.
+	var preAckFailMsg string
+	switch {
+	case rpcErr != nil:
+		preAckFailMsg = rpcErr.Error()
+	case resp != nil && !resp.GetAcked():
+		preAckFailMsg = "plugin returned acked=false"
+		if resp.GetError() != nil {
+			preAckFailMsg = fmt.Sprintf("plugin returned acked=false: %s", resp.GetError().GetMessage())
+		}
+	case resp != nil && resp.GetError() != nil:
+		preAckFailMsg = fmt.Sprintf("plugin returned error: %s", resp.GetError().GetMessage())
+	}
+
+	if preAckFailMsg != "" {
+		// Deregister the waiter — no row will be inserted, so no one will ever
+		// send on this channel.
+		d.waitersMu.Lock()
+		delete(d.waiters, reqID)
+		d.waitersMu.Unlock()
+
+		incRPCError("Request", targetInstance.PluginID, targetInstance.ID)
+
+		if d.cfg.WriteRunStep != nil {
+			_ = d.cfg.WriteRunStep(ctx, rc.RunID, "feedback_dispatch_error", map[string]interface{}{
+				"message":     preAckFailMsg,
+				"code":        "feedback_dispatch_error",
+				"instance":    targetInstance.InstanceName,
+				"request_id":  reqID,
+			})
+		}
+		return "", fmt.Errorf("%w: %s", ErrPreAckFailed, preAckFailMsg)
+	}
+
+	// Pre-ack succeeded: persist the pending request row.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	var expiresAtStr *string
+	if expiresAt != nil {
+		s := expiresAt.UTC().Format(time.RFC3339Nano)
+		expiresAtStr = &s
+	}
+	var entryID *string
+	if targetEntry.EntryID != nil {
+		entryID = targetEntry.EntryID
+	}
+	if _, dbErr := d.cfg.Queries.CreatePluginPendingRequest(ctx, db.CreatePluginPendingRequestParams{
+		ID:               reqID,
+		PluginInstanceID: targetInstance.ID,
+		RunID:            rc.RunID,
+		AudienceEntryID:  entryID,
+		ToolName:         rc.ToolName,
+		ExpiresAt:        expiresAtStr,
+		CreatedAt:        now,
+	}); dbErr != nil {
+		// Row insert failed; clean up the waiter to avoid leaking the channel.
+		d.waitersMu.Lock()
+		delete(d.waiters, reqID)
+		d.waitersMu.Unlock()
+		return "", fmt.Errorf("persist plugin pending request: %w", dbErr)
+	}
+
+	return reqID, nil
+}
+
+// Resolve delivers the operator's response to the in-flight Request identified
+// by requestID.  It sends the response on the buffered waiter channel and
+// advances the persisted status to "resolved".
+//
+// If the scanner has already timed out the row (ErrTransitionConflict from
+// TransitionResolved), Resolve logs at debug and returns nil — the scanner
+// already handled the run-failure side effects.
+//
+// ErrUnknownRequestID is returned when the requestID is not in the waiters
+// map (never issued, already resolved, or expired).
+func (d *Dispatcher) Resolve(ctx context.Context, requestID, responseJSON string) error {
+	d.waitersMu.Lock()
+	ch, ok := d.waiters[requestID]
+	if !ok {
+		d.waitersMu.Unlock()
+		return ErrUnknownRequestID
+	}
+	delete(d.waiters, requestID)
+	d.waitersMu.Unlock()
+
+	// Deliver the response to the waiting Wait call (non-blocking; channel has
+	// capacity 1 so this never stalls even if Wait already returned on timeout).
+	select {
+	case ch <- responseJSON:
+	default:
+		// Wait already drained or closed — response discarded but that is fine.
+	}
+
+	if err := TransitionResolved(ctx, d.cfg.Queries, requestID, responseJSON); err != nil {
+		if errors.Is(err, ErrTransitionConflict) {
+			// The scanner already timed out this row while we were delivering the
+			// response.  The run is already being failed; nothing more to do.
+			slog.Debug("resolve: transition conflict — scanner already timed out request",
+				"request_id", requestID,
+			)
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// Wait blocks until the request identified by requestID is resolved, the
+// supplied timeout fires, or ctx is cancelled.
+//
+// When the local timer wins the race: TransitionTimedOut is attempted.  Only
+// when CAS reports rows == 1 (this caller won) is WriteRunStep called with a
+// "plugin_request_timeout" step — avoiding duplicate steps when the background
+// scanner beat us to it.
+func (d *Dispatcher) Wait(ctx context.Context, requestID string, timeout time.Duration) (responseJSON string, err error) {
+	d.waitersMu.Lock()
+	ch, ok := d.waiters[requestID]
+	d.waitersMu.Unlock()
+	if !ok {
+		// Caller may have already called Resolve before Wait; return immediately.
+		return "", ErrUnknownRequestID
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case msg := <-ch:
+		return msg, nil
+
+	case <-ctx.Done():
+		d.waitersMu.Lock()
+		delete(d.waiters, requestID)
+		d.waitersMu.Unlock()
+		return "", ctx.Err()
+
+	case <-timer.C:
+		d.waitersMu.Lock()
+		delete(d.waiters, requestID)
+		d.waitersMu.Unlock()
+
+		// Attempt to claim the timeout via CAS.  Only write the run step when
+		// this caller won (rows == 1).  When ErrTransitionConflict (rows == 0)
+		// the scanner already wrote the step; writing a second one would
+		// duplicate it.
+		if transErr := TransitionTimedOut(ctx, d.cfg.Queries, requestID); transErr != nil {
+			if errors.Is(transErr, ErrTransitionConflict) {
+				// Scanner already timed out this request and wrote the step.
+				slog.Debug("wait timer: transition conflict — scanner already timed out request",
+					"request_id", requestID,
+				)
+				return "", fmt.Errorf("plugin request timed out")
+			}
+			return "", fmt.Errorf("mark plugin request timed out: %w", transErr)
+		}
+
+		// CAS winner: write the timeout step to the run trace.
+		if d.cfg.WriteRunStep != nil {
+			req, dbErr := d.cfg.Queries.GetPluginPendingRequest(ctx, requestID)
+			if dbErr == nil {
+				_ = d.cfg.WriteRunStep(ctx, req.RunID, "plugin_request_timeout", map[string]interface{}{
+					"message":    fmt.Sprintf("plugin request timed out after %s", timeout),
+					"code":       "plugin_request_timeout",
+					"request_id": requestID,
+					"tool_name":  req.ToolName,
+				})
+			}
+		}
+		return "", fmt.Errorf("plugin request timed out")
+	}
+}
+
+// publishAuditEvent emits a generic audit event via the Publisher (if configured).
+func (d *Dispatcher) publishAuditEvent(runID, instance, eventType, message string) {
+	if d.cfg.Publisher == nil {
+		return
+	}
+	payload := map[string]string{
+		"run_id":   runID,
+		"instance": instance,
+		"message":  message,
+	}
+	if data, err := json.Marshal(payload); err == nil {
+		d.cfg.Publisher.Publish("plugin."+eventType, data)
+	}
+}

--- a/internal/plugin/dispatch/channel_metrics.go
+++ b/internal/plugin/dispatch/channel_metrics.go
@@ -1,0 +1,41 @@
+package dispatch
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
+)
+
+// pluginRPCDurationSeconds measures the wall-clock time for each outbound
+// ChannelService RPC, labelled by RPC name, plugin ID, and instance ID.
+var pluginRPCDurationSeconds = promauto.With(metrics.Registry()).NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "gleipnir_plugin_rpc_duration_seconds",
+		Help:    "Latency for outbound ChannelService RPCs by rpc, plugin, and instance.",
+		Buckets: metrics.BucketsFast,
+	},
+	[]string{"rpc", "plugin", "instance"},
+)
+
+// pluginRPCErrorsTotal counts ChannelService RPC failures by RPC name, plugin
+// ID, and instance ID.
+var pluginRPCErrorsTotal = promauto.With(metrics.Registry()).NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "gleipnir_plugin_rpc_errors_total",
+		Help: "ChannelService RPC failures by rpc, plugin, and instance.",
+	},
+	[]string{"rpc", "plugin", "instance"},
+)
+
+// observeRPC records the duration of a completed RPC call.
+func observeRPC(rpc, pluginID, instanceID string, start time.Time) {
+	pluginRPCDurationSeconds.WithLabelValues(rpc, pluginID, instanceID).Observe(time.Since(start).Seconds())
+}
+
+// incRPCError increments the error counter for a failed RPC call.
+func incRPCError(rpc, pluginID, instanceID string) {
+	pluginRPCErrorsTotal.WithLabelValues(rpc, pluginID, instanceID).Inc()
+}

--- a/internal/plugin/dispatch/channel_state.go
+++ b/internal/plugin/dispatch/channel_state.go
@@ -1,0 +1,99 @@
+// Package dispatch routes agent tool and channel calls to plugin instances
+// over gRPC.  This file owns the persisted lifecycle for plugin pending
+// requests: the two-status table (pending → resolved | timed_out) that mirrors
+// the approval and feedback request lifecycles in internal/execution/runstate.
+//
+// NOTE on terminology: there are two state machines involved in a Request flow.
+//
+//	Persisted lifecycle (this file): pending → resolved | timed_out.
+//	  Transitions are CAS-guarded via WHERE status='pending' on the
+//	  plugin_pending_requests row (ADR-038 spirit; no version column on this
+//	  table — status-equality CAS matches the feedback_requests precedent).
+//
+//	In-memory pre-ack micro-state: issued → pre_acked.
+//	  Lives only inside Dispatcher.Request during the 5s pre-ack window.
+//	  Never persisted; a pre-ack failure writes a feedback_dispatch_error step
+//	  and returns ErrPreAckFailed without inserting a plugin_pending_requests row.
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+)
+
+// ErrIllegalTransition is returned when a caller attempts a status transition
+// that is not in legalTransitions.
+var ErrIllegalTransition = errors.New("channel request: illegal status transition")
+
+// ErrTransitionConflict is returned when the CAS UPDATE finds rows_affected == 0,
+// meaning another writer (the timeout scanner or a concurrent Resolve call) already
+// advanced the row.  Callers must treat this as "the row is in a valid state —
+// your write was simply lost" rather than a fatal error.
+var ErrTransitionConflict = errors.New("channel request: transition lost to concurrent writer")
+
+// ChannelRequestStatus is the type for the plugin_pending_requests.status column.
+type ChannelRequestStatus string
+
+const (
+	StatusPending   ChannelRequestStatus = "pending"
+	StatusResolved  ChannelRequestStatus = "resolved"
+	StatusTimedOut  ChannelRequestStatus = "timed_out"
+)
+
+// legalTransitions enumerates valid status progressions for plugin pending
+// requests.  Only pending is non-terminal; resolved and timed_out have no
+// entry so any attempt to transition out of them returns ErrIllegalTransition.
+var legalTransitions = map[ChannelRequestStatus][]ChannelRequestStatus{
+	StatusPending: {StatusResolved, StatusTimedOut},
+}
+
+// isLegalTransition reports whether transitioning from → to is permitted.
+func isLegalTransition(from, to ChannelRequestStatus) bool {
+	for _, allowed := range legalTransitions[from] {
+		if allowed == to {
+			return true
+		}
+	}
+	return false
+}
+
+// TransitionResolved marks a plugin_pending_request as resolved with the given
+// response JSON.  Returns ErrTransitionConflict when rows_affected == 0 (the
+// scanner already marked it timed_out).
+func TransitionResolved(ctx context.Context, q *db.Queries, requestID, responseJSON string) error {
+	return transition(ctx, q, requestID, StatusResolved, &responseJSON)
+}
+
+// TransitionTimedOut marks a plugin_pending_request as timed_out.  Returns
+// ErrTransitionConflict when rows_affected == 0 (another writer already resolved
+// or timed-out the row).
+func TransitionTimedOut(ctx context.Context, q *db.Queries, requestID string) error {
+	return transition(ctx, q, requestID, StatusTimedOut, nil)
+}
+
+// transition is the shared implementation for all persisted status changes.
+func transition(ctx context.Context, q *db.Queries, requestID string, to ChannelRequestStatus, response *string) error {
+	if !isLegalTransition(StatusPending, to) {
+		return fmt.Errorf("%w: pending → %s", ErrIllegalTransition, to)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	rows, err := q.UpdatePluginPendingRequestStatus(ctx, db.UpdatePluginPendingRequestStatusParams{
+		Status:     string(to),
+		Response:   response,
+		ResolvedAt: &now,
+		ID:         requestID,
+	})
+	if err != nil {
+		return fmt.Errorf("update plugin pending request status: %w", err)
+	}
+	if rows == 0 {
+		// WHERE status='pending' guard: another writer already resolved this row.
+		return fmt.Errorf("%w: request %s", ErrTransitionConflict, requestID)
+	}
+	return nil
+}

--- a/internal/plugin/dispatch/channel_test.go
+++ b/internal/plugin/dispatch/channel_test.go
@@ -1,0 +1,725 @@
+package dispatch_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"google.golang.org/grpc"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
+)
+
+// ---- fake ChannelServiceClient ----
+
+// fakeChannelClient implements channelv1.ChannelServiceClient via hooks so
+// tests can inject arbitrary responses without standing up a real gRPC server.
+type fakeChannelClient struct {
+	notifyHook  func(ctx context.Context, req *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error)
+	requestHook func(ctx context.Context, req *channelv1.RequestRequest) (*channelv1.RequestResponse, error)
+}
+
+func (f *fakeChannelClient) Notify(ctx context.Context, in *channelv1.NotifyRequest, _ ...grpc.CallOption) (*channelv1.NotifyResponse, error) {
+	if f.notifyHook != nil {
+		return f.notifyHook(ctx, in)
+	}
+	return &channelv1.NotifyResponse{Ok: true}, nil
+}
+
+func (f *fakeChannelClient) Request(ctx context.Context, in *channelv1.RequestRequest, _ ...grpc.CallOption) (*channelv1.RequestResponse, error) {
+	if f.requestHook != nil {
+		return f.requestHook(ctx, in)
+	}
+	return &channelv1.RequestResponse{Acked: true}, nil
+}
+
+// Ensure fakeChannelClient satisfies the interface.
+var _ channelv1.ChannelServiceClient = (*fakeChannelClient)(nil)
+
+// ---- DB helpers ----
+
+// insertPlugin inserts a minimal plugin row and returns its ID.
+func insertPlugin(t *testing.T, s *db.Store, id, name string) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.DB().Exec(
+		`INSERT INTO plugins(id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at)
+		 VALUES (?, ?, '1.0.0', '{}', 'pubkey', 'active', 0, ?, ?)`,
+		id, name, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insertPlugin %s: %v", id, err)
+	}
+	return id
+}
+
+// insertPluginInstance inserts a minimal plugin_instances row and returns its ID.
+func insertPluginInstance(t *testing.T, s *db.Store, id, pluginID, instanceName string) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.DB().Exec(
+		`INSERT INTO plugin_instances(id, plugin_id, instance_name, config_json, version, created_at, updated_at)
+		 VALUES (?, ?, ?, '{}', 0, ?, ?)`,
+		id, pluginID, instanceName, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insertPluginInstance %s: %v", id, err)
+	}
+	return id
+}
+
+// insertAudience inserts a plugin_audiences row and returns its ID.
+func insertAudience(t *testing.T, s *db.Store, id, name string) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.DB().Exec(
+		`INSERT INTO plugin_audiences(id, name, version, created_at, updated_at)
+		 VALUES (?, ?, 0, ?, ?)`,
+		id, name, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insertAudience %s: %v", id, err)
+	}
+	return id
+}
+
+// insertAudienceEntry inserts an audience_entries row.
+func insertAudienceEntry(t *testing.T, s *db.Store, id, audienceID, instanceID string, position int64, notify, request bool) {
+	t.Helper()
+	notifyInt := int64(0)
+	if notify {
+		notifyInt = 1
+	}
+	requestInt := int64(0)
+	if request {
+		requestInt = 1
+	}
+	_, err := s.DB().Exec(
+		`INSERT INTO audience_entries(id, audience_id, plugin_instance_id, position, notify, request, config_json)
+		 VALUES (?, ?, ?, ?, ?, ?, '{}')`,
+		id, audienceID, instanceID, position, notifyInt, requestInt,
+	)
+	if err != nil {
+		t.Fatalf("insertAudienceEntry %s: %v", id, err)
+	}
+}
+
+// ---- dispatcher factory helpers ----
+
+type dispatcherSetup struct {
+	store     *db.Store
+	clientMap map[string]*fakeChannelClient // instanceName → fake
+	steps     []capturedStep
+	stepsMu   sync.Mutex
+}
+
+type capturedStep struct {
+	runID    string
+	stepType string
+	payload  map[string]interface{}
+}
+
+func (ds *dispatcherSetup) newDispatcher(notifyTimeout, preAckTimeout time.Duration) *dispatch.Dispatcher {
+	return dispatch.NewDispatcher(dispatch.DispatcherConfig{
+		Queries:       ds.store.Queries(),
+		// Connect is not called when NewChannelClient is set; nil is safe here.
+		NotifyTimeout: notifyTimeout,
+		PreAckTimeout: preAckTimeout,
+		WriteRunStep: func(ctx context.Context, runID, stepType string, payload map[string]interface{}) error {
+			ds.stepsMu.Lock()
+			ds.steps = append(ds.steps, capturedStep{runID: runID, stepType: stepType, payload: payload})
+			ds.stepsMu.Unlock()
+			return nil
+		},
+		NewChannelClient: func(instanceName string) channelv1.ChannelServiceClient {
+			ds.stepsMu.Lock()
+			c := ds.clientMap[instanceName]
+			ds.stepsMu.Unlock()
+			if c == nil {
+				return &fakeChannelClient{}
+			}
+			return c
+		},
+	})
+}
+
+func (ds *dispatcherSetup) stepsByType(stepType string) []capturedStep {
+	ds.stepsMu.Lock()
+	defer ds.stepsMu.Unlock()
+	var out []capturedStep
+	for _, s := range ds.steps {
+		if s.stepType == stepType {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func newSetup(t *testing.T) *dispatcherSetup {
+	t.Helper()
+	s := testutil.NewTestStore(t)
+	return &dispatcherSetup{
+		store:     s,
+		clientMap: make(map[string]*fakeChannelClient),
+	}
+}
+
+// ---- Notify tests ----
+
+// TestNotify_ParallelFanOut exercises three entries: one ok, one ok=false with
+// an error envelope, one gRPC error.  All three should be invoked; the run is
+// unaffected; audit events are emitted for the two failures.
+func TestNotify_ParallelFanOut(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "my-plugin")
+	inst1 := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	inst2 := insertPluginInstance(t, ds.store, "i2", pluginID, "inst-nok")
+	inst3 := insertPluginInstance(t, ds.store, "i3", pluginID, "inst-err")
+	audID := insertAudience(t, ds.store, "aud1", "aud-fanout")
+	insertAudienceEntry(t, ds.store, "ae1", audID, inst1, 0, true, false)
+	insertAudienceEntry(t, ds.store, "ae2", audID, inst2, 1, true, false)
+	insertAudienceEntry(t, ds.store, "ae3", audID, inst3, 2, true, false)
+
+	var invokedMu sync.Mutex
+	invoked := map[string]bool{}
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		notifyHook: func(_ context.Context, req *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+			invokedMu.Lock()
+			invoked["inst-ok"] = true
+			invokedMu.Unlock()
+			return &channelv1.NotifyResponse{Ok: true}, nil
+		},
+	}
+	ds.clientMap["inst-nok"] = &fakeChannelClient{
+		notifyHook: func(_ context.Context, req *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+			invokedMu.Lock()
+			invoked["inst-nok"] = true
+			invokedMu.Unlock()
+			return &channelv1.NotifyResponse{
+				Ok:    false,
+				Error: &commonv1.ErrorEnvelope{Message: "delivery failed"},
+			}, nil
+		},
+	}
+	ds.clientMap["inst-err"] = &fakeChannelClient{
+		notifyHook: func(_ context.Context, req *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+			invokedMu.Lock()
+			invoked["inst-err"] = true
+			invokedMu.Unlock()
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	d := ds.newDispatcher(500*time.Millisecond, 50*time.Millisecond)
+	rc := dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "alert"}
+
+	start := time.Now()
+	err := d.Notify(context.Background(), audID, rc, "run_failed", `{}`)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Notify returned unexpected error: %v", err)
+	}
+
+	invokedMu.Lock()
+	for _, name := range []string{"inst-ok", "inst-nok", "inst-err"} {
+		if !invoked[name] {
+			t.Errorf("expected instance %q to be invoked, but it was not", name)
+		}
+	}
+	invokedMu.Unlock()
+
+	// Wall clock must be well under NotifyTimeout * 1.5 (parallel, not serial).
+	if elapsed > 750*time.Millisecond {
+		t.Errorf("Notify took %v, want < 750ms (serial execution suspected)", elapsed)
+	}
+}
+
+// TestNotify_EmptyAudience verifies that Notify on an empty audience returns
+// nil without calling the client factory.
+func TestNotify_EmptyAudience(t *testing.T) {
+	ds := newSetup(t)
+	audID := insertAudience(t, ds.store, "aud-empty", "empty")
+	// No entries inserted.
+
+	var called atomic.Bool
+	ds.clientMap["whatever"] = &fakeChannelClient{
+		notifyHook: func(_ context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+			called.Store(true)
+			return &channelv1.NotifyResponse{Ok: true}, nil
+		},
+	}
+
+	d := ds.newDispatcher(200*time.Millisecond, 50*time.Millisecond)
+	if err := d.Notify(context.Background(), audID, dispatch.RouteContext{RunID: "r", PolicyID: "p", ToolName: "t"}, "ev", "{}"); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if called.Load() {
+		t.Error("client factory should not be called for empty audience")
+	}
+}
+
+// TestNotify_DeadlineUpperBound verifies that a blocking fake client is
+// cancelled within NotifyTimeout and non-blocking siblings complete.
+func TestNotify_DeadlineUpperBound(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instBlocking := insertPluginInstance(t, ds.store, "iblk", pluginID, "blocking")
+	instFast := insertPluginInstance(t, ds.store, "iFst", pluginID, "fast")
+	audID := insertAudience(t, ds.store, "aud-deadline", "deadline")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instBlocking, 0, true, false)
+	insertAudienceEntry(t, ds.store, "ae2", audID, instFast, 1, true, false)
+
+	var fastDone atomic.Bool
+	ds.clientMap["blocking"] = &fakeChannelClient{
+		notifyHook: func(ctx context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+			<-ctx.Done() // block until context is cancelled
+			return nil, ctx.Err()
+		},
+	}
+	ds.clientMap["fast"] = &fakeChannelClient{
+		notifyHook: func(_ context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+			fastDone.Store(true)
+			return &channelv1.NotifyResponse{Ok: true}, nil
+		},
+	}
+
+	notifyTimeout := 150 * time.Millisecond
+	d := ds.newDispatcher(notifyTimeout, 50*time.Millisecond)
+
+	start := time.Now()
+	err := d.Notify(context.Background(), audID, dispatch.RouteContext{RunID: "r", PolicyID: "p", ToolName: "t"}, "ev", "{}")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Notify returned error: %v", err)
+	}
+
+	// Notify returns nil regardless of failures.
+	slack := 100 * time.Millisecond
+	if elapsed > notifyTimeout+slack {
+		t.Errorf("Notify took %v, want < %v (deadline not enforced)", elapsed, notifyTimeout+slack)
+	}
+	if !fastDone.Load() {
+		t.Error("non-blocking sibling should have completed")
+	}
+}
+
+// TestNotify_SkipsRowsWithNilOrZeroNotify verifies that entries with nil or 0
+// notify, nil EntryID, or nil PluginInstanceID are skipped.
+func TestNotify_SkipsRowsWithNilOrZeroNotify(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instRequest := insertPluginInstance(t, ds.store, "ir", pluginID, "request-only")
+	audID := insertAudience(t, ds.store, "aud-skip", "skip")
+	// Entry with notify=0 (request only).
+	insertAudienceEntry(t, ds.store, "ae1", audID, instRequest, 0, false, true)
+
+	var called atomic.Bool
+	ds.clientMap["request-only"] = &fakeChannelClient{
+		notifyHook: func(_ context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+			called.Store(true)
+			return &channelv1.NotifyResponse{Ok: true}, nil
+		},
+	}
+
+	d := ds.newDispatcher(200*time.Millisecond, 50*time.Millisecond)
+	if err := d.Notify(context.Background(), audID, dispatch.RouteContext{RunID: "r", PolicyID: "p", ToolName: "t"}, "ev", "{}"); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if called.Load() {
+		t.Error("request-only entry should not receive Notify calls")
+	}
+}
+
+// ---- Request tests ----
+
+// TestRequest_PicksFirstRequestEntry verifies that Request selects the first
+// entry with request=true in position order and skips notify-only entries.
+func TestRequest_PicksFirstRequestEntry(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instNotify := insertPluginInstance(t, ds.store, "in", pluginID, "notify-only")
+	instReq1 := insertPluginInstance(t, ds.store, "ir1", pluginID, "req-first")
+	instReq2 := insertPluginInstance(t, ds.store, "ir2", pluginID, "req-second")
+	audID := insertAudience(t, ds.store, "aud-pick", "pick")
+	insertAudienceEntry(t, ds.store, "ae0", audID, instNotify, 0, true, false)
+	insertAudienceEntry(t, ds.store, "ae1", audID, instReq1, 1, false, true)
+	insertAudienceEntry(t, ds.store, "ae2", audID, instReq2, 2, false, true)
+
+	var calledInst atomic.Value
+	ds.clientMap["req-first"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, req *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			calledInst.Store("req-first")
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+	ds.clientMap["req-second"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, req *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			calledInst.Store("req-second")
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	reqID, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "hello", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if reqID == "" {
+		t.Fatal("requestID should not be empty")
+	}
+	if calledInst.Load() != "req-first" {
+		t.Errorf("calledInst = %q, want req-first", calledInst.Load())
+	}
+}
+
+// TestRequest_PreAckSuccess_RowInserted_ResolveFlipsStatus verifies the happy
+// path: pre-ack succeeds → row inserted with status='pending'; Resolve flips
+// it to 'resolved'; request_id is a valid ULID.
+func TestRequest_PreAckSuccess_RowInserted_ResolveFlipsStatus(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	reqID, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if reqID == "" {
+		t.Fatal("requestID is empty")
+	}
+	// Validate that the requestID is a valid ULID.
+	if _, parseErr := ulid.ParseStrict(reqID); parseErr != nil {
+		t.Errorf("requestID %q is not a valid ULID: %v", reqID, parseErr)
+	}
+
+	// Row must be pending in the DB.
+	var status string
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = ?`, reqID).Scan(&status); err != nil {
+		t.Fatalf("query pending request: %v", err)
+	}
+	if status != "pending" {
+		t.Errorf("status = %q, want pending", status)
+	}
+
+	// Resolve must flip it to resolved.
+	if err := d.Resolve(context.Background(), reqID, `{"answer":"yes"}`); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = ?`, reqID).Scan(&status); err != nil {
+		t.Fatalf("query after Resolve: %v", err)
+	}
+	if status != "resolved" {
+		t.Errorf("status after Resolve = %q, want resolved", status)
+	}
+}
+
+// TestRequest_PreAckAckedFalse verifies that acked=false causes a
+// feedback_dispatch_error step, returns ErrPreAckFailed, and does not insert a
+// pending row.
+func TestRequest_PreAckAckedFalse(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-nack")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-nack"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: false}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	_, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if !errors.Is(err, dispatch.ErrPreAckFailed) {
+		t.Errorf("expected ErrPreAckFailed, got %v", err)
+	}
+
+	// WriteRunStep must have been called with feedback_dispatch_error.
+	steps := ds.stepsByType("feedback_dispatch_error")
+	if len(steps) != 1 {
+		t.Errorf("feedback_dispatch_error steps = %d, want 1", len(steps))
+	}
+
+	// No row should be in plugin_pending_requests.
+	var count int
+	if err := ds.store.DB().QueryRow(`SELECT COUNT(*) FROM plugin_pending_requests WHERE run_id = 'run1'`).Scan(&count); err != nil {
+		t.Fatalf("count pending requests: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("pending requests count = %d, want 0", count)
+	}
+}
+
+// TestRequest_PreAckTimeout verifies that a 5s pre-ack timeout (simulated with
+// a tiny timeout) causes the same behaviour as acked=false.
+func TestRequest_PreAckTimeout(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-slow")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-slow"] = &fakeChannelClient{
+		requestHook: func(ctx context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	// Very short pre-ack timeout so the test completes quickly.
+	d := ds.newDispatcher(200*time.Millisecond, 20*time.Millisecond)
+	_, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if !errors.Is(err, dispatch.ErrPreAckFailed) {
+		t.Errorf("expected ErrPreAckFailed, got %v", err)
+	}
+
+	steps := ds.stepsByType("feedback_dispatch_error")
+	if len(steps) != 1 {
+		t.Errorf("feedback_dispatch_error steps = %d, want 1", len(steps))
+	}
+}
+
+// TestRequest_PreAckRespError verifies that resp.Error != nil is treated as a
+// pre-ack failure.
+func TestRequest_PreAckRespError(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-err")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-err"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{
+				Acked: false,
+				Error: &commonv1.ErrorEnvelope{Message: "internal plugin error"},
+			}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	_, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if !errors.Is(err, dispatch.ErrPreAckFailed) {
+		t.Errorf("expected ErrPreAckFailed, got %v", err)
+	}
+}
+
+// TestRequest_ZeroRequestEntries verifies that an audience with no request=true
+// entries returns ErrNoRequestCapableEntry.
+func TestRequest_ZeroRequestEntries(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "notify-only")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, true, false)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	_, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "r", PolicyID: "p", ToolName: "t"}, "prompt", nil)
+	if !errors.Is(err, dispatch.ErrNoRequestCapableEntry) {
+		t.Errorf("expected ErrNoRequestCapableEntry, got %v", err)
+	}
+
+	var count int
+	if err := ds.store.DB().QueryRow(`SELECT COUNT(*) FROM plugin_pending_requests`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("pending requests count = %d, want 0", count)
+	}
+}
+
+// ---- Resolve tests ----
+
+// TestResolve_UnknownRequestID returns ErrUnknownRequestID.
+func TestResolve_UnknownRequestID(t *testing.T) {
+	ds := newSetup(t)
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	err := d.Resolve(context.Background(), "01JUNK00000NOTREAL0000000", `{}`)
+	if !errors.Is(err, dispatch.ErrUnknownRequestID) {
+		t.Errorf("expected ErrUnknownRequestID, got %v", err)
+	}
+}
+
+// TestResolve_ScannerRace verifies that when the scanner has already set
+// status='timed_out', Resolve swallows ErrTransitionConflict and returns nil.
+func TestResolve_ScannerRace(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	reqID, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	// Simulate scanner winning the race by pre-setting status='timed_out'.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err = ds.store.DB().Exec(
+		`UPDATE plugin_pending_requests SET status='timed_out', resolved_at=? WHERE id=?`,
+		now, reqID,
+	)
+	if err != nil {
+		t.Fatalf("pre-set timed_out: %v", err)
+	}
+
+	// Resolve must return nil (conflict swallowed).
+	if err := d.Resolve(context.Background(), reqID, `{"answer":"late"}`); err != nil {
+		t.Errorf("Resolve returned error after scanner won race: %v", err)
+	}
+}
+
+// ---- Wait tests ----
+
+// TestWait_TimerWins_WritesRunStep verifies that when the Wait timer fires, it
+// writes exactly one plugin_request_timeout step (CAS winner).
+func TestWait_TimerWins_WritesRunStep(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	reqID, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	// Wait with a short timeout; no one will call Resolve.
+	_, waitErr := d.Wait(context.Background(), reqID, 30*time.Millisecond)
+	if waitErr == nil {
+		t.Fatal("Wait should have returned an error (timeout)")
+	}
+
+	// Exactly one plugin_request_timeout step.
+	steps := ds.stepsByType("plugin_request_timeout")
+	if len(steps) != 1 {
+		t.Errorf("plugin_request_timeout steps = %d, want 1", len(steps))
+	}
+
+	// Row must be timed_out.
+	var status string
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = ?`, reqID).Scan(&status); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if status != "timed_out" {
+		t.Errorf("status = %q, want timed_out", status)
+	}
+}
+
+// TestWait_ScannerWon_NoRunStep verifies that when the scanner pre-sets
+// status='timed_out' before Wait's timer fires, Wait does NOT write a second
+// run step (CAS loser path).
+func TestWait_ScannerWon_NoRunStep(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	reqID, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	// Simulate scanner pre-claiming the timeout before Wait's timer fires.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := ds.store.DB().Exec(
+		`UPDATE plugin_pending_requests SET status='timed_out', resolved_at=? WHERE id=?`,
+		now, reqID,
+	); err != nil {
+		t.Fatalf("pre-set timed_out: %v", err)
+	}
+
+	_, waitErr := d.Wait(context.Background(), reqID, 30*time.Millisecond)
+	if waitErr == nil {
+		t.Fatal("Wait should return error on timeout")
+	}
+
+	// Scanner won the CAS — Wait must NOT write a step.
+	steps := ds.stepsByType("plugin_request_timeout")
+	if len(steps) != 0 {
+		t.Errorf("plugin_request_timeout steps = %d, want 0 (scanner already won)", len(steps))
+	}
+}

--- a/internal/plugin/dispatch/errors.go
+++ b/internal/plugin/dispatch/errors.go
@@ -13,3 +13,19 @@ var ErrCallTimeout = errors.New("plugin: call exceeded deadline")
 // and the bounded queue is also at capacity — the call is rejected immediately
 // rather than blocking indefinitely.
 var ErrQueueFull = errors.New("plugin: queue full")
+
+// ErrPreAckFailed is returned by Dispatcher.Request when the plugin does not
+// acknowledge the request within the pre-ack deadline, or returns acked: false,
+// or returns a non-nil error envelope.  Callers should map this to
+// runstate.TransitionRunFailed.
+var ErrPreAckFailed = errors.New("plugin: channel request pre-ack failed")
+
+// ErrNoRequestCapableEntry is returned by Dispatcher.Request when the audience
+// has no entries with request: true (either the audience is empty, or all
+// entries have notify-only capability).
+var ErrNoRequestCapableEntry = errors.New("plugin: no request-capable entry in audience")
+
+// ErrUnknownRequestID is returned by Dispatcher.Resolve when the requestID is
+// not in the in-memory waiters map — either it was never issued by this
+// Dispatcher instance, or it has already been resolved or expired.
+var ErrUnknownRequestID = errors.New("plugin: unknown request ID")

--- a/internal/timeout/scanner.go
+++ b/internal/timeout/scanner.go
@@ -148,6 +148,48 @@ func NewFeedbackScanner(store *db.Store, interval time.Duration, opts ...Scanner
 	return NewScanner(store, interval, cfg, opts...)
 }
 
+// NewPluginRequestScanner creates a Scanner that checks for expired plugin
+// pending requests on the given interval.  Only rows with a non-NULL expires_at
+// are candidates (rows without a timeout are excluded).
+func NewPluginRequestScanner(store *db.Store, interval time.Duration, opts ...ScannerOption) *Scanner {
+	cfg := Config{
+		Name: "plugin_request",
+		ListExpired: func(ctx context.Context, cutoff string) ([]ExpiredItem, error) {
+			rows, err := store.Queries().ListExpiredPluginPendingRequests(ctx, &cutoff)
+			if err != nil {
+				return nil, err
+			}
+			items := make([]ExpiredItem, len(rows))
+			for i, r := range rows {
+				items[i] = ExpiredItem{ID: r.ID, RunID: r.RunID, ToolName: r.ToolName}
+			}
+			return items, nil
+		},
+		ClaimTimeout: func(ctx context.Context, id string, now string) (int64, error) {
+			return store.Queries().UpdatePluginPendingRequestStatus(ctx, db.UpdatePluginPendingRequestStatusParams{
+				Status:     "timed_out",
+				Response:   nil,
+				ResolvedAt: &now,
+				ID:         id,
+			})
+		},
+		WaitingRunStatus: model.RunStatusWaitingForFeedback,
+		ErrorCode:        "plugin_request_timeout",
+		ErrorMessage: func(toolName string) string {
+			return fmt.Sprintf("plugin request timeout: no response received within the configured timeout for %s", toolName)
+		},
+		SSEEventName: "plugin.request.timed_out",
+		SSEPayload: func(id, runID string) map[string]string {
+			return map[string]string{
+				"request_id": id,
+				"run_id":     runID,
+				"status":     "timed_out",
+			}
+		},
+	}
+	return NewScanner(store, interval, cfg, opts...)
+}
+
 // Scanner periodically scans for expired pending requests and resolves them as
 // timed-out failures. It is constructed via NewApprovalScanner or
 // NewFeedbackScanner, which supply domain-specific callbacks.

--- a/internal/timeout/scanner_test.go
+++ b/internal/timeout/scanner_test.go
@@ -601,3 +601,163 @@ func TestScanner_RestartInterrupted_ThenTimeout(t *testing.T) {
 		t.Errorf("run.status_changed events from scanner = %d, want 0", n)
 	}
 }
+
+// ---- plugin_request scanner tests ----
+
+// insertPluginForScanner inserts the minimum rows required by
+// plugin_pending_requests foreign keys: a plugin row and a plugin_instances row.
+// Returns the instance ID.
+func insertPluginForScanner(t *testing.T, s *db.Store) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.DB().Exec(
+		`INSERT INTO plugins(id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at)
+		 VALUES ('plug1', 'test-plugin', '1.0.0', '{}', 'pk', 'active', 0, ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("insertPlugin: %v", err)
+	}
+	_, err = s.DB().Exec(
+		`INSERT INTO plugin_instances(id, plugin_id, instance_name, config_json, version, created_at, updated_at)
+		 VALUES ('inst1', 'plug1', 'inst', '{}', 0, ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("insertPluginInstance: %v", err)
+	}
+	return "inst1"
+}
+
+// insertPluginPendingRequest inserts a plugin_pending_requests row with the given
+// expiresAt (RFC3339Nano string).  Pass an empty string for no timeout.
+func insertPluginPendingRequest(t *testing.T, s *db.Store, id, instanceID, runID, toolName string, expiresAt string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	var expiresAtArg interface{}
+	if expiresAt != "" {
+		expiresAtArg = expiresAt
+	}
+	_, err := s.DB().Exec(
+		`INSERT INTO plugin_pending_requests(id, plugin_instance_id, run_id, tool_name, status, expires_at, created_at)
+		 VALUES (?, ?, ?, ?, 'pending', ?, ?)`,
+		id, instanceID, runID, toolName, expiresAtArg, now,
+	)
+	if err != nil {
+		t.Fatalf("insertPluginPendingRequest %s: %v", id, err)
+	}
+}
+
+// TestPluginRequestScanner_ExpiredRequest_MarksTimeoutAndFails verifies the
+// happy-path timeout: expired pending request is marked timed_out and the run
+// is failed with an error step.
+func TestPluginRequestScanner_ExpiredRequest_MarksTimeoutAndFails(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusWaitingForFeedback)
+	instID := insertPluginForScanner(t, s)
+	insertPluginPendingRequest(t, s, "req1", instID, "r1", "ask_tool", pastTimestamp())
+
+	scanner := timeout.NewPluginRequestScanner(s, time.Minute)
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	var status string
+	if err := s.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = 'req1'`).Scan(&status); err != nil {
+		t.Fatalf("query request: %v", err)
+	}
+	if status != "timed_out" {
+		t.Errorf("status = %q, want timed_out", status)
+	}
+
+	var runStatus string
+	if err := s.DB().QueryRow(`SELECT status FROM runs WHERE id = 'r1'`).Scan(&runStatus); err != nil {
+		t.Fatalf("query run: %v", err)
+	}
+	if runStatus != "failed" {
+		t.Errorf("run status = %q, want failed", runStatus)
+	}
+
+	// An error step must exist with plugin_request_timeout code.
+	var content string
+	if err := s.DB().QueryRow(`SELECT content FROM run_steps WHERE run_id = 'r1' AND type = 'error'`).Scan(&content); err != nil {
+		t.Fatalf("query error step: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		t.Errorf("step content not valid JSON: %v", err)
+	} else if payload["code"] != "plugin_request_timeout" {
+		t.Errorf("step code = %q, want plugin_request_timeout", payload["code"])
+	}
+}
+
+// TestPluginRequestScanner_NoExpiry_NotCollected verifies that rows without
+// an expires_at are never collected (indefinite-wait semantics).
+func TestPluginRequestScanner_NoExpiry_NotCollected(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusWaitingForFeedback)
+	instID := insertPluginForScanner(t, s)
+	insertPluginPendingRequest(t, s, "req1", instID, "r1", "ask_tool", "") // no expires_at
+
+	scanner := timeout.NewPluginRequestScanner(s, time.Minute)
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	var status string
+	if err := s.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = 'req1'`).Scan(&status); err != nil {
+		t.Fatalf("query request: %v", err)
+	}
+	if status != "pending" {
+		t.Errorf("status = %q, want pending (no expires_at must not be collected)", status)
+	}
+}
+
+// TestPluginRequestScanner_RunNotWaiting_RowTimedOutNoRunStep verifies that
+// when the run is not in waiting_for_feedback (e.g. already interrupted), the
+// scanner still marks the row timed_out but does NOT write an error step or
+// change the run status.
+func TestPluginRequestScanner_RunNotWaiting_RowTimedOutNoRunStep(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	// Run already interrupted — not in waiting_for_feedback.
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusInterrupted)
+	instID := insertPluginForScanner(t, s)
+	insertPluginPendingRequest(t, s, "req1", instID, "r1", "ask_tool", pastTimestamp())
+
+	pub := &testutil.RecordingPublisher{}
+	scanner := timeout.NewPluginRequestScanner(s, time.Minute, timeout.WithPublisher(pub))
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	// Row must still be marked timed_out.
+	var status string
+	if err := s.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = 'req1'`).Scan(&status); err != nil {
+		t.Fatalf("query request: %v", err)
+	}
+	if status != "timed_out" {
+		t.Errorf("status = %q, want timed_out", status)
+	}
+
+	// Run must remain interrupted (not changed).
+	var runStatus string
+	if err := s.DB().QueryRow(`SELECT status FROM runs WHERE id = 'r1'`).Scan(&runStatus); err != nil {
+		t.Fatalf("query run: %v", err)
+	}
+	if runStatus != "interrupted" {
+		t.Errorf("run status = %q, want interrupted", runStatus)
+	}
+
+	// No error step should have been written.
+	if n := countErrorSteps(t, s, "r1"); n != 0 {
+		t.Errorf("error steps = %d, want 0 (run was not waiting_for_feedback)", n)
+	}
+
+	// No events published because run was not in waiting state.
+	if n := countEventsByType(pub, "run.status_changed"); n != 0 {
+		t.Errorf("run.status_changed events = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
Closes #205

## Summary

Host-side dispatcher for plugin `ChannelService` RPCs:

- **`Notify`** — parallel fan-out across all `notify=true` audience entries, each goroutine bounded by a 10s deadline (sync.WaitGroup, not errgroup). Failures (gRPC error, `!resp.Ok`, `resp.Error`) are logged + audit-event'd + counted but never propagate; the run is unaffected (spec §6.2).
- **`Request`** — picks the first `request=true` entry in position order, 5s pre-ack deadline. Pre-ack failure writes a `feedback_dispatch_error` step and returns `ErrPreAckFailed` (caller maps to `TransitionRunFailed`). On pre-ack success, inserts a row into `plugin_pending_requests` (status=`pending`) and the caller blocks on `Wait`.
- **`Resolve`** — wakes the in-process waiter and CAS-flips the row to `resolved`. Race with the scanner's `timed_out` is benign (`ErrTransitionConflict` swallowed).
- **`Wait`** — select on waiter / ctx / timer; the timer arm only writes the `plugin_request_timeout` step when the CAS reports it won the race.

## Notable details

- `request_id` is a ULID with **no generation suffix** — instance-scoped per spec §4.2 so a post-hot-reload generation can resolve a request issued by its predecessor.
- Persisted lifecycle (`pending → resolved | timed_out`) uses status-equality CAS (`WHERE status='pending'`), mirroring `feedback_requests`. The in-memory pre-ack micro-state (`issued → pre_acked`) is a 2-value local variable, never persisted.
- Scanner integration via `internal/timeout.NewPluginRequestScanner` — no new goroutine.
- `gleipnir_plugin_rpc_duration_seconds` registered per ADR-047 on the custom Prometheus registry with `BucketsFast` and labels `{rpc, plugin, instance}`.
- Package boundary preserved: `internal/plugin/dispatch` does NOT import `internal/execution/agent`. `WriteRunStep` is injected as a callback in `DispatcherConfig`.

## Known dependency

`Dispatcher.Resolve` is dead code in production until a follow-up extends `internal/plugin/hostsvc/handlers.go:WriteAuditStep` to also look up `plugin_pending_requests` and call `Dispatcher.Resolve`. Today it routes through `GetFeedbackRequest` only. The dispatcher unit tests exercise `Resolve` directly so the wiring will land safely.

## Plan & process

<details>
<summary>Architecture plan</summary>

Files:
1. `internal/plugin/dispatch/channel_state.go` — persisted-lifecycle state machine (mirrors `internal/execution/runstate/`)
2. `internal/plugin/dispatch/channel_metrics.go` — `gleipnir_plugin_rpc_duration_seconds` histogram + error counter
3. `internal/plugin/dispatch/channel.go` — `Dispatcher`, `DispatcherConfig`, `Notify`/`Request`/`Resolve`/`Wait`
4. `internal/plugin/dispatch/errors.go` — `ErrPreAckFailed`, `ErrNoRequestCapableEntry`, `ErrUnknownRequestID`
5. `internal/timeout/scanner.go` — `NewPluginRequestScanner` constructor
6. `internal/plugin/dispatch/channel_test.go` — 13 cases covering routing, transitions, error classification, fan-out parallelism, waiter lifecycle, CAS-winner branching, scanner-vs-Resolve race
7. `internal/timeout/scanner_test.go` — 3 plugin_request scanner sub-tests

</details>

- Review cycles: 1 (plan went through one architect revision after plan-reviewer flagged: missing `!resp.GetOk()` failure check, wrong instance-lookup query, `*int64` vs `bool` for SQLite int booleans, errgroup→WaitGroup, Wait timer CAS-winner check, dead-code dependency on `WriteAuditStep`)
- CLAUDE.md: no updates needed (no new packages, env vars, routes, or ADRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop