### PR TITLE
feat: wire process.Manager into dispatch.ConnFactory

### DIFF
--- a/conn_factory_test.go
+++ b/conn_factory_test.go
@@ -1,0 +1,160 @@
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/connectivity"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+	"github.com/felag-engineering/gleipnir/internal/plugin/identity"
+	"github.com/felag-engineering/gleipnir/internal/plugin/process"
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+)
+
+// TestMain intercepts the test binary when run as a plugin fixture subprocess.
+// When GLEIPNIR_TEST_FIXTURE=serve-via-sdk the test binary serves the plugin
+// protocol instead of running the test suite — the standard Go re-exec pattern
+// for tests that spawn subprocesses.
+func TestMain(m *testing.M) {
+	if os.Getenv("GLEIPNIR_TEST_FIXTURE") == "serve-via-sdk" {
+		serve.Serve(
+			serve.WithChannelService(func(_ hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+				return &connFactoryFixtureChannel{}
+			}),
+		)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// connFactoryFixtureChannel returns Ok=true on every Notify call.
+type connFactoryFixtureChannel struct {
+	channelv1.UnimplementedChannelServiceServer
+}
+
+func (s *connFactoryFixtureChannel) Notify(_ context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+	return &channelv1.NotifyResponse{Ok: true}, nil
+}
+
+// TestManagerConnFactory covers the three observable states of managerConnFactory.
+func TestManagerConnFactory(t *testing.T) {
+	t.Run("nil_manager_returns_unavailable", func(t *testing.T) {
+		f := &managerConnFactory{}
+		_, err := f.Connect("any-instance")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, dispatch.ErrManagerUnavailable) {
+			t.Errorf("want dispatch.ErrManagerUnavailable, got %v", err)
+		}
+	})
+
+	t.Run("missing_instance_returns_not_running", func(t *testing.T) {
+		reg := identity.New()
+		mgr := process.NewManager(process.ManagerConfig{
+			Querier:        &connFactoryFakeQuerier{},
+			IdentityIssuer: reg,
+		})
+
+		f := &managerConnFactory{}
+		f.setManager(mgr)
+
+		_, err := f.Connect("nonexistent-instance")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, dispatch.ErrInstanceNotRunning) {
+			t.Errorf("want dispatch.ErrInstanceNotRunning, got %v", err)
+		}
+	})
+
+	t.Run("running_instance_returns_conn", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("fixture subprocess: skipped in short mode")
+		}
+
+		reg := identity.New()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		plugin := db.Plugin{ID: "p1", Status: "active"}
+		instance := db.PluginInstance{
+			ID:           "factory-test-instance",
+			PluginID:     "p1",
+			InstanceName: "factory-test",
+			HealthState:  "healthy",
+		}
+
+		// Use a TestProcessStarter that calls the real process.Start but with the
+		// GLEIPNIR_TEST_FIXTURE env var injected via a Launch wrapper. This causes
+		// the re-exec'd subprocess to run serve.Serve (our fixture above) rather
+		// than the test suite — identical to the fixtureConfig pattern in
+		// internal/plugin/process/process_test.go.
+		//
+		// The real process.Start path (not the stub) must be taken so that
+		// inst.Client().Conn() is backed by a live gRPC connection. Without it,
+		// managerConnFactory.Connect would return a nil conn from the accessor.
+		mgr := process.NewManager(process.ManagerConfig{
+			Querier:        &connFactoryFakeQuerier{},
+			IdentityIssuer: reg,
+			TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+				cfg.BinaryPath = os.Args[0]
+				cfg.Launch = func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
+					os.Setenv("GLEIPNIR_TEST_FIXTURE", "serve-via-sdk")
+					client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
+					os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
+					return client, teardown, err
+				}
+				return process.Start(ctx, cfg)
+			},
+		})
+
+		if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+			t.Fatalf("Manager.Start: %v", err)
+		}
+		defer mgr.StopAll(ctx) //nolint:errcheck
+
+		f := &managerConnFactory{}
+		f.setManager(mgr)
+
+		conn, err := f.Connect("factory-test")
+		if err != nil {
+			t.Fatalf("Connect(%q): %v", "factory-test", err)
+		}
+		if conn == nil {
+			t.Fatal("Connect returned nil conn")
+		}
+		if state := conn.GetState(); state == connectivity.Shutdown {
+			t.Errorf("conn state is Shutdown, want live connection")
+		}
+	})
+}
+
+// connFactoryFakeQuerier satisfies process.Manager's querier interface with
+// empty in-memory data. Manager unit tests that use TestProcessStarter never
+// invoke StartAllActive, so these methods are no-ops.
+type connFactoryFakeQuerier struct{}
+
+func (q *connFactoryFakeQuerier) ListPluginsByStatus(_ context.Context, _ string) ([]db.Plugin, error) {
+	return nil, nil
+}
+func (q *connFactoryFakeQuerier) ListPluginInstancesByPlugin(_ context.Context, _ string) ([]db.PluginInstance, error) {
+	return nil, nil
+}
+func (q *connFactoryFakeQuerier) GetPluginInstanceByID(_ context.Context, _ string) (db.PluginInstance, error) {
+	return db.PluginInstance{}, errors.New("not found")
+}
+func (q *connFactoryFakeQuerier) UpdatePluginInstanceHealth(_ context.Context, _ db.UpdatePluginInstanceHealthParams) (int64, error) {
+	return 1, nil
+}

--- a/internal/plugin/dispatch/channel_integration_test.go
+++ b/internal/plugin/dispatch/channel_integration_test.go
@@ -1,0 +1,157 @@
+//go:build unix
+
+package dispatch_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+	"github.com/felag-engineering/gleipnir/internal/plugin/identity"
+	"github.com/felag-engineering/gleipnir/internal/plugin/process"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
+)
+
+// TestDispatcher_Notify_ProductionWiring exercises the full production wire:
+//
+//	real subprocess started via process.Manager.Start
+//	→ Manager.LookupByName resolves the instance name
+//	→ Client.Conn() provides the live gRPC connection
+//	→ channelv1.NewChannelServiceClient(conn) wraps it
+//	→ Notify RPC reaches the fixture's ChannelService
+//	→ fixture responds Ok=true
+//
+// This is the integration assertion required by issue #317: the production
+// ConnFactory (backed by Manager.LookupByName + Client.Conn()) routes a Notify
+// call through to a real subprocess. The Connect closure is inline here because
+// we are testing the dispatcher path, not the managerConnFactory helper (which
+// has its own unit test in conn_factory_test.go).
+func TestDispatcher_Notify_ProductionWiring(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fixture subprocess: skipped in short mode")
+	}
+
+	// Stand up an in-memory SQLite store, mirroring the existing test-utility
+	// pattern from channel_test.go.
+	s := testutil.NewTestStore(t)
+
+	// Seed the DB with a plugin, an instance, an audience, and a Notify-enabled
+	// audience entry targeting the real instance we will start below.
+	const instanceName = "dispatch-integration-inst"
+	const instanceID = "dispatch-integ-i1"
+	pluginID := insertPlugin(t, s, "dispatch-integ-p1", "dispatch-integ-plugin")
+	insertPluginInstance(t, s, instanceID, pluginID, instanceName)
+	audID := insertAudience(t, s, "dispatch-integ-aud1", "dispatch-integ-audience", 1 /* disable in-app fallback */)
+	insertAudienceEntry(t, s, "dispatch-integ-ae1", audID, instanceID, 0, true, false)
+
+	// Start a real subprocess via process.Manager.Start. The TestProcessStarter
+	// wraps the real process.Start with the re-exec env injection so the
+	// subprocess runs our dispatchFixtureChannel (registered in TestMain above)
+	// instead of the test suite.
+	//
+	// Using the real process.Start path (not the stub) is mandatory: only it
+	// populates inst.Client().Conn() with a live gRPC connection. The stub
+	// processStarter used by TestManager_ServerInterceptors_PropagateToConfig
+	// returns a synthetic Instance with no live client.
+	reg := identity.New()
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        &dispatchIntegFakeQuerier{},
+		IdentityIssuer: reg,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			cfg.BinaryPath = os.Args[0]
+			cfg.Launch = func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
+				os.Setenv("GLEIPNIR_TEST_FIXTURE", "dispatch-serve-via-sdk")
+				client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
+				os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
+				return client, teardown, err
+			}
+			return process.Start(ctx, cfg)
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	plugin := db.Plugin{ID: pluginID, Status: "active"}
+	instance := db.PluginInstance{
+		ID:           instanceID,
+		PluginID:     pluginID,
+		InstanceName: instanceName,
+		HealthState:  "healthy",
+	}
+
+	if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+		t.Fatalf("Manager.Start: %v", err)
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		if err := mgr.StopAll(stopCtx); err != nil {
+			t.Logf("StopAll: %v", err)
+		}
+	}()
+
+	// Build the production ConnFactory as an inline closure over the manager.
+	// This duplicates the trivial body of managerConnFactory.Connect; the helper
+	// struct is unit-tested separately in conn_factory_test.go. Here we test the
+	// dispatcher path, so an inline closure keeps the focus on the dispatcher.
+	connFactory := func(name string) (*grpc.ClientConn, error) {
+		inst := mgr.LookupByName(name)
+		if inst == nil {
+			t.Errorf("LookupByName(%q) returned nil — instance not registered", name)
+			return nil, dispatch.ErrInstanceNotRunning
+		}
+		conn := inst.Client().Conn()
+		if conn == nil {
+			t.Errorf("inst.Client().Conn() is nil for %q — real process.Start path required", name)
+			return nil, dispatch.ErrInstanceNotRunning
+		}
+		if conn.GetState() == connectivity.Shutdown {
+			t.Errorf("conn state is Shutdown for %q", name)
+		}
+		return conn, nil
+	}
+
+	dispatcher := dispatch.NewDispatcher(dispatch.DispatcherConfig{
+		Queries: s.Queries(),
+		Connect: connFactory,
+	})
+
+	rc := dispatch.RouteContext{
+		RunID:    "run-dispatch-integ",
+		PolicyID: "policy-dispatch-integ",
+		ToolName: "test.notify",
+	}
+
+	notifyCtx, notifyCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer notifyCancel()
+
+	if err := dispatcher.Notify(notifyCtx, audID, rc, "test.event", "{}"); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+}
+
+// dispatchIntegFakeQuerier satisfies process.Manager's querier interface with
+// empty in-memory data. We drive the manager via Start()/StopAll() directly in
+// the test; StartAllActive is never called so these methods are no-ops.
+type dispatchIntegFakeQuerier struct{}
+
+func (q *dispatchIntegFakeQuerier) ListPluginsByStatus(_ context.Context, _ string) ([]db.Plugin, error) {
+	return nil, nil
+}
+func (q *dispatchIntegFakeQuerier) ListPluginInstancesByPlugin(_ context.Context, _ string) ([]db.PluginInstance, error) {
+	return nil, nil
+}
+func (q *dispatchIntegFakeQuerier) GetPluginInstanceByID(_ context.Context, _ string) (db.PluginInstance, error) {
+	return db.PluginInstance{}, nil
+}
+func (q *dispatchIntegFakeQuerier) UpdatePluginInstanceHealth(_ context.Context, _ db.UpdatePluginInstanceHealthParams) (int64, error) {
+	return 1, nil
+}

--- a/internal/plugin/dispatch/errors.go
+++ b/internal/plugin/dispatch/errors.go
@@ -29,3 +29,14 @@ var ErrNoRequestCapableEntry = errors.New("plugin: no request-capable entry in a
 // not in the in-memory waiters map — either it was never issued by this
 // Dispatcher instance, or it has already been resolved or expired.
 var ErrUnknownRequestID = errors.New("plugin: unknown request ID")
+
+// ErrInstanceNotRunning is returned by a ConnFactory when no subprocess is
+// currently registered for the requested instance name. The host dispatcher
+// wraps this with the instance name before returning it to callers.
+var ErrInstanceNotRunning = errors.New("plugin: instance not running")
+
+// ErrManagerUnavailable is returned by a ConnFactory when the host plugin
+// subsystem is disabled or the process.Manager has not yet been constructed
+// (i.e. setManager has not been called). Callers can distinguish this from
+// ErrInstanceNotRunning to tell apart "subsystem off" from "instance crashed".
+var ErrManagerUnavailable = errors.New("plugin: process manager unavailable")

--- a/internal/plugin/dispatch/pool_test.go
+++ b/internal/plugin/dispatch/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -17,13 +18,38 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	sdkproto "github.com/felag-engineering/gleipnir/plugin-sdk/proto"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 func TestMain(m *testing.M) {
+	// Intercept the re-exec pattern used by integration tests that need a real
+	// plugin subprocess. When this test binary is re-launched as a subprocess
+	// (by setting GLEIPNIR_TEST_FIXTURE), it acts as a plugin server rather than
+	// running the test suite.
+	if os.Getenv("GLEIPNIR_TEST_FIXTURE") == "dispatch-serve-via-sdk" {
+		serve.Serve(
+			serve.WithChannelService(func(_ hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+				return &dispatchFixtureChannel{}
+			}),
+		)
+		os.Exit(0)
+	}
 	goleak.VerifyTestMain(m)
+}
+
+// dispatchFixtureChannel is a trivial ChannelService that returns Ok=true on
+// every Notify call. Used by TestDispatcher_Notify_ProductionWiring.
+type dispatchFixtureChannel struct {
+	channelv1.UnimplementedChannelServiceServer
+}
+
+func (s *dispatchFixtureChannel) Notify(_ context.Context, _ *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+	return &channelv1.NotifyResponse{Ok: true}, nil
 }
 
 // fakeToolServer is a test double for toolv1.ToolServiceServer.

--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -370,6 +370,28 @@ func (m *Manager) Lookup(instanceID string) *Instance {
 	return m.instances[instanceID]
 }
 
+// LookupByName returns the running Instance whose InstanceName matches name, or
+// nil if no such subprocess is running.
+//
+// Manager's primary index is by ULID (instance.ID); this helper supports the
+// dispatch layer, whose ConnFactory contract is keyed on the human-readable
+// instance_name (the same value persisted in plugin_instances.instance_name and
+// threaded through dispatch.Pool/dispatch.Dispatcher).
+//
+// Implementation is a linear scan under m.mu. The instances map is small (one
+// entry per running plugin instance) so this is fine; a second name→id index
+// would add lifecycle complexity for no measurable benefit.
+func (m *Manager) LookupByName(name string) *Instance {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, inst := range m.instances {
+		if inst.cfg.InstanceName == name {
+			return inst
+		}
+	}
+	return nil
+}
+
 // buildHealthSetter returns a HealthSetter closure that routes through
 // pluginstate.SetHealthState with the manager's DB querier and publisher.
 // ErrIllegalTransition is treated as warn-and-continue because the instance

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/plugin/generation"
 	"github.com/felag-engineering/gleipnir/internal/plugin/hostsvc"
 	"github.com/felag-engineering/gleipnir/internal/plugin/identity"
+	"github.com/felag-engineering/gleipnir/internal/plugin/process"
 	"github.com/felag-engineering/gleipnir/internal/policy"
 	"github.com/felag-engineering/gleipnir/internal/settings"
 	"github.com/felag-engineering/gleipnir/internal/timeout"
@@ -136,21 +138,22 @@ func run(cfg config.Config) error {
 	)
 	feedbackScanner.Start(ctx)
 
+	// connFactory bridges the dispatch layer to the host's process.Manager.
+	// It is constructed now (before pluginPool and pluginDispatcher) but the
+	// manager is injected later via setManager, after loader.StartManager
+	// succeeds. Using an atomic pointer lets the factory be captured by value
+	// in both call sites while still seeing the manager once it is available.
+	// Before setManager runs, Connect returns ErrManagerUnavailable — correct
+	// because no plugin subprocesses are running yet.
+	connFactory := &managerConnFactory{}
+
 	// Plugin dispatch pool: routes agent tool calls to plugin instances via gRPC.
-	// stubConnFactory returns an error because subprocess lifecycle (process start,
-	// UDS socket path) is wired in a follow-up issue. Plugin tools are only added
-	// to agent.Config.PluginTools once the registrar has registered them, and that
-	// registration is gated on the loader-side subprocess-up event — so this stub
-	// is unreachable in practice until that follow-up lands.
-	stubConnFactory := func(instanceName string) (*grpc.ClientConn, error) {
-		return nil, fmt.Errorf("plugin %q not started (subprocess lifecycle not yet wired)", instanceName)
-	}
 	pluginPool := dispatch.New(dispatch.Config{
 		CallTimeout:          cfg.MCPTimeout,
 		CancelTimeout:        5 * time.Second,
 		DefaultMaxConcurrent: 50,
 		DefaultMaxQueueDepth: 50,
-		Connect:              stubConnFactory,
+		Connect:              connFactory.Connect,
 	})
 
 	// pluginDispatchAdapter wraps *dispatch.Pool to satisfy agent.PluginToolDispatcher,
@@ -200,7 +203,7 @@ func run(cfg config.Config) error {
 
 		pluginDispatcher := dispatch.NewDispatcher(dispatch.DispatcherConfig{
 			Queries: store.Queries(),
-			Connect: stubConnFactory,
+			Connect: connFactory.Connect,
 		})
 
 		hostSvc := hostsvc.NewServer(
@@ -228,6 +231,10 @@ func run(cfg config.Config) error {
 		}); err != nil {
 			return fmt.Errorf("start plugin manager: %w", err)
 		}
+		// Publish the manager to the factory so Connect calls can now resolve
+		// running instances. This runs after StartManager so the manager is
+		// fully initialised before any call can reach it.
+		connFactory.setManager(loader.Manager())
 	}
 
 	// Registry construction is placed after encryption key parsing so
@@ -475,6 +482,10 @@ func run(cfg config.Config) error {
 
 	// Close the plugin dispatch pool after all runs have drained so no new
 	// Cancel RPCs are issued after the connections are torn down.
+	// Note: StopAll above already tore down each subprocess's gRPC transport
+	// via go-plugin's Kill(). pluginPool.Close() may therefore hit already-closed
+	// connections; grpc.ErrClientConnClosing is swallowed by Pool.Close's firstErr
+	// capture and is not surfaced here. This re-close is benign post-StopAll.
 	if err := pluginPool.Close(); err != nil {
 		slog.Warn("plugin dispatch pool close error", "err", err)
 	}
@@ -680,4 +691,41 @@ func (a *pluginDispatchAdapter) Call(ctx context.Context, runID, policyID, insta
 		}
 	}
 	return output, isError, err
+}
+
+// managerConnFactory resolves a *grpc.ClientConn for a named plugin instance by
+// looking it up in the host's process.Manager. It is the production ConnFactory
+// that replaces the old stubConnFactory.
+//
+// The argument is the human-readable instance_name (matching
+// dispatch.ConnFactory's contract and the plugin_instances.instance_name
+// column), NOT the ULID. We therefore call Manager.LookupByName, not Lookup.
+//
+// The manager is set via setManager after loader.StartManager succeeds. Until
+// then (or when plugins are disabled), Connect returns ErrManagerUnavailable.
+// The atomic.Pointer lets connFactory be wired into dispatch.New and
+// dispatch.NewDispatcher before StartManager runs; late-binding is safe because
+// no plugin subprocess is reachable until StartManager completes anyway.
+type managerConnFactory struct {
+	mgr atomic.Pointer[process.Manager]
+}
+
+func (f *managerConnFactory) setManager(m *process.Manager) { f.mgr.Store(m) }
+
+func (f *managerConnFactory) Connect(instanceName string) (*grpc.ClientConn, error) {
+	m := f.mgr.Load()
+	if m == nil {
+		return nil, fmt.Errorf("%w: %q", dispatch.ErrManagerUnavailable, instanceName)
+	}
+	inst := m.LookupByName(instanceName)
+	if inst == nil {
+		return nil, fmt.Errorf("%w: %q", dispatch.ErrInstanceNotRunning, instanceName)
+	}
+	conn := inst.Client().Conn()
+	if conn == nil {
+		// Defence in depth: Client.Conn() should always be non-nil for instances
+		// returned by the real process.Start path (hostwire.GRPCClient sets conn).
+		return nil, fmt.Errorf("%w: %q (nil conn)", dispatch.ErrInstanceNotRunning, instanceName)
+	}
+	return conn, nil
 }

--- a/plugin-sdk/hostwire/hostwire.go
+++ b/plugin-sdk/hostwire/hostwire.go
@@ -69,7 +69,20 @@ type Client struct {
 	Channel   channelv1.ChannelServiceClient
 	Trigger   triggerv1.TriggerServiceClient
 	Bootstrap bootstrapv1.BootstrapServiceClient
+
+	// conn is the underlying gRPC connection backing the typed service clients.
+	// Retained here so Conn() can expose it to the host dispatcher layer.
+	conn *grpc.ClientConn
 }
+
+// Conn returns the underlying gRPC connection that backs the typed service
+// clients. The production host dispatcher uses this to satisfy
+// dispatch.ConnFactory: it constructs channelv1.NewChannelServiceClient(conn)
+// for each plugin instance rather than going through the typed Client fields
+// (which are equivalent but require the full Client to be available).
+//
+// This is an additive SDK change per ADR-042 SDK stability rules.
+func (c *Client) Conn() *grpc.ClientConn { return c.conn }
 
 // Options configures a Launch call.
 type Options struct {
@@ -189,6 +202,7 @@ func (p *gleipnirPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBrok
 		Channel:   channelv1.NewChannelServiceClient(conn),
 		Trigger:   triggerv1.NewTriggerServiceClient(conn),
 		Bootstrap: bootstrapv1.NewBootstrapServiceClient(conn),
+		conn:      conn,
 	}, nil
 }
 


### PR DESCRIPTION
Closes #317

## Summary
- Replaces `stubConnFactory` in `main.go` (which always errored with `"plugin %q not started (subprocess lifecycle not yet wired)"`) with a real `managerConnFactory` that consults the running `process.Manager` and returns the per-instance gRPC conn.
- After this lands, audience `Notify` calls dispatched by `internal/plugin/dispatch` actually reach the plugin subprocess — completing the Phase 5 end-to-end wire that #316 (SDK runtime) started.

## Key design
- **`hostwire.Client.Conn()`** new accessor exposes the underlying `*grpc.ClientConn` that go-plugin handed in. Additive SDK change — no callers break.
- **`process.Manager.LookupByName(name)`** bridges `dispatch.ConnFactory func(instanceName string)` (keyed on the human-readable `InstanceName`, e.g. `"ntfy-prod"`) to the manager's internal map (keyed on the ULID `instance.ID`). Without this distinction every dispatch would silently miss — this was the bug the plan-reviewer caught before implementation.
- **`managerConnFactory` uses `atomic.Pointer[process.Manager]`** because the dispatchers must be constructed before `loader.StartManager` (`runManager.WithPluginCanceller(pluginPool)` and `hostsvc.NewServer(...pluginDispatcher...)` both need them earlier in main.go's wiring). `setManager` is called after `StartManager` returns; before that, `Connect` returns `ErrManagerUnavailable`.
- **New sentinels** `ErrInstanceNotRunning` and `ErrManagerUnavailable` live in `internal/plugin/dispatch/errors.go` next to the existing call-path sentinels.

## What this completes
After this PR + #316 (already merged), the full Phase 5 path works end-to-end without manual SQL or workarounds:

| Step | Status |
|---|---|
| Plugin subprocess runs | #316 |
| Host spawns subprocesses on startup (`manager.StartAllActive`) | already there |
| Audience CRUD references a plugin instance | already there (#290) |
| **Dispatcher resolves instance_name → live gRPC conn → Notify RPC** | **this PR** |

## Plan

<details>
<summary>Architecture plan + review highlights</summary>

See `.dev-loop/plan.md` (not committed). Highlights:
- Identity-mismatch trap caught by plan-reviewer cycle: `ConnFactory` keys on `instanceName`, `Manager.Lookup` keys on `instance.ID`. Resolved with `LookupByName`.
- Test fixture must use real `process.Manager.Start` (the `serve-via-sdk` re-exec pattern), NOT the stub starter from `TestManager_ServerInterceptors_PropagateToConfig` — otherwise `inst.Client().Conn()` is nil and the test asserts the wrong thing.
- `loader.Manager()` is already exported (no work needed there).

</details>

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/plugin/... ./plugin-sdk/hostwire/... .` all passing
- [x] `TestManagerConnFactory` — three subtests covering nil manager, missing instance, and a real running subprocess via the `serve-via-sdk` re-exec fixture
- [x] `TestDispatcher_Notify_ProductionWiring` — full integration: spawns a real channel plugin fixture, dispatches `Notify` through the production `dispatch.Dispatcher` wired with the new `Connect` closure, asserts `Ok=true`
- [x] Both new test files gated with `//go:build unix` (matching the existing `process_test.go` pattern — go-plugin needs POSIX process management)

## Pipeline metadata
- Generated by the agentic dev loop. Architect plan went through 1 revise cycle (plan-reviewer caught the identity-mismatch bug; the fix added `Manager.LookupByName` instead of overloading `Lookup`). Code-review approved without changes.
- Independent of #316 at the wiring layer, though end-to-end Phase 5 demos depend on both being merged.
- CLAUDE.md / frontend/CLAUDE.md unchanged — no new packages, env vars, API routes, or domain enums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)