### PR TITLE
feat: refresh failure → unhealthy + admin Re-authorize button

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -507,6 +507,15 @@ export interface ApiPluginInstanceForAudience {
   // version is the CAS version of the instance row, used for optimistic
   // concurrency control on subscription scope saves.
   version: number
+  // auth_strategy is the manifest-declared credential strategy
+  // (e.g. "oauth2_authcode", "oauth2_clientcred", "static_api_key").
+  // Empty string when the manifest has no auth section. Used by the
+  // Re-authorize banner to determine which OAuth flow to restart (#228).
+  auth_strategy?: string
+  // health_detail is the detail string from the most recent health transition.
+  // Absent when the instance has no detail. Used together with auth_strategy
+  // and state to gate the Re-authorize banner (#228).
+  health_detail?: string
 }
 
 // Request body interfaces for audience mutations.

--- a/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.module.css
+++ b/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.module.css
@@ -1,0 +1,4 @@
+/* ReauthorizeButton has no additional styles beyond what Button provides.
+   This file exists so the component folder structure is consistent with other
+   admin components (e.g. PluginHealthChip) that may need component-specific
+   overrides in future. */

--- a/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.stories.tsx
+++ b/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@/tokens.css'
+import { ReauthorizeButton } from './ReauthorizeButton'
+
+const meta: Meta<typeof ReauthorizeButton> = {
+  title: 'Admin/ReauthorizeButton',
+  component: ReauthorizeButton,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <div style={{ padding: 16 }}>
+          <Story />
+        </div>
+      </QueryClientProvider>
+    ),
+  ],
+  args: {
+    pluginId: 'plugin-slack-01',
+    instanceId: 'inst-slack-prod',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ReauthorizeButton>
+
+// For oauth2_authcode: clicking will attempt to navigate to an authorize URL.
+export const AuthcodeStrategy: Story = {
+  args: { strategy: 'oauth2_authcode' },
+}
+
+// For oauth2_clientcred: clicking performs the token exchange synchronously
+// (no browser redirect).
+export const ClientcredStrategy: Story = {
+  args: { strategy: 'oauth2_clientcred' },
+}
+
+// Non-OAuth strategies render nothing — the component is a no-op.
+export const NonOAuthStrategyRendersNothing: Story = {
+  args: { strategy: 'static_api_key' },
+}
+
+// Pending state — the button is disabled and shows "Starting…".
+// Note: Storybook can't freeze mutation.isPending=true without MSW; the
+// unit test in ReauthorizeButton.test.tsx validates this behavior directly.
+export const PendingState: Story = {
+  args: { strategy: 'oauth2_authcode' },
+  name: 'Pending state (label "Starting…")',
+}
+
+// Error state — the mutation has failed; the button is re-enabled for retry.
+export const ErrorState: Story = {
+  args: { strategy: 'oauth2_authcode' },
+  name: 'Error state (button re-enabled after failure)',
+}

--- a/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.test.tsx
+++ b/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { ReauthorizeButton } from './ReauthorizeButton'
+import type { BeginPluginOAuthResponse } from '@/hooks/mutations/plugins'
+
+vi.mock('@/hooks/mutations/plugins')
+import { useBeginPluginOAuth } from '@/hooks/mutations/plugins'
+
+// Helpers
+
+function renderButton(strategy: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ReauthorizeButton pluginId="plugin-1" instanceId="inst-1" strategy={strategy} />
+    </QueryClientProvider>,
+  )
+}
+
+function mockMutation(overrides: Partial<ReturnType<typeof useBeginPluginOAuth>>) {
+  vi.mocked(useBeginPluginOAuth).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useBeginPluginOAuth>)
+}
+
+// Reset mocks between tests
+beforeEach(() => {
+  mockMutation({})
+})
+
+// --- Strategy gate ---
+
+describe('ReauthorizeButton — strategy gate', () => {
+  it('renders a button for oauth2_authcode', () => {
+    renderButton('oauth2_authcode')
+    expect(screen.getByRole('button', { name: 'Re-authorize' })).toBeInTheDocument()
+  })
+
+  it('renders a button for oauth2_clientcred', () => {
+    renderButton('oauth2_clientcred')
+    expect(screen.getByRole('button', { name: 'Re-authorize' })).toBeInTheDocument()
+  })
+
+  it('renders nothing for non-OAuth strategies', () => {
+    renderButton('static_api_key')
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for header_set strategy', () => {
+    renderButton('header_set')
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for basic_auth strategy', () => {
+    renderButton('basic_auth')
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})
+
+// --- Authcode redirect ---
+
+describe('ReauthorizeButton — authcode redirect', () => {
+  it('sets window.location.href to authorize_url on success', () => {
+    // Replace window.location entirely so jsdom's non-configurable href doesn't block us.
+    const originalLocation = window.location
+    let capturedHref = ''
+    const fakeLocation = Object.create(null)
+    Object.assign(fakeLocation, {
+      pathname: '/admin/plugins/plugin-1/instances/inst-1',
+      search: '',
+    })
+    Object.defineProperty(fakeLocation, 'href', {
+      get() { return capturedHref },
+      set(v: string) { capturedHref = v },
+      configurable: true,
+    })
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: fakeLocation,
+    })
+
+    const mutateFn = vi.fn((_params, opts) => {
+      const res: BeginPluginOAuthResponse = { authorize_url: 'https://provider.example.com/auth' }
+      opts?.onSuccess?.(res)
+    })
+    mockMutation({ mutate: mutateFn })
+
+    renderButton('oauth2_authcode')
+    fireEvent.click(screen.getByRole('button', { name: 'Re-authorize' }))
+
+    expect(mutateFn).toHaveBeenCalledOnce()
+    expect(capturedHref).toBe('https://provider.example.com/auth')
+
+    Object.defineProperty(window, 'location', { writable: true, value: originalLocation })
+  })
+})
+
+// --- Clientcred: no redirect ---
+
+describe('ReauthorizeButton — clientcred no redirect', () => {
+  it('calls mutate and does not redirect when authorize_url is absent', () => {
+    const mutateFn = vi.fn((_params, opts) => {
+      const res: BeginPluginOAuthResponse = { status: 'ok' }
+      opts?.onSuccess?.(res)
+    })
+    mockMutation({ mutate: mutateFn })
+
+    renderButton('oauth2_clientcred')
+    fireEvent.click(screen.getByRole('button', { name: 'Re-authorize' }))
+
+    expect(mutateFn).toHaveBeenCalledOnce()
+    // No navigation assertion — the browser stays on the same page, which is
+    // the correct behavior for a synchronous clientcred grant.
+  })
+})
+
+// --- Pending state ---
+
+describe('ReauthorizeButton — pending state', () => {
+  it('shows "Starting…" and is disabled while isPending', () => {
+    mockMutation({ isPending: true })
+    renderButton('oauth2_authcode')
+    const btn = screen.getByRole('button', { name: 'Starting…' })
+    expect(btn).toBeDisabled()
+  })
+})
+
+// --- Error path ---
+
+describe('ReauthorizeButton — error path', () => {
+  it('calls mutate even when a previous call errored (button stays enabled)', () => {
+    const mutateFn = vi.fn()
+    mockMutation({ mutate: mutateFn, isPending: false })
+
+    renderButton('oauth2_authcode')
+    fireEvent.click(screen.getByRole('button', { name: 'Re-authorize' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Re-authorize' }))
+
+    expect(mutateFn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.tsx
+++ b/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@/components/Button'
+import { useBeginPluginOAuth } from '@/hooks/mutations/plugins'
+
+interface ReauthorizeButtonProps {
+  pluginId: string
+  instanceId: string
+  strategy: string
+}
+
+const OAUTH_STRATEGIES = ['oauth2_authcode', 'oauth2_clientcred']
+
+// ReauthorizeButton renders a primary button that restarts the OAuth dance for
+// an instance whose token refresh has failed (#228). It only renders for OAuth
+// strategies; calling it on a non-OAuth instance is a no-op by design so it
+// can safely be dropped into surfaces that may not gate strategy up-front.
+export function ReauthorizeButton({ pluginId, instanceId, strategy }: ReauthorizeButtonProps) {
+  const mutation = useBeginPluginOAuth()
+
+  // Defense-in-depth: only OAuth strategies need re-authorization. The page
+  // already gates on isOAuthRefreshFailure, so this guard should not normally
+  // fire in production.
+  if (!OAUTH_STRATEGIES.includes(strategy)) {
+    return null
+  }
+
+  function handleClick() {
+    const returnUrl = window.location.pathname + window.location.search
+    mutation.mutate(
+      { pluginId, instanceId, returnUrl },
+      {
+        onSuccess(data) {
+          if (data.authorize_url) {
+            // authcode: redirect the browser to the provider's authorization page.
+            window.location.href = data.authorize_url
+          }
+          // clientcred: exchange is synchronous; query invalidation in the
+          // mutation's onSuccess already refreshes instance state.
+        },
+      },
+    )
+  }
+
+  return (
+    <Button
+      variant="primary"
+      size="small"
+      onClick={handleClick}
+      disabled={mutation.isPending}
+    >
+      {mutation.isPending ? 'Starting…' : 'Re-authorize'}
+    </Button>
+  )
+}

--- a/frontend/src/hooks/mutations/plugins.ts
+++ b/frontend/src/hooks/mutations/plugins.ts
@@ -3,6 +3,48 @@ import { apiFetch } from '@/api/fetch'
 import type { ApiAcceptNewKeyResponse } from '@/api/types'
 import { queryKeys } from '../queryKeys'
 
+// BeginPluginOAuthParams carries the inputs for POST .../oauth/begin.
+export interface BeginPluginOAuthParams {
+  pluginId: string
+  instanceId: string
+  returnUrl: string
+}
+
+// BeginPluginOAuthResponse is the server response from POST .../oauth/begin.
+// For oauth2_authcode the server returns authorize_url; the browser must
+// navigate there to continue the OAuth dance.
+// For oauth2_clientcred the exchange is synchronous and the server returns
+// status: "ok" with no authorize_url.
+export interface BeginPluginOAuthResponse {
+  authorize_url?: string
+  status?: string
+}
+
+// useBeginPluginOAuth posts to the begin-oauth endpoint for an instance.
+// On success it invalidates the plugin-instances query so re-authorization
+// state (health_state, health_detail) is refreshed across the UI.
+export function useBeginPluginOAuth() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ pluginId, instanceId, returnUrl }: BeginPluginOAuthParams) =>
+      apiFetch<BeginPluginOAuthResponse>(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances/${encodeURIComponent(instanceId)}/oauth/begin`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ return_url: returnUrl }),
+        },
+      ),
+    onSuccess: () => {
+      // Refresh instance list so health state reflects any synchronous change
+      // (clientcred) or a prior refresh-failure banner clears after authcode
+      // round-trip.
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.admin.pluginInstances,
+      })
+    },
+  })
+}
+
 // SetInstanceSubscriptionScopeParams carries the payload for
 // PUT /api/v1/admin/plugins/{id}/instances/{iid}/subscription-scope.
 export interface SetInstanceSubscriptionScopeParams {

--- a/frontend/src/pages/AdminPluginInstancePage.module.css
+++ b/frontend/src/pages/AdminPluginInstancePage.module.css
@@ -19,6 +19,21 @@
   color: var(--text-primary);
 }
 
+/* Re-authorize banner — shown when health_state is unhealthy due to OAuth
+   refresh failure. Amber tint matches the approval-pending color convention. */
+
+.reauthBanner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(240, 200, 48, 0.12); /* amber tint — --color-amber at 12% opacity */
+  border: 1px solid rgba(240, 200, 48, 0.3);
+  border-radius: 4px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
 /* Tabs */
 
 .tabs {

--- a/frontend/src/pages/AdminPluginInstancePage.stories.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.stories.tsx
@@ -5,6 +5,7 @@ import '@/tokens.css'
 import AdminPluginInstancePage from './AdminPluginInstancePage'
 import { queryKeys } from '@/hooks/queryKeys'
 import type { ApiPluginInstanceForAudience } from '@/api/types'
+import { RefreshFailureDetailPrefix } from '@/utils/pluginHealth'
 
 const PLUGIN_ID = 'plugin-slack-01'
 const INSTANCE_ID = 'inst-slack-prod'
@@ -15,6 +16,7 @@ const FIXTURE_WITH_SCHEMA: ApiPluginInstanceForAudience = {
   plugin_name: 'Slack',
   instance_name: 'slack-prod',
   state: 'healthy',
+  auth_strategy: 'oauth2_authcode',
   implements_notify: true,
   implements_request: true,
   config_schema: null,
@@ -50,6 +52,44 @@ const FIXTURE_NO_SCHEMA: ApiPluginInstanceForAudience = {
   implements_request: false,
   config_schema: null,
   version: 0,
+  event_kinds: [],
+  auth_strategy: 'none',
+}
+
+const FIXTURE_OAUTH_REFRESH_FAILED_AUTHCODE: ApiPluginInstanceForAudience = {
+  id: INSTANCE_ID,
+  plugin_id: PLUGIN_ID,
+  plugin_name: 'Slack',
+  instance_name: 'slack-prod',
+  state: 'unhealthy',
+  health_detail: `${RefreshFailureDetailPrefix}: token expired`,
+  auth_strategy: 'oauth2_authcode',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: null,
+  version: 3,
+  event_kinds: [],
+  subscription_schema: {
+    type: 'object',
+    properties: {
+      channels: { type: 'array', items: { type: 'string' } },
+    },
+  },
+  subscription_scope: { channels: ['#incidents'] },
+}
+
+const FIXTURE_OAUTH_REFRESH_FAILED_CLIENTCRED: ApiPluginInstanceForAudience = {
+  id: INSTANCE_ID,
+  plugin_id: PLUGIN_ID,
+  plugin_name: 'Jira',
+  instance_name: 'jira-prod',
+  state: 'unhealthy',
+  health_detail: `${RefreshFailureDetailPrefix}: server returned 401`,
+  auth_strategy: 'oauth2_clientcred',
+  implements_notify: false,
+  implements_request: true,
+  config_schema: null,
+  version: 5,
   event_kinds: [],
 }
 
@@ -110,4 +150,17 @@ export const Loading: Story = {
       </MemoryRouter>
     </QueryClientProvider>
   ),
+}
+
+// OAuth refresh failed (authcode) — shows the Re-authorize banner with an
+// oauth2_authcode strategy instance. Clicking Re-authorize would navigate
+// to the provider's authorization page.
+export const OAuthRefreshFailedAuthcode: Story = {
+  render: () => <Wrapper instances={[FIXTURE_OAUTH_REFRESH_FAILED_AUTHCODE]} />,
+}
+
+// OAuth refresh failed (clientcred) — same banner, but Re-authorize performs
+// the client credentials exchange synchronously (no browser redirect).
+export const OAuthRefreshFailedClientcred: Story = {
+  render: () => <Wrapper instances={[FIXTURE_OAUTH_REFRESH_FAILED_CLIENTCRED]} />,
 }

--- a/frontend/src/pages/AdminPluginInstancePage.test.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.test.tsx
@@ -6,14 +6,20 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 
 import AdminPluginInstancePage from './AdminPluginInstancePage'
 import type { ApiPluginInstanceForAudience } from '@/api/types'
+import { RefreshFailureDetailPrefix } from '@/utils/pluginHealth'
 
 // --- Module mocks ---
 
 vi.mock('@/hooks/queries/admin')
 vi.mock('@/hooks/mutations/plugins')
+vi.mock('@/components/admin/ReauthorizeButton/ReauthorizeButton', () => ({
+  ReauthorizeButton: ({ strategy }: { strategy: string }) => (
+    <button data-testid="reauth-btn" data-strategy={strategy}>Re-authorize</button>
+  ),
+}))
 
 import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
-import { useSetInstanceSubscriptionScope } from '@/hooks/mutations/plugins'
+import { useSetInstanceSubscriptionScope, useBeginPluginOAuth } from '@/hooks/mutations/plugins'
 
 // --- Fixtures ---
 
@@ -26,6 +32,7 @@ const INSTANCE_WITH_SCHEMA: ApiPluginInstanceForAudience = {
   plugin_name: 'Slack',
   instance_name: 'slack-prod',
   state: 'healthy',
+  auth_strategy: 'oauth2_authcode',
   implements_notify: true,
   implements_request: true,
   config_schema: null,
@@ -49,11 +56,27 @@ const INSTANCE_NO_SCHEMA: ApiPluginInstanceForAudience = {
   plugin_name: 'Webhook',
   instance_name: 'webhook-prod',
   state: 'healthy',
+  auth_strategy: 'none',
   implements_notify: false,
   implements_request: false,
   config_schema: null,
   event_kinds: [],
   version: 0,
+}
+
+const INSTANCE_OAUTH_REFRESH_FAILED: ApiPluginInstanceForAudience = {
+  id: INSTANCE_ID,
+  plugin_id: PLUGIN_ID,
+  plugin_name: 'Slack',
+  instance_name: 'slack-prod',
+  state: 'unhealthy',
+  health_detail: `${RefreshFailureDetailPrefix}: token expired`,
+  auth_strategy: 'oauth2_authcode',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: null,
+  event_kinds: [],
+  version: 2,
 }
 
 // --- Helpers ---
@@ -62,10 +85,11 @@ function makeQueryClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function renderPage() {
+function renderPage(search = '') {
+  const path = `/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}${search}`
   return render(
     <QueryClientProvider client={makeQueryClient()}>
-      <MemoryRouter initialEntries={[`/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}`]}>
+      <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/admin/plugins/:id/instances/:iid" element={<AdminPluginInstancePage />} />
         </Routes>
@@ -93,6 +117,10 @@ function mockMutationNoop() {
     mutate: vi.fn(),
     isPending: false,
   } as unknown as ReturnType<typeof useSetInstanceSubscriptionScope>)
+  vi.mocked(useBeginPluginOAuth).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useBeginPluginOAuth>)
 }
 
 function mockMutationSuccess(onSuccessCapture?: (fn: () => void) => void) {
@@ -180,5 +208,90 @@ describe('AdminPluginInstancePage — without subscription_schema', () => {
     renderPage()
     expect(screen.getByRole('button', { name: /config/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /credentials/i })).toBeInTheDocument()
+  })
+})
+
+describe('AdminPluginInstancePage — Re-authorize banner visibility', () => {
+  beforeEach(() => {
+    mockMutationNoop()
+  })
+
+  it('shows the Re-authorize banner when instance is unhealthy with refresh-failure detail', () => {
+    mockInstancesLoaded([INSTANCE_OAUTH_REFRESH_FAILED])
+    renderPage()
+    expect(screen.getByText(/oauth credentials need re-authorization/i)).toBeInTheDocument()
+    expect(screen.getByTestId('reauth-btn')).toBeInTheDocument()
+  })
+
+  it('does NOT show the banner for a healthy instance', () => {
+    mockInstancesLoaded([INSTANCE_WITH_SCHEMA])
+    renderPage()
+    expect(screen.queryByText(/oauth credentials need re-authorization/i)).not.toBeInTheDocument()
+    expect(screen.queryByTestId('reauth-btn')).not.toBeInTheDocument()
+  })
+
+  it('does NOT show the banner for an unhealthy instance without refresh-failure detail', () => {
+    const unhealthyOther: ApiPluginInstanceForAudience = {
+      ...INSTANCE_OAUTH_REFRESH_FAILED,
+      health_detail: 'something else went wrong',
+    }
+    mockInstancesLoaded([unhealthyOther])
+    renderPage()
+    expect(screen.queryByTestId('reauth-btn')).not.toBeInTheDocument()
+  })
+
+  it('passes auth_strategy to ReauthorizeButton', () => {
+    mockInstancesLoaded([INSTANCE_OAUTH_REFRESH_FAILED])
+    renderPage()
+    expect(screen.getByTestId('reauth-btn')).toHaveAttribute('data-strategy', 'oauth2_authcode')
+  })
+})
+
+describe('AdminPluginInstancePage — oauth_ok query param', () => {
+  // The page reads window.location.search directly (not from React Router) so
+  // the jsdom window.location must match. Replace it with a stub for these tests.
+
+  function withLocationSearch(search: string, fn: () => void) {
+    const originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, search },
+    })
+    fn()
+    Object.defineProperty(window, 'location', { writable: true, value: originalLocation })
+  }
+
+  it('invalidates plugin-instances query on mount when ?oauth_ok=1 is present', async () => {
+    mockInstancesLoaded([INSTANCE_WITH_SCHEMA])
+    mockMutationNoop()
+
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue()
+
+    withLocationSearch('?oauth_ok=1', () => {
+      renderPage()
+    })
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled()
+    })
+
+    invalidateSpy.mockRestore()
+  })
+
+  it('does NOT invalidate when ?oauth_ok is absent', async () => {
+    mockInstancesLoaded([INSTANCE_WITH_SCHEMA])
+    mockMutationNoop()
+
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue()
+
+    withLocationSearch('', () => {
+      renderPage()
+    })
+
+    // Allow effects to flush.
+    await new Promise((r) => setTimeout(r, 50))
+    expect(invalidateSpy).not.toHaveBeenCalled()
+
+    invalidateSpy.mockRestore()
   })
 })

--- a/frontend/src/pages/AdminPluginInstancePage.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.tsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from 'react'
 import { Link, useParams } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
 import { PageHeader } from '@/components/PageHeader'
 import { Button } from '@/components/Button'
 import { FieldError } from '@/components/form/FieldError/FieldError'
+import { ReauthorizeButton } from '@/components/admin/ReauthorizeButton/ReauthorizeButton'
 import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
 import { useSetInstanceSubscriptionScope } from '@/hooks/mutations/plugins'
+import { isOAuthRefreshFailure } from '@/utils/pluginHealth'
+import { queryKeys } from '@/hooks/queryKeys'
 import type { ApiError } from '@/api/fetch'
 import styles from './AdminPluginInstancePage.module.css'
 
@@ -246,6 +250,7 @@ function SubscriptionsTab({
 export default function AdminPluginInstancePage() {
   const { id: pluginId, iid: instanceId } = useParams<{ id: string; iid: string }>()
   const [activeTab, setActiveTab] = useState<Tab>('subscriptions')
+  const queryClient = useQueryClient()
 
   const { data: allInstances, status } = usePluginInstancesForAudience()
 
@@ -260,6 +265,18 @@ export default function AdminPluginInstancePage() {
       setActiveTab('config')
     }
   }, [status, hasSubscriptionSchema, activeTab])
+
+  // After a successful OAuth authcode round-trip the callback handler redirects
+  // the browser back here with ?oauth_ok=1. Invalidate the instance list so the
+  // Re-authorize banner clears without requiring a manual refresh.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('oauth_ok') === '1') {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.admin.pluginInstances })
+    }
+  // Run once on mount; queryClient reference is stable.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   function renderTabContent() {
     if (status === 'pending') {
@@ -313,6 +330,17 @@ export default function AdminPluginInstancePage() {
       </Link>
 
       <PageHeader title={`${pluginName} / ${instanceName}`} />
+
+      {instance && isOAuthRefreshFailure(instance.state, instance.health_detail) && (
+        <div className={styles.reauthBanner}>
+          <span>OAuth credentials need re-authorization.</span>
+          <ReauthorizeButton
+            pluginId={pluginId!}
+            instanceId={instanceId!}
+            strategy={instance.auth_strategy ?? ''}
+          />
+        </div>
+      )}
 
       <nav className={styles.tabs} aria-label="Instance settings">
         {hasSubscriptionSchema && (

--- a/frontend/src/utils/pluginHealth.ts
+++ b/frontend/src/utils/pluginHealth.ts
@@ -28,6 +28,17 @@ export function worstHealth(states: PluginHealthState[]): PluginHealthState {
   return worst
 }
 
+// RefreshFailureDetailPrefix is the stable prefix written by the backend's
+// MarkRefreshFailed into the instance health_detail field. Matching on this
+// prefix is the contract for showing the Re-authorize button (#228).
+export const RefreshFailureDetailPrefix = 'oauth refresh failed'
+
+// isOAuthRefreshFailure returns true when the instance is unhealthy specifically
+// because an OAuth token refresh failed. This gates the Re-authorize banner.
+export function isOAuthRefreshFailure(state: string, detail?: string): boolean {
+  return state === 'unhealthy' && (detail?.startsWith(RefreshFailureDetailPrefix) ?? false)
+}
+
 // pluginHealthLabel returns the human-readable display label for a health state.
 export function pluginHealthLabel(state: PluginHealthState): string {
   switch (state) {

--- a/internal/http/api/audience_handler.go
+++ b/internal/http/api/audience_handler.go
@@ -134,6 +134,15 @@ type pluginInstanceForAudienceDTO struct {
 	SubscriptionSchema interface{}          `json:"subscription_schema"`
 	SubscriptionScope  map[string]any       `json:"subscription_scope"`
 	Version            int64                `json:"version"`
+	// AuthStrategy is the auth strategy declared in the manifest (e.g.
+	// "oauth2_authcode", "oauth2_clientcred", "static_api_key"). Used by the
+	// admin UI to decide whether to show the Re-authorize button (#228).
+	AuthStrategy string `json:"auth_strategy"`
+	// HealthDetail is the detail string from the most recent health transition.
+	// Omitted when empty. Used together with AuthStrategy to gate the
+	// Re-authorize banner: detail prefix "oauth refresh failed" + oauth strategy
+	// → show the button.
+	HealthDetail string `json:"health_detail,omitempty"`
 }
 
 // ListPluginInstances handles GET /api/v1/admin/plugin-instances.
@@ -237,6 +246,11 @@ func (h *AudienceHandler) ListPluginInstances(w http.ResponseWriter, r *http.Req
 			subscriptionScope = map[string]any{}
 		}
 
+		healthDetail := ""
+		if inst.HealthDetail != nil {
+			healthDetail = *inst.HealthDetail
+		}
+
 		dtos = append(dtos, pluginInstanceForAudienceDTO{
 			ID:                 inst.ID,
 			PluginID:           inst.PluginID,
@@ -250,6 +264,8 @@ func (h *AudienceHandler) ListPluginInstances(w http.ResponseWriter, r *http.Req
 			SubscriptionSchema: subscriptionSchema,
 			SubscriptionScope:  subscriptionScope,
 			Version:            inst.Version,
+			AuthStrategy:       string(manifest.Auth.Strategy),
+			HealthDetail:       healthDetail,
 		})
 	}
 

--- a/internal/http/api/audience_handler_test.go
+++ b/internal/http/api/audience_handler_test.go
@@ -1099,3 +1099,60 @@ func TestListPluginInstances_WithEventKindExamplesAndBindingSchema(t *testing.T)
 		t.Errorf("examples[0].payload.channel = %v, want #incidents", ek.Examples[0].Payload["channel"])
 	}
 }
+
+// oauthManifestYAML declares an oauth2_authcode strategy so we can test
+// that auth_strategy is populated from the manifest Auth field.
+const oauthManifestYAML = `
+id: test-oauth-plugin
+name: OAuth Plugin
+version: 1.0.0
+auth:
+  strategy: oauth2_authcode
+`
+
+// TestListPluginInstances_AuthStrategyAndHealthDetail verifies that the
+// auth_strategy and health_detail fields are populated in the DTO (#228).
+func TestListPluginInstances_AuthStrategyAndHealthDetail(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	snap := configvalidate.NewSnapshotter(store.Queries())
+	t.Cleanup(func() { snap.ResetCache(); configvalidate.ResetCache() })
+
+	pluginID := seedPlugin(t, store, "oauth-plugin", oauthManifestYAML)
+	instID := seedPluginInstance(t, store, "oauth-inst", pluginID)
+
+	// Drive the instance to unhealthy with a detail string.
+	detail := "oauth refresh failed: token expired"
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := store.Queries().UpdatePluginInstanceHealth(context.Background(), db.UpdatePluginInstanceHealthParams{
+		HealthState:     "unhealthy",
+		HealthDetail:    &detail,
+		UpdatedAt:       now,
+		ID:              instID,
+		ExpectedVersion: 0,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePluginInstanceHealth: %v", err)
+	}
+
+	w := do(t, newPluginInstancesRouter(store, snap), http.MethodGet, "/", nil, model.RoleOperator)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\nbody: %s", w.Code, w.Body.String())
+	}
+
+	var items []struct {
+		ID           string `json:"id"`
+		AuthStrategy string `json:"auth_strategy"`
+		HealthDetail string `json:"health_detail"`
+	}
+	parseData(t, w, &items)
+
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	if items[0].AuthStrategy != "oauth2_authcode" {
+		t.Errorf("auth_strategy = %q, want %q", items[0].AuthStrategy, "oauth2_authcode")
+	}
+	if items[0].HealthDetail != detail {
+		t.Errorf("health_detail = %q, want %q", items[0].HealthDetail, detail)
+	}
+}

--- a/internal/plugin/oauth/manager.go
+++ b/internal/plugin/oauth/manager.go
@@ -199,5 +199,16 @@ func (m *Manager) BeginClientcred(ctx context.Context, instanceID string) error 
 	}
 
 	m.store.EmitIssued(ctx, instanceID)
+
+	// Transition the instance to healthy if it was waiting for re-authorization.
+	// Mirrors HandleCallback: both ErrIllegalTransition (already healthy) and
+	// ErrTransitionConflict (concurrent writer) are benign outcomes here.
+	_ = pluginstate.SetHealthState(
+		ctx, m.store.health, nil, instanceID,
+		pluginstate.OriginHost,
+		model.PluginHealthStateHealthy,
+		"oauth client credentials issued",
+	)
+
 	return nil
 }

--- a/internal/plugin/oauth/manager_test.go
+++ b/internal/plugin/oauth/manager_test.go
@@ -2,12 +2,16 @@ package oauth
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
 )
 
 // Tests do NOT call t.Parallel — they share the package clock.
@@ -218,6 +222,53 @@ func TestHandleCallback_ExpiredState_Error(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expired") {
 		t.Errorf("expected expiry error, got: %v", err)
+	}
+}
+
+func TestBeginClientcred_SuccessTransitionsToHealthy(t *testing.T) {
+	// Spin up a minimal fake token endpoint so the clientcredentials exchange succeeds.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok-abc",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	// Seed an instance in unhealthy state (simulating a prior refresh failure).
+	creds := testCreds("oauth2_clientcred")
+	creds.TokenURL = tokenServer.URL + "/token"
+	plain, err := creds.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	enc, err := noopEncrypt(plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	q := &fakeOAuthQuerier{
+		instance: db.PluginInstance{
+			ID:                   "inst-1",
+			HealthState:          string(model.PluginHealthStateUnhealthy),
+			Version:              1,
+			CredentialsEncrypted: &enc,
+		},
+	}
+
+	mgr, _ := newTestManager(q, "https://gleipnir.example.com")
+	if err := mgr.BeginClientcred(context.Background(), "inst-1"); err != nil {
+		t.Fatalf("BeginClientcred: %v", err)
+	}
+
+	// The health transition to healthy must have been recorded.
+	if len(q.healthUpdates) == 0 {
+		t.Fatal("expected at least one UpdatePluginInstanceHealth call, got none")
+	}
+	last := q.healthUpdates[len(q.healthUpdates)-1]
+	if last.HealthState != string(model.PluginHealthStateHealthy) {
+		t.Errorf("expected health_state=%q, got %q", model.PluginHealthStateHealthy, last.HealthState)
 	}
 }
 

--- a/internal/plugin/oauth/store.go
+++ b/internal/plugin/oauth/store.go
@@ -30,6 +30,12 @@ const (
 	auditCredentialCleared = "plugin_credentials_cleared"
 )
 
+// RefreshFailureDetailPrefix is the stable prefix used in the health-state
+// detail field when MarkRefreshFailed drives an instance to unhealthy.
+// The admin UI matches on this prefix to decide whether to show the
+// "Re-authorize" button — pinning it as a constant makes the contract explicit.
+const RefreshFailureDetailPrefix = "oauth refresh failed"
+
 // ErrWrongStrategy is returned by Set* methods when the stored credential
 // strategy does not match the operation — e.g. calling SetStaticAPIKey on an
 // instance whose manifest declares header_set.
@@ -186,12 +192,12 @@ func (s *DBStore) SaveToken(ctx context.Context, instanceID string, tok *oauth2.
 // drives the instance to PluginHealthStateUnhealthy so the admin "Re-authorize"
 // UI surface (#228) can pick it up.
 func (s *DBStore) MarkRefreshFailed(ctx context.Context, instanceID string, cause error) error {
-	detail := "oauth refresh failed"
+	detail := RefreshFailureDetailPrefix
 	if cause != nil {
-		detail = fmt.Sprintf("oauth refresh failed: %s", cause)
+		detail = fmt.Sprintf("%s: %s", RefreshFailureDetailPrefix, cause)
 	}
 
-	s.emitAudit(ctx, auditOAuthRefreshFailed, instanceID, map[string]any{
+	s.emitAudit(ctx, auditOAuthRefreshFailed, "warning", instanceID, map[string]any{
 		"error": detail,
 	})
 
@@ -212,7 +218,7 @@ func (s *DBStore) MarkRefreshFailed(ctx context.Context, instanceID string, caus
 // EmitIssued writes a plugin_oauth_issued audit event. Called by Manager after
 // a successful token exchange (authcode) or initial clientcred grant.
 func (s *DBStore) EmitIssued(ctx context.Context, instanceID string) {
-	s.emitAudit(ctx, auditOAuthIssued, instanceID, nil)
+	s.emitAudit(ctx, auditOAuthIssued, "info", instanceID, nil)
 }
 
 // EmitRefreshed writes a plugin_oauth_refreshed audit event. Called by
@@ -220,13 +226,13 @@ func (s *DBStore) EmitIssued(ctx context.Context, instanceID string) {
 // SaveToken. The initial token exchange (authcode/clientcred) uses EmitIssued
 // instead so the audit log distinguishes "first grant" from "later refresh".
 func (s *DBStore) EmitRefreshed(ctx context.Context, instanceID string) {
-	s.emitAudit(ctx, auditOAuthRefreshed, instanceID, nil)
+	s.emitAudit(ctx, auditOAuthRefreshed, "info", instanceID, nil)
 }
 
 // EmitRevoked writes a plugin_oauth_revoked audit event. Intended for future
 // revocation flows; not yet called from any production path in #224.
 func (s *DBStore) EmitRevoked(ctx context.Context, instanceID string) {
-	s.emitAudit(ctx, auditOAuthRevoked, instanceID, nil)
+	s.emitAudit(ctx, auditOAuthRevoked, "info", instanceID, nil)
 }
 
 // credentialsExpiresAt extracts the token expiry from StoredCredentials and
@@ -265,7 +271,7 @@ func (s *DBStore) SetStaticAPIKey(ctx context.Context, instanceID, headerName, s
 		}
 		err = s.SaveCredentials(ctx, instanceID, creds, ver)
 		if err == nil {
-			s.emitAudit(ctx, auditCredentialSet, instanceID, map[string]any{
+			s.emitAudit(ctx, auditCredentialSet, "info", instanceID, map[string]any{
 				"strategy": creds.Strategy,
 				"action":   "set_static_api_key",
 				"key":      headerName,
@@ -319,7 +325,7 @@ func (s *DBStore) SetHeaderSetEntry(ctx context.Context, instanceID string, head
 		}
 		err = s.SaveCredentials(ctx, instanceID, creds, ver)
 		if err == nil {
-			s.emitAudit(ctx, auditCredentialSet, instanceID, map[string]any{
+			s.emitAudit(ctx, auditCredentialSet, "info", instanceID, map[string]any{
 				"strategy": creds.Strategy,
 				"action":   "set_header",
 				"key":      header.Name,
@@ -366,7 +372,7 @@ func (s *DBStore) DeleteHeaderSetEntry(ctx context.Context, instanceID, headerNa
 		creds.HeaderSet.Headers = kept
 		err = s.SaveCredentials(ctx, instanceID, creds, ver)
 		if err == nil {
-			s.emitAudit(ctx, auditCredentialDeleted, instanceID, map[string]any{
+			s.emitAudit(ctx, auditCredentialDeleted, "info", instanceID, map[string]any{
 				"strategy": creds.Strategy,
 				"key":      headerName,
 			})
@@ -399,7 +405,7 @@ func (s *DBStore) SetBasicAuth(ctx context.Context, instanceID, username, passwo
 		creds.BasicAuth = &BasicAuthCreds{Username: username, Password: password}
 		err = s.SaveCredentials(ctx, instanceID, creds, ver)
 		if err == nil {
-			s.emitAudit(ctx, auditCredentialSet, instanceID, map[string]any{
+			s.emitAudit(ctx, auditCredentialSet, "info", instanceID, map[string]any{
 				"strategy": creds.Strategy,
 				"action":   "set_basic_auth",
 			})
@@ -430,7 +436,7 @@ func (s *DBStore) ClearCredentials(ctx context.Context, instanceID string) error
 		cleared := StoredCredentials{Strategy: strategy}
 		err = s.SaveCredentials(ctx, instanceID, cleared, ver)
 		if err == nil {
-			s.emitAudit(ctx, auditCredentialCleared, instanceID, map[string]any{
+			s.emitAudit(ctx, auditCredentialCleared, "info", instanceID, map[string]any{
 				"strategy": strategy,
 			})
 			return nil
@@ -445,7 +451,8 @@ func (s *DBStore) ClearCredentials(ctx context.Context, instanceID string) error
 // emitAudit inserts a plugin audit event row. Failures are logged but not
 // surfaced to the caller — the upstream operation (token save, health set) has
 // already committed and the audit event is informational.
-func (s *DBStore) emitAudit(ctx context.Context, eventType, instanceID string, extra map[string]any) {
+// severity must be one of "info", "warning", or "error".
+func (s *DBStore) emitAudit(ctx context.Context, eventType, severity, instanceID string, extra map[string]any) {
 	payload := map[string]any{"instance_id": instanceID}
 	for k, v := range extra {
 		payload[k] = v
@@ -455,7 +462,7 @@ func (s *DBStore) emitAudit(ctx context.Context, eventType, instanceID string, e
 	_, err := s.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
 		PluginInstanceID: &instanceID,
 		EventType:        eventType,
-		Severity:         "info",
+		Severity:         severity,
 		ActorUserID:      nil,
 		PayloadJson:      string(body),
 		CreatedAt:        now,

--- a/internal/plugin/oauth/store_test.go
+++ b/internal/plugin/oauth/store_test.go
@@ -244,20 +244,44 @@ func TestDBStore_MarkRefreshFailed_WritesAuditAndUnhealthy(t *testing.T) {
 		t.Fatalf("MarkRefreshFailed: %v", err)
 	}
 
-	// Should have emitted a refresh_failed audit event.
-	foundAudit := false
-	for _, ev := range q.auditEvents {
+	// Should have emitted a refresh_failed audit event with severity "warning" (AC #2).
+	var foundAuditEvent *db.InsertPluginAuditEventParams
+	for i, ev := range q.auditEvents {
 		if ev.EventType == auditOAuthRefreshFailed {
-			foundAudit = true
+			foundAuditEvent = &q.auditEvents[i]
 		}
 	}
-	if !foundAudit {
+	if foundAuditEvent == nil {
 		t.Errorf("expected %q audit event, none found in %v", auditOAuthRefreshFailed, q.auditEvents)
+	} else if foundAuditEvent.Severity != "warning" {
+		t.Errorf("expected refresh_failed audit severity %q, got %q", "warning", foundAuditEvent.Severity)
 	}
 
 	// Should have driven the instance to unhealthy.
 	if q.instance.HealthState != string(model.PluginHealthStateUnhealthy) {
 		t.Errorf("expected instance health_state=unhealthy, got %q", q.instance.HealthState)
+	}
+}
+
+func TestDBStore_EmitIssued_SeverityInfo(t *testing.T) {
+	q := &fakeOAuthQuerier{
+		instance: db.PluginInstance{ID: "inst-1", HealthState: "healthy", Version: 0},
+	}
+	store := NewDBStore(q, noopEncrypt, noopDecrypt, q, func() time.Time { return time.Unix(1000000, 0) })
+
+	store.EmitIssued(context.Background(), "inst-1")
+
+	var found *db.InsertPluginAuditEventParams
+	for i, ev := range q.auditEvents {
+		if ev.EventType == auditOAuthIssued {
+			found = &q.auditEvents[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected %q audit event", auditOAuthIssued)
+	}
+	if found.Severity != "info" {
+		t.Errorf("expected severity %q, got %q", "info", found.Severity)
 	}
 }
 


### PR DESCRIPTION
Closes #228

Targets `plugin-architecture` (per the `/dev-loop 228 merge into plugin-architecture` invocation).

## Summary
- Refresh failure already drove instances to `unhealthy` via `MarkRefreshFailed`; this PR (a) bumps that audit event's severity from `info` to `warning` (AC #2) and (b) plugs the symmetric gap in `BeginClientcred` so a successful client-credentials re-issue transitions back to `healthy` (AC #5 — `HandleCallback` already did this for authcode).
- New admin Re-authorize banner on `/admin/plugins/{id}/instances/{iid}`: shows when `isOAuthRefreshFailure(state, detail)` (state `unhealthy` + detail prefix `oauth refresh failed`), and triggers the existing `POST .../oauth/begin` endpoint. Authcode redirects to the returned `authorize_url`; clientcred awaits the synchronous re-issue and invalidates the page query.
- Page additionally invalidates `pluginInstances` on mount when `?oauth_ok=1` is present in the URL so the banner clears after returning from the OAuth provider.

## Architecture plan
<details>
<summary>Click to expand</summary>

The plan is in `.dev-loop/plan.md` on the branch (not committed). Key decisions:

- **Detail-prefix gate, not a new health-state value.** Spec accepts either `auth_expired` or `unhealthy + detail`. Adding a new state would touch the state-machine graph and severity ranking — out of scope. Pinned `RefreshFailureDetailPrefix = "oauth refresh failed"` as an exported Go constant + matching TS constant so the FE substring-match has a stable contract.
- **DTO extension over new endpoint.** `pluginInstanceForAudienceDTO` gains `auth_strategy` + `health_detail` — page already consumes this list.
- **`BeginClientcred` healthy transition** mirrors `HandleCallback` exactly (`_ = pluginstate.SetHealthState(...)`) — both `ErrIllegalTransition` and `ErrTransitionConflict` are benign for a "make sure we're healthy now" call.
- **Re-authorize as its own component** for Storybook + isolated unit tests of the strategy-branched click handler.

</details>

## Review cycles
1 (architect plan reviewer flagged 3 blockers + 3 suggestions; revised plan addressed all of them; code-reviewer APPROVED on first cycle).

## Documentation
`Stage 6.5: CLAUDE.md files are current — no updates needed.` (No new packages, env vars, routes, or ADRs.)

## Test plan
- [ ] Cause an OAuth refresh failure (e.g. revoke the upstream token); confirm the banner appears on `/admin/plugins/{id}/instances/{iid}` with the cause text.
- [ ] Click Re-authorize on an authcode instance → browser navigates to the IdP; on return the banner clears.
- [ ] Click Re-authorize on a clientcred instance → no redirect; banner clears after the synchronous exchange.
- [ ] Confirm `plugin_audit_events` has the `plugin_oauth_refresh_failed` row with severity `warning`.

🤖 Generated by the agentic dev-loop (issue #228).