### PR TITLE
feat: subscribed trigger type in policy YAML schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ See `frontend/CLAUDE.md` for detailed frontend architecture (routes, design syst
 
 **Agent** — a run scoped to a specific policy. Tools not granted to a run are never registered with the agent; they do not exist from the agent's perspective.
 
-**Policy** — YAML config defining trigger, agent task prompt, capability grants, and limits. Five trigger types: `webhook`, `manual`, `scheduled`, `poll`, `cron`.
+**Policy** — YAML config defining trigger, agent task prompt, capability grants, and limits. Six trigger types: `webhook`, `manual`, `scheduled`, `poll`, `cron`, `subscribed`.
 
 **Trigger types:**
 - `webhook` — HTTP POST to `/api/v1/webhooks/{policyID}` fires a run
@@ -76,6 +76,7 @@ See `frontend/CLAUDE.md` for detailed frontend architecture (routes, design syst
 - `scheduled` — one-shot runs at specific ISO-8601 timestamps (defined via `fire_at` list in policy YAML; auto-pauses when exhausted)
 - `poll` — recurring polling with MCP tool invocations and JSONPath condition checks
 - `cron` — recurring runs on a 5-field POSIX cron expression (`cron_expr`); runs indefinitely until paused
+- `subscribed` — plugin-sourced events. Policy binds to a `(source, event_kind)` pair declared by an installed plugin's manifest; binding filters use typed form fields (not JSONPath) derived from the manifest's `event_kinds[].binding_schema`. Internal-only type — UI never renders the word "subscribed" (per ADR-048). Runtime dispatch lands in #214.
 
 **Capabilities** — two categories, tracked in Gleipnir's own DB (not in MCP servers):
 - `tool` — MCP tools the agent can call, optionally approval-gated, optionally parameter-scoped (ADR-017)

--- a/internal/db/migrations/0032_add_subscribed_trigger_type.go
+++ b/internal/db/migrations/0032_add_subscribed_trigger_type.go
@@ -1,0 +1,108 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// AddSubscribedTriggerType updates the CHECK constraints on policies, runs, and
+// trigger_queue to include 'subscribed'. New deployments get this from
+// 0001_initial.sql (which already has the updated constraints); this migration
+// is a no-op for them.
+//
+// SQLite cannot ALTER CHECK constraints, so we use the table-recreation pattern.
+// PRAGMA foreign_keys must be toggled OUTSIDE the transaction (SQLite requirement).
+type AddSubscribedTriggerType struct{}
+
+func (m *AddSubscribedTriggerType) Version() int { return 22 }
+func (m *AddSubscribedTriggerType) Name() string { return "add_subscribed_trigger_type" }
+
+func (m *AddSubscribedTriggerType) RequiresForeignKeysOff() bool { return true }
+
+func (m *AddSubscribedTriggerType) ShouldSkip(ctx context.Context, db *sql.DB) (bool, error) {
+	var policiesSQL string
+	err := db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='policies'`,
+	).Scan(&policiesSQL)
+	if err != nil {
+		return false, fmt.Errorf("query policies schema: %w", err)
+	}
+	return strings.Contains(policiesSQL, "'subscribed'"), nil
+}
+
+func (m *AddSubscribedTriggerType) Up(ctx context.Context, tx *sql.Tx) error {
+	// Column order for *_new tables must exactly match the column order in the
+	// current tables (as seen by existing deployments after all prior migrations).
+	// The INSERT INTO ... SELECT * relies on positional column alignment.
+	ddl := `
+CREATE TABLE policies_new (
+    id                        TEXT PRIMARY KEY,
+    name                      TEXT NOT NULL UNIQUE,
+    trigger_type              TEXT NOT NULL CHECK(trigger_type IN ('webhook','manual','scheduled','poll','cron','subscribed')),
+    yaml                      TEXT NOT NULL,
+    created_at                TEXT NOT NULL,
+    updated_at                TEXT NOT NULL,
+    paused_at                 TEXT,
+    webhook_secret_encrypted  TEXT
+);
+INSERT INTO policies_new SELECT * FROM policies;
+DROP TABLE policies;
+ALTER TABLE policies_new RENAME TO policies;
+CREATE INDEX idx_policies_trigger_type ON policies(trigger_type);
+
+CREATE TABLE runs_new (
+    id              TEXT    PRIMARY KEY,
+    policy_id       TEXT    NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
+    status          TEXT    NOT NULL CHECK(status IN (
+                        'pending',
+                        'running',
+                        'waiting_for_approval',
+                        'waiting_for_feedback',
+                        'complete',
+                        'failed',
+                        'interrupted'
+                    )),
+    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron', 'subscribed')),
+    trigger_payload TEXT    NOT NULL,
+    started_at      TEXT    NOT NULL,
+    completed_at    TEXT,
+    token_cost      INTEGER NOT NULL DEFAULT 0,
+    error           TEXT,
+    thread_id       TEXT,
+    created_at      TEXT    NOT NULL,
+    system_prompt   TEXT,
+    model           TEXT    NOT NULL DEFAULT '',
+    version         INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO runs_new SELECT * FROM runs;
+DROP TABLE runs;
+ALTER TABLE runs_new RENAME TO runs;
+CREATE INDEX idx_runs_status         ON runs(status);
+CREATE INDEX idx_runs_created_at     ON runs(created_at DESC);
+CREATE INDEX idx_runs_policy_created ON runs(policy_id, created_at DESC);
+CREATE INDEX idx_runs_policy_status  ON runs(policy_id, status);
+
+CREATE TABLE trigger_queue_new (
+    id              TEXT    PRIMARY KEY,
+    policy_id       TEXT    NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
+    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron', 'subscribed')),
+    trigger_payload TEXT    NOT NULL,
+    position        INTEGER NOT NULL,
+    created_at      TEXT    NOT NULL,
+    UNIQUE(policy_id, position)
+);
+INSERT INTO trigger_queue_new SELECT * FROM trigger_queue;
+DROP TABLE trigger_queue;
+ALTER TABLE trigger_queue_new RENAME TO trigger_queue;
+CREATE INDEX idx_trigger_queue_policy_position ON trigger_queue(policy_id, position);`
+
+	if _, err := tx.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("recreate tables for subscribed trigger type: %w", err)
+	}
+
+	slog.Info("migrated tables to include subscribed trigger type")
+	return nil
+}

--- a/internal/db/migrations/registry.go
+++ b/internal/db/migrations/registry.go
@@ -25,5 +25,6 @@ func All() []Migration {
 		&AddPluginTables{},
 		&AddPluginAudiencesAndPendingRequests{},
 		&AddDisableInAppFallback{},
+		&AddSubscribedTriggerType{},
 	}
 }

--- a/internal/db/plugins.sql.go
+++ b/internal/db/plugins.sql.go
@@ -161,6 +161,37 @@ func (q *Queries) GetPluginByName(ctx context.Context, name string) (Plugin, err
 	return i, err
 }
 
+const getPluginInstanceByGlobalName = `-- name: GetPluginInstanceByGlobalName :one
+SELECT id, plugin_id, instance_name, config_json, credentials_encrypted, credentials_expires_at, handshake_versions, health_state, health_detail, last_oauth_callback_url, version, created_at, updated_at FROM plugin_instances WHERE instance_name = ?1 LIMIT 1
+`
+
+// GetPluginInstanceByGlobalName finds the first instance with the given name
+// across all plugins. Used by subscribed trigger binding to resolve the
+// operator-readable source name to an instance ID.
+// Note: plugin_instances UNIQUE is (plugin_id, instance_name), not global, so
+// cross-plugin name collisions are silently first-wins here. Revisit when #213
+// settles the instance-id pattern.
+func (q *Queries) GetPluginInstanceByGlobalName(ctx context.Context, instanceName string) (PluginInstance, error) {
+	row := q.db.QueryRowContext(ctx, getPluginInstanceByGlobalName, instanceName)
+	var i PluginInstance
+	err := row.Scan(
+		&i.ID,
+		&i.PluginID,
+		&i.InstanceName,
+		&i.ConfigJson,
+		&i.CredentialsEncrypted,
+		&i.CredentialsExpiresAt,
+		&i.HandshakeVersions,
+		&i.HealthState,
+		&i.HealthDetail,
+		&i.LastOauthCallbackUrl,
+		&i.Version,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getPluginInstanceByID = `-- name: GetPluginInstanceByID :one
 SELECT id, plugin_id, instance_name, config_json, credentials_encrypted, credentials_expires_at, handshake_versions, health_state, health_detail, last_oauth_callback_url, version, created_at, updated_at FROM plugin_instances WHERE id = ?1
 `

--- a/internal/db/queries/plugins.sql
+++ b/internal/db/queries/plugins.sql
@@ -44,6 +44,15 @@ SELECT * FROM plugin_instances WHERE id = :id;
 -- name: GetPluginInstanceByName :one
 SELECT * FROM plugin_instances WHERE plugin_id = :plugin_id AND instance_name = :instance_name;
 
+-- GetPluginInstanceByGlobalName finds the first instance with the given name
+-- across all plugins. Used by subscribed trigger binding to resolve the
+-- operator-readable source name to an instance ID.
+-- Note: plugin_instances UNIQUE is (plugin_id, instance_name), not global, so
+-- cross-plugin name collisions are silently first-wins here. Revisit when #213
+-- settles the instance-id pattern.
+-- name: GetPluginInstanceByGlobalName :one
+SELECT * FROM plugin_instances WHERE instance_name = :instance_name LIMIT 1;
+
 -- name: ListPluginInstances :many
 SELECT * FROM plugin_instances ORDER BY plugin_id, instance_name;
 

--- a/internal/http/api/policy_handler.go
+++ b/internal/http/api/policy_handler.go
@@ -53,6 +53,8 @@ func (h *PolicyHandler) notifyTriggers(ctx context.Context, policyID string, tri
 		if h.cron != nil {
 			h.cron.Notify(ctx, policyID)
 		}
+	case model.TriggerTypeSubscribed:
+		// No daemon to notify. The TriggerService dispatcher is wired in #214.
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -33,11 +33,12 @@ const (
 type TriggerType string
 
 const (
-	TriggerTypeWebhook   TriggerType = "webhook"
-	TriggerTypeManual    TriggerType = "manual"
-	TriggerTypeScheduled TriggerType = "scheduled"
-	TriggerTypePoll      TriggerType = "poll"
-	TriggerTypeCron      TriggerType = "cron"
+	TriggerTypeWebhook    TriggerType = "webhook"
+	TriggerTypeManual     TriggerType = "manual"
+	TriggerTypeScheduled  TriggerType = "scheduled"
+	TriggerTypePoll       TriggerType = "poll"
+	TriggerTypeCron       TriggerType = "cron"
+	TriggerTypeSubscribed TriggerType = "subscribed"
 )
 
 // AllTriggerTypes lists every TriggerType constant. Update this slice when a
@@ -50,6 +51,7 @@ var AllTriggerTypes = []TriggerType{
 	TriggerTypeScheduled,
 	TriggerTypePoll,
 	TriggerTypeCron,
+	TriggerTypeSubscribed,
 }
 
 // StepType identifies the kind of event recorded in a run's reasoning trace.
@@ -335,6 +337,9 @@ type TriggerConfig struct {
 	Match       MatchMode       // poll and webhook filter; defaults to MatchAll
 	Checks      []PollCheck     // poll: MCP tool checks (at least one required); webhook: body filter checks (optional)
 	CronExpr    string          // cron only, 5-field POSIX expression
+	Source      string          // subscribed only: plugin instance name
+	EventKind   string          // subscribed only: event kind declared by the plugin
+	Binding     map[string]any  // subscribed only: per-event-kind binding config, validated against the manifest's binding_schema
 }
 
 // FeedbackConfig controls the native human-in-the-loop feedback channel.

--- a/internal/policy/parser.go
+++ b/internal/policy/parser.go
@@ -114,6 +114,12 @@ func convertTrigger(r rawTrigger) model.TriggerConfig {
 		tc.CronExpr = strings.TrimSpace(r.CronExpr)
 	}
 
+	if tc.Type == model.TriggerTypeSubscribed {
+		tc.Source = strings.TrimSpace(r.Source)
+		tc.EventKind = strings.TrimSpace(r.EventKind)
+		tc.Binding = r.Binding
+	}
+
 	if tc.Type == model.TriggerTypePoll {
 		if r.Interval != "" {
 			d, err := time.ParseDuration(r.Interval)
@@ -328,14 +334,17 @@ type rawModel struct {
 }
 
 type rawTrigger struct {
-	Type          string     `yaml:"type"`
-	FireAt        []string   `yaml:"fire_at"`        // scheduled only, RFC3339 timestamps
-	WebhookSecret string     `yaml:"webhook_secret"` // rejected at save time; never propagated to TriggerConfig
-	Auth          string     `yaml:"auth"`           // webhook only: hmac | bearer | none
-	Interval      string     `yaml:"interval"`       // poll only, Go duration string (e.g. "5m")
-	Match         string     `yaml:"match"`          // poll and webhook: "all" or "any", default: "all"
-	Checks        []rawCheck `yaml:"checks"`         // poll: at least one required; webhook: optional body filter
-	CronExpr      string     `yaml:"cron_expr"`      // cron only, 5-field POSIX expression
+	Type          string         `yaml:"type"`
+	FireAt        []string       `yaml:"fire_at"`        // scheduled only, RFC3339 timestamps
+	WebhookSecret string         `yaml:"webhook_secret"` // rejected at save time; never propagated to TriggerConfig
+	Auth          string         `yaml:"auth"`           // webhook only: hmac | bearer | none
+	Interval      string         `yaml:"interval"`       // poll only, Go duration string (e.g. "5m")
+	Match         string         `yaml:"match"`          // poll and webhook: "all" or "any", default: "all"
+	Checks        []rawCheck     `yaml:"checks"`         // poll: at least one required; webhook: optional body filter
+	CronExpr      string         `yaml:"cron_expr"`      // cron only, 5-field POSIX expression
+	Source        string         `yaml:"source"`         // subscribed only: plugin instance name
+	EventKind     string         `yaml:"event_kind"`     // subscribed only: event kind identifier
+	Binding       map[string]any `yaml:"binding"`        // subscribed only: per-event-kind binding config
 }
 
 // rawCheck is one entry in a poll trigger's checks list.

--- a/internal/policy/parser_test.go
+++ b/internal/policy/parser_test.go
@@ -1158,6 +1158,18 @@ capabilities:
 agent:
   task: do it
 `,
+		model.TriggerTypeSubscribed: `
+name: rt-subscribed
+trigger:
+  type: subscribed
+  source: my-plugin
+  event_kind: channel_message
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`,
 	}
 
 	// Catch the case where AllTriggerTypes grew but the fixture map above was not updated.
@@ -1185,6 +1197,93 @@ agent:
 				t.Errorf("Validate() error: %v", err)
 			}
 		})
+	}
+}
+
+func TestParse_Subscribed(t *testing.T) {
+	raw := `
+name: sub-policy
+trigger:
+  type: subscribed
+  source: my-plugin-instance
+  event_kind: channel_message
+  binding:
+    filter: ".*"
+    priority: 1
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: handle event
+`
+	p, err := Parse(raw, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if p.Trigger.Type != model.TriggerTypeSubscribed {
+		t.Errorf("trigger.type = %q, want %q", p.Trigger.Type, model.TriggerTypeSubscribed)
+	}
+	if p.Trigger.Source != "my-plugin-instance" {
+		t.Errorf("trigger.source = %q, want %q", p.Trigger.Source, "my-plugin-instance")
+	}
+	if p.Trigger.EventKind != "channel_message" {
+		t.Errorf("trigger.event_kind = %q, want %q", p.Trigger.EventKind, "channel_message")
+	}
+	if p.Trigger.Binding["filter"] != ".*" {
+		t.Errorf("trigger.binding[filter] = %v, want %q", p.Trigger.Binding["filter"], ".*")
+	}
+	if p.Trigger.Binding["priority"] != 1 {
+		t.Errorf("trigger.binding[priority] = %v, want 1", p.Trigger.Binding["priority"])
+	}
+}
+
+func TestParse_Subscribed_NilBindingOK(t *testing.T) {
+	// Binding is optional; omitting it should leave Binding as nil.
+	raw := `
+name: sub-no-binding
+trigger:
+  type: subscribed
+  source: my-plugin
+  event_kind: heartbeat
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`
+	p, err := Parse(raw, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Trigger.Binding != nil {
+		t.Errorf("trigger.binding = %v, want nil (omitted)", p.Trigger.Binding)
+	}
+}
+
+func TestParse_Subscribed_SourceTrimmed(t *testing.T) {
+	// Source and EventKind are trimmed of surrounding whitespace by the parser.
+	raw := `
+name: sub-whitespace
+trigger:
+  type: subscribed
+  source: "  my-plugin  "
+  event_kind: "  heartbeat  "
+capabilities:
+  tools:
+    - tool: srv.tool
+agent:
+  task: do it
+`
+	p, err := Parse(raw, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Trigger.Source != "my-plugin" {
+		t.Errorf("trigger.source = %q, want %q (should be trimmed)", p.Trigger.Source, "my-plugin")
+	}
+	if p.Trigger.EventKind != "heartbeat" {
+		t.Errorf("trigger.event_kind = %q, want %q (should be trimmed)", p.Trigger.EventKind, "heartbeat")
 	}
 }
 

--- a/internal/policy/service.go
+++ b/internal/policy/service.go
@@ -73,12 +73,13 @@ type SaveResult struct {
 
 // Service orchestrates policy parse → validate → store operations.
 type Service struct {
-	store            *db.Store
-	lookup           ToolLookup        // nil if MCP registry is unavailable
-	modelValidator   ModelValidator    // nil skips model name validation
-	optionsValidator OptionsValidator  // nil skips provider options validation
-	settings         *settings.Service // nil falls back to compiled defaults
-	encrypter        SecretCipher      // nil means encryption not configured
+	store               *db.Store
+	lookup              ToolLookup                  // nil if MCP registry is unavailable
+	modelValidator      ModelValidator              // nil skips model name validation
+	optionsValidator    OptionsValidator            // nil skips provider options validation
+	settings            *settings.Service           // nil falls back to compiled defaults
+	encrypter           SecretCipher                // nil means encryption not configured
+	subscribedValidator *SubscribedBindingValidator // nil skips plugin binding validation
 }
 
 // NewService returns a policy Service. lookup may be nil if MCP registry
@@ -110,6 +111,9 @@ func (s *Service) Create(ctx context.Context, rawYAML string) (*SaveResult, erro
 	}
 	if err := Validate(parsed); err != nil {
 		return nil, err
+	}
+	if issues := s.runSubscribedValidator(ctx, parsed); len(issues) > 0 {
+		return nil, &ValidationError{Errors: issues}
 	}
 	if err := s.validateProviderOptions(parsed); err != nil {
 		return nil, &ValidationError{Errors: []Issue{{Field: "model", Message: err.Error()}}}
@@ -177,6 +181,9 @@ func (s *Service) Update(ctx context.Context, policyID string, rawYAML string) (
 	}
 	if err := Validate(parsed); err != nil {
 		return nil, err
+	}
+	if issues := s.runSubscribedValidator(ctx, parsed); len(issues) > 0 {
+		return nil, &ValidationError{Errors: issues}
 	}
 	if err := s.validateProviderOptions(parsed); err != nil {
 		return nil, &ValidationError{Errors: []Issue{{Field: "model", Message: err.Error()}}}
@@ -270,6 +277,13 @@ func generateWebhookSecret() (string, error) {
 // When nil (the default), those operations return ErrEncryptionUnavailable.
 func (s *Service) WithWebhookSecretEncrypter(e SecretCipher) {
 	s.encrypter = e
+}
+
+// WithSubscribedBindingValidator sets the validator used for subscribed-trigger
+// binding validation. When nil (the default), subscribed binding validation is
+// skipped — structural checks in Validate still run.
+func (s *Service) WithSubscribedBindingValidator(v *SubscribedBindingValidator) {
+	s.subscribedValidator = v
 }
 
 // RotateWebhookSecret generates a fresh 64-hex secret, encrypts it, and persists
@@ -414,6 +428,16 @@ func (s *Service) resolveDefaults(ctx context.Context) (string, string) {
 		return "", ""
 	}
 	return provider, modelName
+}
+
+// runSubscribedValidator runs the I/O-touching subscribed binding validator if
+// one is configured and the trigger type is subscribed. Returns nil (not empty
+// slice) when the validator is absent — structural checks already ran in Validate.
+func (s *Service) runSubscribedValidator(ctx context.Context, p *model.ParsedPolicy) []Issue {
+	if s.subscribedValidator == nil {
+		return nil
+	}
+	return s.subscribedValidator.Validate(ctx, p.Trigger)
 }
 
 // checkToolRefs issues non-blocking warnings for tool references that don't

--- a/internal/policy/subscribed_validator.go
+++ b/internal/policy/subscribed_validator.go
@@ -1,0 +1,101 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
+)
+
+// InstanceManifestResolver resolves a plugin instance name to its instance ID.
+// The caller then passes the ID to Snapshotter.ForInstanceID to load the manifest.
+// Keeping the interface minimal (name→ID only) makes it easy to fake in tests.
+type InstanceManifestResolver interface {
+	ResolveInstanceByName(ctx context.Context, name string) (instanceID string, err error)
+}
+
+// SubscribedBindingValidator performs I/O-touching validation for subscribed
+// triggers: it resolves the source instance, checks that the plugin provides a
+// TriggerService, verifies the event_kind is declared, and validates the binding
+// block against the manifest's binding_schema.
+//
+// Validation is BLOCKING — a non-existent plugin reference can never produce a
+// run, so we reject at save time (422) rather than warning.
+type SubscribedBindingValidator struct {
+	resolver InstanceManifestResolver
+	snap     *configvalidate.Snapshotter
+}
+
+// NewSubscribedBindingValidator returns a SubscribedBindingValidator backed by
+// the given resolver and snapshotter.
+func NewSubscribedBindingValidator(resolver InstanceManifestResolver, snap *configvalidate.Snapshotter) *SubscribedBindingValidator {
+	return &SubscribedBindingValidator{resolver: resolver, snap: snap}
+}
+
+// Validate checks the subscribed-trigger fields in t. Returns nil when t is not
+// a subscribed trigger (fast-path skip) or when all checks pass. Returns one or
+// more Issues on failure.
+func (v *SubscribedBindingValidator) Validate(ctx context.Context, t model.TriggerConfig) []Issue {
+	if t.Type != model.TriggerTypeSubscribed {
+		return nil
+	}
+
+	var issues []Issue
+	add := func(field, format string, args ...any) {
+		issues = append(issues, Issue{Field: field, Message: fmt.Sprintf(format, args...)})
+	}
+
+	// Step 1: resolve the named instance to an ID.
+	instanceID, err := v.resolver.ResolveInstanceByName(ctx, t.Source)
+	if err != nil {
+		add("trigger.source", "no plugin instance named %q", t.Source)
+		return issues
+	}
+
+	// Step 2: fetch the manifest for that instance.
+	m, err := v.snap.ForInstanceID(ctx, instanceID)
+	if err != nil {
+		add("trigger.source", "could not load manifest for instance %q: %v", t.Source, err)
+		return issues
+	}
+
+	// Step 3: verify the plugin provides a TriggerService.
+	if m.Services.Trigger == "" || len(m.EventKinds) == 0 {
+		add("trigger.source", "plugin instance %q does not provide a TriggerService", t.Source)
+		return issues
+	}
+
+	// Step 4: compile the binding validator for the named event kind.
+	bv, err := configvalidate.ForTriggerBinding(m, t.EventKind)
+	if err != nil {
+		if errors.Is(err, configvalidate.ErrEventKindNotFound) {
+			add("trigger.event_kind", "event_kind %q not declared by plugin instance %q", t.EventKind, t.Source)
+		} else {
+			add("trigger.event_kind", "could not compile binding schema for event_kind %q: %v", t.EventKind, err)
+		}
+		return issues
+	}
+
+	// Step 5: validate the binding block against the schema (nil binding is
+	// treated as an empty map — the schema decides whether that is valid).
+	binding := any(t.Binding)
+	if binding == nil {
+		binding = map[string]any{}
+	}
+	fieldErrs, err := bv.Validate(binding)
+	if err != nil {
+		add("trigger.binding", "binding validation error: %v", err)
+		return issues
+	}
+	for _, fe := range fieldErrs {
+		field := "trigger.binding"
+		if fe.Field != "" {
+			field = "trigger.binding." + fe.Field
+		}
+		issues = append(issues, Issue{Field: field, Message: fe.Message})
+	}
+
+	return issues
+}

--- a/internal/policy/subscribed_validator_test.go
+++ b/internal/policy/subscribed_validator_test.go
@@ -1,0 +1,270 @@
+package policy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
+	"gopkg.in/yaml.v3"
+)
+
+// fakeResolver implements InstanceManifestResolver for tests.
+type fakeResolver struct {
+	instances map[string]string // name → instanceID
+}
+
+func (f *fakeResolver) ResolveInstanceByName(_ context.Context, name string) (string, error) {
+	id, ok := f.instances[name]
+	if !ok {
+		return "", fmt.Errorf("instance not found: %q", name)
+	}
+	return id, nil
+}
+
+// fakeManifestQuerier implements configvalidate.ManifestQuerier for tests.
+type fakeManifestQuerier struct {
+	plugins   map[string]db.Plugin         // pluginID → Plugin row
+	instances map[string]db.PluginInstance // instanceID → PluginInstance row
+}
+
+func (q *fakeManifestQuerier) GetPluginByID(_ context.Context, id string) (db.Plugin, error) {
+	p, ok := q.plugins[id]
+	if !ok {
+		return db.Plugin{}, sql.ErrNoRows
+	}
+	return p, nil
+}
+
+func (q *fakeManifestQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
+	inst, ok := q.instances[id]
+	if !ok {
+		return db.PluginInstance{}, sql.ErrNoRows
+	}
+	return inst, nil
+}
+
+// buildManifestYAML returns raw manifest YAML for a TriggerService plugin with
+// the given event kinds and optional binding schemas.
+func buildManifestYAML(t *testing.T, eventKinds []sdkmanifest.EventKindDecl) string {
+	t.Helper()
+	m := sdkmanifest.Manifest{
+		SchemaVersion: "1",
+		Name:          "test-plugin",
+		Version:       "1.0.0",
+		Services:      sdkmanifest.Services{Trigger: "v1"},
+		EventKinds:    eventKinds,
+	}
+	raw, err := yaml.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return string(raw)
+}
+
+// buildBindingSchema returns a *yaml.Node for a simple JSON Schema that
+// requires a string field named "filter".
+func buildBindingSchema(t *testing.T) *yaml.Node {
+	t.Helper()
+	schemaYAML := `
+type: object
+properties:
+  filter:
+    type: string
+required:
+  - filter
+additionalProperties: false
+`
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(schemaYAML), &node); err != nil {
+		t.Fatalf("unmarshal binding schema: %v", err)
+	}
+	// yaml.Unmarshal produces a document node; unwrap to the content node.
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return node.Content[0]
+	}
+	return &node
+}
+
+// newTestValidator wires up a SubscribedBindingValidator with fakes. It returns
+// the validator plus the underlying Snapshotter so tests can call ResetCache.
+func newTestValidator(t *testing.T, instanceName, instanceID, manifestYAML string) (*SubscribedBindingValidator, *configvalidate.Snapshotter) {
+	t.Helper()
+
+	resolver := &fakeResolver{
+		instances: map[string]string{instanceName: instanceID},
+	}
+	querier := &fakeManifestQuerier{
+		plugins: map[string]db.Plugin{
+			"plugin-1": {ID: "plugin-1", ManifestSnapshot: manifestYAML},
+		},
+		instances: map[string]db.PluginInstance{
+			instanceID: {ID: instanceID, PluginID: "plugin-1"},
+		},
+	}
+	snap := configvalidate.NewSnapshotter(querier)
+	return NewSubscribedBindingValidator(resolver, snap), snap
+}
+
+func subscribedTrigger(source, eventKind string, binding map[string]any) model.TriggerConfig {
+	return model.TriggerConfig{
+		Type:      model.TriggerTypeSubscribed,
+		Source:    source,
+		EventKind: eventKind,
+		Binding:   binding,
+	}
+}
+
+func TestSubscribedValidator_NonSubscribedTrigger(t *testing.T) {
+	// Non-subscribed triggers must be skipped immediately (nil return).
+	v, _ := newTestValidator(t, "inst", "inst-id", buildManifestYAML(t, nil))
+	issues := v.Validate(context.Background(), model.TriggerConfig{Type: model.TriggerTypeWebhook})
+	if issues != nil {
+		t.Errorf("expected nil for non-subscribed trigger, got %v", issues)
+	}
+}
+
+func TestSubscribedValidator_UnknownSource(t *testing.T) {
+	manifestYAML := buildManifestYAML(t, []sdkmanifest.EventKindDecl{{Kind: "heartbeat"}})
+	v, snap := newTestValidator(t, "known-instance", "inst-1", manifestYAML)
+	defer snap.ResetCache()
+
+	issues := v.Validate(context.Background(), subscribedTrigger("unknown-instance", "heartbeat", nil))
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(issues), issues)
+	}
+	if issues[0].Field != "trigger.source" {
+		t.Errorf("field = %q, want trigger.source", issues[0].Field)
+	}
+	if !containsString(issues[0].Message, "unknown-instance") {
+		t.Errorf("message %q should mention the unknown instance name", issues[0].Message)
+	}
+}
+
+func TestSubscribedValidator_NoTriggerService(t *testing.T) {
+	// Manifest without Services.Trigger set.
+	noTriggerManifest := `
+schema_version: "1"
+name: test-plugin
+version: 1.0.0
+services: {}
+`
+	querier := &fakeManifestQuerier{
+		plugins:   map[string]db.Plugin{"p1": {ID: "p1", ManifestSnapshot: noTriggerManifest}},
+		instances: map[string]db.PluginInstance{"i1": {ID: "i1", PluginID: "p1"}},
+	}
+	snap := configvalidate.NewSnapshotter(querier)
+	defer snap.ResetCache()
+	resolver := &fakeResolver{instances: map[string]string{"my-inst": "i1"}}
+	v := NewSubscribedBindingValidator(resolver, snap)
+
+	issues := v.Validate(context.Background(), subscribedTrigger("my-inst", "heartbeat", nil))
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(issues), issues)
+	}
+	if issues[0].Field != "trigger.source" {
+		t.Errorf("field = %q, want trigger.source", issues[0].Field)
+	}
+	if !containsString(issues[0].Message, "TriggerService") {
+		t.Errorf("message %q should mention TriggerService", issues[0].Message)
+	}
+}
+
+func TestSubscribedValidator_UnknownEventKind(t *testing.T) {
+	manifestYAML := buildManifestYAML(t, []sdkmanifest.EventKindDecl{{Kind: "heartbeat"}})
+	v, snap := newTestValidator(t, "inst", "i1", manifestYAML)
+	defer snap.ResetCache()
+
+	issues := v.Validate(context.Background(), subscribedTrigger("inst", "no_such_kind", nil))
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(issues), issues)
+	}
+	if issues[0].Field != "trigger.event_kind" {
+		t.Errorf("field = %q, want trigger.event_kind", issues[0].Field)
+	}
+	if !containsString(issues[0].Message, "no_such_kind") {
+		t.Errorf("message %q should mention the unknown event kind", issues[0].Message)
+	}
+}
+
+func TestSubscribedValidator_ValidNoBinding(t *testing.T) {
+	manifestYAML := buildManifestYAML(t, []sdkmanifest.EventKindDecl{{Kind: "heartbeat"}})
+	v, snap := newTestValidator(t, "inst", "i1", manifestYAML)
+	defer snap.ResetCache()
+
+	issues := v.Validate(context.Background(), subscribedTrigger("inst", "heartbeat", nil))
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+func TestSubscribedValidator_BindingSchemaViolation(t *testing.T) {
+	schema := buildBindingSchema(t) // requires "filter" string field
+	manifestYAML := buildManifestYAML(t, []sdkmanifest.EventKindDecl{
+		{Kind: "channel_message", BindingSchema: schema},
+	})
+	v, snap := newTestValidator(t, "inst", "i1", manifestYAML)
+	defer snap.ResetCache()
+
+	// Provide a binding that's missing the required "filter" field.
+	issues := v.Validate(context.Background(), subscribedTrigger("inst", "channel_message", map[string]any{
+		"unknown_field": "bad",
+	}))
+	if len(issues) == 0 {
+		t.Fatal("expected binding schema violation issues, got none")
+	}
+	for _, iss := range issues {
+		if !containsString(iss.Field, "trigger.binding") {
+			t.Errorf("field %q should start with trigger.binding", iss.Field)
+		}
+	}
+}
+
+func TestSubscribedValidator_ValidBinding(t *testing.T) {
+	schema := buildBindingSchema(t) // requires "filter" string field
+	manifestYAML := buildManifestYAML(t, []sdkmanifest.EventKindDecl{
+		{Kind: "channel_message", BindingSchema: schema},
+	})
+	v, snap := newTestValidator(t, "inst", "i1", manifestYAML)
+	defer snap.ResetCache()
+
+	issues := v.Validate(context.Background(), subscribedTrigger("inst", "channel_message", map[string]any{
+		"filter": ".*",
+	}))
+	if len(issues) != 0 {
+		t.Errorf("expected no issues for valid binding, got %v", issues)
+	}
+}
+
+func TestSubscribedValidator_CacheHit(t *testing.T) {
+	// Repeated calls with the same manifest+eventKind must compile the binding
+	// validator schema only once. We verify this by ensuring ForTriggerBinding
+	// is idempotent: two Validate calls succeed and produce no issues. The
+	// underlying cachedCompile function is covered in configvalidate tests; here
+	// we just confirm the integration is wired correctly.
+	schema := buildBindingSchema(t)
+	manifestYAML := buildManifestYAML(t, []sdkmanifest.EventKindDecl{
+		{Kind: "channel_message", BindingSchema: schema},
+	})
+	v, snap := newTestValidator(t, "inst", "i1", manifestYAML)
+	defer snap.ResetCache()
+
+	tc := subscribedTrigger("inst", "channel_message", map[string]any{"filter": "x"})
+
+	for i := range 3 {
+		issues := v.Validate(context.Background(), tc)
+		if len(issues) != 0 {
+			t.Fatalf("call %d: unexpected issues %v", i+1, issues)
+		}
+	}
+}
+
+// containsString is a local test helper.
+func containsString(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/internal/policy/validator.go
+++ b/internal/policy/validator.go
@@ -73,7 +73,7 @@ func validateTrigger(t model.TriggerConfig) []Issue {
 	}
 
 	if !t.Type.Valid() {
-		add("trigger.type", "trigger.type %q is invalid; must be webhook, manual, scheduled, poll, or cron", t.Type)
+		add("trigger.type", "trigger.type %q is invalid; must be webhook, manual, scheduled, poll, cron, or subscribed", t.Type)
 		return issues // can't validate type-specific fields without a valid type
 	}
 
@@ -147,6 +147,14 @@ func validateTrigger(t model.TriggerConfig) []Issue {
 			} else if !c.Comparator.Valid() {
 				add(fmt.Sprintf("trigger.checks[%d].comparator", i), "trigger.checks[%d].comparator %q is invalid; must be equals, not_equals, greater_than, less_than, or contains", i, c.Comparator)
 			}
+		}
+
+	case model.TriggerTypeSubscribed:
+		if t.Source == "" {
+			add("trigger.source", "trigger.source is required for subscribed triggers")
+		}
+		if t.EventKind == "" {
+			add("trigger.event_kind", "trigger.event_kind is required for subscribed triggers")
 		}
 	}
 

--- a/internal/policy/validator_test.go
+++ b/internal/policy/validator_test.go
@@ -612,6 +612,32 @@ func assertIssueField(t *testing.T, p *model.ParsedPolicy, field, messageSubstr 
 	}
 }
 
+func TestValidate_SubscribedTrigger_Valid(t *testing.T) {
+	p := validPolicy()
+	p.Trigger.Type = model.TriggerTypeSubscribed
+	p.Trigger.Source = "my-plugin"
+	p.Trigger.EventKind = "channel_message"
+	if err := Validate(p); err != nil {
+		t.Errorf("expected valid subscribed trigger, got: %v", err)
+	}
+}
+
+func TestValidate_SubscribedTrigger_MissingSource(t *testing.T) {
+	p := validPolicy()
+	p.Trigger.Type = model.TriggerTypeSubscribed
+	p.Trigger.EventKind = "channel_message"
+	// Source is intentionally empty
+	assertIssueField(t, p, "trigger.source", "required")
+}
+
+func TestValidate_SubscribedTrigger_MissingEventKind(t *testing.T) {
+	p := validPolicy()
+	p.Trigger.Type = model.TriggerTypeSubscribed
+	p.Trigger.Source = "my-plugin"
+	// EventKind is intentionally empty
+	assertIssueField(t, p, "trigger.event_kind", "required")
+}
+
 // TestValidate_IssueFields verifies that each validator rule tags its output
 // with the canonical field path exposed to the frontend. One representative
 // case per field family suffices — the full rule logic is covered by the

--- a/main.go
+++ b/main.go
@@ -350,6 +350,13 @@ func run(cfg config.Config) error {
 	if webhookEncrypter != nil {
 		policyService.WithWebhookSecretEncrypter(webhookEncrypter)
 	}
+	if cfg.PluginsEnabled {
+		snap := configvalidate.NewSnapshotter(store.Queries())
+		resolver := &pluginInstanceResolver{q: store.Queries()}
+		policyService.WithSubscribedBindingValidator(
+			policy.NewSubscribedBindingValidator(resolver, snap),
+		)
+	}
 	policyWebhookHandler := api.NewPolicyWebhookHandler(policyService)
 
 	scheduler := trigger.NewScheduler(store, launcher, systemSettings)
@@ -691,6 +698,20 @@ func (a *pluginDispatchAdapter) Call(ctx context.Context, runID, policyID, insta
 		}
 	}
 	return output, isError, err
+}
+
+// pluginInstanceResolver adapts *db.Queries to satisfy policy.InstanceManifestResolver.
+// It looks up a plugin instance by its human-readable name across all plugins.
+type pluginInstanceResolver struct {
+	q *db.Queries
+}
+
+func (r *pluginInstanceResolver) ResolveInstanceByName(ctx context.Context, name string) (string, error) {
+	inst, err := r.q.GetPluginInstanceByGlobalName(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("resolve instance %q: %w", name, err)
+	}
+	return inst.ID, nil
 }
 
 // managerConnFactory resolves a *grpc.ClientConn for a named plugin instance by

--- a/schemas/policy.yaml
+++ b/schemas/policy.yaml
@@ -75,7 +75,10 @@ model:
 
 trigger:
 
-  # type: webhook | manual | scheduled | poll | cron — required
+  # type: webhook | manual | scheduled | poll | cron | subscribed — required
+  #   subscribed: policy fires when a plugin's TriggerService emits a matching
+  #   event. The UI presents subscribed triggers using the event kind's
+  #   human-readable name rather than the string "subscribed" (spec §7.1).
   type: webhook
 
 
@@ -174,6 +177,27 @@ trigger:
   #   down when a fire time passed, that fire is silently skipped (no
   #   catch-up). Cron policies run indefinitely until paused or deleted.
   cron_expr: "0 9 * * 1"
+
+
+  # --- subscribed ---
+  # source: string — required for subscribed
+  #   The plugin instance name that provides the TriggerService to listen to.
+  #   Must match an existing plugin_instances.instance_name; resolved globally
+  #   by name (LIMIT 1 across all plugins — unique instance names are strongly
+  #   recommended). Runtime dispatch is wired in issue #214.
+  source: my-plugin-instance
+
+  # event_kind: string — required for subscribed
+  #   The event kind identifier (e.g. "channel_message") declared by the plugin
+  #   in its manifest under event_kinds[].kind. Must be present in the manifest.
+  event_kind: channel_message
+
+  # binding: map — optional
+  #   Per-event-kind binding configuration. Validated at save time against the
+  #   manifest's event_kinds[].binding_schema using JSON Schema. The shape is
+  #   defined by the plugin author; see the plugin's manifest for the schema.
+  binding:
+    filter: ".*"
 
 
 # ---------------------------------------------------------------------------

--- a/schemas/sql_schemas.sql
+++ b/schemas/sql_schemas.sql
@@ -66,7 +66,7 @@ CREATE INDEX idx_mcp_tools_server_id ON mcp_tools(server_id);
 CREATE TABLE policies (
     id              TEXT    PRIMARY KEY,  -- ULID
     name            TEXT    NOT NULL UNIQUE,
-    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron')),
+    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron', 'subscribed')),
     yaml            TEXT    NOT NULL,
     -- Encrypted webhook shared secret (AES-256-GCM, key from GLEIPNIR_ENCRYPTION_KEY).
     -- Stored outside yaml because yaml is returned wholesale via GET /api/v1/policies/:id — see ADR-034.
@@ -110,7 +110,7 @@ CREATE TABLE runs (
                         'failed',
                         'interrupted'
                     )),
-    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron')),
+    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron', 'subscribed')),
     trigger_payload TEXT    NOT NULL,     -- JSON blob
     started_at      TEXT    NOT NULL,     -- ISO 8601 UTC
     completed_at    TEXT,                 -- nullable, ISO 8601 UTC
@@ -302,7 +302,7 @@ CREATE TABLE user_roles (
 CREATE TABLE trigger_queue (
     id              TEXT    PRIMARY KEY,  -- ULID
     policy_id       TEXT    NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
-    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron')),
+    trigger_type    TEXT    NOT NULL CHECK(trigger_type IN ('webhook', 'manual', 'scheduled', 'poll', 'cron', 'subscribed')),
     trigger_payload TEXT    NOT NULL,     -- JSON blob
     position        INTEGER NOT NULL,     -- monotonically increasing per-policy ordering
     created_at      TEXT    NOT NULL,     -- ISO 8601 UTC


### PR DESCRIPTION
Closes #216
Milestone: Phase 6 — TriggerService (#160)
Implements: ADR-048

## Summary

Lands the **internal `subscribed` trigger type** at the schema/parser/validator layer. A subscribed policy binds to a `(source, event_kind)` pair declared by an installed plugin's manifest, with a typed `binding` block validated at save time against the manifest's `event_kinds[].binding_schema`.

**What runs:** policy parsing + structural validation + DB save with the new CHECK value. **What doesn't yet:** runtime dispatch — saved subscribed policies lie dormant until #214 wires the TriggerService.

## Acceptance criteria

- [x] `schemas/policy.yaml` documents `subscribed` (type, source, event_kind, binding)
- [x] `internal/policy/` parser + validator handle the new type
- [x] Validation: source must reference an existing plugin instance whose manifest declares a TriggerService; event_kind must be declared by that plugin
- [x] Binding validated against the manifest's `event_kinds[].binding_schema` via `santhosh-tekuri/jsonschema/v6` (existing `configvalidate.ForTriggerBinding`)
- [x] Compiled validator cached — key is `"trigger:<event_kind>:<sha256(schema)>"` per the existing per-package cache; identical schema bytes across manifests collapse onto the same compiled validator
- [x] v1 limit preserved — `trigger:` remains a single object in YAML; no list shape introduced
- [x] `policies.trigger_type` indexed column accepts `'subscribed'` via new migration `0032_add_subscribed_trigger_type.go` (`Version() = 22`; table-recreation pattern from migration 0026)

## What changed

- **Model**: `TriggerTypeSubscribed` added to `TriggerType` enum and `AllTriggerTypes`. `TriggerConfig` gains sparse `Source`, `EventKind`, `Binding` fields (mirrors how `FireAt` / `CronExpr` are type-specific).
- **Migration `0032`** widens DB CHECK on `policies.trigger_type`, `runs.trigger_type`, `trigger_queue.trigger_type` via the table-recreation pattern (SQLite can't `ALTER … CHECK`). `RequiresForeignKeysOff()` returns true to match the pattern in `0026`. `ShouldSkip` probes for `'subscribed'` in the policies DDL.
- **Schema docs**: `schemas/sql_schemas.sql` CHECK lists updated for documentation parity. `schemas/policy.yaml` gets a new `--- subscribed ---` block.
- **Parser** (`internal/policy/parser.go`): `rawTrigger` gains the three new YAML-tagged fields; `convertTrigger` populates them when `type == subscribed`.
- **Structural validator** (`internal/policy/validator.go`): pure no-I/O `case TriggerTypeSubscribed` that requires `source != ""` and `event_kind != ""`.
- **I/O validator** (new `internal/policy/subscribed_validator.go`): `InstanceManifestResolver` interface (`ResolveInstanceByName(ctx, name) (instanceID string, err error)`) + `SubscribedBindingValidator` struct. Resolves source → instance → manifest, checks `Services.Trigger != ""` and the event_kind is declared, then runs the binding through `configvalidate.ForTriggerBinding`. **Returns a BLOCKING `ValidationError`** (422), not a warning — an unresolvable plugin reference can never produce a run.
- **Service wiring**: `internal/policy/service.go` gets the void-setter `WithSubscribedBindingValidator` (matches `WithWebhookSecretEncrypter`); `Create` and `Update` call the validator after structural `Validate` and before model-options check.
- **`main.go`**: small `pluginInstanceResolver` adapter over `store.Queries()`; constructed and attached when `GLEIPNIR_PLUGINS_ENABLED=true`.
- **`policy_handler.go::notifyTriggers`**: explicit comment-only `case TriggerTypeSubscribed: // No daemon to notify. The TriggerService dispatcher is wired in #214.` — so the deliberate omission stays greppable.
- **New sqlc query**: `GetPluginInstanceByGlobalName` (global cross-plugin name lookup; see "Known gap" below).
- **CLAUDE.md**: trigger-types count + `subscribed` entry added.

## Tests

- `parser_test.go`: subscribed added to the `AllTriggerTypes` round-trip fixture, plus three focused tests (binding round-trip, nil-binding, whitespace trimming).
- `validator_test.go`: 3 structural cases (missing source, missing event_kind, valid minimal).
- `subscribed_validator_test.go` (new, 7 cases): non-subscribed fast-path skip, unknown source, no TriggerService, unknown event_kind, binding violation, valid binding, cache-call idempotency.

## Known gap (flagged for follow-up)

`plugin_instances` has `UNIQUE (plugin_id, instance_name)` only — there's no global uniqueness on `instance_name`. `GetPluginInstanceByGlobalName` is silently first-wins on cross-plugin name collisions. The query file carries a TODO; the right fix is to mirror whichever instance-id pattern the audience picker (#213) settles on. Out of scope for #216.

## Coordinator note: `sqlc generate` cascade

The developer's local `sqlc` is **v1.31.1**; the checked-in files were generated with **v1.30.0**. Running `sqlc generate` cascade-regenerated all 33 `*.sql.go` files with cosmetic version-comment bumps AND retyped `HasScheduledRunSince` from `int64` → `bool` (correct per `EXISTS` semantics in v1.31). The coordinator reverted the cascade and kept only the new `GetPluginInstanceByGlobalName` query in `plugins.sql.go` (with the v1.30.0 comment preserved). The sqlc version bump should land in a dedicated PR.

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` on the agent branch. Plan-reviewer caught 3 blockers on first pass:
- Migration `Version()` must be 22, not 32 (`0031` is at version 21).
- `GetPluginInstanceByGlobalName` does not exist — must be added explicitly + sqlc generate.
- `notifyTriggers` switch needs an explicit comment-only case for grep-ability.

All three folded into the revised plan, all three landed in the implementation.

</details>

## Review cycles

One cycle. Reviewer flagged one non-blocking doc-comment inaccuracy (`Validate` returns nil on success, not "empty slice not nil"); fixed in the same commit.

## CLAUDE.md updated

- "Core domain concepts" trigger types count updated from five → six
- New `subscribed` bullet referencing ADR-048 and noting runtime dispatch lands in #214

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/policy/... ./internal/db/migrations/... ./internal/trigger/... ./internal/db/...` green
- [x] `go vet ./...` clean (via commit hook)
- [x] Migration round-trip (commit hook runs migration tests)
- [ ] Manual: save a subscribed policy via the API and confirm 422 on unknown source / unknown event_kind / binding mismatch (UI not yet rendering — curl-only verification once #214 + frontend land)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.