### PR TITLE
feat: pull-only credential delivery — doc hardening + audit-discipline test (#229)

### DIFF
--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -337,6 +337,52 @@ func TestGetCredentials_NoCaching(t *testing.T) {
 	}
 }
 
+// TestGetCredentials_NoAuditEventOnRead asserts that GetCredentials never
+// inserts a row into plugin_audit_events — reads are logged via slog only
+// (spec §9.4, AC4). The test covers both the configured-credentials branch
+// and the nil-credentials branch.
+func TestGetCredentials_NoAuditEventOnRead(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured credentials", func(t *testing.T) {
+		t.Parallel()
+		creds := `{"strategy":"static_api_key"}`
+		encrypted, err := admin.Encrypt(testEncryptionKey, creds)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		q := &fakeQuerier{
+			instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", CredentialsEncrypted: &encrypted},
+		}
+		srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+		if _, err := srv.GetCredentials(context.Background(), &hostv1.GetCredentialsRequest{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if rows := q.all(); len(rows) != 0 {
+			t.Errorf("GetCredentials wrote %d audit event(s); want 0", len(rows))
+		}
+	})
+
+	t.Run("nil credentials", func(t *testing.T) {
+		t.Parallel()
+		// CredentialsEncrypted is nil — instance has no credentials configured yet.
+		q := &fakeQuerier{
+			instance: db.PluginInstance{ID: "iid-2", PluginID: "plug-2", CredentialsEncrypted: nil},
+		}
+		srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+		if _, err := srv.GetCredentials(context.Background(), &hostv1.GetCredentialsRequest{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if rows := q.all(); len(rows) != 0 {
+			t.Errorf("GetCredentials wrote %d audit event(s); want 0", len(rows))
+		}
+	})
+}
+
 // --- tests: GetRunContext ---
 
 func TestGetRunContext_RequiresCallID(t *testing.T) {

--- a/plugin-sdk/credentials/credentials.go
+++ b/plugin-sdk/credentials/credentials.go
@@ -5,6 +5,14 @@
 // Strategy constants are defined in plugin-sdk/manifest (e.g.
 // manifest.AuthStrategyStaticAPIKey). This package is stdlib-only so it can be
 // embedded in any plugin binary without dragging in host-side dependencies.
+//
+// # No plugin-side caching (spec §9.4)
+//
+// Plugins MUST call GetCredentials on every outbound substrate request and MUST
+// NOT cache the returned Credentials across calls. The host rotates OAuth2
+// tokens transparently; a cached token will be stale after the first rotation.
+// The host itself performs no in-process caching beyond the request scope, so
+// the round-trip cost is bounded by a single DB read per call.
 package credentials
 
 import (
@@ -16,11 +24,11 @@ import (
 // Strategy constants mirror the AuthStrategy* constants in plugin-sdk/manifest
 // so this package does not import manifest (keeping it stdlib-only).
 const (
-	StrategyNone          = "none"
-	StrategyStaticAPIKey  = "static_api_key"
-	StrategyHeaderSet     = "header_set"
-	StrategyBasicAuth     = "basic_auth"
-	StrategyOAuth2Authcode  = "oauth2_authcode"
+	StrategyNone             = "none"
+	StrategyStaticAPIKey     = "static_api_key"
+	StrategyHeaderSet        = "header_set"
+	StrategyBasicAuth        = "basic_auth"
+	StrategyOAuth2Authcode   = "oauth2_authcode"
 	StrategyOAuth2Clientcred = "oauth2_clientcred"
 )
 
@@ -79,6 +87,9 @@ type BasicAuth struct {
 
 // Unmarshal decodes the JSON blob returned by the GetCredentials RPC into a
 // Credentials value. Returns an error if the input is not valid JSON.
+//
+// Do not cache the returned Credentials; call host.GetCredentials on every
+// outbound substrate request so OAuth2 token rotations are picked up (spec §9.4).
 func Unmarshal(data []byte) (Credentials, error) {
 	var c Credentials
 	if err := json.Unmarshal(data, &c); err != nil {
@@ -124,6 +135,6 @@ func (c Credentials) Apply(req *http.Request) {
 		}
 		req.SetBasicAuth(c.BasicAuth.Username, c.BasicAuth.Password)
 
-	// none and oauth2_* are intentional no-ops.
+		// none and oauth2_* are intentional no-ops.
 	}
 }

--- a/plugin-sdk/credentials/credentials_test.go
+++ b/plugin-sdk/credentials/credentials_test.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,10 +11,10 @@ import (
 // TestApply_StaticAPIKey verifies that Apply sets the correct header value.
 func TestApply_StaticAPIKey(t *testing.T) {
 	tests := []struct {
-		name        string
-		creds       Credentials
-		wantHeader  string
-		wantValue   string
+		name       string
+		creds      Credentials
+		wantHeader string
+		wantValue  string
 	}{
 		{
 			name: "with scheme",
@@ -133,6 +134,36 @@ func TestApply_OAuth2_NoOp(t *testing.T) {
 			creds.Apply(req) // must not panic or set headers
 		})
 	}
+}
+
+// ExampleUnmarshal shows the correct per-request usage pattern: GetCredentials
+// is called inside the request loop, not hoisted out. This ensures the plugin
+// always holds a fresh token after an OAuth2 rotation (spec §9.4).
+func ExampleUnmarshal() {
+	// credentialJSONFromHost simulates the bytes returned by host.GetCredentials.
+	credentialJSONFromHost := func() []byte {
+		b, _ := json.Marshal(Credentials{
+			Strategy:     StrategyStaticAPIKey,
+			StaticAPIKey: &StaticAPIKey{HeaderName: "X-API-Key", APIKey: "tok-abc"},
+		})
+		return b
+	}
+
+	requests := []string{"/endpoint/1", "/endpoint/2"}
+	for _, path := range requests {
+		// Call GetCredentials here — inside the loop — not before it.
+		creds, err := Unmarshal(credentialJSONFromHost())
+		if err != nil {
+			fmt.Printf("credential error: %v\n", err)
+			return
+		}
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		creds.Apply(req)
+		fmt.Printf("%s %s\n", req.Method, req.URL.Path)
+	}
+	// Output:
+	// GET /endpoint/1
+	// GET /endpoint/2
 }
 
 // TestUnmarshal_RoundTrip verifies Marshal → Unmarshal for each strategy.


### PR DESCRIPTION
Closes #229

## Summary

Most of #229 already shipped across #224 (OAuth), #226 (non-OAuth credential strategies), and #228 (refresh→unhealthy). This PR closes the remaining gaps:

- **SDK doc hardening (AC3):** `plugin-sdk/credentials` package doc and `Unmarshal` godoc now normatively forbid plugin-side caching of returned `Credentials`, referencing spec §9.4. An `ExampleUnmarshal` demonstrates the per-request call pattern.
- **Audit-discipline regression test (AC4):** `TestGetCredentials_NoAuditEventOnRead` in `internal/plugin/hostsvc` asserts zero `InsertPluginAuditEvent` calls across both the configured-credentials and nil-credentials branches of `GetCredentials`. Reads must stay on slog only.

## Acceptance criteria status

- [x] AC1 — `GetCredentials(user_id)` RPC — enforced at the proto layer via `reserved 100; reserved "user_id";` in `host.proto`. The generated Go type has no `UserId` accessor; the runtime wire-drops the field before the handler is invoked. No handler change possible.
- [x] AC2 — No host-side caching beyond request scope (`handlers.go:97`; `TestGetCredentials_NoCaching` proves it).
- [x] AC3 — Plugin-side no-caching documented in SDK; lint hint waived per issue text ("probably just a doc note").
- [x] AC4 — Reads → slog via logctx; not `plugin_audit_events`. New structural test added.
- [x] AC5 — Mutation events: `plugin_oauth_issued`, `plugin_oauth_refreshed`, `plugin_oauth_refresh_failed` wired; `plugin_credentials_{set,deleted,cleared}` wired. **`plugin_oauth_revoked` is deferred** — the `EmitRevoked` helper exists in `store.go` but has no caller. The natural caller is the not-yet-implemented uninstall flow; wiring it here would be speculative.
- [x] AC6 — `run_steps` is not polluted; credential paths use `plugin_audit_events` only.

## Architecture plan

<details>
<summary>Plan (post-review revision)</summary>

The original plan proposed a `user_id` reject guard and a handler change. The plan-reviewer caught that `user_id` is a proto-reserved field — generated Go has no accessor, so the guard would not compile. The reviewer also caught that `EmitRevoked` is a stub with zero callers, so AC5 was marked PARTIAL/DEFERRED rather than DONE.

Final scope: three files modified — SDK doc note, SDK example, one new hostsvc test.

</details>

## Pipeline

- Brainstorming: not triggered (issue well-specified)
- Review cycles: 1 (APPROVE on first pass)
- CLAUDE.md updated: no
- Generated by the agentic dev-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)