### PR TITLE
feat: late-callback rejection for plugin channel Requests (#209)

### DIFF
--- a/internal/plugin/dispatch/channel.go
+++ b/internal/plugin/dispatch/channel.go
@@ -67,15 +67,6 @@ type DispatcherConfig struct {
 //
 // Package boundary: internal/plugin must not import internal/execution/agent.
 // WriteRunStep is injected via DispatcherConfig to preserve that boundary.
-//
-// KNOWN DEPENDENCY / DEAD-CODE WINDOW: Dispatcher.Resolve is currently dead
-// code in production.  At the time this was written, WriteAuditStep in
-// internal/plugin/hostsvc/handlers.go dispatches feedback_response payloads
-// exclusively via q.GetFeedbackRequest.  It does NOT consult
-// plugin_pending_requests and does NOT call Dispatcher.Resolve.  Resolve
-// becomes reachable once a follow-up issue extends WriteAuditStep to also look
-// up plugin_pending_requests and invoke Dispatcher.Resolve.  Until then, the
-// unit tests exercise Resolve directly.
 type Dispatcher struct {
 	cfg DispatcherConfig
 
@@ -399,18 +390,19 @@ func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteCon
 // by requestID.  It sends the response on the buffered waiter channel and
 // advances the persisted status to "resolved".
 //
-// If the scanner has already timed out the row (ErrTransitionConflict from
-// TransitionResolved), Resolve logs at debug and returns nil — the scanner
-// already handled the run-failure side effects.
-//
-// ErrUnknownRequestID is returned when the requestID is not in the waiters
-// map (never issued, already resolved, or expired).
-func (d *Dispatcher) Resolve(ctx context.Context, requestID, responseJSON string) error {
+// Return values:
+//   - (true, nil)  — CAS transition succeeded; waiter notified.
+//   - (false, nil) — ErrTransitionConflict from TransitionResolved: the scanner
+//     already timed out the row; caller should treat this as a late callback.
+//   - (false, ErrUnknownRequestID) — requestID not in the in-memory waiters map;
+//     may mean the server restarted (evicted waiter) or the ID was never issued.
+//   - (false, err) — unexpected DB error; caller should return Internal.
+func (d *Dispatcher) Resolve(ctx context.Context, requestID, responseJSON string) (resolved bool, err error) {
 	d.waitersMu.Lock()
 	ch, ok := d.waiters[requestID]
 	if !ok {
 		d.waitersMu.Unlock()
-		return ErrUnknownRequestID
+		return false, ErrUnknownRequestID
 	}
 	delete(d.waiters, requestID)
 	d.waitersMu.Unlock()
@@ -430,11 +422,11 @@ func (d *Dispatcher) Resolve(ctx context.Context, requestID, responseJSON string
 			slog.Debug("resolve: transition conflict — scanner already timed out request",
 				"request_id", requestID,
 			)
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 // Wait blocks until the request identified by requestID is resolved, the

--- a/internal/plugin/dispatch/channel_test.go
+++ b/internal/plugin/dispatch/channel_test.go
@@ -445,9 +445,13 @@ func TestRequest_PreAckSuccess_RowInserted_ResolveFlipsStatus(t *testing.T) {
 		t.Errorf("status = %q, want pending", status)
 	}
 
-	// Resolve must flip it to resolved.
-	if err := d.Resolve(context.Background(), reqID, `{"answer":"yes"}`); err != nil {
-		t.Fatalf("Resolve: %v", err)
+	// Resolve must flip it to resolved and return (true, nil).
+	resolved, resolveErr := d.Resolve(context.Background(), reqID, `{"answer":"yes"}`)
+	if resolveErr != nil {
+		t.Fatalf("Resolve error: %v", resolveErr)
+	}
+	if !resolved {
+		t.Error("Resolve resolved = false, want true")
 	}
 
 	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = ?`, reqID).Scan(&status); err != nil {
@@ -640,13 +644,102 @@ func TestRequest_ZeroRequestEntries_DisableTrue_ErrNoRequestCapable(t *testing.T
 
 // ---- Resolve tests ----
 
-// TestResolve_UnknownRequestID returns ErrUnknownRequestID.
+// TestResolve_UnknownRequestID verifies (false, ErrUnknownRequestID) when the
+// requestID is not in the in-memory waiters map.
 func TestResolve_UnknownRequestID(t *testing.T) {
 	ds := newSetup(t)
 	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
-	err := d.Resolve(context.Background(), "01JUNK00000NOTREAL0000000", `{}`)
+	resolved, err := d.Resolve(context.Background(), "01JUNK00000NOTREAL0000000", `{}`)
 	if !errors.Is(err, dispatch.ErrUnknownRequestID) {
 		t.Errorf("expected ErrUnknownRequestID, got %v", err)
+	}
+	if resolved {
+		t.Error("resolved = true, want false for unknown request ID")
+	}
+}
+
+// TestResolve_HappyPath verifies (true, nil) when the request is pending and
+// no scanner has raced.
+func TestResolve_HappyPath(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	reqID, _, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	resolved, resolveErr := d.Resolve(context.Background(), reqID, `{"answer":"yes"}`)
+	if resolveErr != nil {
+		t.Fatalf("Resolve error: %v", resolveErr)
+	}
+	if !resolved {
+		t.Error("resolved = false, want true for pending request")
+	}
+
+	var status string
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = ?`, reqID).Scan(&status); err != nil {
+		t.Fatalf("query after Resolve: %v", err)
+	}
+	if status != "resolved" {
+		t.Errorf("status = %q, want resolved", status)
+	}
+}
+
+// TestResolve_ScannerConflict verifies (false, nil) when the scanner has
+// already set status='timed_out' (ErrTransitionConflict is swallowed).
+func TestResolve_ScannerConflict(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	reqID, _, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	// Scanner wins: pre-set status to timed_out.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := ds.store.DB().Exec(
+		`UPDATE plugin_pending_requests SET status='timed_out', resolved_at=? WHERE id=?`,
+		now, reqID,
+	); err != nil {
+		t.Fatalf("pre-set timed_out: %v", err)
+	}
+
+	resolved, resolveErr := d.Resolve(context.Background(), reqID, `{"answer":"late"}`)
+	if resolveErr != nil {
+		t.Errorf("Resolve returned unexpected error: %v", resolveErr)
+	}
+	if resolved {
+		t.Error("resolved = true, want false when scanner already timed out")
 	}
 }
 
@@ -685,9 +778,13 @@ func TestResolve_ScannerRace(t *testing.T) {
 		t.Fatalf("pre-set timed_out: %v", err)
 	}
 
-	// Resolve must return nil (conflict swallowed).
-	if err := d.Resolve(context.Background(), reqID, `{"answer":"late"}`); err != nil {
+	// Resolve must return (false, nil) — conflict swallowed, resolved=false.
+	resolved, err := d.Resolve(context.Background(), reqID, `{"answer":"late"}`)
+	if err != nil {
 		t.Errorf("Resolve returned error after scanner won race: %v", err)
+	}
+	if resolved {
+		t.Error("resolved = true, want false when scanner already won race")
 	}
 }
 

--- a/internal/plugin/hostsvc/audit_guard.go
+++ b/internal/plugin/hostsvc/audit_guard.go
@@ -29,6 +29,12 @@ const EventTypeUnauthorizedTier2Call = "unauthorized_tier2_call"
 // Severity is always "high".
 const EventTypeUnauthorizedRequestID = "unauthorized_request_id"
 
+// EventTypeFeedbackResponseLate is the plugin_audit_events.event_type value
+// written when a plugin delivers a feedback_response for a request that has
+// already been resolved or timed out (spec §4.2 late-callback paragraph).
+// Severity is "warning". Run state is not mutated.
+const EventTypeFeedbackResponseLate = "feedback_response_late"
+
 // AuditQuerier is the narrow DB interface this package needs. A *db.Queries
 // value satisfies it; the narrow interface makes tests cheaper to write.
 type AuditQuerier interface {

--- a/internal/plugin/hostsvc/end_to_end_integration_test.go
+++ b/internal/plugin/hostsvc/end_to_end_integration_test.go
@@ -448,7 +448,7 @@ func TestHostsvcE2E_WriteAuditStep_HappyPath(t *testing.T) {
 		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
 	}
 
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub)
+	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{
@@ -558,7 +558,7 @@ func TestHostsvcE2E_WriteAuditStep_WrongStepType(t *testing.T) {
 		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
 	}
 
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub)
+	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{
@@ -651,7 +651,7 @@ func TestHostsvcE2E_WriteAuditStep_MissingToken(t *testing.T) {
 		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
 	}
 
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub)
+	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{
@@ -698,6 +698,210 @@ func TestHostsvcE2E_WriteAuditStep_MissingToken(t *testing.T) {
 	}
 	if callIDCount.Load() != 0 {
 		t.Errorf("call-id interceptor count = %d, want 0 (short-circuit)", callIDCount.Load())
+	}
+}
+
+// ── plugin-substrate integration tests ───────────────────────────────────────
+
+// TestHostsvcE2E_WriteAuditStep_PluginSubstrate_Late verifies that when a
+// plugin_pending_requests row exists with status='resolved', WriteAuditStep
+// returns ok=false and emits a feedback_response_late audit event at severity
+// "warning" without touching run state.
+func TestHostsvcE2E_WriteAuditStep_PluginSubstrate_Late(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: subprocess re-exec")
+	}
+
+	store, q := openE2EStore(t)
+	defer store.Close()
+
+	instanceID := "e2e-ps-late-" + model.NewULID()
+	runID, policyID, _ := seedE2EData(t, q, instanceID, "e2e-ps-instance")
+
+	// Insert a plugin_pending_requests row with status='resolved'.
+	pluginReqID := model.NewULID()
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := q.CreatePluginPendingRequest(ctx, db.CreatePluginPendingRequestParams{
+		ID:               pluginReqID,
+		PluginInstanceID: instanceID,
+		RunID:            runID,
+		ToolName:         "ask",
+		CreatedAt:        now,
+	}); err != nil {
+		t.Fatalf("CreatePluginPendingRequest: %v", err)
+	}
+	// Advance to resolved so the handler treats it as late.
+	if _, err := store.DB().ExecContext(ctx,
+		`UPDATE plugin_pending_requests SET status='resolved', resolved_at=? WHERE id=?`,
+		now, pluginReqID,
+	); err != nil {
+		t.Fatalf("set resolved: %v", err)
+	}
+
+	fabricatedCallID := "call-" + model.NewULID()
+	resolver := &fakeCallResolver{callID: fabricatedCallID, runID: runID, policyID: policyID}
+	pub := &countingPublisher{}
+	reg := identity.New()
+	genCtrl := generation.New()
+	genCtrl.RegisterInstance(instanceID)
+
+	var tokenCount, genCount, callIDCount atomic.Int32
+	interceptors := []grpc.UnaryServerInterceptor{
+		countingInterceptor(hostsvc.UnaryInstanceTokenInterceptor(reg), &tokenCount),
+		countingInterceptor(hostsvc.UnaryGenerationRefcountInterceptor(genCtrl), &genCount),
+		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
+	}
+
+	// fakeChannelResolver returns (false, nil) simulating a scanner-conflict
+	// (row resolved, waiter gone).
+	ch := &fakeChannelResolver{resolved: false, err: nil}
+	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, ch)
+
+	resultPath := t.TempDir() + "/result.json"
+	env := []string{
+		"GLEIPNIR_TEST_CALL_ID=" + fabricatedCallID,
+		"GLEIPNIR_TEST_FEEDBACK_REQUEST_ID=" + pluginReqID,
+		"GLEIPNIR_TEST_RESULT_PATH=" + resultPath,
+	}
+
+	inst := startWriteAuditStepFixture(t, instanceID, hostSvc, reg, interceptors, env)
+	raw := pollResultFile(t, resultPath, 30*time.Second)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopCancel()
+	_ = inst.Stop(stopCtx)
+
+	var result struct {
+		Ok  bool   `json:"ok"`
+		Err string `json:"err"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	// ok=false: late callback
+	if result.Ok {
+		t.Error("ok = true, want false for late plugin callback")
+	}
+
+	// Audit event must exist with severity "warning".
+	auditRows, err := q.ListPluginAuditEventsByType(ctx, db.ListPluginAuditEventsByTypeParams{
+		EventType: hostsvc.EventTypeFeedbackResponseLate,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListPluginAuditEventsByType: %v", err)
+	}
+	if len(auditRows) == 0 {
+		t.Error("expected feedback_response_late audit event")
+	}
+	for _, row := range auditRows {
+		if row.Severity != "warning" {
+			t.Errorf("severity = %q, want warning", row.Severity)
+		}
+	}
+
+	// Run state must be unchanged (no run_steps for this request).
+	step, stepErr := q.GetLatestRunStep(ctx, runID)
+	if stepErr == nil && step.Type == "feedback_response" {
+		t.Error("feedback_response run_step written on late callback; want none")
+	}
+}
+
+// TestHostsvcE2E_WriteAuditStep_PluginSubstrate_Happy verifies the happy path:
+// a plugin_pending_requests row with status='pending' causes the handler to
+// call Resolve, which (on success) returns ok=true and publishes an SSE event.
+func TestHostsvcE2E_WriteAuditStep_PluginSubstrate_Happy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: subprocess re-exec")
+	}
+
+	store, q := openE2EStore(t)
+	defer store.Close()
+
+	instanceID := "e2e-ps-happy-" + model.NewULID()
+	runID, policyID, _ := seedE2EData(t, q, instanceID, "e2e-ps-happy-instance")
+
+	pluginReqID := model.NewULID()
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := q.CreatePluginPendingRequest(ctx, db.CreatePluginPendingRequestParams{
+		ID:               pluginReqID,
+		PluginInstanceID: instanceID,
+		RunID:            runID,
+		ToolName:         "ask",
+		CreatedAt:        now,
+	}); err != nil {
+		t.Fatalf("CreatePluginPendingRequest: %v", err)
+	}
+
+	fabricatedCallID := "call-" + model.NewULID()
+	resolver := &fakeCallResolver{callID: fabricatedCallID, runID: runID, policyID: policyID}
+	pub := &countingPublisher{}
+	reg := identity.New()
+	genCtrl := generation.New()
+	genCtrl.RegisterInstance(instanceID)
+
+	var tokenCount, genCount, callIDCount atomic.Int32
+	interceptors := []grpc.UnaryServerInterceptor{
+		countingInterceptor(hostsvc.UnaryInstanceTokenInterceptor(reg), &tokenCount),
+		countingInterceptor(hostsvc.UnaryGenerationRefcountInterceptor(genCtrl), &genCount),
+		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
+	}
+
+	// Fake resolver simulates CAS win.
+	ch := &fakeChannelResolver{resolved: true, err: nil}
+	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, ch)
+
+	resultPath := t.TempDir() + "/result.json"
+	env := []string{
+		"GLEIPNIR_TEST_CALL_ID=" + fabricatedCallID,
+		"GLEIPNIR_TEST_FEEDBACK_REQUEST_ID=" + pluginReqID,
+		"GLEIPNIR_TEST_RESULT_PATH=" + resultPath,
+	}
+
+	inst := startWriteAuditStepFixture(t, instanceID, hostSvc, reg, interceptors, env)
+	raw := pollResultFile(t, resultPath, 30*time.Second)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopCancel()
+	_ = inst.Stop(stopCtx)
+
+	var result struct {
+		Ok  bool   `json:"ok"`
+		Err string `json:"err"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if !result.Ok {
+		t.Errorf("ok = false, err = %q; want ok=true for happy-path plugin substrate", result.Err)
+	}
+
+	// SSE event must have been published.
+	pubEvents, _ := pub.snapshot()
+	found := false
+	for _, ev := range pubEvents {
+		if ev == "plugin.feedback_response_written" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no plugin.feedback_response_written event; got %v", pubEvents)
+	}
+
+	// No feedback_response_late event must have been emitted.
+	auditRows, err := q.ListPluginAuditEventsByType(ctx, db.ListPluginAuditEventsByTypeParams{
+		EventType: hostsvc.EventTypeFeedbackResponseLate,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListPluginAuditEventsByType: %v", err)
+	}
+	if len(auditRows) != 0 {
+		t.Errorf("unexpected feedback_response_late events: %d", len(auditRows))
 	}
 }
 

--- a/internal/plugin/hostsvc/handlers.go
+++ b/internal/plugin/hostsvc/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
 	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
 	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
 	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
@@ -191,22 +192,104 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 		return nil, status.Error(codes.InvalidArgument, "request_id must be set for feedback_response steps")
 	}
 
+	requestID := req.GetRequestId()
+	payloadJSON := req.GetPayloadJson()
+
+	// Plugin-substrate path: look up plugin_pending_requests first. On
+	// sql.ErrNoRows, fall through to the native feedback_requests path below.
+	pendingReq, perr := s.q.GetPluginPendingRequest(ctx, requestID)
+	if perr == nil {
+		// Row exists — this is a plugin-substrate feedback_response.
+		if pendingReq.PluginInstanceID != inst.ID {
+			// Wrong instance: ownership violation.
+			s.writeAuditEvent(ctx, inst.ID, EventTypeUnauthorizedRequestID, "high", map[string]string{
+				"request_id": requestID,
+				"run_id":     pendingReq.RunID,
+				"rpc_method": rpcMethod,
+			})
+			return nil, status.Error(codes.PermissionDenied, "unauthorized_request_id")
+		}
+
+		if s.channels == nil {
+			// Resolver not wired — treat as late callback to avoid silent drop.
+			slog.WarnContext(ctx, "plugin channel resolver not wired; treating as late callback",
+				"request_id", requestID,
+			)
+			s.writeAuditEvent(ctx, inst.ID, EventTypeFeedbackResponseLate, "warning", map[string]string{
+				"request_id": requestID,
+				"reason":     "resolver_unwired",
+				"substrate":  "plugin",
+				"status":     pendingReq.Status,
+			})
+			return &hostv1.WriteAuditStepResponse{
+				Ok: false,
+				Error: &commonv1.ErrorEnvelope{
+					Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
+					Message: EventTypeFeedbackResponseLate,
+				},
+			}, nil
+		}
+
+		resolved, rerr := s.channels.Resolve(ctx, requestID, payloadJSON)
+		if rerr != nil && !errors.Is(rerr, dispatch.ErrUnknownRequestID) {
+			return nil, status.Errorf(codes.Internal, "resolve plugin request: %v", rerr)
+		}
+
+		if !resolved {
+			reason := "late"
+			if errors.Is(rerr, dispatch.ErrUnknownRequestID) {
+				// The in-memory waiter was evicted (server restart or scanner race)
+				// but the DB row exists, so the request is no longer actionable.
+				reason = "evicted_waiter"
+			}
+			s.writeAuditEvent(ctx, inst.ID, EventTypeFeedbackResponseLate, "warning", map[string]string{
+				"request_id": requestID,
+				"reason":     reason,
+				"substrate":  "plugin",
+				"status":     pendingReq.Status,
+			})
+			return &hostv1.WriteAuditStepResponse{
+				Ok: false,
+				Error: &commonv1.ErrorEnvelope{
+					Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
+					Message: EventTypeFeedbackResponseLate,
+				},
+			}, nil
+		}
+
+		// CAS won: publish SSE event and return ok=true. The agent loop's
+		// Dispatcher.Wait writes its own audit step; we do not duplicate it here.
+		if eventData, marshalErr := json.Marshal(map[string]string{
+			"run_id":      pendingReq.RunID,
+			"request_id":  requestID,
+			"instance_id": inst.ID,
+			"step_type":   "feedback_response",
+		}); marshalErr == nil {
+			s.publisher.Publish("plugin.feedback_response_written", eventData)
+		}
+		return &hostv1.WriteAuditStepResponse{Ok: true}, nil
+	}
+	if !errors.Is(perr, sql.ErrNoRows) {
+		return nil, status.Errorf(codes.Internal, "get plugin pending request: %v", perr)
+	}
+	// sql.ErrNoRows: not a plugin-substrate request — fall through to native path.
+
 	// Look up the feedback request; reject late responses without mutating state.
-	fr, err := s.q.GetFeedbackRequest(ctx, req.GetRequestId())
+	fr, err := s.q.GetFeedbackRequest(ctx, requestID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get feedback request: %v", err)
 	}
 	if fr.Status != "pending" {
 		// Spec §4.2 line 106: record the late attempt and return ok=false.
-		s.writeAuditEvent(ctx, inst.ID, "feedback_response_late", "medium", map[string]string{
-			"request_id": req.GetRequestId(),
+		s.writeAuditEvent(ctx, inst.ID, EventTypeFeedbackResponseLate, "warning", map[string]string{
+			"request_id": requestID,
 			"status":     fr.Status,
 		})
 		return &hostv1.WriteAuditStepResponse{
 			Ok: false,
 			Error: &commonv1.ErrorEnvelope{
 				Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
-				Message: "feedback_response_late",
+				Message: EventTypeFeedbackResponseLate,
 			},
 		}, nil
 	}
@@ -226,7 +309,7 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 	}
 	if !policyGrantsInstance(policy.Yaml, inst.InstanceName) {
 		s.writeAuditEvent(ctx, inst.ID, EventTypeUnauthorizedRequestID, "high", map[string]string{
-			"request_id": req.GetRequestId(),
+			"request_id": requestID,
 			"run_id":     fr.RunID,
 			"rpc_method": rpcMethod,
 		})
@@ -250,7 +333,7 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 		RunID:      fr.RunID,
 		StepNumber: nextStep,
 		Type:       "feedback_response",
-		Content:    req.GetPayloadJson(),
+		Content:    payloadJSON,
 		TokenCost:  0,
 		CreatedAt:  time.Now().UTC().Format(time.RFC3339Nano),
 	})
@@ -259,12 +342,11 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	payloadJSON := req.GetPayloadJson()
 	_, err = s.q.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
 		Status:     "resolved",
 		Response:   &payloadJSON,
 		ResolvedAt: &now,
-		ID:         req.GetRequestId(),
+		ID:         requestID,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "update feedback request status: %v", err)
@@ -272,10 +354,10 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 
 	// Publish so SSE subscribers and tests can observe the step.
 	if eventData, marshalErr := json.Marshal(map[string]string{
-		"run_id":     fr.RunID,
-		"request_id": req.GetRequestId(),
+		"run_id":      fr.RunID,
+		"request_id":  requestID,
 		"instance_id": inst.ID,
-		"step_type":  "feedback_response",
+		"step_type":   "feedback_response",
 	}); marshalErr == nil {
 		s.publisher.Publish("plugin.feedback_response_written", eventData)
 	}

--- a/internal/plugin/hostsvc/server.go
+++ b/internal/plugin/hostsvc/server.go
@@ -26,6 +26,7 @@ type Querier interface {
 	UpdateFeedbackRequestStatus(ctx context.Context, arg db.UpdateFeedbackRequestStatusParams) (int64, error)
 	GetRun(ctx context.Context, id string) (db.Run, error)
 	GetPolicy(ctx context.Context, id string) (db.Policy, error)
+	GetPluginPendingRequest(ctx context.Context, id string) (db.PluginPendingRequest, error)
 	// Tier-2 RPC support
 	GetPluginByID(ctx context.Context, id string) (db.Plugin, error)
 	ListPolicies(ctx context.Context) ([]db.Policy, error)
@@ -56,6 +57,13 @@ type InstanceBinder interface {
 	InstanceIDFromContext(ctx context.Context) (instanceID string, ok bool)
 }
 
+// ChannelResolver delivers a plugin-substrate feedback response to the
+// in-flight Request waiter identified by requestID.  Satisfied by
+// *dispatch.Dispatcher.  nil is a valid value for NewServer (see docs there).
+type ChannelResolver interface {
+	Resolve(ctx context.Context, requestID, responseJSON string) (resolved bool, err error)
+}
+
 // Server implements hostv1.HostServiceServer for all Host RPCs. Tier-1 RPCs
 // are always available; Tier-2 RPCs (RunHistoryRead, UserDirectoryRead) require
 // a matching capability declaration in the plugin manifest (spec §8.2).
@@ -68,6 +76,9 @@ type Server struct {
 	binder        InstanceBinder
 	publisher     event.Publisher
 	metrics       *pluginMetrics
+	// channels is nil when the plugin substrate is disabled; WriteAuditStep
+	// treats nil as "resolver unwired" and collapses into the late-callback path.
+	channels ChannelResolver
 }
 
 // Register implements hostwire.HostServer by registering *Server as the
@@ -82,12 +93,19 @@ func (s *Server) Register(srv *grpc.Server) {
 // binder must be non-nil; pass a concrete implementation that resolves the
 // caller's plugin instance ID from the request context (production wiring uses
 // NewContextBinder paired with UnaryInstanceTokenInterceptor — see issue #202).
+//
+// channels may be nil (e.g. in tests that only exercise the native
+// feedback_requests path). When nil and a plugin_pending_requests row is found
+// for a WriteAuditStep request_id, the call is treated as a late callback with
+// reason="resolver_unwired" and a warning is logged. Production wiring passes
+// the *dispatch.Dispatcher.
 func NewServer(
 	q Querier,
 	encryptionKey []byte,
 	resolver CallContextResolver,
 	binder InstanceBinder,
 	publisher event.Publisher,
+	channels ChannelResolver,
 ) *Server {
 	if binder == nil {
 		panic("hostsvc.NewServer: binder must not be nil")
@@ -99,5 +117,6 @@ func NewServer(
 		binder:        binder,
 		publisher:     publisher,
 		metrics:       newPluginMetrics(),
+		channels:      channels,
 	}
 }

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -52,6 +52,7 @@ type fakeQuerier struct {
 
 	createRunStepResult db.RunStep
 	createRunStepErr    error
+	createRunStepCalls  int
 
 	run    db.Run
 	runErr error
@@ -80,6 +81,12 @@ type fakeQuerier struct {
 	usersByRole    []db.ListActiveUsersByRoleRow
 	usersByRoleErr error
 
+	// pluginPendingRequest is returned by GetPluginPendingRequest.
+	// When pluginPendingRequestErr is sql.ErrNoRows, GetPluginPendingRequest
+	// returns (zero, sql.ErrNoRows) to trigger the native fall-through path.
+	pluginPendingRequest    db.PluginPendingRequest
+	pluginPendingRequestErr error
+
 	mu sync.Mutex
 }
 
@@ -107,6 +114,7 @@ func (f *fakeQuerier) UpdateFeedbackRequestStatus(_ context.Context, _ db.Update
 }
 
 func (f *fakeQuerier) CreateRunStep(_ context.Context, _ db.CreateRunStepParams) (db.RunStep, error) {
+	f.createRunStepCalls++
 	return f.createRunStepResult, f.createRunStepErr
 }
 
@@ -149,8 +157,22 @@ func (f *fakeQuerier) ListActiveUsersByRole(_ context.Context, _ string) ([]db.L
 	return f.usersByRole, f.usersByRoleErr
 }
 
+func (f *fakeQuerier) GetPluginPendingRequest(_ context.Context, _ string) (db.PluginPendingRequest, error) {
+	return f.pluginPendingRequest, f.pluginPendingRequestErr
+}
+
 // compile-time check
 var _ hostsvc.Querier = (*fakeQuerier)(nil)
+
+// fakeChannelResolver satisfies hostsvc.ChannelResolver with configurable returns.
+type fakeChannelResolver struct {
+	resolved bool
+	err      error
+}
+
+func (f *fakeChannelResolver) Resolve(_ context.Context, _, _ string) (bool, error) {
+	return f.resolved, f.err
+}
 
 // fakeResolver satisfies hostsvc.CallContextResolver.
 type fakeResolver struct {
@@ -223,7 +245,7 @@ func (h *testSlogHandler) all() []slog.Record {
 func newTestServer(t *testing.T, q *fakeQuerier, resolver hostsvc.CallContextResolver, pub *fakePublisher) *hostsvc.Server {
 	t.Helper()
 	binder := &fakeInstanceBinder{id: "iid-test", ok: true}
-	return hostsvc.NewServer(q, testEncryptionKey, resolver, binder, pub)
+	return hostsvc.NewServer(q, testEncryptionKey, resolver, binder, pub, nil)
 }
 
 func ctxWithCallID(callID string) context.Context {
@@ -445,8 +467,9 @@ func TestWriteAuditStep_LateFeedback(t *testing.T) {
 	t.Parallel()
 
 	q := &fakeQuerier{
-		instance:        db.PluginInstance{ID: "iid-1", PluginID: "plug-1"},
-		feedbackRequest: db.FeedbackRequest{ID: "fr-1", RunID: "run-1", Status: "responded"},
+		instance:                db.PluginInstance{ID: "iid-1", PluginID: "plug-1"},
+		feedbackRequest:         db.FeedbackRequest{ID: "fr-1", RunID: "run-1", Status: "responded"},
+		pluginPendingRequestErr: sql.ErrNoRows, // native path
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
 
@@ -465,12 +488,15 @@ func TestWriteAuditStep_LateFeedback(t *testing.T) {
 		t.Errorf("error.message = %q, want feedback_response_late", resp.GetError().GetMessage())
 	}
 
-	// A feedback_response_late audit event must have been inserted.
+	// A feedback_response_late audit event must have been inserted with severity "warning".
 	events := q.all()
 	found := false
 	for _, e := range events {
-		if e.EventType == "feedback_response_late" {
+		if e.EventType == hostsvc.EventTypeFeedbackResponseLate {
 			found = true
+			if e.Severity != "warning" {
+				t.Errorf("severity = %q, want warning", e.Severity)
+			}
 		}
 	}
 	if !found {
@@ -489,6 +515,7 @@ func TestWriteAuditStep_HappyPath(t *testing.T) {
 		updateFeedbackStatusRows: 1,
 		run:                      db.Run{ID: "run-ok", PolicyID: "pol-ok"},
 		policy:                   db.Policy{ID: "pol-ok", Yaml: policyYAMLWithTool("myplugin.do_thing")},
+		pluginPendingRequestErr:   sql.ErrNoRows, // native path
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
 
@@ -539,7 +566,7 @@ func newTestServerWithContextBinder(
 	pub *fakePublisher,
 ) *hostsvc.Server {
 	t.Helper()
-	return hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub)
+	return hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 }
 
 // callWriteAuditStep runs UnaryInstanceTokenInterceptor then calls
@@ -569,10 +596,11 @@ func TestWriteAuditStep_RequestIDOutOfScope(t *testing.T) {
 
 	// The policy YAML does NOT grant any tool prefixed "myplugin.".
 	q := &fakeQuerier{
-		instance:        db.PluginInstance{ID: "iid-oos", PluginID: "plug-oos", InstanceName: "myplugin"},
-		feedbackRequest: db.FeedbackRequest{ID: "fr-oos", RunID: "run-oos", Status: "pending"},
-		run:             db.Run{ID: "run-oos", PolicyID: "pol-other"},
-		policy:          db.Policy{ID: "pol-other", Yaml: policyYAMLWithTool("otherplugin.do_thing")},
+		instance:                db.PluginInstance{ID: "iid-oos", PluginID: "plug-oos", InstanceName: "myplugin"},
+		feedbackRequest:         db.FeedbackRequest{ID: "fr-oos", RunID: "run-oos", Status: "pending"},
+		run:                     db.Run{ID: "run-oos", PolicyID: "pol-other"},
+		policy:                  db.Policy{ID: "pol-other", Yaml: policyYAMLWithTool("otherplugin.do_thing")},
+		pluginPendingRequestErr: sql.ErrNoRows, // native path
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
 
@@ -631,6 +659,7 @@ func TestWriteAuditStep_RequestIDInScope_Success(t *testing.T) {
 		updateFeedbackStatusRows: 1,
 		run:                      db.Run{ID: "run-inscope", PolicyID: "pol-inscope"},
 		policy:                   db.Policy{ID: "pol-inscope", Yaml: policyYAMLWithTool("myplugin.do_thing")},
+		pluginPendingRequestErr:   sql.ErrNoRows, // native path
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
 
@@ -686,6 +715,7 @@ func TestWriteAuditStep_RequestIDInScopeAcrossGenerations(t *testing.T) {
 		updateFeedbackStatusRows: 1,
 		run:                      db.Run{ID: "run-crossgen", PolicyID: "pol-crossgen"},
 		policy:                   db.Policy{ID: "pol-crossgen", Yaml: policyYAMLWithTool("crossgen.action")},
+		pluginPendingRequestErr:   sql.ErrNoRows, // native path
 	}
 
 	pub := &fakePublisher{}
@@ -706,6 +736,314 @@ func TestWriteAuditStep_RequestIDInScopeAcrossGenerations(t *testing.T) {
 	}
 }
 
+// --- tests: WriteAuditStep (plugin substrate) ---
+
+// pendingRequest returns a db.PluginPendingRequest for testing with the given
+// instanceID as PluginInstanceID and the given status.
+func pendingRequest(instanceID, status string) db.PluginPendingRequest {
+	return db.PluginPendingRequest{
+		ID:               "req-plugin-1",
+		PluginInstanceID: instanceID,
+		RunID:            "run-plugin-1",
+		ToolName:         "ask",
+		Status:           status,
+	}
+}
+
+// TestPluginSubstrate_HappyPath verifies that a pending plugin request is
+// resolved and returns ok=true with no run_step written by this handler.
+func TestPluginSubstrate_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance:             db.PluginInstance{ID: "iid-ps", PluginID: "plug-ps"},
+		pluginPendingRequest: pendingRequest("iid-ps", "pending"),
+	}
+	ch := &fakeChannelResolver{resolved: true, err: nil}
+	pub := &fakePublisher{}
+	binder := &fakeInstanceBinder{id: "iid-ps", ok: true}
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, pub, ch)
+
+	ctx := ctxWithCallID("call-ps-happy")
+	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+		StepType:    "feedback_response",
+		RequestId:   "req-plugin-1",
+		PayloadJson: `{"answer":"yes"}`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if !resp.GetOk() {
+		t.Errorf("ok = false, want true")
+	}
+
+	// No run_step should be inserted — agent loop's Wait writes its own step.
+	if q.createRunStepCalls != 0 {
+		t.Errorf("CreateRunStep called %d times on plugin substrate happy path; want 0", q.createRunStepCalls)
+	}
+
+	// SSE event must be published.
+	evts := pub.all()
+	found := false
+	for _, ev := range evts {
+		if ev == "plugin.feedback_response_written" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected plugin.feedback_response_written event, got %v", evts)
+	}
+}
+
+// TestPluginSubstrate_LateAlreadyResolved verifies that when Resolve returns
+// (false, nil) for an already-resolved row, the handler returns ok=false with
+// a feedback_response_late event.
+func TestPluginSubstrate_LateAlreadyResolved(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance:             db.PluginInstance{ID: "iid-late", PluginID: "plug-late"},
+		pluginPendingRequest: pendingRequest("iid-late", "resolved"),
+	}
+	ch := &fakeChannelResolver{resolved: false, err: nil}
+	binder := &fakeInstanceBinder{id: "iid-late", ok: true}
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
+
+	ctx := ctxWithCallID("call-ps-late")
+	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+		StepType:  "feedback_response",
+		RequestId: "req-plugin-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if resp.GetOk() {
+		t.Error("ok = true, want false for late callback")
+	}
+	if resp.GetError().GetMessage() != hostsvc.EventTypeFeedbackResponseLate {
+		t.Errorf("error.message = %q, want %q", resp.GetError().GetMessage(), hostsvc.EventTypeFeedbackResponseLate)
+	}
+
+	events := q.all()
+	var found bool
+	for _, e := range events {
+		if e.EventType == hostsvc.EventTypeFeedbackResponseLate {
+			found = true
+			if e.Severity != "warning" {
+				t.Errorf("severity = %q, want warning", e.Severity)
+			}
+			var payload map[string]string
+			if err := json.Unmarshal([]byte(e.PayloadJson), &payload); err == nil {
+				if payload["reason"] != "late" {
+					t.Errorf("reason = %q, want late", payload["reason"])
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected feedback_response_late audit event, found none")
+	}
+}
+
+// TestPluginSubstrate_LateAlreadyTimedOut verifies that a timed_out row also
+// collapses into the late-callback path with reason="late".
+func TestPluginSubstrate_LateAlreadyTimedOut(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance:             db.PluginInstance{ID: "iid-to", PluginID: "plug-to"},
+		pluginPendingRequest: pendingRequest("iid-to", "timed_out"),
+	}
+	ch := &fakeChannelResolver{resolved: false, err: nil}
+	binder := &fakeInstanceBinder{id: "iid-to", ok: true}
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
+
+	ctx := ctxWithCallID("call-ps-timedout")
+	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+		StepType:  "feedback_response",
+		RequestId: "req-plugin-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if resp.GetOk() {
+		t.Error("ok = true, want false for timed_out callback")
+	}
+
+	events := q.all()
+	var found bool
+	for _, e := range events {
+		if e.EventType == hostsvc.EventTypeFeedbackResponseLate {
+			found = true
+			if e.Severity != "warning" {
+				t.Errorf("severity = %q, want warning", e.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected feedback_response_late audit event, found none")
+	}
+}
+
+// TestPluginSubstrate_EvictedWaiter verifies (false, ErrUnknownRequestID) from
+// Resolve collapses into the late-callback path with reason="evicted_waiter".
+func TestPluginSubstrate_EvictedWaiter(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance:             db.PluginInstance{ID: "iid-ev", PluginID: "plug-ev"},
+		pluginPendingRequest: pendingRequest("iid-ev", "pending"),
+	}
+	ch := &fakeChannelResolver{resolved: false, err: dispatch.ErrUnknownRequestID}
+	binder := &fakeInstanceBinder{id: "iid-ev", ok: true}
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
+
+	ctx := ctxWithCallID("call-ps-evicted")
+	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+		StepType:  "feedback_response",
+		RequestId: "req-plugin-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if resp.GetOk() {
+		t.Error("ok = true, want false for evicted waiter")
+	}
+
+	events := q.all()
+	var found bool
+	for _, e := range events {
+		if e.EventType == hostsvc.EventTypeFeedbackResponseLate {
+			found = true
+			var payload map[string]string
+			if err := json.Unmarshal([]byte(e.PayloadJson), &payload); err == nil {
+				if payload["reason"] != "evicted_waiter" {
+					t.Errorf("reason = %q, want evicted_waiter", payload["reason"])
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected feedback_response_late audit event, found none")
+	}
+}
+
+// TestPluginSubstrate_NilResolver verifies that s.channels == nil with a found
+// row produces a feedback_response_late event with reason="resolver_unwired".
+func TestPluginSubstrate_NilResolver(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance:             db.PluginInstance{ID: "iid-nil", PluginID: "plug-nil"},
+		pluginPendingRequest: pendingRequest("iid-nil", "pending"),
+	}
+	// channels=nil
+	binder := &fakeInstanceBinder{id: "iid-nil", ok: true}
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+
+	ctx := ctxWithCallID("call-ps-nil")
+	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+		StepType:  "feedback_response",
+		RequestId: "req-plugin-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if resp.GetOk() {
+		t.Error("ok = true, want false when resolver unwired")
+	}
+
+	events := q.all()
+	var found bool
+	for _, e := range events {
+		if e.EventType == hostsvc.EventTypeFeedbackResponseLate {
+			found = true
+			var payload map[string]string
+			if err := json.Unmarshal([]byte(e.PayloadJson), &payload); err == nil {
+				if payload["reason"] != "resolver_unwired" {
+					t.Errorf("reason = %q, want resolver_unwired", payload["reason"])
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected feedback_response_late audit event, found none")
+	}
+}
+
+// TestPluginSubstrate_UnauthorizedInstance verifies that a request_id routed
+// to a different instance is rejected with unauthorized_request_id (high severity).
+func TestPluginSubstrate_UnauthorizedInstance(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance: db.PluginInstance{ID: "iid-caller", PluginID: "plug-caller"},
+		// Row belongs to a different instance.
+		pluginPendingRequest: pendingRequest("iid-other", "pending"),
+	}
+	binder := &fakeInstanceBinder{id: "iid-caller", ok: true}
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+
+	ctx := ctxWithCallID("call-ps-unauth")
+	_, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+		StepType:  "feedback_response",
+		RequestId: "req-plugin-1",
+	})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+	if st.Message() != "unauthorized_request_id" {
+		t.Errorf("message = %q, want unauthorized_request_id", st.Message())
+	}
+
+	events := q.all()
+	var found bool
+	for _, e := range events {
+		if e.EventType == hostsvc.EventTypeUnauthorizedRequestID {
+			found = true
+			if e.Severity != "high" {
+				t.Errorf("severity = %q, want high", e.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected unauthorized_request_id audit event, found none")
+	}
+}
+
+// TestPluginSubstrate_FallThroughToFeedbackRequests verifies that when
+// GetPluginPendingRequest returns sql.ErrNoRows, the handler falls through to
+// the native feedback_requests path.
+func TestPluginSubstrate_FallThroughToFeedbackRequests(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance:                 db.PluginInstance{ID: "iid-ft", PluginID: "plug-ft", InstanceName: "myplugin"},
+		pluginPendingRequestErr:  sql.ErrNoRows,
+		feedbackRequest:          db.FeedbackRequest{ID: "fr-native", RunID: "run-native", Status: "pending"},
+		latestStep:               db.RunStep{StepNumber: 0},
+		updateFeedbackStatusRows: 1,
+		run:                      db.Run{ID: "run-native", PolicyID: "pol-native"},
+		policy:                   db.Policy{ID: "pol-native", Yaml: policyYAMLWithTool("myplugin.do_thing")},
+	}
+	pub := &fakePublisher{}
+	binder := &fakeInstanceBinder{id: "iid-ft", ok: true}
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, pub, nil)
+
+	ctx := ctxWithCallID("call-ft")
+	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+		StepType:  "feedback_response",
+		RequestId: "fr-native",
+	})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if !resp.GetOk() {
+		t.Error("ok = false, want true on native fall-through path")
+	}
+}
+
 // --- tests: EmitMetric ---
 
 func TestEmitMetric_ForcePrefix(t *testing.T) {
@@ -714,7 +1052,7 @@ func TestEmitMetric_ForcePrefix(t *testing.T) {
 	q := &fakeQuerier{
 		instance: db.PluginInstance{ID: "iid-prefix", PluginID: "plug-prefix"},
 	}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-prefix", ok: true}, &fakePublisher{})
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-prefix", ok: true}, &fakePublisher{}, nil)
 
 	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
 		Name:  "prefix_test_metric",
@@ -729,7 +1067,7 @@ func TestEmitMetric_AutoInjectLabels(t *testing.T) {
 	q := &fakeQuerier{
 		instance: db.PluginInstance{ID: "inst-auto-label", PluginID: "plug-auto-label"},
 	}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "inst-auto-label", ok: true}, &fakePublisher{})
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "inst-auto-label", ok: true}, &fakePublisher{}, nil)
 
 	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
 		Name:  "auto_label_verify_metric",
@@ -779,7 +1117,7 @@ func TestEmitMetric_RejectsInconsistentLabelKeys(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-incons", PluginID: "plug-incons"},
 	}
 	binder := &fakeInstanceBinder{id: "iid-incons", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{})
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	// First emission: registers the metric with label key "a".
 	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
@@ -834,7 +1172,7 @@ func TestEmitMetric_CardinalityCap(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-cap", PluginID: "plug-cap"},
 	}
 	binder := &fakeInstanceBinder{id: "iid-cap", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{})
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	// Emit 100 distinct values for label "env" — all must succeed.
 	for i := 0; i < 100; i++ {
@@ -868,7 +1206,7 @@ func TestEmitMetric_CardinalityCap_Concurrent(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-conc", PluginID: "plug-conc"},
 	}
 	binder := &fakeInstanceBinder{id: "iid-conc", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{})
+	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	const total = 200
 	var successes, exhausted atomic.Int64
@@ -1184,7 +1522,7 @@ func TestNewServer_NilBinderPanics(t *testing.T) {
 	}()
 
 	q := &fakeQuerier{}
-	hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, nil, &fakePublisher{})
+	hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, nil, &fakePublisher{}, nil)
 }
 
 // ── test helpers: Tier-2 manifest snapshots ───────────────────────────────────

--- a/main.go
+++ b/main.go
@@ -197,12 +197,18 @@ func run(cfg config.Config) error {
 		identityReg := identity.New()
 		genCtrl := generation.New()
 
+		pluginDispatcher := dispatch.NewDispatcher(dispatch.DispatcherConfig{
+			Queries: store.Queries(),
+			Connect: stubConnFactory,
+		})
+
 		hostSvc := hostsvc.NewServer(
 			store.Queries(),
 			encryptionKey,
 			pluginPool,
 			hostsvc.NewContextBinder(),
 			broadcaster,
+			pluginDispatcher,
 		)
 
 		interceptors := []grpc.UnaryServerInterceptor{


### PR DESCRIPTION
Closes #209

## Summary

Closes the dead-code window left by **#205** — `Dispatcher.Resolve` is now reachable from production via `hostsvc.WriteAuditStep`. Plugin late callbacks (a `plugin_pending_requests` row that's no longer in `pending`) are rejected with a `feedback_response_late` audit event without mutating run state.

## Changes

- **`Dispatcher.Resolve` signature** → `(resolved bool, err error)`. Surfaces the CAS-conflict outcome the host needs to distinguish a successful resolve from "row already resolved/timed_out by scanner or another writer".

- **`WriteAuditStep` lookup order**: plugin_pending_requests FIRST, fall through to feedback_requests on `sql.ErrNoRows`. ULIDs are indistinguishable by shape; plugin substrate must come first so a request originated by `Dispatcher.Request` resolves correctly.

- **Plugin substrate branch**:
  - Ownership: `PluginInstanceID == calling instance` (direct row-level FK; no policy YAML walk)
  - `resolved=true` → publish SSE event, return `Ok=true` — **no `CreateRunStep`**, the agent loop's `Dispatcher.Wait` writes its own audit step
  - `resolved=false` (CAS conflict) OR `ErrUnknownRequestID` (waiter evicted) OR nil resolver → emit `feedback_response_late` audit event at severity `warning`, with `reason="late"` / `"evicted_waiter"` / `"resolver_unwired"`. Return `Ok=false` with `feedback_response_late` envelope. No run-state change, no run_step.
  - Other resolver error → `Internal`.

- **`ChannelResolver` interface** added on `hostsvc.Server` (nil-safe — when nil and a row is found, the path collapses to the late-callback path with reason `"resolver_unwired"`).

- **`main.go`** wires `dispatch.Dispatcher` into `NewServer`.

## Pre-existing bug fix included

The native-path late-event call at `handlers.go:201` was writing severity `"medium"`, which violates the `plugin_audit_events.severity` CHECK constraint (`info|warning|high|critical`). That call would have failed at runtime if it ever fired. Now writes `"warning"` on both native and plugin paths, with both paths using the new `EventTypeFeedbackResponseLate` constant.

## Plan & process

<details>
<summary>Architecture plan</summary>

Files (8):
1. `internal/plugin/dispatch/channel.go` — `Resolve` signature change
2. `internal/plugin/dispatch/channel_test.go` — test updates + 2 new cases
3. `internal/plugin/hostsvc/audit_guard.go` — `EventTypeFeedbackResponseLate` constant
4. `internal/plugin/hostsvc/server.go` — `ChannelResolver` interface, `channels` field, `NewServer` signature
5. `internal/plugin/hostsvc/handlers.go` — plugin-substrate branch + native-path bug fix
6. `internal/plugin/hostsvc/server_test.go` — fakeChannelResolver + 7 new test cases + native test severity update
7. `internal/plugin/hostsvc/end_to_end_integration_test.go` — 2 e2e tests (Late + Happy)
8. `main.go` — Dispatcher → NewServer wiring

</details>

- Review cycles: 1 plan-revision (plan-reviewer caught: invalid severities `"medium"` / `"normal"` vs CHECK constraint, `s.channels == nil` contradiction, `ErrUnknownRequestID` should also be late-callback path). Code review approved cycle 1 with one trivial fix (vacuous test assertion → call counter).
- CLAUDE.md: no updates needed — handler-internal change covered by existing `hostsvc/` paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop