### PR TITLE
feat: implement plugin-sdk serve.Serve() + EmitManifest() runtime

### DIFF
--- a/internal/plugin/process/process_fixture_test.go
+++ b/internal/plugin/process/process_fixture_test.go
@@ -16,8 +16,11 @@ import (
 	"google.golang.org/grpc/status"
 
 	bootstrapv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/bootstrap/v1"
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	handshakev1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/handshake/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 // runFixtureServePlugin starts a go-plugin subprocess listener and blocks until
@@ -152,6 +155,28 @@ func runFixtureServeEchoToken() {
 	case <-quit:
 	case <-done:
 	}
+}
+
+// runFixtureServeViaSDK calls serve.Serve with a trivial ChannelService stub so
+// the host-side process tests exercise the real SDK Serve path rather than a
+// hand-rolled go-plugin listener. This catches regressions where the SDK's
+// serve.Serve is broken but the hand-rolled fixture still passes.
+func runFixtureServeViaSDK() {
+	serve.Serve(
+		serve.WithChannelService(func(_ hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+			return &sdkFixtureChannelService{}
+		}),
+	)
+}
+
+// sdkFixtureChannelService is a trivial ChannelService that returns Ok=true on
+// every Notify call. Used only by runFixtureServeViaSDK.
+type sdkFixtureChannelService struct {
+	channelv1.UnimplementedChannelServiceServer
+}
+
+func (s *sdkFixtureChannelService) Notify(_ context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+	return &channelv1.NotifyResponse{Ok: true}, nil
 }
 
 // ── go-plugin GRPCPlugin implementation ─────────────────────────────────────

--- a/internal/plugin/process/process_test.go
+++ b/internal/plugin/process/process_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/plugin/identity"
 	"github.com/felag-engineering/gleipnir/internal/plugin/process"
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
 )
 
@@ -48,6 +49,9 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	case "echo-token":
 		runFixtureServeEchoToken()
+		os.Exit(0)
+	case "serve-via-sdk":
+		runFixtureServeViaSDK()
 		os.Exit(0)
 	}
 	os.Exit(m.Run())
@@ -541,6 +545,64 @@ func TestStart_OldTokenRejectedAfterReissue(t *testing.T) {
 		t.Error("new token not found in registry")
 	} else if id != cfg.InstanceID {
 		t.Errorf("new token resolved to %q, want %q", id, cfg.InstanceID)
+	}
+}
+
+// TestStart_RealSDKServe verifies that a subprocess started via the real
+// serve.Serve (the "serve-via-sdk" fixture mode) starts, completes the
+// hostwire.Launch handshake, responds to a ChannelService.Notify RPC, and
+// stops cleanly. The Notify dispatch is the critical assertion: it confirms
+// that serve.Serve actually registered the adapter on the gRPC server. Without
+// it, a broken adapter registration would not be caught by the handshake alone.
+func TestStart_RealSDKServe(t *testing.T) {
+	reg := identity.New()
+	cfg := fixtureConfig(t, "serve-via-sdk", reg, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	inst, err := process.Start(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Start with serve-via-sdk fixture: %v", err)
+	}
+
+	// Token must be present and valid.
+	if inst.Token() == "" {
+		t.Fatal("Token() is empty")
+	}
+	if _, ok := reg.Lookup(inst.Token()); !ok {
+		t.Fatal("token not found in registry")
+	}
+
+	// Dispatch a Notify RPC to confirm the ChannelService adapter is wired.
+	// If serve.Serve did not register the adapter, this call returns
+	// codes.Unavailable and the test fails — catching the regression described
+	// in the issue.
+	notifyCtx, notifyCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer notifyCancel()
+	resp, err := inst.Client().Channel.Notify(notifyCtx, &channelv1.NotifyRequest{})
+	if err != nil {
+		t.Fatalf("Channel.Notify: %v", err)
+	}
+	if !resp.GetOk() {
+		t.Errorf("Channel.Notify: want Ok=true, got Ok=false; error=%v", resp.GetError())
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer stopCancel()
+	if err := inst.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	select {
+	case <-inst.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("done channel did not close within 10s after Stop")
+	}
+
+	// Token must be revoked after stop.
+	if _, ok := reg.Lookup(inst.Token()); ok {
+		t.Error("token still in registry after Stop")
 	}
 }
 

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/main.go.tmpl
@@ -1,20 +1,24 @@
 package main
 
 import (
-	"flag"
-	"os"
+	"net/http"
 
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 func main() {
-	emitManifest := flag.Bool("emit-manifest", false, "write manifest JSON to stdout and exit")
-	flag.Parse()
-
-	if *emitManifest {
-		serve.EmitManifest()
-		os.Exit(0)
-	}
-
-	serve.Serve()
+	// serve.Serve is the last call in every plugin binary. Passing
+	// --emit-manifest as the first argument causes it to write the manifest
+	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	serve.Serve(
+		serve.WithManifest(pluginManifest),
+		serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+			// TODO: replace with your ChannelService constructor. The host
+			// client is used for GetInstanceConfig, GetCredentials, and
+			// other Host RPCs.
+			return NewChannelService(host, http.DefaultClient)
+		}),
+	)
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/main.go.tmpl
@@ -1,20 +1,32 @@
 package main
 
 import (
-	"flag"
-	"os"
+	"net/http"
 
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 func main() {
-	emitManifest := flag.Bool("emit-manifest", false, "write manifest JSON to stdout and exit")
-	flag.Parse()
-
-	if *emitManifest {
-		serve.EmitManifest()
-		os.Exit(0)
-	}
-
-	serve.Serve()
+	// serve.Serve is the last call in every plugin binary. Passing
+	// --emit-manifest as the first argument causes it to write the manifest
+	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	serve.Serve(
+		serve.WithManifest(pluginManifest),
+		serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+			// TODO: replace with your ChannelService constructor.
+			return NewChannelService(host, http.DefaultClient)
+		}),
+		serve.WithToolService(func(host hostv1.HostServiceClient) toolv1.ToolServiceServer {
+			// TODO: replace with your ToolService constructor.
+			return NewToolService(host)
+		}),
+		serve.WithTriggerService(func(host hostv1.HostServiceClient) triggerv1.TriggerServiceServer {
+			// TODO: replace with your TriggerService constructor.
+			return NewTriggerService(host)
+		}),
+	)
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/main.go.tmpl
@@ -1,20 +1,20 @@
 package main
 
 import (
-	"flag"
-	"os"
-
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 func main() {
-	emitManifest := flag.Bool("emit-manifest", false, "write manifest JSON to stdout and exit")
-	flag.Parse()
-
-	if *emitManifest {
-		serve.EmitManifest()
-		os.Exit(0)
-	}
-
-	serve.Serve()
+	// serve.Serve is the last call in every plugin binary. Passing
+	// --emit-manifest as the first argument causes it to write the manifest
+	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	serve.Serve(
+		serve.WithManifest(pluginManifest),
+		serve.WithToolService(func(host hostv1.HostServiceClient) toolv1.ToolServiceServer {
+			// TODO: replace with your ToolService constructor.
+			return NewToolService(host)
+		}),
+	)
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/main.go.tmpl
@@ -1,20 +1,20 @@
 package main
 
 import (
-	"flag"
-	"os"
-
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 func main() {
-	emitManifest := flag.Bool("emit-manifest", false, "write manifest JSON to stdout and exit")
-	flag.Parse()
-
-	if *emitManifest {
-		serve.EmitManifest()
-		os.Exit(0)
-	}
-
-	serve.Serve()
+	// serve.Serve is the last call in every plugin binary. Passing
+	// --emit-manifest as the first argument causes it to write the manifest
+	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	serve.Serve(
+		serve.WithManifest(pluginManifest),
+		serve.WithTriggerService(func(host hostv1.HostServiceClient) triggerv1.TriggerServiceServer {
+			// TODO: replace with your TriggerService constructor.
+			return NewTriggerService(host)
+		}),
+	)
 }

--- a/plugin-sdk/examples/minimal-tool/main.go
+++ b/plugin-sdk/examples/minimal-tool/main.go
@@ -1,13 +1,25 @@
 package main
 
-import "github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+import (
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+)
 
 func main() {
-	// serve.Serve() is the last call in every plugin binary. It wires up the
-	// go-plugin transport, registers ToolService, and blocks until the host
-	// disconnects.
+	// serve.Serve wires up the go-plugin transport, registers ToolService, and
+	// blocks until the host disconnects or a signal is received.
 	//
-	// This is a Phase-3 stub and panics if called directly. Run service_test.go
-	// instead to exercise ToolService in-process via loopback TCP (127.0.0.1:0).
-	serve.Serve()
+	// Passing --emit-manifest as the first argument causes it to write the
+	// manifest JSON to stdout and exit (used by gleipnir-plugin gen-manifest).
+	//
+	// A bare serve.Serve() with no options is valid: the plugin responds to
+	// the handshake and Bootstrap.Bind but all service RPCs return
+	// codes.Unavailable, which is the correct documented behaviour.
+	serve.Serve(
+		serve.WithManifest(pluginManifest),
+		serve.WithToolService(func(host hostv1.HostServiceClient) toolv1.ToolServiceServer {
+			return NewToolService(host)
+		}),
+	)
 }

--- a/plugin-sdk/serve/doc.go
+++ b/plugin-sdk/serve/doc.go
@@ -7,27 +7,90 @@
 // serve.EmitManifest() is called when the binary is invoked with
 // --emit-manifest. It writes the plugin's manifest JSON to stdout so that
 // gleipnir-plugin gen-manifest can capture and canonicalise it.
-//
-// Both functions are stubs; the full implementation lands in the Phase 3
-// loader PR alongside the plugin host. (#170)
 package serve
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+
+	goplugin "github.com/hashicorp/go-plugin"
+
+	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+)
 
 // Serve starts the plugin subprocess listener. It is the last call in a plugin
 // binary's main() function and does not return under normal operation.
 //
-// This stub panics so that compilation succeeds while the implementation is
-// pending. The Phase 3 loader PR replaces this with the real implementation.
-// (#170)
-func Serve() {
-	panic("serve.Serve: not yet implemented — Phase 3 loader PR (#170)")
+// If the first argument is "--emit-manifest", Serve delegates to
+// emitManifestAndExit and the process exits 0 (or 2 if no manifest was provided
+// via WithManifest). This detection happens before any flag.Parse() call, so
+// scaffold templates must not call flag.Parse() themselves.
+//
+// Otherwise, Serve runs go-plugin's server in a goroutine and blocks until
+// either the server exits on its own (host disconnects) or a SIGTERM/SIGINT
+// signal is received. SIGTERM is handled here because go-plugin v1.6.3 catches
+// only SIGINT internally; the OS default for SIGTERM is immediate process kill,
+// which would prevent any cleanup.
+//
+// Passing zero options is valid: Serve responds correctly to the handshake and
+// Bootstrap.Bind, but all service RPCs return codes.Unavailable.
+func Serve(opts ...Option) {
+	cfg := newConfig(opts)
+
+	// Positional flag detection chosen so scaffold templates can drop their
+	// own flag.Parse() block (which would consume --emit-manifest before Serve
+	// sees it). Using os.Args[1] directly avoids interfering with any flags the
+	// plugin author may wish to define for other purposes.
+	if len(os.Args) > 1 && os.Args[1] == "--emit-manifest" {
+		emitManifestAndExit(cfg)
+		return // unreachable: emitManifestAndExit calls os.Exit
+	}
+
+	impl := newPluginGRPCPlugin(cfg)
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, cfg.stopSignals...)
+	defer signal.Stop(quit)
+
+	done := make(chan struct{})
+	go func() {
+		goplugin.Serve(&goplugin.ServeConfig{
+			HandshakeConfig: hostwire.HandshakeConfig,
+			Plugins:         goplugin.PluginSet{"gleipnir": impl},
+			GRPCServer:      goplugin.DefaultGRPCServer,
+		})
+		close(done)
+	}()
+
+	select {
+	case <-quit:
+		// Best-effort drain. We own the SIGTERM path because go-plugin's
+		// internal handler covers only SIGINT. SIGKILL or a crash bypasses this
+		// entirely, so shutdown() must be treated as best-effort, not a
+		// correctness guarantee.
+	case <-done:
+	}
+	impl.shutdown()
 }
 
-// EmitManifest writes the plugin's manifest as JSON to stdout, then exits.
-// It is invoked when the binary is called with the --emit-manifest flag.
-// gleipnir-plugin gen-manifest uses this output to produce deterministic YAML.
-//
-// This stub panics; the real implementation lands with the Phase 3 loader PR.
-// (#170)
-func EmitManifest() {
-	panic("serve.EmitManifest: not yet implemented — Phase 3 loader PR (#170)")
+// EmitManifest writes m as JSON to stdout. Plugin authors can call this
+// directly when they wire their own --emit-manifest flag, but scaffolded
+// templates should rely on Serve's built-in detection instead.
+func EmitManifest(m manifest.Manifest) {
+	enc := json.NewEncoder(os.Stdout)
+	_ = enc.Encode(m)
+}
+
+// emitManifestAndExit writes the manifest JSON to stdout and exits. Exits 2
+// with an error message if no manifest was registered via WithManifest.
+func emitManifestAndExit(cfg *config) {
+	if cfg.manifest == nil {
+		fmt.Fprintln(os.Stderr, "serve: --emit-manifest requires WithManifest(...) to be passed to Serve")
+		os.Exit(2)
+	}
+	EmitManifest(*cfg.manifest)
+	os.Exit(0)
 }

--- a/plugin-sdk/serve/options.go
+++ b/plugin-sdk/serve/options.go
@@ -1,0 +1,77 @@
+package serve
+
+import (
+	"log/slog"
+	"os"
+	"syscall"
+
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+)
+
+// config holds the resolved options for a Serve or EmitManifest call.
+type config struct {
+	channelFactory func(hostv1.HostServiceClient) channelv1.ChannelServiceServer
+	toolFactory    func(hostv1.HostServiceClient) toolv1.ToolServiceServer
+	triggerFactory func(hostv1.HostServiceClient) triggerv1.TriggerServiceServer
+	manifest       *manifest.Manifest
+	stopSignals    []os.Signal
+	logger         *slog.Logger
+}
+
+// newConfig applies opts in order and fills in defaults for any unset field.
+func newConfig(opts []Option) *config {
+	cfg := &config{
+		stopSignals: []os.Signal{syscall.SIGTERM, syscall.SIGINT},
+		logger:      slog.Default(),
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+	return cfg
+}
+
+// Option is a functional option for Serve.
+type Option func(*config)
+
+// WithChannelService registers a ChannelService factory. The factory receives
+// the typed HostServiceClient after Bootstrap.Bind completes, so it has access
+// to GetInstanceConfig, GetCredentials, and other host RPCs from the start of
+// the first call.
+func WithChannelService(f func(hostv1.HostServiceClient) channelv1.ChannelServiceServer) Option {
+	return func(c *config) { c.channelFactory = f }
+}
+
+// WithToolService registers a ToolService factory. The factory contract is the
+// same as WithChannelService: the HostServiceClient is available from the first
+// RPC call onward.
+//
+// Phase 6 wires this for real tool plugins; shipping the option now avoids an
+// API bump later.
+func WithToolService(f func(hostv1.HostServiceClient) toolv1.ToolServiceServer) Option {
+	return func(c *config) { c.toolFactory = f }
+}
+
+// WithTriggerService registers a TriggerService factory. Mirrors WithChannelService
+// semantically; real wiring lands in Phase 6/8.
+func WithTriggerService(f func(hostv1.HostServiceClient) triggerv1.TriggerServiceServer) Option {
+	return func(c *config) { c.triggerFactory = f }
+}
+
+// WithManifest supplies the plugin's manifest so that Serve can advertise the
+// correct plugin version in Handshake.Negotiate and so that --emit-manifest can
+// write the manifest JSON to stdout.
+//
+// Required for --emit-manifest to succeed; optional for normal serve mode.
+func WithManifest(m manifest.Manifest) Option {
+	return func(c *config) { c.manifest = &m }
+}
+
+// WithLogger overrides the logger used for internal serve diagnostics. The
+// default is slog.Default(). Useful in tests to capture log output.
+func WithLogger(l *slog.Logger) Option {
+	return func(c *config) { c.logger = l }
+}

--- a/plugin-sdk/serve/server.go
+++ b/plugin-sdk/serve/server.go
@@ -1,0 +1,263 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	bootstrapv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/bootstrap/v1"
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	handshakev1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/handshake/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+)
+
+// sdkVersion is the version string reported in Handshake.Negotiate.
+// It identifies the SDK release, not the plugin version.
+const sdkVersion = "0.1.0"
+
+// pluginGRPCPlugin is the go-plugin GRPCPlugin implementation that all SDK
+// users share. One instance is created per Serve call.
+//
+// The adapter pattern is used for service registration: go-plugin calls
+// GRPCServer before the host connection is established, so we cannot call the
+// user's factory yet. We register adapter wrappers immediately and install the
+// real implementations after Bootstrap.Bind fires.
+type pluginGRPCPlugin struct {
+	goplugin.Plugin
+
+	cfg *config
+
+	// broker is stored in GRPCServer so Bind can dial the host.
+	broker *goplugin.GRPCBroker
+
+	// hostConn is the connection to HostService, established inside Bind.
+	// Closed by shutdown().
+	hostConn *grpc.ClientConn
+
+	// adapters registered on the gRPC server in GRPCServer; each holds a
+	// pointer that is populated atomically inside Bind after the host
+	// connection is ready.
+	channel *channelAdapter
+	tool    *toolAdapter
+	trigger *triggerAdapter
+}
+
+func newPluginGRPCPlugin(cfg *config) *pluginGRPCPlugin {
+	return &pluginGRPCPlugin{
+		cfg:     cfg,
+		channel: &channelAdapter{},
+		tool:    &toolAdapter{},
+		trigger: &triggerAdapter{},
+	}
+}
+
+// GRPCServer is called by go-plugin before the server starts accepting
+// connections. We register the adapters and the bootstrap/handshake services
+// here. The user's real implementations are injected by Bind after the host
+// connection is available.
+func (p *pluginGRPCPlugin) GRPCServer(broker *goplugin.GRPCBroker, s *grpc.Server) error {
+	p.broker = broker
+
+	handshakev1.RegisterHandshakeServiceServer(s, p)
+	bootstrapv1.RegisterBootstrapServiceServer(s, p)
+
+	// Always register adapters for all three services so the gRPC server
+	// exposes a stable surface. Adapters return codes.Unavailable until Bind
+	// installs the real impl. Services whose factory is nil will always return
+	// Unavailable — that is the documented zero-capability behaviour.
+	channelv1.RegisterChannelServiceServer(s, p.channel)
+	toolv1.RegisterToolServiceServer(s, p.tool)
+	triggerv1.RegisterTriggerServiceServer(s, p.trigger)
+
+	return nil
+}
+
+// GRPCClient is not used on the plugin side.
+func (p *pluginGRPCPlugin) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, _ *grpc.ClientConn) (interface{}, error) {
+	return nil, status.Error(codes.Unimplemented, "serve: GRPCClient not used on plugin side")
+}
+
+// Negotiate implements handshakev1.HandshakeServiceServer. It advertises the
+// actual capabilities derived from the registered factories.
+func (p *pluginGRPCPlugin) Negotiate(_ context.Context, _ *handshakev1.NegotiateRequest) (*handshakev1.NegotiateResponse, error) {
+	pluginVersion := "0.0.0"
+	if p.cfg.manifest != nil {
+		pluginVersion = p.cfg.manifest.Version
+	}
+
+	var caps []handshakev1.ServiceCapability
+	// Capability values mirror the proto enum: TOOL=1, CHANNEL=2, TRIGGER=3.
+	if p.cfg.channelFactory != nil {
+		caps = append(caps, handshakev1.ServiceCapability_SERVICE_CAPABILITY_CHANNEL)
+	}
+	if p.cfg.toolFactory != nil {
+		caps = append(caps, handshakev1.ServiceCapability_SERVICE_CAPABILITY_TOOL)
+	}
+	if p.cfg.triggerFactory != nil {
+		caps = append(caps, handshakev1.ServiceCapability_SERVICE_CAPABILITY_TRIGGER)
+	}
+
+	return &handshakev1.NegotiateResponse{
+		SdkVersion:         sdkVersion,
+		PluginVersion:      pluginVersion,
+		Ok:                 true,
+		ActualCapabilities: caps,
+	}, nil
+}
+
+// Bind implements bootstrapv1.BootstrapServiceServer. The host calls this once
+// after Negotiate succeeds, passing the broker stream ID we must Dial to reach
+// HostService.
+//
+// We dial the broker here — eagerly, right after Bind — rather than lazily on
+// the first RPC call. This keeps the adapter-forwarding path simple (no
+// once-in-every-method lazy dial) and surfaces connection errors early.
+func (p *pluginGRPCPlugin) Bind(_ context.Context, req *bootstrapv1.BindRequest) (*bootstrapv1.BindResponse, error) {
+	brokerID := req.GetHostBrokerId()
+
+	// DialWithOptions attaches the token interceptor; bare Dial(id) would drop it.
+	conn, err := p.broker.DialWithOptions(brokerID, grpc.WithUnaryInterceptor(TokenInterceptorFromEnv()))
+	if err != nil {
+		return &bootstrapv1.BindResponse{
+			Ok:          false,
+			ErrorDetail: fmt.Sprintf("dial host broker %d: %v", brokerID, err),
+		}, nil
+	}
+
+	p.hostConn = conn
+	hostClient := hostv1.NewHostServiceClient(conn)
+
+	// Install user implementations into adapters now that the host client is ready.
+	if p.cfg.channelFactory != nil {
+		p.channel.install(p.cfg.channelFactory(hostClient))
+	}
+	if p.cfg.toolFactory != nil {
+		p.tool.install(p.cfg.toolFactory(hostClient))
+	}
+	if p.cfg.triggerFactory != nil {
+		p.trigger.install(p.cfg.triggerFactory(hostClient))
+	}
+
+	return &bootstrapv1.BindResponse{Ok: true}, nil
+}
+
+// shutdown closes the host connection. Called on the SIGTERM/SIGINT path;
+// best-effort because SIGKILL or a crash will skip it entirely.
+func (p *pluginGRPCPlugin) shutdown() {
+	if p.hostConn != nil {
+		_ = p.hostConn.Close()
+	}
+}
+
+// ── adapters ─────────────────────────────────────────────────────────────────
+
+// channelAdapter forwards every ChannelService RPC to the real implementation
+// installed by Bind. Calls that arrive before Bind (which should not happen in
+// production but can in tests) receive codes.Unavailable.
+type channelAdapter struct {
+	channelv1.UnimplementedChannelServiceServer
+
+	mu   sync.RWMutex
+	real channelv1.ChannelServiceServer
+}
+
+func (a *channelAdapter) install(impl channelv1.ChannelServiceServer) {
+	a.mu.Lock()
+	a.real = impl
+	a.mu.Unlock()
+}
+
+func (a *channelAdapter) Notify(ctx context.Context, req *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+	a.mu.RLock()
+	impl := a.real
+	a.mu.RUnlock()
+	if impl == nil {
+		return nil, status.Error(codes.Unavailable, "plugin not yet bound or ChannelService not registered")
+	}
+	return impl.Notify(ctx, req)
+}
+
+func (a *channelAdapter) Request(ctx context.Context, req *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+	a.mu.RLock()
+	impl := a.real
+	a.mu.RUnlock()
+	if impl == nil {
+		return nil, status.Error(codes.Unavailable, "plugin not yet bound or ChannelService not registered")
+	}
+	return impl.Request(ctx, req)
+}
+
+// toolAdapter forwards every ToolService RPC to the real implementation.
+type toolAdapter struct {
+	toolv1.UnimplementedToolServiceServer
+
+	mu   sync.RWMutex
+	real toolv1.ToolServiceServer
+}
+
+func (a *toolAdapter) install(impl toolv1.ToolServiceServer) {
+	a.mu.Lock()
+	a.real = impl
+	a.mu.Unlock()
+}
+
+func (a *toolAdapter) ListTools(ctx context.Context, req *toolv1.ListToolsRequest) (*toolv1.ListToolsResponse, error) {
+	a.mu.RLock()
+	impl := a.real
+	a.mu.RUnlock()
+	if impl == nil {
+		return nil, status.Error(codes.Unavailable, "plugin not yet bound or ToolService not registered")
+	}
+	return impl.ListTools(ctx, req)
+}
+
+func (a *toolAdapter) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv1.CallResponse, error) {
+	a.mu.RLock()
+	impl := a.real
+	a.mu.RUnlock()
+	if impl == nil {
+		return nil, status.Error(codes.Unavailable, "plugin not yet bound or ToolService not registered")
+	}
+	return impl.Call(ctx, req)
+}
+
+func (a *toolAdapter) Cancel(ctx context.Context, req *toolv1.CancelRequest) (*toolv1.CancelResponse, error) {
+	a.mu.RLock()
+	impl := a.real
+	a.mu.RUnlock()
+	if impl == nil {
+		return nil, status.Error(codes.Unavailable, "plugin not yet bound or ToolService not registered")
+	}
+	return impl.Cancel(ctx, req)
+}
+
+// triggerAdapter forwards every TriggerService RPC to the real implementation.
+type triggerAdapter struct {
+	triggerv1.UnimplementedTriggerServiceServer
+
+	mu   sync.RWMutex
+	real triggerv1.TriggerServiceServer
+}
+
+func (a *triggerAdapter) install(impl triggerv1.TriggerServiceServer) {
+	a.mu.Lock()
+	a.real = impl
+	a.mu.Unlock()
+}
+
+func (a *triggerAdapter) Start(req *triggerv1.StartRequest, stream triggerv1.TriggerService_StartServer) error {
+	a.mu.RLock()
+	impl := a.real
+	a.mu.RUnlock()
+	if impl == nil {
+		return status.Error(codes.Unavailable, "plugin not yet bound or TriggerService not registered")
+	}
+	return impl.Start(req, stream)
+}

--- a/plugin-sdk/serve/server_test.go
+++ b/plugin-sdk/serve/server_test.go
@@ -1,0 +1,391 @@
+//go:build unix
+
+package serve_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+	sdkproto "github.com/felag-engineering/gleipnir/plugin-sdk/proto"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+)
+
+// TestMain intercepts the test binary when run with GLEIPNIR_SERVE_TEST_FIXTURE
+// set so it acts as a plugin subprocess instead of running the test suite. This
+// is the standard Go re-exec pattern for subprocess tests.
+func TestMain(m *testing.M) {
+	switch os.Getenv("GLEIPNIR_SERVE_TEST_FIXTURE") {
+	case "channel-only":
+		// Registers a ChannelService that returns Ok=true on every Notify.
+		// Does NOT call the host, so no token verification happens here.
+		serve.Serve(
+			serve.WithChannelService(func(_ hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+				return &notifyOkService{}
+			}),
+		)
+		os.Exit(0)
+
+	case "channel-calls-host":
+		// Registers a ChannelService that calls host.GetInstanceConfig on every
+		// Notify, so the host server records incoming metadata including the token.
+		serve.Serve(
+			serve.WithManifest(fixtureManifest),
+			serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+				return &notifyWithHostCallService{host: host}
+			}),
+		)
+		os.Exit(0)
+
+	case "channel-pid":
+		// Writes "pid=<N>\n" to stderr so the test can read the PID and send
+		// SIGTERM directly to the subprocess, then serves a basic ChannelService.
+		fmt.Fprintf(os.Stderr, "pid=%d\n", os.Getpid())
+		serve.Serve(
+			serve.WithChannelService(func(_ hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+				return &notifyOkService{}
+			}),
+		)
+		os.Exit(0)
+
+	case "emit-manifest":
+		// serve.Serve detects --emit-manifest in os.Args and writes JSON to stdout.
+		// This mode is only reached when --emit-manifest is NOT the first arg;
+		// TestEmitManifest passes --emit-manifest explicitly to the subprocess.
+		serve.Serve(
+			serve.WithManifest(fixtureManifest),
+		)
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+// ── fixture manifest ─────────────────────────────────────────────────────────
+
+var fixtureManifest = manifest.Manifest{
+	SchemaVersion: "v1",
+	Name:          "serve-test-fixture",
+	Version:       "1.2.3",
+	Services:      manifest.Services{Channel: "v1"},
+	Auth:          manifest.AuthDecl{Mode: "instance_credentials", Strategy: "none"},
+}
+
+// ── plugin-side service stubs ─────────────────────────────────────────────────
+
+// notifyOkService returns Ok=true for every Notify call.
+type notifyOkService struct {
+	channelv1.UnimplementedChannelServiceServer
+}
+
+func (s *notifyOkService) Notify(_ context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+	return &channelv1.NotifyResponse{Ok: true}, nil
+}
+
+// notifyWithHostCallService calls host.GetInstanceConfig on every Notify so the
+// token interceptor fires and the host server can record the metadata.
+type notifyWithHostCallService struct {
+	channelv1.UnimplementedChannelServiceServer
+	host hostv1.HostServiceClient
+}
+
+func (s *notifyWithHostCallService) Notify(ctx context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+	// WithCallContext propagates the host-injected call ID on the outgoing RPC,
+	// which is the normal plugin practice per spec §8.5.
+	hostCtx := serve.WithCallContext(ctx)
+	_, _ = s.host.GetInstanceConfig(hostCtx, &hostv1.GetInstanceConfigRequest{})
+	return &channelv1.NotifyResponse{Ok: true}, nil
+}
+
+// ── host-side server ─────────────────────────────────────────────────────────
+
+// recordingHostServer implements hostwire.HostServer and records the incoming
+// metadata from every GetInstanceConfig call so tests can inspect the token.
+type recordingHostServer struct {
+	hostv1.UnimplementedHostServiceServer
+
+	mu       sync.Mutex
+	received []metadata.MD
+}
+
+func (h *recordingHostServer) Register(s *grpc.Server) {
+	hostv1.RegisterHostServiceServer(s, h)
+}
+
+func (h *recordingHostServer) GetInstanceConfig(ctx context.Context, _ *hostv1.GetInstanceConfigRequest) (*hostv1.GetInstanceConfigResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		h.mu.Lock()
+		h.received = append(h.received, md.Copy())
+		h.mu.Unlock()
+	}
+	return &hostv1.GetInstanceConfigResponse{ConfigJson: `{}`}, nil
+}
+
+func (h *recordingHostServer) incomingMDs() []metadata.MD {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]metadata.MD, len(h.received))
+	copy(out, h.received)
+	return out
+}
+
+// noopHostServer registers no services. Used when the test does not need the
+// plugin to call back.
+type noopHostServer struct{}
+
+func (noopHostServer) Register(_ *grpc.Server) {}
+
+// ── launch helper ─────────────────────────────────────────────────────────────
+
+// launchFixture re-execs the test binary in the given fixture mode using
+// hostwire.Launch. token, if non-empty, is set as GLEIPNIR_INSTANCE_TOKEN so
+// the SDK's TokenInterceptorFromEnv picks it up.
+func launchFixture(t *testing.T, fixtureMode string, host hostwire.HostServer, token string) (*hostwire.Client, func(), error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	env := []string{"GLEIPNIR_SERVE_TEST_FIXTURE=" + fixtureMode}
+	if token != "" {
+		env = append(env, serve.InstanceTokenEnvVar+"="+token)
+	}
+
+	if host == nil {
+		host = noopHostServer{}
+	}
+
+	return hostwire.Launch(ctx, os.Args[0], host, hostwire.Options{
+		StartupTimeout: 20 * time.Second,
+		Env:            env,
+	})
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+// TestServe_RegistersChannelService verifies that Serve registers the user's
+// ChannelService factory and that Notify returns Ok=true.
+func TestServe_RegistersChannelService(t *testing.T) {
+	t.Parallel()
+
+	client, teardown, err := launchFixture(t, "channel-only", nil, "")
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.Channel.Notify(ctx, &channelv1.NotifyRequest{})
+	if err != nil {
+		t.Fatalf("Notify RPC: %v", err)
+	}
+	if !resp.GetOk() {
+		t.Errorf("Notify: want Ok=true, got Ok=false; error=%v", resp.GetError())
+	}
+}
+
+// TestServe_TokenInterceptorAttached verifies that the SDK wires
+// TokenInterceptorFromEnv via broker.DialWithOptions (not the bare broker.Dial
+// which silently drops interceptors). Without DialWithOptions the instance token
+// set in GLEIPNIR_INSTANCE_TOKEN never reaches the host-side server.
+func TestServe_TokenInterceptorAttached(t *testing.T) {
+	t.Parallel()
+
+	const testToken = "test-token-interceptor-abc123"
+
+	recorder := &recordingHostServer{}
+	client, teardown, err := launchFixture(t, "channel-calls-host", recorder, testToken)
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Notify triggers host.GetInstanceConfig inside the fixture service, which
+	// is where the outgoing metadata (containing the instance token) is recorded.
+	resp, err := client.Channel.Notify(ctx, &channelv1.NotifyRequest{})
+	if err != nil {
+		t.Fatalf("Notify RPC: %v", err)
+	}
+	if !resp.GetOk() {
+		t.Errorf("Notify: want Ok=true, got Ok=false")
+	}
+
+	mds := recorder.incomingMDs()
+	if len(mds) == 0 {
+		t.Fatal("host server received no GetInstanceConfig calls — fixture did not call back to host")
+	}
+
+	// At least one GetInstanceConfig must have carried the instance token.
+	found := false
+	for _, md := range mds {
+		if vals := md.Get(sdkproto.InstanceTokenMetadataKey); len(vals) > 0 && vals[0] == testToken {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no incoming GetInstanceConfig call carried token %q; metadata seen: %v", testToken, mds)
+	}
+}
+
+// TestServe_NoCapabilityWithoutFactory verifies that calling a service whose
+// factory was not registered returns codes.Unavailable. The "channel-only"
+// fixture registers only ChannelService; calling ToolService.Call must fail.
+func TestServe_NoCapabilityWithoutFactory(t *testing.T) {
+	t.Parallel()
+
+	client, teardown, err := launchFixture(t, "channel-only", nil, "")
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err = client.Tool.Call(ctx, &toolv1.CallRequest{})
+	if err == nil {
+		t.Fatal("Tool.Call with no ToolService registered: expected gRPC error, got nil")
+	}
+	s, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("Tool.Call error is not a gRPC status: %v", err)
+	}
+	if s.Code() != codes.Unavailable {
+		t.Errorf("Tool.Call: want codes.Unavailable, got %s (%q)", s.Code(), s.Message())
+	}
+}
+
+// TestServe_SigtermDrains verifies that serve.Serve exits cleanly when the
+// subprocess receives SIGTERM. The fixture writes its PID to stderr before
+// calling Serve; the test reads that PID and sends SIGTERM directly via
+// syscall.Kill. This ensures the test actually exercises the SIGTERM handler
+// in serve.Serve — if the handler were deleted, the OS default for SIGTERM
+// would still kill the process, so the bounded-exit assertion alone is
+// insufficient. What we care about here is that the handler path is reached,
+// not that it performs any particular cleanup action.
+func TestServe_SigtermDrains(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Pipe subprocess stderr so we can scan for the "pid=<N>" line that the
+	// "channel-pid" fixture emits before calling serve.Serve. io.Pipe is safe
+	// for concurrent reads and writes (go-plugin writes from its copy goroutine
+	// while we scan the read end here).
+	stderrR, stderrW := io.Pipe()
+	pidReady := make(chan int, 1)
+	go func() {
+		scanner := bufio.NewScanner(stderrR)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "pid=") {
+				pid, err := strconv.Atoi(strings.TrimPrefix(line, "pid="))
+				if err == nil {
+					select {
+					case pidReady <- pid:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	exited := make(chan struct{})
+
+	client, teardown, err := hostwire.Launch(ctx, os.Args[0], noopHostServer{}, hostwire.Options{
+		StartupTimeout: 20 * time.Second,
+		Env:            []string{"GLEIPNIR_SERVE_TEST_FIXTURE=channel-pid"},
+		Stderr:         stderrW,
+		OnProcessExited: func() {
+			stderrW.Close() // unblocks the scanner goroutine so it exits cleanly
+			close(exited)
+		},
+	})
+	if err != nil {
+		stderrR.Close()
+		stderrW.Close()
+		t.Fatalf("launch: %v", err)
+	}
+	_ = client
+	defer teardown() // ensures cleanup even if the test fails before SIGTERM
+
+	// Wait for the subprocess to emit its PID line.
+	var pid int
+	select {
+	case pid = <-pidReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("subprocess did not write pid= line within 10s")
+	}
+
+	start := time.Now()
+	// Send SIGTERM directly so the serve.Serve signal handler fires, not
+	// hostwire's Kill() path (which closes the broker connection instead).
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		t.Fatalf("Kill(SIGTERM): %v", err)
+	}
+
+	select {
+	case <-exited:
+		t.Logf("subprocess exited within %s after SIGTERM", time.Since(start))
+	case <-time.After(10 * time.Second):
+		t.Fatal("subprocess did not exit within 10s after SIGTERM")
+	}
+}
+
+// TestEmitManifest verifies that running the binary with --emit-manifest as
+// the first argument writes manifest JSON to stdout that round-trips correctly.
+func TestEmitManifest(t *testing.T) {
+	t.Parallel()
+
+	// Re-exec this test binary with --emit-manifest. TestMain's "emit-manifest"
+	// fixture mode calls serve.Serve(WithManifest(fixtureManifest)); serve.Serve
+	// detects os.Args[1]=="--emit-manifest" and calls EmitManifest before the
+	// plugin server starts.
+	cmd := exec.Command(os.Args[0], "--emit-manifest")
+	cmd.Env = append(os.Environ(), "GLEIPNIR_SERVE_TEST_FIXTURE=emit-manifest")
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run with --emit-manifest: %v\noutput: %s", err, out)
+	}
+
+	var got manifest.Manifest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal manifest JSON: %v\nraw output: %s", err, out)
+	}
+
+	if got.Name != fixtureManifest.Name {
+		t.Errorf("Name: want %q, got %q", fixtureManifest.Name, got.Name)
+	}
+	if got.Version != fixtureManifest.Version {
+		t.Errorf("Version: want %q, got %q", fixtureManifest.Version, got.Version)
+	}
+	if got.Services.Channel != fixtureManifest.Services.Channel {
+		t.Errorf("Services.Channel: want %q, got %q", fixtureManifest.Services.Channel, got.Services.Channel)
+	}
+}

--- a/plugins/ntfy/integration_test.go
+++ b/plugins/ntfy/integration_test.go
@@ -1,0 +1,156 @@
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
+)
+
+// ntfyBinaryPath holds the path to the ntfy binary compiled by TestMain.
+var ntfyBinaryPath string
+
+// TestMain builds the ntfy binary once for all integration tests. If the
+// Go toolchain is not on PATH, all integration tests are skipped.
+func TestMain(m *testing.M) {
+	// Skip early if go is not available — the integration test requires building.
+	if _, err := exec.LookPath("go"); err != nil {
+		// Cannot skip from TestMain; set a flag instead and skip per-test.
+		os.Exit(m.Run())
+	}
+
+	dir, err := os.MkdirTemp("", "ntfy-integration-*")
+	if err != nil {
+		panic("create temp dir: " + err.Error())
+	}
+	defer os.RemoveAll(dir)
+
+	binaryPath := filepath.Join(dir, "ntfy")
+	// Build the ntfy binary from the module root of this package.
+	build := exec.Command("go", "build", "-o", binaryPath, ".")
+	build.Dir, _ = os.Getwd()
+	if out, err := build.CombinedOutput(); err != nil {
+		// Print the build output to help diagnose failures and exit.
+		os.Stderr.Write(out)
+		os.Exit(1)
+	}
+
+	ntfyBinaryPath = binaryPath
+	os.Exit(m.Run())
+}
+
+// skipIfNoBinary skips the test if the ntfy binary was not built (go not on PATH).
+func skipIfNoBinary(t *testing.T) {
+	t.Helper()
+	if ntfyBinaryPath == "" {
+		t.Skip("skipping: go toolchain not on PATH or ntfy binary not built")
+	}
+}
+
+// ntfyHostServer is a hostwire.HostServer that serves GetInstanceConfig and
+// GetCredentials, returning the ntfy server URL and an empty credential set.
+type ntfyHostServer struct {
+	hostv1.UnimplementedHostServiceServer
+	instanceConfigJSON string
+}
+
+func (h *ntfyHostServer) Register(s *grpc.Server) {
+	hostv1.RegisterHostServiceServer(s, h)
+}
+
+func (h *ntfyHostServer) GetInstanceConfig(_ context.Context, _ *hostv1.GetInstanceConfigRequest) (*hostv1.GetInstanceConfigResponse, error) {
+	return &hostv1.GetInstanceConfigResponse{ConfigJson: h.instanceConfigJSON}, nil
+}
+
+func (h *ntfyHostServer) GetCredentials(_ context.Context, _ *hostv1.GetCredentialsRequest) (*hostv1.GetCredentialsResponse, error) {
+	// No API key — ntfy supports unauthenticated topics in our test setup.
+	return &hostv1.GetCredentialsResponse{CredentialsJson: `{}`}, nil
+}
+
+// TestNtfy_EndToEnd is a full end-to-end integration test. It:
+//  1. Starts a fake ntfy HTTP server (httptest.Server).
+//  2. Spawns the real ntfy binary via hostwire.Launch with a HostServer that
+//     returns the fake server URL in GetInstanceConfig.
+//  3. Dispatches ChannelService.Notify via the hostwire client.
+//  4. Asserts the fake ntfy server received exactly one POST to the expected
+//     topic path.
+func TestNtfy_EndToEnd(t *testing.T) {
+	skipIfNoBinary(t)
+
+	// 1. Fake ntfy HTTP backend — records the first POST.
+	var postCount atomic.Int32
+	var gotPath string
+	var gotBody string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		postCount.Add(1)
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	// 2. Spawn the ntfy binary via hostwire.Launch.
+	instanceCfg := map[string]string{
+		"server_url":    backend.URL,
+		"default_topic": "test",
+	}
+	cfgJSON, _ := json.Marshal(instanceCfg)
+
+	host := &ntfyHostServer{instanceConfigJSON: string(cfgJSON)}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, teardown, err := hostwire.Launch(ctx, ntfyBinaryPath, host, hostwire.Options{
+		StartupTimeout: 20 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("hostwire.Launch: %v", err)
+	}
+	defer teardown()
+
+	// 3. Dispatch Notify via the hostwire client.
+	notifyCtx, notifyCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer notifyCancel()
+
+	resp, err := client.Channel.Notify(notifyCtx, &channelv1.NotifyRequest{
+		PayloadJson: `{"body":"integration test message"}`,
+	})
+	if err != nil {
+		t.Fatalf("Channel.Notify: %v", err)
+	}
+	if !resp.GetOk() {
+		errMsg := ""
+		if resp.GetError() != nil {
+			errMsg = resp.GetError().GetMessage()
+		}
+		t.Fatalf("Notify: want Ok=true, got Ok=false; error=%q", errMsg)
+	}
+
+	// 4. Assert the fake ntfy server received exactly one POST to /test.
+	if n := postCount.Load(); n != 1 {
+		t.Errorf("fake ntfy server: want 1 POST, got %d", n)
+	}
+	if gotPath != "/test" {
+		t.Errorf("POST path: want /test, got %q", gotPath)
+	}
+	if gotBody != "integration test message" {
+		t.Errorf("POST body: want %q, got %q", "integration test message", gotBody)
+	}
+}

--- a/plugins/ntfy/main.go
+++ b/plugins/ntfy/main.go
@@ -1,13 +1,18 @@
 package main
 
-import "github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+import (
+	"net/http"
+
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+)
 
 func main() {
-	// serve.Serve() is the last call in every plugin binary. It wires up the
-	// go-plugin transport, registers ChannelService, and blocks until the host
-	// disconnects.
-	//
-	// This is a Phase-3 stub and panics if called directly. Run service_test.go
-	// instead to exercise ChannelService in-process via loopback TCP (127.0.0.1:0).
-	serve.Serve()
+	serve.Serve(
+		serve.WithManifest(pluginManifest),
+		serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+			return NewChannelService(host, http.DefaultClient)
+		}),
+	)
 }


### PR DESCRIPTION
Closes #315

## Summary
- Replaces the panic stubs in `plugin-sdk/serve/doc.go` with a real `Serve(opts ...Option)` that wraps `hashicorp/go-plugin`. User services are registered via `WithChannelService` / `WithToolService` / `WithTriggerService`, and each factory receives a `hostv1.HostServiceClient` that is broker-dialed with `TokenInterceptorFromEnv()` so every Host RPC carries the per-generation identity token.
- `--emit-manifest` is detected positionally so scaffold templates can drop their own `flag.Parse()` blocks. The four templates (channel/tool/trigger/combo) and the `minimal-tool` example are updated; `plugins/ntfy/main.go` is rewired to the new option API.
- The SDK owns SIGTERM. `hashicorp/go-plugin@v1.6.3` only catches SIGINT (`server.go:464`), so `Serve` runs `goplugin.Serve` in a goroutine and selects on its own `signal.Notify` channel.
- Adapter pattern resolves the GRPCServer-before-Bind ordering: services must be registered before the gRPC server starts serving, but the host client is only available after `Bootstrap.Bind`. Adapters hold a mutex-guarded pointer to the real impl and return `codes.Unavailable` until Bind installs it.
- A new `serve-via-sdk` fixture mode in `internal/plugin/process/process_test.go` dispatches a real `ChannelService.Notify` over hostwire — so a broken SDK runtime now fails the host-side test matrix instead of silently passing.

## Plan

<details>
<summary>Click to expand the architecture plan</summary>

See `.dev-loop/plan.md` (not committed). Highlights:
- Adapter pattern for late service init (RWMutex-guarded user-impl pointer, returns `codes.Unavailable` between `GRPCServer` and `Bind`)
- `broker.DialWithOptions(id, grpc.WithUnaryInterceptor(serve.TokenInterceptorFromEnv()))` — not bare `Dial`, which silently ignores dial options
- Manifest passed in via `WithManifest(...)` rather than auto-discovered, because Tool/Trigger descriptors are richer than gRPC reflection can express
- `--emit-manifest` is intercepted positionally so scaffold templates with `flag.Parse()` no longer need their own handling

</details>

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean (main module + plugin-sdk + plugins/ntfy)
- [x] `go test ./internal/plugin/... ./plugin-sdk/serve/...` all passing
- [x] `cd plugins/ntfy && go test ./...` passing (includes the new `integration_test.go` end-to-end test that builds the ntfy binary, spawns it via hostwire, dispatches Notify, and asserts a POST landed on an `httptest.Server`)
- [x] New unit tests in `plugin-sdk/serve/server_test.go`: `TestServe_RegistersChannelService`, `TestServe_TokenInterceptorAttached`, `TestServe_NoCapabilityWithoutFactory`, `TestServe_SigtermDrains` (real `syscall.Kill(pid, SIGTERM)` via a PID side-channel from the fixture), `TestEmitManifest`
- [x] New host-side test `TestStart_RealSDKServe` in `internal/plugin/process/process_test.go` dispatches a real `Channel.Notify` RPC end-to-end

## Pipeline metadata
- Generated by the agentic dev loop. Architect plan went through 1 plan-review revise cycle (SIGTERM/SIGINT handling, `broker.DialWithOptions` correction, scaffold-template fallout). Implementation went through 1 code-review revise cycle (SIGTERM test was previously asserting the wrong path; `TestStart_RealSDKServe` was missing the actual Notify dispatch).
- CLAUDE.md / frontend/CLAUDE.md unchanged — no new packages under `internal/`, no new env vars, no API/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)