### PR TITLE
feat: /admin/audiences page (list, create, edit, delete)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -32,6 +32,9 @@ npm run build-storybook  # static Storybook build
 /admin/users        → user management (admin)
 /admin/models       → model enable/disable, provider key management (admin)
 /admin/system       → system settings (public URL, run limits, system info) (admin)
+/admin/audiences    → audience list (admin|operator: + new; auditor: read-only)
+/admin/audiences/new → create audience (admin|operator)
+/admin/audiences/:id → audience detail/editor (admin|operator: edit; auditor: read-only)
 *                   → 404 not found
 ```
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
+        "@rjsf/core": "^5.24.13",
+        "@rjsf/utils": "^5.24.13",
+        "@rjsf/validator-ajv8": "^5.24.13",
         "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-query-devtools": "^5.99.0",
         "focus-trap-react": "^12.0.0",
@@ -1284,6 +1287,68 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@rjsf/core": {
+      "version": "5.24.13",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.24.13.tgz",
+      "integrity": "sha512-ONTr14s7LFIjx2VRFLuOpagL76sM/HPy6/OhdBfq6UukINmTIs6+aFN0GgcR0aXQHFDXQ7f/fel0o/SO05Htdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "markdown-to-jsx": "^7.4.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^5.24.x",
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/utils": {
+      "version": "5.24.13",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.13.tgz",
+      "integrity": "sha512-rNF8tDxIwTtXzz5O/U23QU73nlhgQNYJ+Sv5BAwQOIyhIE2Z3S5tUiSVMwZHt0julkv/Ryfwi+qsD4FiE5rOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema-merge-allof": "^0.8.1",
+        "jsonpointer": "^5.0.1",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@rjsf/validator-ajv8": {
+      "version": "5.24.13",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.24.13.tgz",
+      "integrity": "sha512-oWHP7YK581M8I5cF1t+UXFavnv+bhcqjtL1a7MG/Kaffi0EwhgcYjODrD8SsnrhncsEYMqSECr4ZOEoirnEUWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^5.24.x"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
@@ -2513,6 +2578,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2863,6 +2961,27 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dependencies": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3332,6 +3451,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -3348,6 +3473,22 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -3691,8 +3832,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -3768,6 +3908,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/json-schema-merge-allof": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-lcm": "^1.1.2",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.20"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3790,6 +3959,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lightningcss": {
@@ -4053,6 +4231,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -4132,6 +4334,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.7.17",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.17.tgz",
+      "integrity": "sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/mdn-data": {
@@ -4286,6 +4505,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -4492,6 +4720,23 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4727,7 +4972,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5363,6 +5607,39 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
+      "license": "MIT"
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,9 @@
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/ibm-plex-sans": "^5.2.8",
+    "@rjsf/core": "^5.24.13",
+    "@rjsf/utils": "^5.24.13",
+    "@rjsf/validator-ajv8": "^5.24.13",
     "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-query-devtools": "^5.99.0",
     "focus-trap-react": "^12.0.0",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -469,3 +469,40 @@ export interface ApiAudienceReferences {
   policies: ApiAudiencePolicyRef[]
   in_flight_runs: ApiAudienceInFlightRun[]
 }
+
+// Matches internal/http/api/audience_handler.go (GET /api/v1/admin/plugin-instances).
+// Pending in #290.
+export interface ApiPluginInstanceForAudience {
+  id: string
+  plugin_id: string
+  instance_name: string
+  state: PluginHealthState
+  implements_notify: boolean
+  implements_request: boolean
+  config_schema: Record<string, unknown> | null
+}
+
+// Request body interfaces for audience mutations.
+// Matches internal/http/api/audience_handler.go.
+
+export interface AudienceEntryInput {
+  plugin_instance_id: string
+  notify: boolean
+  request: boolean
+  config: Record<string, unknown>
+}
+
+export interface AudienceCreateRequest {
+  name: string
+  disable_in_app_fallback: boolean
+  entries: AudienceEntryInput[]
+}
+
+export interface AudienceUpdateRequest {
+  name: string
+  disable_in_app_fallback: boolean
+  // Must be `expected_version` to match audienceSaveRequest.ExpectedVersion's
+  // json:"expected_version,omitempty" tag in audience_handler.go.
+  expected_version: number
+  entries: AudienceEntryInput[]
+}

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.module.css
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.module.css
@@ -1,0 +1,146 @@
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-section);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.sectionDesc {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+/* Name field */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-second);
+}
+
+.input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-mid);
+  border-radius: 4px;
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-blue);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+
+.input:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Entry list */
+
+.entryList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* Advanced toggle row */
+
+.advancedRow {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.toggleLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-second);
+  cursor: pointer;
+}
+
+.toggleLabel:has(input:disabled) {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.fallbackWarning {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-amber);
+}
+
+/* Footer */
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+}
+
+.footerRight {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+/* Banner */
+
+.conflictBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(in srgb, var(--color-amber) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-amber) 25%, transparent);
+  border-radius: var(--radius-section);
+  font-size: var(--text-sm);
+  color: var(--color-amber);
+}
+
+.readOnlyNotice {
+  margin: 0;
+  padding: var(--space-3);
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+  border-left: 3px solid var(--text-muted);
+  border-radius: 4px;
+  font-size: var(--text-sm);
+  color: var(--text-second);
+}

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.stories.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.stories.tsx
@@ -1,0 +1,241 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@/tokens.css'
+import { AudienceEditor } from './AudienceEditor'
+import type {
+  ApiAudience,
+  ApiAudienceReferences,
+  ApiPluginInstanceForAudience,
+} from '@/api/types'
+import { ApiError } from '@/api/fetch'
+
+// Fixtures
+
+const PLUGIN_SLACK: ApiPluginInstanceForAudience = {
+  id: 'slack-primary',
+  plugin_id: 'com.example.slack',
+  instance_name: 'slack-primary',
+  state: 'healthy',
+  implements_notify: true,
+  implements_request: false,
+  config_schema: {
+    type: 'object',
+    properties: {
+      channel: { type: 'string', title: 'Channel', description: 'Slack channel name (e.g. #ops)' },
+      mention: { type: 'string', title: 'Mention', description: 'User or group to @-mention' },
+    },
+    required: ['channel'],
+  },
+}
+
+const PLUGIN_NTFY: ApiPluginInstanceForAudience = {
+  id: 'ntfy-backup',
+  plugin_id: 'com.example.ntfy',
+  instance_name: 'ntfy-backup',
+  state: 'unsigned_permissive',
+  implements_notify: true,
+  implements_request: false,
+  config_schema: {
+    type: 'object',
+    properties: {
+      topic: { type: 'string', title: 'Topic', description: 'ntfy topic name' },
+    },
+    required: ['topic'],
+  },
+}
+
+const PLUGIN_PAGERDUTY: ApiPluginInstanceForAudience = {
+  id: 'pagerduty-main',
+  plugin_id: 'com.example.pagerduty',
+  instance_name: 'pagerduty-main',
+  state: 'healthy',
+  implements_notify: false,
+  implements_request: true,
+  config_schema: null,
+}
+
+const ALL_PLUGINS = [PLUGIN_SLACK, PLUGIN_NTFY, PLUGIN_PAGERDUTY]
+
+const AUDIENCE_SINGLE: ApiAudience = {
+  id: 'aud-1',
+  name: 'ops-team',
+  disable_in_app_fallback: false,
+  version: 3,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-04-01T12:00:00Z',
+  entries: [
+    {
+      id: 'e1',
+      plugin_instance_id: 'slack-primary',
+      position: 0,
+      notify: true,
+      request: false,
+      config: { channel: '#ops' },
+    },
+  ],
+}
+
+const AUDIENCE_MULTI: ApiAudience = {
+  id: 'aud-2',
+  name: 'all-hands',
+  disable_in_app_fallback: false,
+  version: 7,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-04-15T09:00:00Z',
+  entries: [
+    {
+      id: 'e1',
+      plugin_instance_id: 'slack-primary',
+      position: 0,
+      notify: true,
+      request: false,
+      config: { channel: '#incidents' },
+    },
+    {
+      id: 'e2',
+      plugin_instance_id: 'ntfy-backup',
+      position: 1,
+      notify: true,
+      request: false,
+      config: {},
+    },
+    {
+      id: 'e3',
+      plugin_instance_id: 'pagerduty-main',
+      position: 2,
+      notify: false,
+      request: true,
+      config: {},
+    },
+  ],
+}
+
+const REFS_EMPTY: ApiAudienceReferences = {
+  policies: [],
+  in_flight_runs: [],
+}
+
+const REFS_WITH_POLICIES: ApiAudienceReferences = {
+  policies: [
+    { id: 'p1', name: 'deploy-bot' },
+    { id: 'p2', name: 'smoke-tests' },
+  ],
+  in_flight_runs: [{ id: 'run-abc123', policy_id: 'p1', status: 'running' }],
+}
+
+function wrap(children: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <div style={{ maxWidth: 900, padding: '24px' }}>{children}</div>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const meta: Meta<typeof AudienceEditor> = {
+  title: 'Admin/AudienceEditor/AudienceEditor',
+  component: AudienceEditor,
+}
+
+export default meta
+type Story = StoryObj<typeof AudienceEditor>
+
+export const EmptyAudience: Story = {
+  render: () =>
+    wrap(
+      <AudienceEditor
+        initial={null}
+        pluginInstances={ALL_PLUGINS}
+        references={null}
+        canManage={true}
+        onSave={async (req) => {
+          console.log('save', req)
+          return { id: 'new', name: 'new', disable_in_app_fallback: false, version: 1, created_at: '', updated_at: '', entries: [] }
+        }}
+        saveError={null}
+        deleteError={null}
+      />,
+    ),
+}
+
+export const SingleEntry: Story = {
+  render: () =>
+    wrap(
+      <AudienceEditor
+        initial={AUDIENCE_SINGLE}
+        pluginInstances={ALL_PLUGINS}
+        references={REFS_EMPTY}
+        canManage={true}
+        onSave={async (req) => { console.log('save', req); return AUDIENCE_SINGLE }}
+        onDelete={async () => { console.log('delete') }}
+        saveError={null}
+        deleteError={null}
+      />,
+    ),
+}
+
+export const MultiEntryMixedCapabilities: Story = {
+  render: () =>
+    wrap(
+      <AudienceEditor
+        initial={AUDIENCE_MULTI}
+        pluginInstances={ALL_PLUGINS}
+        references={REFS_EMPTY}
+        canManage={true}
+        onSave={async (req) => { console.log('save', req); return AUDIENCE_MULTI }}
+        onDelete={async () => { console.log('delete') }}
+        saveError={null}
+        deleteError={null}
+      />,
+    ),
+}
+
+export const WithReferences: Story = {
+  render: () =>
+    wrap(
+      <AudienceEditor
+        initial={AUDIENCE_MULTI}
+        pluginInstances={ALL_PLUGINS}
+        references={REFS_WITH_POLICIES}
+        canManage={true}
+        onSave={async (req) => { console.log('save', req); return AUDIENCE_MULTI }}
+        onDelete={async () => { console.log('delete') }}
+        saveError={null}
+        deleteError={null}
+      />,
+    ),
+}
+
+export const ReadOnlyAuditor: Story = {
+  render: () =>
+    wrap(
+      <AudienceEditor
+        initial={AUDIENCE_MULTI}
+        pluginInstances={ALL_PLUGINS}
+        references={REFS_WITH_POLICIES}
+        canManage={false}
+        onSave={async () => AUDIENCE_MULTI}
+        saveError={null}
+        deleteError={null}
+      />,
+    ),
+}
+
+export const VersionConflict: Story = {
+  render: () =>
+    wrap(
+      <AudienceEditor
+        initial={AUDIENCE_SINGLE}
+        pluginInstances={ALL_PLUGINS}
+        references={REFS_EMPTY}
+        canManage={true}
+        onSave={async () => { throw new ApiError(409, 'run status transition lost to concurrent writer') }}
+        onDelete={async () => {}}
+        saveError={new ApiError(409, 'run status transition lost to concurrent writer')}
+        deleteError={null}
+      />,
+    ),
+}

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.test.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.test.tsx
@@ -1,0 +1,296 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { AudienceEditor } from './AudienceEditor'
+import type {
+  ApiAudience,
+  ApiAudienceReferences,
+  ApiPluginInstanceForAudience,
+} from '@/api/types'
+import { ApiError } from '@/api/fetch'
+
+// Mock react-router-dom's useNavigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+// Fixtures
+
+const PLUGIN_NOTIFY_ONLY: ApiPluginInstanceForAudience = {
+  id: 'slack-1',
+  plugin_id: 'com.example.slack',
+  instance_name: 'slack-1',
+  state: 'healthy',
+  implements_notify: true,
+  implements_request: false,
+  config_schema: null,
+}
+
+const PLUGIN_REQUEST_ONLY: ApiPluginInstanceForAudience = {
+  id: 'pd-1',
+  plugin_id: 'com.example.pagerduty',
+  instance_name: 'pd-1',
+  state: 'healthy',
+  implements_notify: false,
+  implements_request: true,
+  config_schema: null,
+}
+
+const ALL_PLUGINS = [PLUGIN_NOTIFY_ONLY, PLUGIN_REQUEST_ONLY]
+
+const AUDIENCE: ApiAudience = {
+  id: 'aud-1',
+  name: 'ops-team',
+  disable_in_app_fallback: false,
+  version: 3,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-04-01T12:00:00Z',
+  entries: [
+    {
+      id: 'e1',
+      plugin_instance_id: 'slack-1',
+      position: 0,
+      notify: true,
+      request: false,
+      config: {},
+    },
+    {
+      id: 'e2',
+      plugin_instance_id: 'pd-1',
+      position: 1,
+      notify: false,
+      request: true,
+      config: {},
+    },
+  ],
+}
+
+const REFS_EMPTY: ApiAudienceReferences = { policies: [], in_flight_runs: [] }
+
+const REFS_WITH_POLICIES: ApiAudienceReferences = {
+  policies: [{ id: 'p1', name: 'deploy-bot' }],
+  in_flight_runs: [],
+}
+
+function renderEditor(
+  props: Partial<Parameters<typeof AudienceEditor>[0]> & {
+    initial?: ApiAudience | null
+  } = {},
+) {
+  const defaults = {
+    initial: AUDIENCE as ApiAudience | null,
+    pluginInstances: ALL_PLUGINS,
+    references: REFS_EMPTY,
+    canManage: true,
+    onSave: vi.fn().mockResolvedValue(AUDIENCE),
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    saveError: null,
+    deleteError: null,
+  }
+  return render(
+    <MemoryRouter>
+      <AudienceEditor {...defaults} {...props} />
+    </MemoryRouter>,
+  )
+}
+
+describe('AudienceEditor — basic rendering', () => {
+  it('shows audience name in name input', () => {
+    renderEditor()
+    const input = screen.getByLabelText(/audience name/i) as HTMLInputElement
+    expect(input.value).toBe('ops-team')
+  })
+
+  it('renders Save and Delete buttons when canManage', () => {
+    renderEditor()
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete audience/i })).toBeInTheDocument()
+  })
+
+  it('hides Save and Delete buttons when !canManage', () => {
+    renderEditor({ canManage: false })
+    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /delete audience/i })).not.toBeInTheDocument()
+  })
+
+  it('shows read-only notice when !canManage', () => {
+    renderEditor({ canManage: false })
+    expect(screen.getByText(/read-only access/i)).toBeInTheDocument()
+  })
+})
+
+describe('AudienceEditor — Notify disabled when implements_notify=false', () => {
+  it('disables Notify checkbox for pd-1 which has implements_notify=false', () => {
+    renderEditor()
+    // Find entry 2 (pd-1) — it renders Notify checkbox second
+    const notifyCheckboxes = screen.getAllByRole('checkbox', { name: /notify/i })
+    // Entry 1 (slack-1) implements_notify=true → enabled
+    expect(notifyCheckboxes[0]).not.toBeDisabled()
+    // Entry 2 (pd-1) implements_notify=false → disabled
+    expect(notifyCheckboxes[1]).toBeDisabled()
+  })
+
+  it('shows title tooltip for disabled Notify', () => {
+    renderEditor()
+    const notifyLabels = screen.getAllByTitle('This plugin does not implement Notify')
+    expect(notifyLabels.length).toBeGreaterThan(0)
+  })
+})
+
+describe('AudienceEditor — Request disabled when implements_request=false', () => {
+  it('disables Request checkbox for slack-1 which has implements_request=false', () => {
+    renderEditor()
+    const requestCheckboxes = screen.getAllByRole('checkbox', { name: /request/i })
+    // Entry 1 (slack-1) implements_request=false → disabled
+    expect(requestCheckboxes[0]).toBeDisabled()
+    // Entry 2 (pd-1) implements_request=true → enabled
+    expect(requestCheckboxes[1]).not.toBeDisabled()
+  })
+})
+
+describe('AudienceEditor — drag-reorder', () => {
+  it('updates entry order when Move Down is clicked', async () => {
+    renderEditor()
+    // Before: slack-1 at index 0, pd-1 at index 1
+    const moveDownBtns = screen.getAllByRole('button', { name: /move down/i })
+    // Click Move Down on entry 1 (index 0)
+    await userEvent.click(moveDownBtns[0])
+
+    // After: pd-1 is now at position 1 label and slack-1 at position 2
+    // The position numbers (1, 2) are rendered as text
+    const positions = document.querySelectorAll('[class*="position"]')
+    // We check that the entries exist and there are still 2 user entries
+    expect(positions.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('updates entry order when Move Up is clicked', async () => {
+    renderEditor()
+    const moveUpBtns = screen.getAllByRole('button', { name: /move up/i })
+    // Move up on entry 2 (index 1, pd-1)
+    await userEvent.click(moveUpBtns[1])
+    // Just verify no errors thrown and re-render happens
+    expect(screen.getAllByRole('button', { name: /move up/i }).length).toBeGreaterThan(0)
+  })
+})
+
+describe('AudienceEditor — SaveGuardDialog opens conditionally', () => {
+  it('does NOT show SaveGuardDialog when references is empty', async () => {
+    const onSave = vi.fn().mockResolvedValue(AUDIENCE)
+    renderEditor({ references: REFS_EMPTY, onSave })
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+  })
+
+  it('shows SaveGuardDialog when references has policies', async () => {
+    const onSave = vi.fn().mockResolvedValue(AUDIENCE)
+    renderEditor({ references: REFS_WITH_POLICIES, onSave })
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // onSave not yet called — user must confirm
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('calls onSave after confirming in SaveGuardDialog', async () => {
+    const onSave = vi.fn().mockResolvedValue(AUDIENCE)
+    renderEditor({ references: REFS_WITH_POLICIES, onSave })
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /save anyway/i }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+  })
+})
+
+describe('AudienceEditor — payload serialization', () => {
+  it('strips auto entries before submitting', async () => {
+    const audienceWithAuto: ApiAudience = {
+      ...AUDIENCE,
+      entries: [
+        ...AUDIENCE.entries,
+        {
+          id: '__auto__',
+          plugin_instance_id: '',
+          position: 99,
+          notify: true,
+          request: true,
+          config: {},
+          auto: true,
+        },
+      ],
+    }
+    const onSave = vi.fn().mockResolvedValue(audienceWithAuto)
+    renderEditor({ initial: audienceWithAuto, references: REFS_EMPTY, onSave })
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+    const req = onSave.mock.calls[0][0]
+    // No auto entries should be in the payload
+    expect(req.entries.every((e: { plugin_instance_id: string }) => e.plugin_instance_id !== '')).toBe(true)
+  })
+
+  it('includes expected_version in edit mode', async () => {
+    const onSave = vi.fn().mockResolvedValue(AUDIENCE)
+    renderEditor({ initial: AUDIENCE, references: REFS_EMPTY, onSave })
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+    const req = onSave.mock.calls[0][0]
+    expect(req).toHaveProperty('expected_version', AUDIENCE.version)
+  })
+
+  it('does NOT include expected_version in create mode', async () => {
+    const onSave = vi.fn().mockResolvedValue(AUDIENCE)
+    renderEditor({ initial: null, references: null, onSave })
+
+    // Fill in a name (required)
+    fireEvent.change(screen.getByLabelText(/audience name/i), { target: { value: 'new-aud' } })
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+    const req = onSave.mock.calls[0][0]
+    expect(req).not.toHaveProperty('expected_version')
+  })
+})
+
+describe('AudienceEditor — 409 version conflict banner', () => {
+  it('shows reload banner when saveError.status === 409', () => {
+    const conflictError = new ApiError(409, 'run status transition lost to concurrent writer')
+    renderEditor({ saveError: conflictError })
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/reload audience/i)).toBeInTheDocument()
+  })
+
+  it('does NOT show reload banner when saveError is null', () => {
+    renderEditor({ saveError: null })
+    // Only alert roles are from error/success alerts, check none match the conflict text
+    const alerts = document.querySelectorAll('[role="alert"]')
+    alerts.forEach((a) => {
+      expect(a.textContent).not.toMatch(/reload audience/i)
+    })
+  })
+})
+
+describe('AudienceEditor — add entry', () => {
+  it('appends a new blank entry when + Add entry is clicked', async () => {
+    renderEditor()
+    const initialPositions = screen.getAllByRole('button', { name: /remove entry/i })
+    const initialCount = initialPositions.length
+
+    await userEvent.click(screen.getByRole('button', { name: /\+ add entry/i }))
+
+    const afterPositions = screen.getAllByRole('button', { name: /remove entry/i })
+    expect(afterPositions.length).toBe(initialCount + 1)
+  })
+})

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
@@ -1,0 +1,433 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/Button/Button'
+import type {
+  ApiAudience,
+  ApiAudienceEntry,
+  ApiAudienceReferences,
+  ApiPluginInstanceForAudience,
+  AudienceCreateRequest,
+  AudienceUpdateRequest,
+} from '@/api/types'
+import type { ApiError } from '@/api/fetch'
+import { RoutingPreview } from './RoutingPreview'
+import { EntryRow } from './EntryRow'
+import { SaveGuardDialog } from './SaveGuardDialog'
+import alertStyles from '@/styles/alerts.module.css'
+import styles from './AudienceEditor.module.css'
+
+interface Props {
+  initial: ApiAudience | null
+  pluginInstances: ApiPluginInstanceForAudience[]
+  references: ApiAudienceReferences | null
+  canManage: boolean
+  onSave: (req: AudienceCreateRequest | AudienceUpdateRequest) => Promise<ApiAudience>
+  onDelete?: () => Promise<void>
+  saveError: ApiError | null
+  deleteError: ApiError | null
+}
+
+function makeBlankEntry(): ApiAudienceEntry {
+  return {
+    id: `new-${Date.now()}-${Math.random()}`,
+    plugin_instance_id: '',
+    position: 0,
+    notify: true,
+    request: false,
+    config: {},
+  }
+}
+
+export function AudienceEditor({
+  initial,
+  pluginInstances,
+  references,
+  canManage,
+  onSave,
+  onDelete,
+  saveError,
+  deleteError,
+}: Props) {
+  const navigate = useNavigate()
+
+  const [name, setName] = useState(initial?.name ?? '')
+  const [disableInAppFallback, setDisableInAppFallback] = useState(
+    initial?.disable_in_app_fallback ?? false,
+  )
+  // Filter out auto entries — they're server-injected; we keep them only for display.
+  const [entries, setEntries] = useState<ApiAudienceEntry[]>(
+    (initial?.entries ?? []).filter((e) => !e.auto),
+  )
+  const [dirty, setDirty] = useState(false)
+  const [showSaveGuard, setShowSaveGuard] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  // Drag state: which index is being dragged and which index is the drop target.
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+
+  function markDirty() {
+    if (!dirty) setDirty(true)
+  }
+
+  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setName(e.target.value)
+    markDirty()
+  }
+
+  function handleDisableFallbackChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setDisableInAppFallback(e.target.checked)
+    markDirty()
+  }
+
+  function handleEntryChange(index: number, updated: ApiAudienceEntry) {
+    setEntries((prev) => prev.map((e, i) => (i === index ? updated : e)))
+    markDirty()
+  }
+
+  function handleAddEntry() {
+    setEntries((prev) => [...prev, makeBlankEntry()])
+    markDirty()
+  }
+
+  function handleRemoveEntry(index: number) {
+    setEntries((prev) => prev.filter((_, i) => i !== index))
+    markDirty()
+  }
+
+  function handleMoveUp(index: number) {
+    if (index === 0) return
+    setEntries((prev) => {
+      const next = [...prev]
+      ;[next[index - 1], next[index]] = [next[index], next[index - 1]]
+      return next
+    })
+    markDirty()
+  }
+
+  function handleMoveDown(index: number) {
+    setEntries((prev) => {
+      if (index >= prev.length - 1) return prev
+      const next = [...prev]
+      ;[next[index], next[index + 1]] = [next[index + 1], next[index]]
+      return next
+    })
+    markDirty()
+  }
+
+  const handleDragStart = useCallback((index: number) => {
+    setDragIndex(index)
+  }, [])
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent, index: number) => {
+      e.preventDefault()
+      if (dragOverIndex !== index) setDragOverIndex(index)
+    },
+    [dragOverIndex],
+  )
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent, dropIndex: number) => {
+      e.preventDefault()
+      if (dragIndex === null || dragIndex === dropIndex) {
+        setDragIndex(null)
+        setDragOverIndex(null)
+        return
+      }
+      setEntries((prev) => {
+        const next = [...prev]
+        const [moved] = next.splice(dragIndex, 1)
+        next.splice(dropIndex, 0, moved)
+        return next
+      })
+      setDragIndex(null)
+      setDragOverIndex(null)
+      markDirty()
+    },
+    [dragIndex], // eslint-disable-line react-hooks/exhaustive-deps
+  )
+
+  function buildPayload(): AudienceCreateRequest | AudienceUpdateRequest {
+    const entryInputs = entries.map((e) => ({
+      plugin_instance_id: e.plugin_instance_id,
+      notify: e.notify,
+      request: e.request,
+      config: e.config,
+    }))
+
+    if (initial) {
+      return {
+        name,
+        disable_in_app_fallback: disableInAppFallback,
+        expected_version: initial.version,
+        entries: entryInputs,
+      } satisfies AudienceUpdateRequest
+    }
+
+    return {
+      name,
+      disable_in_app_fallback: disableInAppFallback,
+      entries: entryInputs,
+    } satisfies AudienceCreateRequest
+  }
+
+  function handleSaveClick() {
+    const hasRefs =
+      (references?.policies.length ?? 0) > 0 || (references?.in_flight_runs.length ?? 0) > 0
+
+    if (hasRefs && initial) {
+      setShowSaveGuard(true)
+      return
+    }
+    void doSave()
+  }
+
+  async function doSave() {
+    setIsSaving(true)
+    try {
+      await onSave(buildPayload())
+      setDirty(false)
+    } finally {
+      setIsSaving(false)
+      setShowSaveGuard(false)
+    }
+  }
+
+  async function handleDeleteClick() {
+    if (!onDelete) return
+    setIsDeleting(true)
+    try {
+      await onDelete()
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  // The synthetic in-app entry for display purposes only.
+  const displayEntries: ApiAudienceEntry[] = [
+    ...entries,
+    ...(!disableInAppFallback
+      ? [
+          {
+            id: '__auto__',
+            plugin_instance_id: '',
+            position: entries.length,
+            notify: true,
+            request: true,
+            config: {},
+            auto: true,
+          },
+        ]
+      : []),
+  ]
+
+  const noRequestCapable =
+    disableInAppFallback &&
+    !entries.some((e) => e.request && !!e.plugin_instance_id)
+
+  return (
+    <div className={styles.editor}>
+      {/* Version conflict banner */}
+      {saveError?.status === 409 && (
+        <div className={styles.conflictBanner} role="alert">
+          <span>
+            This audience was updated by another session. Reload to see the latest version before
+            saving again.
+          </span>
+          <Button
+            variant="ghost"
+            size="small"
+            onClick={() => window.location.reload()}
+          >
+            Reload audience
+          </Button>
+        </div>
+      )}
+
+      {/* Routing preview */}
+      <RoutingPreview entries={displayEntries} disableInAppFallback={disableInAppFallback} />
+
+      {/* Name */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Name</h2>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="audience-name">
+            Audience name <span aria-hidden>*</span>
+          </label>
+          <input
+            id="audience-name"
+            className={styles.input}
+            type="text"
+            value={name}
+            onChange={handleNameChange}
+            disabled={!canManage}
+            minLength={1}
+            maxLength={64}
+            required
+            placeholder="e.g. ops-team"
+          />
+        </div>
+      </section>
+
+      {/* Entries */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Entries</h2>
+        <p className={styles.sectionDesc}>
+          Channels are tried in order. Drag rows to reorder or use the up/down arrows.
+          The synthetic <code>gleipnir.in-app</code> fallback is appended automatically unless
+          explicitly disabled.
+        </p>
+
+        <ol className={styles.entryList}>
+          {entries.map((entry, index) => (
+            <EntryRow
+              key={entry.id}
+              entry={entry}
+              index={index}
+              totalCount={entries.length}
+              pluginInstances={pluginInstances}
+              onChange={(updated) => handleEntryChange(index, updated)}
+              onRemove={() => handleRemoveEntry(index)}
+              onMoveUp={() => handleMoveUp(index)}
+              onMoveDown={() => handleMoveDown(index)}
+              onDragStart={(e) => {
+                e.dataTransfer.effectAllowed = 'move'
+                handleDragStart(index)
+              }}
+              onDragOver={(e) => handleDragOver(e, index)}
+              onDrop={(e) => handleDrop(e, index)}
+              isDragging={dragIndex === index}
+              isDragOver={dragOverIndex === index && dragIndex !== index}
+              disabled={!canManage}
+            />
+          ))}
+          {!disableInAppFallback && (
+            <EntryRow
+              key="__auto__"
+              entry={{
+                id: '__auto__',
+                plugin_instance_id: '',
+                position: entries.length,
+                notify: true,
+                request: true,
+                config: {},
+                auto: true,
+              }}
+              index={entries.length}
+              totalCount={entries.length + 1}
+              pluginInstances={pluginInstances}
+              onChange={() => {}}
+              onRemove={() => {}}
+              onMoveUp={() => {}}
+              onMoveDown={() => {}}
+              onDragStart={() => {}}
+              onDragOver={() => {}}
+              onDrop={() => {}}
+              isDragging={false}
+              isDragOver={false}
+              disabled={true}
+            />
+          )}
+        </ol>
+
+        {canManage && (
+          <Button variant="secondary" size="small" type="button" onClick={handleAddEntry}>
+            + Add entry
+          </Button>
+        )}
+      </section>
+
+      {/* Advanced */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Advanced</h2>
+        <div className={styles.advancedRow}>
+          <label className={styles.toggleLabel}>
+            <input
+              type="checkbox"
+              checked={disableInAppFallback}
+              onChange={handleDisableFallbackChange}
+              disabled={!canManage}
+            />
+            Disable in-app fallback
+          </label>
+        </div>
+        {disableInAppFallback && noRequestCapable && (
+          <p className={styles.fallbackWarning}>
+            Warning: no Request-capable entry and in-app fallback is disabled. Channel Requests
+            will have no handler.
+          </p>
+        )}
+      </section>
+
+      {/* Save/delete errors (non-409) */}
+      {saveError && saveError.status !== 409 && (
+        <div className={alertStyles.alertError} role="alert">
+          {saveError.detail ?? saveError.message}
+        </div>
+      )}
+      {deleteError && deleteError.status !== 409 && (
+        <div className={alertStyles.alertError} role="alert">
+          {deleteError.detail ?? deleteError.message}
+        </div>
+      )}
+      {deleteError?.status === 409 && (
+        <div className={alertStyles.alertError} role="alert">
+          Cannot delete: this audience is referenced by{' '}
+          {deleteError.detail ?? 'one or more policies'}.
+        </div>
+      )}
+
+      {/* Footer */}
+      {canManage && (
+        <div className={styles.footer}>
+          {initial && onDelete && (
+            <Button
+              variant="danger"
+              type="button"
+              onClick={() => void handleDeleteClick()}
+              disabled={isDeleting || isSaving}
+            >
+              {isDeleting ? 'Deleting…' : 'Delete audience'}
+            </Button>
+          )}
+          <div className={styles.footerRight}>
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={() => navigate('/admin/audiences')}
+              disabled={isSaving || isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              type="button"
+              onClick={handleSaveClick}
+              disabled={isSaving || isDeleting || !name.trim()}
+            >
+              {isSaving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!canManage && (
+        <p className={styles.readOnlyNotice}>
+          You have read-only access. Editing requires an admin or operator role.
+        </p>
+      )}
+
+      {/* Save guard dialog */}
+      {showSaveGuard && references && (
+        <SaveGuardDialog
+          references={references}
+          onConfirm={() => void doSave()}
+          onCancel={() => setShowSaveGuard(false)}
+          isPending={isSaving}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/admin/AudienceEditor/EntryRow.module.css
+++ b/frontend/src/components/admin/AudienceEditor/EntryRow.module.css
@@ -1,0 +1,185 @@
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+
+.rowAuto {
+  border-style: dashed;
+  background: var(--bg-canvas);
+}
+
+.dragging {
+  opacity: 0.5;
+}
+
+.dragOver {
+  border-top: 2px solid var(--color-blue);
+}
+
+.rowHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.dragHandle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: grab;
+  border-radius: 3px;
+}
+
+.dragHandle:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.dragHandle:not(:disabled):hover {
+  color: var(--text-second);
+  background: var(--bg-subtle);
+}
+
+.reorderButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.reorderBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px var(--space-1);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.reorderBtn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.reorderBtn:not(:disabled):hover {
+  color: var(--text-second);
+  background: var(--bg-subtle);
+}
+
+.position {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--text-muted);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.autoLabel {
+  flex: 1;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-second);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.pickerWrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+}
+
+.picker {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-mid);
+  border-radius: 4px;
+  padding: var(--space-1) var(--space-2);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+}
+
+.picker:focus {
+  outline: none;
+  border-color: var(--color-blue);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+
+.picker:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.toggleLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--text-second);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.toggleLabel:has(input:disabled) {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.removeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 3px;
+  margin-left: auto;
+}
+
+.removeBtn:not(:disabled):hover {
+  color: var(--color-red);
+  background: color-mix(in srgb, var(--color-red) 10%, transparent);
+}
+
+.removeBtn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.configSection {
+  padding-left: calc(var(--space-3) + 14px + var(--space-2) + 14px + var(--space-2) + 24px + var(--space-2));
+}
+
+.noConfig {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/frontend/src/components/admin/AudienceEditor/EntryRow.tsx
+++ b/frontend/src/components/admin/AudienceEditor/EntryRow.tsx
@@ -1,0 +1,233 @@
+import Form from '@rjsf/core'
+// The AJV8 validator type doesn't perfectly align with the strict generic
+// constraint on Form<Record<string,unknown>>; cast to any here — AJV is
+// UX-only, backend santhosh-tekuri/jsonschema is the contract (ADR spec §6).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import validatorRaw from '@rjsf/validator-ajv8'
+import type { RJSFSchema } from '@rjsf/utils'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const validator = validatorRaw as any
+import { GripVertical, ChevronUp, ChevronDown, Trash2 } from 'lucide-react'
+import { PluginHealthChip } from '@/components/admin/PluginHealthChip/PluginHealthChip'
+import type { ApiAudienceEntry, ApiPluginInstanceForAudience } from '@/api/types'
+import styles from './EntryRow.module.css'
+
+// Suppress the default rjsf submit button via uiSchema.
+const UI_SCHEMA_NO_SUBMIT = {
+  'ui:submitButtonOptions': { norender: true },
+}
+
+interface Props {
+  entry: ApiAudienceEntry
+  index: number
+  totalCount: number
+  pluginInstances: ApiPluginInstanceForAudience[]
+  onChange: (updated: ApiAudienceEntry) => void
+  onRemove: () => void
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onDragStart: (e: React.DragEvent) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDrop: (e: React.DragEvent) => void
+  isDragging: boolean
+  isDragOver: boolean
+  disabled: boolean
+}
+
+export function EntryRow({
+  entry,
+  index,
+  totalCount,
+  pluginInstances,
+  onChange,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  isDragging,
+  isDragOver,
+  disabled,
+}: Props) {
+  // Auto-entries (the synthetic in-app fallback) are always read-only.
+  const isAuto = !!entry.auto
+  const isDisabled = disabled || isAuto
+
+  const selectedInstance = pluginInstances.find((p) => p.id === entry.plugin_instance_id)
+
+  const canNotify = selectedInstance?.implements_notify ?? true
+  const canRequest = selectedInstance?.implements_request ?? true
+
+  // Group plugin instances by plugin_id for the <select> optgroups.
+  const grouped = new Map<string, ApiPluginInstanceForAudience[]>()
+  for (const pi of pluginInstances) {
+    const group = grouped.get(pi.plugin_id) ?? []
+    group.push(pi)
+    grouped.set(pi.plugin_id, group)
+  }
+
+  const schema = selectedInstance?.config_schema as RJSFSchema | null | undefined
+
+  function handlePluginChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    onChange({ ...entry, plugin_instance_id: e.target.value })
+  }
+
+  function handleNotifyChange(e: React.ChangeEvent<HTMLInputElement>) {
+    onChange({ ...entry, notify: e.target.checked })
+  }
+
+  function handleRequestChange(e: React.ChangeEvent<HTMLInputElement>) {
+    onChange({ ...entry, request: e.target.checked })
+  }
+
+  function handleConfigChange({ formData }: { formData?: Record<string, unknown> }) {
+    onChange({ ...entry, config: formData ?? {} })
+  }
+
+  const rowClass = [
+    styles.row,
+    isAuto ? styles.rowAuto : '',
+    isDragging ? styles.dragging : '',
+    isDragOver ? styles.dragOver : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <li
+      className={rowClass}
+      draggable={!isDisabled}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      <div className={styles.rowHeader}>
+        {/* Drag handle */}
+        <button
+          type="button"
+          className={styles.dragHandle}
+          aria-label="Drag to reorder"
+          disabled={isDisabled}
+          tabIndex={-1}
+        >
+          <GripVertical size={14} strokeWidth={1.5} aria-hidden />
+        </button>
+
+        {/* Keyboard reorder buttons for accessibility */}
+        <div className={styles.reorderButtons}>
+          <button
+            type="button"
+            className={styles.reorderBtn}
+            aria-label="Move up"
+            disabled={isDisabled || index === 0}
+            onClick={onMoveUp}
+          >
+            <ChevronUp size={12} strokeWidth={2} aria-hidden />
+          </button>
+          <button
+            type="button"
+            className={styles.reorderBtn}
+            aria-label="Move down"
+            disabled={isDisabled || index >= totalCount - 1}
+            onClick={onMoveDown}
+          >
+            <ChevronDown size={12} strokeWidth={2} aria-hidden />
+          </button>
+        </div>
+
+        <span className={styles.position}>{index + 1}</span>
+
+        {/* Plugin instance picker */}
+        {isAuto ? (
+          <span className={styles.autoLabel}>gleipnir.in-app (built-in fallback)</span>
+        ) : (
+          <div className={styles.pickerWrapper}>
+            <select
+              className={styles.picker}
+              value={entry.plugin_instance_id}
+              onChange={handlePluginChange}
+              disabled={isDisabled}
+              aria-label={`Plugin instance for entry ${index + 1}`}
+            >
+              <option value="">— select plugin instance —</option>
+              {Array.from(grouped.entries()).map(([pluginId, instances]) => (
+                <optgroup key={pluginId} label={pluginId}>
+                  {instances.map((pi) => (
+                    <option key={pi.id} value={pi.id}>
+                      {pi.instance_name}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            {selectedInstance && (
+              <PluginHealthChip state={selectedInstance.state} />
+            )}
+          </div>
+        )}
+
+        {/* Notify toggle */}
+        <label
+          className={styles.toggleLabel}
+          title={!canNotify ? 'This plugin does not implement Notify' : undefined}
+        >
+          <input
+            type="checkbox"
+            checked={entry.notify}
+            onChange={handleNotifyChange}
+            disabled={isDisabled || !canNotify}
+            aria-label={`Notify for entry ${index + 1}`}
+          />
+          Notify
+        </label>
+
+        {/* Request toggle */}
+        <label
+          className={styles.toggleLabel}
+          title={!canRequest ? 'This plugin does not implement Request' : undefined}
+        >
+          <input
+            type="checkbox"
+            checked={entry.request}
+            onChange={handleRequestChange}
+            disabled={isDisabled || !canRequest}
+            aria-label={`Request for entry ${index + 1}`}
+          />
+          Request
+        </label>
+
+        {!isAuto && (
+          <button
+            type="button"
+            className={styles.removeBtn}
+            aria-label={`Remove entry ${index + 1}`}
+            disabled={isDisabled}
+            onClick={onRemove}
+          >
+            <Trash2 size={14} strokeWidth={1.5} aria-hidden />
+          </button>
+        )}
+      </div>
+
+      {/* Config form — rendered from plugin's JSON Schema via rjsf */}
+      {!isAuto && selectedInstance && (
+        <div className={styles.configSection}>
+          {schema && Object.keys(schema).length > 0 ? (
+            <Form
+              schema={schema}
+              validator={validator}
+              formData={entry.config}
+              uiSchema={UI_SCHEMA_NO_SUBMIT}
+              onChange={handleConfigChange}
+              disabled={isDisabled}
+            />
+          ) : (
+            <p className={styles.noConfig}>No configuration required</p>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}

--- a/frontend/src/components/admin/AudienceEditor/RoutingPreview.module.css
+++ b/frontend/src/components/admin/AudienceEditor/RoutingPreview.module.css
@@ -1,0 +1,36 @@
+.routingPreview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background: color-mix(in srgb, var(--color-blue) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-blue) 24%, transparent);
+  border-radius: var(--radius-section);
+}
+
+.routingRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  font-size: var(--text-sm);
+}
+
+.routingIcon {
+  color: var(--color-blue);
+  flex-shrink: 0;
+}
+
+.routingLabel {
+  color: var(--text-second);
+  font-weight: var(--weight-medium);
+}
+
+.routingValue {
+  color: var(--text-primary);
+}
+
+.muted {
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/frontend/src/components/admin/AudienceEditor/RoutingPreview.stories.tsx
+++ b/frontend/src/components/admin/AudienceEditor/RoutingPreview.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import '@/tokens.css'
+import { RoutingPreview } from './RoutingPreview'
+import type { ApiAudienceEntry } from '@/api/types'
+
+const meta: Meta<typeof RoutingPreview> = {
+  title: 'Admin/AudienceEditor/RoutingPreview',
+  component: RoutingPreview,
+}
+
+export default meta
+type Story = StoryObj<typeof RoutingPreview>
+
+const notifyEntry = (id: string, pluginId: string): ApiAudienceEntry => ({
+  id,
+  plugin_instance_id: pluginId,
+  position: 0,
+  notify: true,
+  request: false,
+  config: {},
+})
+
+const requestEntry = (id: string, pluginId: string): ApiAudienceEntry => ({
+  id,
+  plugin_instance_id: pluginId,
+  position: 1,
+  notify: false,
+  request: true,
+  config: {},
+})
+
+const bothEntry = (id: string, pluginId: string): ApiAudienceEntry => ({
+  id,
+  plugin_instance_id: pluginId,
+  position: 0,
+  notify: true,
+  request: true,
+  config: {},
+})
+
+const autoEntry: ApiAudienceEntry = {
+  id: '__auto__',
+  plugin_instance_id: '',
+  position: 99,
+  notify: true,
+  request: true,
+  config: {},
+  auto: true,
+}
+
+export const Empty: Story = {
+  args: {
+    entries: [],
+    disableInAppFallback: true,
+  },
+}
+
+export const NotifyOnly: Story = {
+  args: {
+    entries: [notifyEntry('e1', 'slack-primary')],
+    disableInAppFallback: false,
+  },
+}
+
+export const RequestOnly: Story = {
+  args: {
+    entries: [requestEntry('e1', 'pagerduty-main')],
+    disableInAppFallback: false,
+  },
+}
+
+export const Mixed: Story = {
+  args: {
+    entries: [
+      notifyEntry('e1', 'slack-primary'),
+      notifyEntry('e2', 'ntfy-backup'),
+      requestEntry('e3', 'pagerduty-main'),
+    ],
+    disableInAppFallback: false,
+  },
+}
+
+export const WithAutoEntry: Story = {
+  args: {
+    entries: [notifyEntry('e1', 'slack-primary'), autoEntry],
+    disableInAppFallback: false,
+  },
+}

--- a/frontend/src/components/admin/AudienceEditor/RoutingPreview.tsx
+++ b/frontend/src/components/admin/AudienceEditor/RoutingPreview.tsx
@@ -1,0 +1,61 @@
+import { Bell, MessageSquare } from 'lucide-react'
+import type { ApiAudienceEntry } from '@/api/types'
+import styles from './RoutingPreview.module.css'
+
+interface Props {
+  entries: ApiAudienceEntry[]
+  disableInAppFallback?: boolean
+}
+
+function entryDisplayName(entry: ApiAudienceEntry): string {
+  if (entry.auto) return 'gleipnir.in-app (built-in fallback)'
+  return entry.plugin_instance_id || '(unset)'
+}
+
+// instanceName is optional so callers without plugin instance data can still use this.
+export function RoutingPreview({ entries, disableInAppFallback }: Props) {
+  const notifyEntries = entries.filter((e) => e.notify)
+  const requestEntry = entries.find((e) => e.request) ?? null
+
+  // If in-app fallback is not disabled and not already in entries, treat it as implicitly appended.
+  const hasAutoEntry = entries.some((e) => e.auto)
+  const notifyNames = notifyEntries.map((e) => entryDisplayName(e))
+  const inAppLabel = 'gleipnir.in-app (built-in fallback)'
+
+  // Append in-app to notify display when it would be auto-injected.
+  const notifyDisplay =
+    !disableInAppFallback && !hasAutoEntry
+      ? [...notifyNames, inAppLabel]
+      : notifyNames.length > 0
+        ? notifyNames
+        : notifyEntries.map((e) => entryDisplayName(e))
+
+  const requestDisplay = requestEntry
+    ? entryDisplayName(requestEntry)
+    : !disableInAppFallback
+      ? inAppLabel
+      : null
+
+  return (
+    <section className={styles.routingPreview} aria-label="Routing preview">
+      <div className={styles.routingRow}>
+        <Bell size={14} strokeWidth={1.5} aria-hidden className={styles.routingIcon} />
+        <span className={styles.routingLabel}>Notifications fan out to:</span>
+        <span className={styles.routingValue}>
+          {notifyDisplay.length > 0 ? (
+            notifyDisplay.join(', ')
+          ) : (
+            <em className={styles.muted}>no entries</em>
+          )}
+        </span>
+      </div>
+      <div className={styles.routingRow}>
+        <MessageSquare size={14} strokeWidth={1.5} aria-hidden className={styles.routingIcon} />
+        <span className={styles.routingLabel}>Requests routed to:</span>
+        <span className={styles.routingValue}>
+          {requestDisplay ?? <em className={styles.muted}>no Request-capable entry</em>}
+        </span>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.module.css
+++ b/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.module.css
@@ -1,0 +1,40 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.message {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.policyList {
+  list-style: disc;
+  margin: 0;
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
+}
+
+.policyLink {
+  color: var(--color-blue);
+  text-decoration: none;
+}
+
+.policyLink:hover {
+  text-decoration: underline;
+}
+
+.inFlightWarning {
+  font-size: var(--text-sm);
+}

--- a/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.stories.tsx
+++ b/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
+import '@/tokens.css'
+import { SaveGuardDialog } from './SaveGuardDialog'
+import type { ApiAudienceReferences } from '@/api/types'
+
+const meta: Meta<typeof SaveGuardDialog> = {
+  title: 'Admin/AudienceEditor/SaveGuardDialog',
+  component: SaveGuardDialog,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof SaveGuardDialog>
+
+const referencesNoInFlight: ApiAudienceReferences = {
+  policies: [
+    { id: 'p1', name: 'deploy-bot' },
+    { id: 'p2', name: 'smoke-tests' },
+  ],
+  in_flight_runs: [],
+}
+
+const referencesWithInFlight: ApiAudienceReferences = {
+  policies: [
+    { id: 'p1', name: 'deploy-bot' },
+    { id: 'p2', name: 'smoke-tests' },
+  ],
+  in_flight_runs: [
+    { id: 'run-abc123', policy_id: 'p1', status: 'running' },
+    { id: 'run-def456', policy_id: 'p2', status: 'waiting_for_approval' },
+  ],
+}
+
+export const NoInFlight: Story = {
+  args: {
+    references: referencesNoInFlight,
+    onConfirm: () => {},
+    onCancel: () => {},
+    isPending: false,
+  },
+}
+
+export const WithInFlight: Story = {
+  args: {
+    references: referencesWithInFlight,
+    onConfirm: () => {},
+    onCancel: () => {},
+    isPending: false,
+  },
+}
+
+export const Saving: Story = {
+  args: {
+    references: referencesWithInFlight,
+    onConfirm: () => {},
+    onCancel: () => {},
+    isPending: true,
+  },
+}

--- a/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.test.tsx
+++ b/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { SaveGuardDialog } from './SaveGuardDialog'
+import type { ApiAudienceReferences } from '@/api/types'
+
+function renderDialog(refs: ApiAudienceReferences, props?: Partial<Parameters<typeof SaveGuardDialog>[0]>) {
+  return render(
+    <MemoryRouter>
+      <SaveGuardDialog
+        references={refs}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        isPending={false}
+        {...props}
+      />
+    </MemoryRouter>,
+  )
+}
+
+const twoRefs: ApiAudienceReferences = {
+  policies: [
+    { id: 'p1', name: 'deploy-bot' },
+    { id: 'p2', name: 'smoke-tests' },
+  ],
+  in_flight_runs: [],
+}
+
+const refsWithInFlight: ApiAudienceReferences = {
+  policies: [{ id: 'p1', name: 'deploy-bot' }],
+  in_flight_runs: [
+    { id: 'run-abc123', policy_id: 'p1', status: 'running' },
+    { id: 'run-def456', policy_id: 'p1', status: 'waiting_for_approval' },
+  ],
+}
+
+describe('SaveGuardDialog', () => {
+  it('renders policy count and policy names', () => {
+    renderDialog(twoRefs)
+    // The count is in a <strong> element; check container textContent.
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.textContent).toMatch(/2.*polic/i)
+    expect(screen.getByRole('link', { name: 'deploy-bot' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'smoke-tests' })).toBeInTheDocument()
+  })
+
+  it('does not show in-flight warning when no in-flight runs', () => {
+    renderDialog(twoRefs)
+    expect(screen.queryByText(/in-flight/i)).not.toBeInTheDocument()
+  })
+
+  it('shows in-flight count and warning text when in_flight_runs is non-empty', () => {
+    renderDialog(refsWithInFlight)
+    // The count (2) is in a <strong> element; the surrounding text contains "in-flight".
+    // Use the alert role to find the whole warning container.
+    const warning = screen.getByRole('alert')
+    expect(warning.textContent).toMatch(/2.*in-flight/i)
+    expect(warning.textContent).toMatch(/change applies to subsequent steps only/i)
+  })
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn()
+    renderDialog(twoRefs, { onCancel })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('calls onConfirm when Save anyway is clicked', async () => {
+    const onConfirm = vi.fn()
+    renderDialog(twoRefs, { onConfirm })
+    await userEvent.click(screen.getByRole('button', { name: /save anyway/i }))
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it('disables Save anyway and shows spinner when isPending', () => {
+    renderDialog(twoRefs, { isPending: true })
+    const btn = screen.getByRole('button', { name: /saving/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('policy links point to the correct /agents/:id route', () => {
+    renderDialog(twoRefs)
+    const link = screen.getByRole('link', { name: 'deploy-bot' })
+    expect(link).toHaveAttribute('href', '/agents/p1')
+  })
+})

--- a/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.tsx
+++ b/frontend/src/components/admin/AudienceEditor/SaveGuardDialog.tsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router-dom'
+import { Modal } from '@/components/Modal/Modal'
+import { ModalFooter } from '@/components/ModalFooter/ModalFooter'
+import type { ApiAudienceReferences } from '@/api/types'
+import alertStyles from '@/styles/alerts.module.css'
+import styles from './SaveGuardDialog.module.css'
+
+interface Props {
+  references: ApiAudienceReferences
+  onConfirm: () => void
+  onCancel: () => void
+  isPending: boolean
+}
+
+export function SaveGuardDialog({ references, onConfirm, onCancel, isPending }: Props) {
+  const footer = (
+    <ModalFooter
+      onCancel={onCancel}
+      onSubmit={onConfirm}
+      isLoading={isPending}
+      submitLabel="Save anyway"
+      loadingLabel="Saving…"
+      variant="primary"
+    />
+  )
+
+  return (
+    <Modal title="Confirm audience change" onClose={onCancel} footer={footer}>
+      <div className={styles.body}>
+        {references.policies.length > 0 && (
+          <div className={styles.section}>
+            <p className={styles.message}>
+              <strong>{references.policies.length}</strong>{' '}
+              {references.policies.length === 1 ? 'policy' : 'policies'} will receive new routing:
+            </p>
+            <ul className={styles.policyList}>
+              {references.policies.map((p) => (
+                <li key={p.id}>
+                  <Link to={`/agents/${p.id}`} className={styles.policyLink} target="_blank" rel="noreferrer">
+                    {p.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {references.in_flight_runs.length > 0 && (
+          <div className={`${alertStyles.alertWarning} ${styles.inFlightWarning}`} role="alert">
+            <strong>{references.in_flight_runs.length}</strong> in-flight{' '}
+            {references.in_flight_runs.length === 1 ? 'run' : 'runs'} affected — change applies to
+            subsequent steps only; in-flight Channel Requests already issued continue to resolve
+            against the previous routing.
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/components/admin/AudienceEditor/index.ts
+++ b/frontend/src/components/admin/AudienceEditor/index.ts
@@ -1,0 +1,4 @@
+export { AudienceEditor } from './AudienceEditor'
+export { EntryRow } from './EntryRow'
+export { RoutingPreview } from './RoutingPreview'
+export { SaveGuardDialog } from './SaveGuardDialog'

--- a/frontend/src/hooks/mutations/admin.ts
+++ b/frontend/src/hooks/mutations/admin.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { apiFetch } from '@/api/fetch'
+import { apiFetch, apiFetchVoid } from '@/api/fetch'
+import type { ApiAudience, AudienceCreateRequest, AudienceUpdateRequest } from '@/api/types'
 import { queryKeys } from '../queryKeys'
 
 export function useSetProviderKey() {
@@ -58,6 +59,49 @@ export function useSetModelEnabled() {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.admin.models })
       void queryClient.invalidateQueries({ queryKey: queryKeys.models.all })
+    },
+  })
+}
+
+export function useCreateAudience() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (req: AudienceCreateRequest) =>
+      apiFetch<ApiAudience>('/admin/audiences', {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.admin.audiences })
+    },
+  })
+}
+
+export function useUpdateAudience() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, req }: { id: string; req: AudienceUpdateRequest }) =>
+      apiFetch<ApiAudience>(`/admin/audiences/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        body: JSON.stringify(req),
+      }),
+    onSuccess: (_data, { id }) => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.admin.audiences })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.admin.audienceDetail(id) })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.admin.audienceReferences(id) })
+    },
+  })
+}
+
+export function useDeleteAudience() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetchVoid(`/admin/audiences/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.admin.audiences })
     },
   })
 }

--- a/frontend/src/hooks/queries/admin.ts
+++ b/frontend/src/hooks/queries/admin.ts
@@ -9,6 +9,7 @@ import type {
   ApiAudienceListItem,
   ApiAudience,
   ApiAudienceReferences,
+  ApiPluginInstanceForAudience,
 } from '@/api/types'
 import { queryKeys } from '../queryKeys'
 
@@ -70,5 +71,13 @@ export function useAudienceReferences(id: string | undefined) {
     queryFn: () =>
       apiFetch<ApiAudienceReferences>(`/admin/audiences/${encodeURIComponent(id!)}/references`),
     enabled: !!id,
+  })
+}
+
+// Pending in #290 — GET /api/v1/admin/plugin-instances.
+export function usePluginInstancesForAudience() {
+  return useQuery({
+    queryKey: queryKeys.admin.pluginInstances,
+    queryFn: () => apiFetch<ApiPluginInstanceForAudience[]>('/admin/plugin-instances'),
   })
 }

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -52,6 +52,7 @@ export const queryKeys = {
     audiences: ['admin', 'audiences'] as const,
     audienceDetail: (id: string) => ['admin', 'audiences', id] as const,
     audienceReferences: (id: string) => ['admin', 'audiences', id, 'references'] as const,
+    pluginInstances: ['admin', 'plugin-instances'] as const,
   },
   config: {
     all: ['config'] as const,

--- a/frontend/src/pages/AdminAudienceDetailPage.tsx
+++ b/frontend/src/pages/AdminAudienceDetailPage.tsx
@@ -1,39 +1,45 @@
-import { Link, useParams } from 'react-router-dom'
-import { ArrowLeft, Bell, MessageSquare } from 'lucide-react'
+import { useCallback } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
 import { PageHeader } from '@/components/PageHeader'
 import { QueryBoundary, SkeletonList } from '@/components/QueryBoundary'
 import { CollapsibleJSON } from '@/components/CollapsibleJSON/CollapsibleJSON'
-import { useAudience, useAudienceReferences } from '@/hooks/queries/admin'
+import { AudienceEditor } from '@/components/admin/AudienceEditor'
+import { RoutingPreview } from '@/components/admin/AudienceEditor'
+import { useAudience, useAudienceReferences, usePluginInstancesForAudience } from '@/hooks/queries/admin'
+import { useUpdateAudience, useDeleteAudience } from '@/hooks/mutations/admin'
 import { useCurrentUser } from '@/hooks/queries/users'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { formatDate, formatTimeAgo } from '@/utils/format'
-import type { ApiAudienceEntry } from '@/api/types'
+import type { ApiAudienceEntry, AudienceUpdateRequest } from '@/api/types'
+import type { ApiError } from '@/api/fetch'
 import styles from './AdminAudienceDetailPage.module.css'
-
-const SYNTHETIC_IN_APP_LABEL = 'gleipnir.in-app (built-in fallback)'
-
-function entryDisplayName(entry: ApiAudienceEntry): string {
-  if (entry.auto) return SYNTHETIC_IN_APP_LABEL
-  return entry.plugin_instance_id || '(unset)'
-}
-
-function routingPreview(entries: ApiAudienceEntry[]): { notify: string[]; request: string | null } {
-  const notify = entries.filter((e) => e.notify).map(entryDisplayName)
-  const requestEntry = entries.find((e) => e.request)
-  return {
-    notify,
-    request: requestEntry ? entryDisplayName(requestEntry) : null,
-  }
-}
 
 export default function AdminAudienceDetailPage() {
   const { id } = useParams<{ id: string }>()
   usePageTitle('Audience')
+  const navigate = useNavigate()
 
   const audienceQuery = useAudience(id)
   const referencesQuery = useAudienceReferences(id)
+  const pluginInstancesQuery = usePluginInstancesForAudience()
   const { data: currentUser } = useCurrentUser()
   const canManage = currentUser?.roles?.some((r) => r === 'admin' || r === 'operator') ?? false
+
+  const updateMutation = useUpdateAudience()
+  const deleteMutation = useDeleteAudience()
+
+  const handleSave = useCallback(
+    async (req: AudienceUpdateRequest) => {
+      return updateMutation.mutateAsync({ id: id!, req })
+    },
+    [id, updateMutation],
+  )
+
+  const handleDelete = useCallback(async () => {
+    await deleteMutation.mutateAsync(id!)
+    navigate('/admin/audiences')
+  }, [id, deleteMutation, navigate])
 
   return (
     <div className={styles.page}>
@@ -52,57 +58,70 @@ export default function AdminAudienceDetailPage() {
       >
         {audienceQuery.data && (
           <>
-            <RoutingPreview entries={audienceQuery.data.entries} />
+            {canManage ? (
+              <AudienceEditor
+                initial={audienceQuery.data}
+                pluginInstances={pluginInstancesQuery.data ?? []}
+                references={referencesQuery.data ?? null}
+                canManage={canManage}
+                onSave={handleSave as Parameters<typeof AudienceEditor>[0]['onSave']}
+                onDelete={handleDelete}
+                saveError={updateMutation.error as ApiError | null}
+                deleteError={deleteMutation.error as ApiError | null}
+              />
+            ) : (
+              <>
+                <RoutingPreview entries={audienceQuery.data.entries} />
 
-            <section className={styles.section}>
-              <h2 className={styles.sectionTitle}>Entries</h2>
-              <p className={styles.sectionDesc}>
-                Channels are tried in order. The synthetic <code>gleipnir.in-app</code> fallback
-                is appended automatically unless explicitly disabled.
-              </p>
-              <ol className={styles.entryList}>
-                {audienceQuery.data.entries.map((entry) => (
-                  <EntryCard key={`${entry.id}:${entry.position}`} entry={entry} />
-                ))}
-              </ol>
-            </section>
+                <section className={styles.section}>
+                  <h2 className={styles.sectionTitle}>Entries</h2>
+                  <p className={styles.sectionDesc}>
+                    Channels are tried in order. The synthetic <code>gleipnir.in-app</code> fallback
+                    is appended automatically unless explicitly disabled.
+                  </p>
+                  <ol className={styles.entryList}>
+                    {audienceQuery.data.entries.map((entry) => (
+                      <EntryCard key={`${entry.id}:${entry.position}`} entry={entry} />
+                    ))}
+                  </ol>
+                </section>
 
-            <section className={styles.section}>
-              <h2 className={styles.sectionTitle}>Metadata</h2>
-              <dl className={styles.meta}>
-                <div className={styles.metaRow}>
-                  <dt>ID</dt>
-                  <dd className={styles.mono}>{audienceQuery.data.id}</dd>
-                </div>
-                <div className={styles.metaRow}>
-                  <dt>Version</dt>
-                  <dd>{audienceQuery.data.version}</dd>
-                </div>
-                <div className={styles.metaRow}>
-                  <dt>Disable in-app fallback</dt>
-                  <dd>{audienceQuery.data.disable_in_app_fallback ? 'Yes' : 'No'}</dd>
-                </div>
-                <div className={styles.metaRow}>
-                  <dt>Created</dt>
-                  <dd>{formatDate(audienceQuery.data.created_at)}</dd>
-                </div>
-                <div className={styles.metaRow}>
-                  <dt>Updated</dt>
-                  <dd>{formatTimeAgo(audienceQuery.data.updated_at)}</dd>
-                </div>
-              </dl>
-            </section>
+                <section className={styles.section}>
+                  <h2 className={styles.sectionTitle}>Metadata</h2>
+                  <dl className={styles.meta}>
+                    <div className={styles.metaRow}>
+                      <dt>ID</dt>
+                      <dd className={styles.mono}>{audienceQuery.data.id}</dd>
+                    </div>
+                    <div className={styles.metaRow}>
+                      <dt>Version</dt>
+                      <dd>{audienceQuery.data.version}</dd>
+                    </div>
+                    <div className={styles.metaRow}>
+                      <dt>Disable in-app fallback</dt>
+                      <dd>{audienceQuery.data.disable_in_app_fallback ? 'Yes' : 'No'}</dd>
+                    </div>
+                    <div className={styles.metaRow}>
+                      <dt>Created</dt>
+                      <dd>{formatDate(audienceQuery.data.created_at)}</dd>
+                    </div>
+                    <div className={styles.metaRow}>
+                      <dt>Updated</dt>
+                      <dd>{formatTimeAgo(audienceQuery.data.updated_at)}</dd>
+                    </div>
+                  </dl>
+                </section>
 
-            <ReferencesSection
-              status={referencesQuery.status}
-              data={referencesQuery.data}
-              onRetry={() => { void referencesQuery.refetch() }}
-            />
+                <ReferencesSection
+                  status={referencesQuery.status}
+                  data={referencesQuery.data}
+                  onRetry={() => { void referencesQuery.refetch() }}
+                />
 
-            {!canManage && (
-              <p className={styles.readOnlyNotice}>
-                You have read-only access. Editing requires an admin or operator role.
-              </p>
+                <p className={styles.readOnlyNotice}>
+                  You have read-only access. Editing requires an admin or operator role.
+                </p>
+              </>
             )}
           </>
         )}
@@ -111,29 +130,12 @@ export default function AdminAudienceDetailPage() {
   )
 }
 
-function RoutingPreview({ entries }: { entries: ApiAudienceEntry[] }) {
-  const { notify, request } = routingPreview(entries)
-  return (
-    <section className={styles.routingPreview} aria-label="Routing preview">
-      <div className={styles.routingRow}>
-        <Bell size={14} strokeWidth={1.5} aria-hidden className={styles.routingIcon} />
-        <span className={styles.routingLabel}>Notifications fan out to:</span>
-        <span className={styles.routingValue}>
-          {notify.length > 0 ? notify.join(', ') : <em className={styles.muted}>no entries</em>}
-        </span>
-      </div>
-      <div className={styles.routingRow}>
-        <MessageSquare size={14} strokeWidth={1.5} aria-hidden className={styles.routingIcon} />
-        <span className={styles.routingLabel}>Requests routed to:</span>
-        <span className={styles.routingValue}>
-          {request ?? <em className={styles.muted}>no Request-capable entry</em>}
-        </span>
-      </div>
-    </section>
-  )
-}
-
 function EntryCard({ entry }: { entry: ApiAudienceEntry }) {
+  function entryDisplayName(e: ApiAudienceEntry): string {
+    if (e.auto) return 'gleipnir.in-app (built-in fallback)'
+    return e.plugin_instance_id || '(unset)'
+  }
+
   return (
     <li className={`${styles.entryCard} ${entry.auto ? styles.entryCardAuto : ''}`}>
       <div className={styles.entryHeader}>

--- a/frontend/src/pages/AdminAudienceNewPage.module.css
+++ b/frontend/src/pages/AdminAudienceNewPage.module.css
@@ -1,0 +1,21 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  align-self: flex-start;
+  font-size: var(--text-sm);
+  color: var(--text-second);
+  text-decoration: none;
+}
+
+.backLink:hover {
+  color: var(--text-primary);
+}

--- a/frontend/src/pages/AdminAudienceNewPage.test.tsx
+++ b/frontend/src/pages/AdminAudienceNewPage.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+import AdminAudienceNewPage from './AdminAudienceNewPage'
+import type { ApiPluginInstanceForAudience } from '@/api/types'
+
+// --- Mocks ---
+
+vi.mock('@/hooks/queries/admin')
+vi.mock('@/hooks/mutations/admin')
+vi.mock('@/hooks/queries/users')
+
+import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
+import { useCreateAudience } from '@/hooks/mutations/admin'
+import { useCurrentUser } from '@/hooks/queries/users'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+// --- Fixtures ---
+
+const ADMIN_USER = { id: 'u1', username: 'alice', roles: ['admin'] }
+const AUDITOR_USER = { id: 'u2', username: 'bob', roles: ['auditor'] }
+
+const PLUGINS: ApiPluginInstanceForAudience[] = [
+  {
+    id: 'slack-1',
+    plugin_id: 'com.example.slack',
+    instance_name: 'slack-1',
+    state: 'healthy',
+    implements_notify: true,
+    implements_request: false,
+    config_schema: null,
+  },
+]
+
+// --- Helpers ---
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderPage(queryClient = makeQueryClient()) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AdminAudienceNewPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function mockPluginsLoaded(plugins: ApiPluginInstanceForAudience[]) {
+  vi.mocked(usePluginInstancesForAudience).mockReturnValue({
+    data: plugins,
+    status: 'success',
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof usePluginInstancesForAudience>)
+}
+
+function mockPluginsPending() {
+  vi.mocked(usePluginInstancesForAudience).mockReturnValue({
+    data: undefined,
+    status: 'pending',
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof usePluginInstancesForAudience>)
+}
+
+function mockCurrentUser(user: typeof ADMIN_USER | null) {
+  vi.mocked(useCurrentUser).mockReturnValue({
+    data: user,
+    status: user ? 'success' : 'pending',
+  } as unknown as ReturnType<typeof useCurrentUser>)
+}
+
+function mockCreateNoop() {
+  vi.mocked(useCreateAudience).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  } as unknown as ReturnType<typeof useCreateAudience>)
+}
+
+// --- Tests ---
+
+describe('AdminAudienceNewPage — loading state', () => {
+  beforeEach(() => {
+    mockPluginsPending()
+    mockCurrentUser(ADMIN_USER)
+    mockCreateNoop()
+  })
+
+  it('shows skeleton while plugin instances load', () => {
+    renderPage()
+    const skeletons = document.querySelectorAll('[aria-hidden="true"]')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+})
+
+describe('AdminAudienceNewPage — create mode', () => {
+  beforeEach(() => {
+    mockPluginsLoaded(PLUGINS)
+    mockCurrentUser(ADMIN_USER)
+    mockCreateNoop()
+  })
+
+  it('renders page title New Audience', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: 'New Audience' })).toBeInTheDocument()
+  })
+
+  it('renders editor in create mode (no Delete button)', () => {
+    renderPage()
+    expect(screen.queryByRole('button', { name: /delete audience/i })).not.toBeInTheDocument()
+  })
+
+  it('renders Save button', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument()
+  })
+
+  it('renders back link to /admin/audiences', () => {
+    renderPage()
+    const link = screen.getByRole('link', { name: /all audiences/i })
+    expect(link).toHaveAttribute('href', '/admin/audiences')
+  })
+})
+
+describe('AdminAudienceNewPage — auditor redirect', () => {
+  it('redirects auditors to /admin/audiences', async () => {
+    mockPluginsLoaded(PLUGINS)
+    mockCurrentUser(AUDITOR_USER)
+    mockCreateNoop()
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/admin/audiences', { replace: true })
+    })
+  })
+})
+
+describe('AdminAudienceNewPage — successful save navigates', () => {
+  it('navigates to /admin/audiences/:id after successful create', async () => {
+    mockPluginsLoaded(PLUGINS)
+    mockCurrentUser(ADMIN_USER)
+
+    const createdAudience = {
+      id: 'new-aud-id',
+      name: 'test',
+      disable_in_app_fallback: false,
+      version: 1,
+      created_at: '',
+      updated_at: '',
+      entries: [],
+    }
+
+    vi.mocked(useCreateAudience).mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue(createdAudience),
+      isPending: false,
+      error: null,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useCreateAudience>)
+
+    renderPage()
+
+    fireEvent.change(screen.getByLabelText(/audience name/i), { target: { value: 'test' } })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/admin/audiences/new-aud-id')
+    })
+  })
+})

--- a/frontend/src/pages/AdminAudienceNewPage.tsx
+++ b/frontend/src/pages/AdminAudienceNewPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
+import { PageHeader } from '@/components/PageHeader'
+import { QueryBoundary, SkeletonList } from '@/components/QueryBoundary'
+import { AudienceEditor } from '@/components/admin/AudienceEditor'
+import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
+import { useCreateAudience } from '@/hooks/mutations/admin'
+import { useCurrentUser } from '@/hooks/queries/users'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import type { AudienceCreateRequest } from '@/api/types'
+import type { ApiError } from '@/api/fetch'
+import styles from './AdminAudienceNewPage.module.css'
+
+export default function AdminAudienceNewPage() {
+  usePageTitle('New Audience')
+  const navigate = useNavigate()
+
+  const { data: currentUser } = useCurrentUser()
+  const canManage = currentUser?.roles?.some((r) => r === 'admin' || r === 'operator') ?? false
+
+  // Guard: redirect non-managers immediately (server enforces, but client guards early).
+  useEffect(() => {
+    if (currentUser && !canManage) {
+      navigate('/admin/audiences', { replace: true })
+    }
+  }, [currentUser, canManage, navigate])
+
+  const pluginInstancesQuery = usePluginInstancesForAudience()
+  const createMutation = useCreateAudience()
+
+  async function handleSave(req: AudienceCreateRequest) {
+    const audience = await createMutation.mutateAsync(req)
+    navigate(`/admin/audiences/${audience.id}`)
+    return audience
+  }
+
+  return (
+    <div className={styles.page}>
+      <Link to="/admin/audiences" className={styles.backLink}>
+        <ArrowLeft size={14} strokeWidth={1.5} aria-hidden />
+        All audiences
+      </Link>
+
+      <PageHeader title="New Audience" />
+
+      <QueryBoundary
+        status={pluginInstancesQuery.status}
+        errorMessage="Failed to load plugin instances."
+        onRetry={() => { void pluginInstancesQuery.refetch() }}
+        skeleton={<SkeletonList count={3} height={48} gap={12} borderRadius={8} />}
+      >
+        <AudienceEditor
+          initial={null}
+          pluginInstances={pluginInstancesQuery.data ?? []}
+          references={null}
+          canManage={canManage}
+          onSave={handleSave as Parameters<typeof AudienceEditor>[0]['onSave']}
+          saveError={createMutation.error as ApiError | null}
+          deleteError={null}
+        />
+      </QueryBoundary>
+    </div>
+  )
+}

--- a/frontend/src/pages/AdminAudiencesPage.tsx
+++ b/frontend/src/pages/AdminAudiencesPage.tsx
@@ -1,6 +1,7 @@
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { PageHeader } from '@/components/PageHeader'
 import { QueryBoundary, SkeletonList } from '@/components/QueryBoundary'
+import { Button } from '@/components/Button'
 import { useAudiences } from '@/hooks/queries/admin'
 import { useCurrentUser } from '@/hooks/queries/users'
 import { usePageTitle } from '@/hooks/usePageTitle'
@@ -9,6 +10,7 @@ import styles from './AdminAudiencesPage.module.css'
 
 export default function AdminAudiencesPage() {
   usePageTitle('Audiences')
+  const navigate = useNavigate()
 
   const { data: audiences, status, refetch } = useAudiences()
   const { data: currentUser } = useCurrentUser()
@@ -16,7 +18,18 @@ export default function AdminAudiencesPage() {
 
   return (
     <div className={styles.page}>
-      <PageHeader title="Audiences" />
+      <PageHeader title="Audiences">
+        {canManage && (
+          <Button
+            variant="primary"
+            size="small"
+            type="button"
+            onClick={() => navigate('/admin/audiences/new')}
+          >
+            + New audience
+          </Button>
+        )}
+      </PageHeader>
 
       <p className={styles.intro}>
         Audiences are shared notification routing groups referenced from policies by name.
@@ -32,9 +45,17 @@ export default function AdminAudiencesPage() {
         emptyState={
           <div className={styles.emptyState}>
             <p className={styles.emptyHeadline}>No audiences</p>
-            <p className={styles.emptySubtext}>
-              Audiences are created by the API. Editing UI is coming soon.
-            </p>
+            {canManage ? (
+              <Button
+                variant="primary"
+                type="button"
+                onClick={() => navigate('/admin/audiences/new')}
+              >
+                Create your first audience
+              </Button>
+            ) : (
+              <p className={styles.emptySubtext}>No audiences have been created yet.</p>
+            )}
           </div>
         }
       >

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -14,6 +14,7 @@ import AdminModelsPage from './pages/AdminModelsPage'
 import AdminSystemPage from './pages/AdminSystemPage'
 import AdminAudiencesPage from './pages/AdminAudiencesPage'
 import AdminAudienceDetailPage from './pages/AdminAudienceDetailPage'
+import AdminAudienceNewPage from './pages/AdminAudienceNewPage'
 import NotFoundPage from './pages/NotFoundPage'
 import { RouteErrorFallback } from './components/ErrorBoundary'
 
@@ -47,6 +48,7 @@ const router = createBrowserRouter([
       { path: 'admin/models', element: <AdminModelsPage />, errorElement: <RouteErrorFallback /> },
       { path: 'admin/system', element: <AdminSystemPage />, errorElement: <RouteErrorFallback /> },
       { path: 'admin/audiences', element: <AdminAudiencesPage />, errorElement: <RouteErrorFallback /> },
+      { path: 'admin/audiences/new', element: <AdminAudienceNewPage />, errorElement: <RouteErrorFallback /> },
       { path: 'admin/audiences/:id', element: <AdminAudienceDetailPage />, errorElement: <RouteErrorFallback /> },
       { path: '*', element: <NotFoundPage /> },
     ],


### PR DESCRIPTION
Closes #210

## Summary

Frontend admin surface for audience management at `/admin/audiences`. Operators/admins can create, edit, and delete audiences through a stateful editor; auditors see a read-only view.

- New `AudienceEditor` component family (editor + EntryRow + SaveGuardDialog + RoutingPreview) under `frontend/src/components/admin/AudienceEditor/`
- New page `/admin/audiences/new` (create mode); `/admin/audiences/:id` upgraded from read-only stub to full editor for managers
- `@rjsf/core` + `@rjsf/validator-ajv8` for JSON-Schema-driven per-entry config forms (locked here per the issue; reused by #219 and #241)
- Drag-to-reorder via native HTML5 DnD with keyboard fallback (Move up / Move down icon buttons)
- Per-entry capability gating: Notify/Request toggles disabled when the plugin instance does not implement that channel (§6.3)
- Save guard dialog: triggered only when audience has ≥1 policy reference; in-flight runs surfaced as a separate amber-flagged block with verbatim copy from spec §11.7
- Optimistic-concurrency: PUT body carries `expected_version`; 409 surfaces a "Reload audience" banner. Mirrors ADR-038
- Role gating: `roles.some(r => r === 'admin' || r === 'operator')` hides Save / Delete / + New / Add-entry from auditors. Server-side enforcement is #290's responsibility

## Storybook stories
Per the issue AC: empty audience, single-entry, multi-entry with mixed Notify/Request capabilities. Plus SaveGuardDialog (no-in-flight, with-in-flight) and RoutingPreview variants.

## Backend dependencies
Audience POST/PUT/DELETE endpoints are **already merged** on `plugin-architecture` (`internal/http/api/audience_handler.go`). Only `GET /api/v1/admin/plugin-instances` is still pending in #290 — until that lands, the plugin picker will be empty (the editor gracefully shows "No plugins installed" copy).

## Documentation
- `frontend/CLAUDE.md` route table updated with the three audience routes.

## Architecture plan

<details>
<summary>Click to expand</summary>

The full plan is in `.dev-loop/plan.md` (not committed). It covered: API contract (request/response shapes including the `expected_version` CAS field), 17 file changes, drag-and-drop accessibility strategy, save-guard threshold logic, synthetic in-app entry stripping, and explicit out-of-scope notes (`GLEIPNIR_PLUGINS_ENABLED=false` UI gating deferred to a follow-up).

Two review cycles: cycle 1 caught real bugs in the plan (`expected_version` field name, JS short-circuit in role check, wrong 409 message-string detection); cycle 2 approved.

</details>

## Test plan
- [x] `npm run build` clean (TypeScript)
- [x] `npx vitest run` — 869 tests pass (32 new)
- [ ] Manual: operator can create + reorder + edit + delete an audience
- [ ] Manual: auditor sees no Save / Delete / + New buttons
- [ ] Manual: SaveGuardDialog appears only when audience is referenced; in-flight banner only when in_flight_runs > 0
- [ ] Manual: Notify/Request toggles disable for plugin instances with implements_*=false
- [ ] Manual: 409 on stale `expected_version` surfaces the reload banner

## Notes
- Targets `plugin-architecture` (not `main`) per the parent epic merge strategy
- One `as any` cast on AJV8 validator import — documented inline; rjsf v5 generic constraint mismatch with `Record<string,unknown>` form data; AJV is UX-only

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.