### PR TITLE
feat: RunHistoryRead subscribed-trigger scoping

### DIFF
--- a/internal/plugin/hostsvc/handlers.go
+++ b/internal/plugin/hostsvc/handlers.go
@@ -612,16 +612,21 @@ func (s *Server) hasTier2Capability(ctx context.Context, inst db.PluginInstance,
 	return m.HasTier2(capability), nil
 }
 
-// scopeProbe is a minimal struct for scanning the capabilities.tools[].tool
-// field out of a policy YAML blob. We use only what is needed to determine
-// whether the policy references the calling instance via tool grants, avoiding
-// a dependency on internal/policy which would create an import cycle.
+// scopeProbe is a minimal struct for scanning the fields out of a policy YAML
+// blob that determine whether the policy references the calling instance.
+// We extract only what is needed to avoid a dependency on internal/policy,
+// which would create an import cycle.
 type scopeProbe struct {
 	Capabilities struct {
 		Tools []struct {
 			Tool string `yaml:"tool"`
 		} `yaml:"tools"`
 	} `yaml:"capabilities"`
+	Trigger struct {
+		Type      string `yaml:"type"`
+		Source    string `yaml:"source"`
+		EventKind string `yaml:"event_kind"`
+	} `yaml:"trigger"`
 }
 
 // policyGrantsInstance reports whether the policy YAML blob grants at least one
@@ -642,11 +647,11 @@ func policyGrantsInstance(policyYAML, instanceName string) bool {
 	return false
 }
 
-// policyIDsForInstance returns the IDs of policies that reference inst's
-// tools — i.e. policies whose capabilities.tools list contains at least one
-// entry with the prefix "<instanceName>.".
-//
-// Subscribed-trigger matching is deferred (TODO: parent #158).
+// policyIDsForInstance returns the IDs of policies that reference inst via
+// tool grants (capabilities.tools contains an entry with the prefix
+// "<instanceName>.") OR via a subscribed trigger (trigger.type == "subscribed"
+// and trigger.source == instanceName). A policy reachable through both paths
+// appears exactly once.
 func (s *Server) policyIDsForInstance(ctx context.Context, inst db.PluginInstance) ([]string, error) {
 	policies, err := s.q.ListPolicies(ctx)
 	if err != nil {
@@ -661,11 +666,21 @@ func (s *Server) policyIDsForInstance(ctx context.Context, inst db.PluginInstanc
 			// Corrupt policy YAML is not a reason to fail the RPC — skip it.
 			continue
 		}
+
+		matched := false
 		for _, t := range probe.Capabilities.Tools {
 			if strings.HasPrefix(t.Tool, prefix) {
-				ids = append(ids, pol.ID)
+				matched = true
 				break
 			}
+		}
+		if !matched &&
+			probe.Trigger.Type == string(model.TriggerTypeSubscribed) &&
+			probe.Trigger.Source == inst.InstanceName {
+			matched = true
+		}
+		if matched {
+			ids = append(ids, pol.ID)
 		}
 	}
 	return ids, nil

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -1727,6 +1727,18 @@ capabilities:
 `
 }
 
+// policyYAMLWithSubscribedSource returns a minimal policy YAML blob with a
+// subscribed trigger pointing at the given source instance and event kind, and
+// no capabilities.tools entries — used to test subscription-based scoping.
+func policyYAMLWithSubscribedSource(source, eventKind string) string {
+	return `task: do something
+trigger:
+  type: subscribed
+  source: ` + source + `
+  event_kind: ` + eventKind + `
+`
+}
+
 // ── tests: RunHistoryRead ─────────────────────────────────────────────────────
 
 func TestRunHistoryRead_CapabilityDenied(t *testing.T) {
@@ -1824,6 +1836,88 @@ func TestRunHistoryRead_ScopedPolicyMatch(t *testing.T) {
 	}
 	if r.GetFinishedAt() != completedAt {
 		t.Errorf("finished_at = %q, want %q", r.GetFinishedAt(), completedAt)
+	}
+}
+
+func TestRunHistoryRead_SubscribedScoping(t *testing.T) {
+	t.Parallel()
+
+	startedAt := "2024-06-01T10:00:00Z"
+	createdAt := "2024-06-01T09:55:00Z"
+
+	// makeRun produces a single ListRunsByPolicyRow for the given policy ID.
+	makeRun := func(runID, policyID string) db.ListRunsByPolicyRow {
+		return db.ListRunsByPolicyRow{
+			ID:        runID,
+			PolicyID:  policyID,
+			Status:    "complete",
+			StartedAt: startedAt,
+			CreatedAt: createdAt,
+		}
+	}
+
+	cases := []struct {
+		name       string
+		policyYAML string
+		wantRuns   int
+	}{
+		{
+			name:       "tool-grant only",
+			policyYAML: policyYAMLWithTool("myplugin.do_thing"),
+			wantRuns:   1,
+		},
+		{
+			name:       "subscription only",
+			policyYAML: policyYAMLWithSubscribedSource("myplugin", "something_happened"),
+			wantRuns:   1,
+		},
+		{
+			// Policy has both a tool grant and a subscribed trigger — the run
+			// must appear exactly once.
+			name: "both tool-grant and subscription",
+			policyYAML: `task: do something
+trigger:
+  type: subscribed
+  source: myplugin
+  event_kind: something_happened
+capabilities:
+  tools:
+    - tool: myplugin.do_thing
+`,
+			wantRuns: 1,
+		},
+		{
+			name:       "neither — different plugin",
+			policyYAML: policyYAMLWithTool("otherplugin.do_thing"),
+			wantRuns:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			policyID := "pol-1"
+			q := &fakeQuerier{
+				instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
+				plugin:   db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("run_history_read")},
+				policies: []db.Policy{
+					{ID: policyID, Yaml: tc.policyYAML},
+				},
+				runsByPolicy: map[string][]db.ListRunsByPolicyRow{
+					policyID: {makeRun("run-1", policyID)},
+				},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			resp, err := srv.RunHistoryRead(context.Background(), &hostv1.RunHistoryReadRequest{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(resp.GetRuns()) != tc.wantRuns {
+				t.Errorf("runs = %d, want %d", len(resp.GetRuns()), tc.wantRuns)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #288

## Summary

Widens `policyIDsForInstance` (`internal/plugin/hostsvc/handlers.go`) so a Tier-2 `RunHistoryRead` caller also sees runs from policies that subscribe to events emitted by the calling plugin instance, in addition to the existing tool-grant scoping. Policies reachable through both paths appear exactly once.

- Extended `scopeProbe` with a `Trigger` sub-struct (`type`, `source`, `event_kind`).
- Added subscribed-source fallback in `policyIDsForInstance`; match is on `trigger.source == instance_name`.
- Removed the deferred-TODO comment; updated the doc comment to describe the dual scoping.
- Used `model.TriggerTypeSubscribed` rather than a bare string literal.

## Test coverage

New table-driven test `TestRunHistoryRead_SubscribedScoping` with four cases per AC #4:
- tool-grant only → in scope
- subscription only → in scope (new behavior)
- both → in scope, exactly once (dedup)
- neither → out of scope

## Scope notes

- `policyGrantsInstance` (used for feedback-request scoping) is intentionally untouched — issue scope is `RunHistoryRead` only. Parity gap noted for a follow-up.
- No new sqlc queries; reuses the existing `ListPolicies` + in-handler YAML scan.

## Pipeline

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` in the source tree during the run. Dual-scope match on `trigger.source`; single `matched` flag for dedup; no new DB queries.

</details>

Review cycles: 1 (plan approved on first pass, code review approved on first pass). CLAUDE.md is current — no documentation updates needed.

🤖 Generated by the agentic /dev-loop pipeline.