### PR TITLE
test(plugin/dispatch): bump blast-radius deadline 3s → 8s

### DIFF
--- a/internal/plugin/dispatch/pool_test.go
+++ b/internal/plugin/dispatch/pool_test.go
@@ -605,7 +605,10 @@ func TestPool_CrossRunBlastRadius(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(3 * time.Second):
+	case <-time.After(8 * time.Second):
+		// Loaded CI runners need more than 3s to unwind: the 30ms CancelTimeout,
+		// the gRPC conn teardown, and both server hooks' ctx-Done branches all
+		// have to fire and propagate before the two Call goroutines return.
 		t.Fatal("calls did not return after blast-radius conn.Close()")
 	}
 


### PR DESCRIPTION
Fixes the observed flake in TestPool_CrossRunBlastRadius:

\`\`\`
--- FAIL: TestPool_CrossRunBlastRadius (3.00s)
    pool_test.go:609: calls did not return after blast-radius conn.Close()
\`\`\`

The test verifies that when CancelTimeout fires on run-A, the resulting \`conn.Close()\` propagates as blast radius to in-flight run-B on the same connection. The warnings in the failing log (\`plugin cancel RPC failed; force-disconnecting\` for both runs, \`plugin conn.Close after cancel timeout\`) confirm the blast-radius path executed correctly — it's the test's own 3s deadline that fired before the goroutines returned.

Locally the test passes 200/200 with and without \`-race\`. On loaded CI runners the cascade (30ms cancel deadline → gRPC conn teardown → server hook ctx.Done branches → client-side Call return → both wg.Done) can run longer than 3s due to scheduling stalls.

Bumping to 8s absorbs the stall without changing what the test verifies. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)