### PR TITLE
feat: public_url change → re-authorize prompt for affected plugin instances

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -35,6 +35,7 @@ npm run build-storybook  # static Storybook build
 /admin/audiences    → audience list (admin|operator: + new; auditor: read-only)
 /admin/audiences/new → create audience (admin|operator)
 /admin/audiences/:id → audience detail/editor (admin|operator: edit; auditor: read-only)
+/admin/plugins      → plugin instance list (admin); groups instances pending re-authorization at top after a public_url change (#230)
 /admin/plugins/:id/instances/:iid → plugin instance editor (admin); Subscriptions tab edits coarse watch scope (#223), Config and Credentials tabs are placeholders for #241/#242
 *                   → 404 not found
 ```

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -367,7 +367,7 @@ export interface ArcadeAuthorizeWaitRequest {
 }
 
 // Matches internal/model/plugin_health.go → PluginHealthState.
-// Ten states across three severity tiers:
+// Eleven states across three severity tiers:
 //   Green  — healthy
 //   Yellow — degraded but operational
 //   Red    — non-functional
@@ -377,6 +377,7 @@ export type PluginHealthState =
   | 'pending_key_approval'
   | 'pending_manifest_approval'
   | 'pending_config_migration'
+  | 'pending_reauthorize'
   | 'unhealthy'
   | 'circuit_broken'
   | 'verification_error'
@@ -516,6 +517,11 @@ export interface ApiPluginInstanceForAudience {
   // Absent when the instance has no detail. Used together with auth_strategy
   // and state to gate the Re-authorize banner (#228).
   health_detail?: string
+  // last_oauth_callback_url is the OAuth callback URL recorded the last time
+  // this instance completed an OAuth flow. Absent when never authorized. Used
+  // by the admin/plugins page to show which URL needs updating after a
+  // public_url change (#230).
+  last_oauth_callback_url?: string
 }
 
 // Request body interfaces for audience mutations.

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import { Activity, Bot, ChevronUp, Cpu, History, Megaphone, Settings2, Users, Wrench } from 'lucide-react'
+import { Activity, Bot, ChevronUp, Cpu, History, Megaphone, Puzzle, Settings2, Users, Wrench } from 'lucide-react'
 import { Logo } from '@/components/Logo/Logo'
 import { NavLink, Outlet, useLocation } from 'react-router-dom'
 import { useSSE } from '@/hooks/useSSE'
@@ -20,6 +20,7 @@ const ADMIN_NAV_ITEMS = [
   { label: 'Users', to: '/admin/users', Icon: Users },
   { label: 'Models', to: '/admin/models', Icon: Cpu },
   { label: 'Audiences', to: '/admin/audiences', Icon: Megaphone },
+  { label: 'Plugins', to: '/admin/plugins', Icon: Puzzle },
   { label: 'System', to: '/admin/system', Icon: Settings2 },
 ]
 
@@ -41,6 +42,7 @@ export default function Layout() {
       : to === '/admin/users' ? location.pathname.startsWith('/admin/users')
       : to === '/admin/models' ? location.pathname.startsWith('/admin/models')
       : to === '/admin/audiences' ? location.pathname.startsWith('/admin/audiences')
+      : to === '/admin/plugins' ? location.pathname.startsWith('/admin/plugins')
       : to === '/admin/system' ? location.pathname.startsWith('/admin/system')
       : location.pathname === to
     const base = active ? `${styles.navLink} ${styles.navLinkActive}` : styles.navLink

--- a/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.tsx
+++ b/frontend/src/components/admin/PluginHealthChip/PluginHealthChip.tsx
@@ -18,6 +18,7 @@ const VARIANT: Record<PluginHealthState, string> = {
   pending_key_approval:       styles.yellow,
   pending_manifest_approval:  styles.yellow,
   pending_config_migration:   styles.yellow,
+  pending_reauthorize:        styles.yellow,
   unhealthy:                  styles.yellow,
   circuit_broken:             styles.red,
   verification_error:         styles.red,

--- a/frontend/src/hooks/queries/admin.ts
+++ b/frontend/src/hooks/queries/admin.ts
@@ -74,7 +74,8 @@ export function useAudienceReferences(id: string | undefined) {
   })
 }
 
-// Pending in #290 — GET /api/v1/admin/plugin-instances.
+// GET /api/v1/admin/plugin-instances — consumed by the audience editor (#290)
+// and the admin/plugins page (#230).
 export function usePluginInstancesForAudience() {
   return useQuery({
     queryKey: queryKeys.admin.pluginInstances,

--- a/frontend/src/pages/AdminPluginsPage.module.css
+++ b/frontend/src/pages/AdminPluginsPage.module.css
@@ -1,0 +1,134 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.intro {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-second);
+}
+
+/* Sections */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sectionTitle {
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.sectionDesc {
+  font-size: var(--text-sm);
+  color: var(--text-second);
+  margin: 0;
+}
+
+.sectionDesc code {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  background: var(--bg-code);
+  border-radius: 3px;
+  padding: 1px var(--space-1);
+}
+
+/* Table */
+
+.tableWrapper {
+  overflow-x: auto;
+  border-radius: var(--radius-section);
+  border: 1px solid var(--border-mid);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.table thead tr {
+  background: var(--bg-elevated);
+}
+
+.table th {
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  font-weight: var(--weight-medium);
+  color: var(--text-second);
+  border-bottom: 1px solid var(--border-mid);
+  white-space: nowrap;
+}
+
+.table td {
+  padding: var(--space-3) var(--space-4);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-subtle);
+  vertical-align: middle;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody tr:hover {
+  background: var(--bg-elevated);
+}
+
+.pluginName {
+  color: var(--text-second);
+  font-weight: var(--weight-medium);
+}
+
+.nameLink {
+  color: var(--color-blue);
+  text-decoration: none;
+  font-weight: var(--weight-medium);
+}
+
+.nameLink:hover {
+  text-decoration: underline;
+}
+
+.callbackUrl {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-second);
+  word-break: break-all;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+/* Empty state */
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-12) 0;
+  text-align: center;
+}
+
+.emptyHeadline {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-medium);
+  color: var(--text-second);
+  margin: 0;
+}
+
+.emptySubtext {
+  font-size: var(--text-sm);
+  color: var(--text-faint);
+  margin: 0;
+}

--- a/frontend/src/pages/AdminPluginsPage.stories.tsx
+++ b/frontend/src/pages/AdminPluginsPage.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import '@/tokens.css'
+import AdminPluginsPage from './AdminPluginsPage'
+import { queryKeys } from '@/hooks/queryKeys'
+import type { ApiPluginInstanceForAudience } from '@/api/types'
+
+const CALLBACK_URL = 'https://gleipnir.example.com/api/v1/admin/plugins/oauth/callback'
+const OLD_CALLBACK_URL = 'https://old.example.com/api/v1/admin/plugins/oauth/callback'
+
+const INSTANCE_HEALTHY: ApiPluginInstanceForAudience = {
+  id: 'inst-slack-prod',
+  plugin_id: 'plugin-slack-01',
+  plugin_name: 'Slack',
+  instance_name: 'slack-prod',
+  state: 'healthy',
+  auth_strategy: 'oauth2_authcode',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: null,
+  version: 2,
+  event_kinds: [],
+  last_oauth_callback_url: CALLBACK_URL,
+}
+
+const INSTANCE_PENDING_REAUTH: ApiPluginInstanceForAudience = {
+  id: 'inst-jira-prod',
+  plugin_id: 'plugin-jira-01',
+  plugin_name: 'Jira',
+  instance_name: 'jira-prod',
+  state: 'pending_reauthorize',
+  auth_strategy: 'oauth2_authcode',
+  implements_notify: false,
+  implements_request: true,
+  config_schema: null,
+  version: 3,
+  event_kinds: [],
+  last_oauth_callback_url: OLD_CALLBACK_URL,
+  health_detail: `public_url changed: recorded callback "${OLD_CALLBACK_URL}" no longer matches current "${CALLBACK_URL}"; re-authorize to update`,
+}
+
+const INSTANCE_UNHEALTHY: ApiPluginInstanceForAudience = {
+  id: 'inst-github-prod',
+  plugin_id: 'plugin-github-01',
+  plugin_name: 'GitHub',
+  instance_name: 'github-prod',
+  state: 'unhealthy',
+  auth_strategy: 'oauth2_clientcred',
+  implements_notify: true,
+  implements_request: false,
+  config_schema: null,
+  version: 1,
+  event_kinds: [],
+}
+
+function makeQueryClient(instances: ApiPluginInstanceForAudience[]): QueryClient {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  qc.setQueryData(queryKeys.admin.pluginInstances, instances)
+  return qc
+}
+
+function Wrapper({ instances }: { instances: ApiPluginInstanceForAudience[] }) {
+  return (
+    <QueryClientProvider client={makeQueryClient(instances)}>
+      <MemoryRouter initialEntries={['/admin/plugins']}>
+        <Routes>
+          <Route path="/admin/plugins" element={<AdminPluginsPage />} />
+          <Route
+            path="/admin/plugins/:id/instances/:iid"
+            element={<div>Instance detail page</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const meta: Meta<typeof AdminPluginsPage> = {
+  title: 'Admin/PluginsPage',
+  component: AdminPluginsPage,
+}
+
+export default meta
+type Story = StoryObj<typeof AdminPluginsPage>
+
+// All instances healthy — no "Needs re-authorization" section.
+export const AllHealthy: Story = {
+  render: () => <Wrapper instances={[INSTANCE_HEALTHY]} />,
+}
+
+// One instance pending re-authorization — shows the "Needs re-authorization"
+// section at the top, grouped separately from the "All instances" list.
+export const WithPendingReauth: Story = {
+  render: () => (
+    <Wrapper instances={[INSTANCE_PENDING_REAUTH, INSTANCE_HEALTHY, INSTANCE_UNHEALTHY]} />
+  ),
+}
+
+// Empty — no plugin instances installed.
+export const Empty: Story = {
+  render: () => <Wrapper instances={[]} />,
+}
+
+// Loading — query data not yet seeded; page shows the loading skeleton.
+export const Loading: Story = {
+  render: () => (
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter initialEntries={['/admin/plugins']}>
+        <Routes>
+          <Route path="/admin/plugins" element={<AdminPluginsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  ),
+}

--- a/frontend/src/pages/AdminPluginsPage.test.tsx
+++ b/frontend/src/pages/AdminPluginsPage.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+import AdminPluginsPage from './AdminPluginsPage'
+import type { ApiPluginInstanceForAudience } from '@/api/types'
+
+// --- Module mocks ---
+
+vi.mock('@/hooks/queries/admin')
+import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
+
+// --- Fixtures ---
+
+const CALLBACK_URL = 'https://gleipnir.example.com/api/v1/admin/plugins/oauth/callback'
+const OLD_CALLBACK_URL = 'https://old.example.com/api/v1/admin/plugins/oauth/callback'
+
+const PLUGIN_ID = 'plugin-slack-01'
+const INSTANCE_ID_SLACK = 'inst-slack-prod'
+const INSTANCE_ID_JIRA = 'inst-jira-prod'
+
+const INSTANCE_HEALTHY: ApiPluginInstanceForAudience = {
+  id: INSTANCE_ID_SLACK,
+  plugin_id: PLUGIN_ID,
+  plugin_name: 'Slack',
+  instance_name: 'slack-prod',
+  state: 'healthy',
+  auth_strategy: 'oauth2_authcode',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: null,
+  version: 2,
+  event_kinds: [],
+  last_oauth_callback_url: CALLBACK_URL,
+}
+
+const INSTANCE_PENDING_REAUTH: ApiPluginInstanceForAudience = {
+  id: INSTANCE_ID_JIRA,
+  plugin_id: 'plugin-jira-01',
+  plugin_name: 'Jira',
+  instance_name: 'jira-prod',
+  state: 'pending_reauthorize',
+  auth_strategy: 'oauth2_authcode',
+  implements_notify: false,
+  implements_request: true,
+  config_schema: null,
+  version: 3,
+  event_kinds: [],
+  last_oauth_callback_url: OLD_CALLBACK_URL,
+}
+
+// --- Helpers ---
+
+function mockInstances(instances: ApiPluginInstanceForAudience[]) {
+  vi.mocked(usePluginInstancesForAudience).mockReturnValue({
+    data: instances,
+    status: 'success',
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof usePluginInstancesForAudience>)
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/admin/plugins']}>
+        <Routes>
+          <Route path="/admin/plugins" element={<AdminPluginsPage />} />
+          <Route
+            path="/admin/plugins/:id/instances/:iid"
+            element={<div>Instance detail</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+// --- Tests ---
+
+describe('AdminPluginsPage', () => {
+  it('shows "Needs re-authorization" section when at least one instance is pending_reauthorize', () => {
+    mockInstances([INSTANCE_PENDING_REAUTH, INSTANCE_HEALTHY])
+
+    renderPage()
+
+    expect(screen.getByText('Needs re-authorization')).toBeInTheDocument()
+    // The Jira instance should appear somewhere on the page (both sections may
+    // render its name, so use getAllByText and assert at least one match).
+    const jiraLinks = screen.getAllByText('jira-prod')
+    expect(jiraLinks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('does not show "Needs re-authorization" section when no instances are pending', () => {
+    mockInstances([INSTANCE_HEALTHY])
+
+    renderPage()
+
+    expect(screen.queryByText('Needs re-authorization')).not.toBeInTheDocument()
+  })
+
+  it('shows all instances in the "All instances" section regardless of state', () => {
+    mockInstances([INSTANCE_PENDING_REAUTH, INSTANCE_HEALTHY])
+
+    renderPage()
+
+    expect(screen.getByText('All instances')).toBeInTheDocument()
+    // Both instances appear in the All instances section.
+    const slackLinks = screen.getAllByText('slack-prod')
+    expect(slackLinks.length).toBeGreaterThanOrEqual(1)
+    const jiraLinks = screen.getAllByText('jira-prod')
+    expect(jiraLinks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('instance row links point to /admin/plugins/{plugin_id}/instances/{id}', () => {
+    mockInstances([INSTANCE_PENDING_REAUTH])
+
+    renderPage()
+
+    const links = screen.getAllByRole('link', { name: 'jira-prod' })
+    for (const link of links) {
+      expect(link).toHaveAttribute(
+        'href',
+        `/admin/plugins/${encodeURIComponent(INSTANCE_PENDING_REAUTH.plugin_id)}/instances/${encodeURIComponent(INSTANCE_ID_JIRA)}`,
+      )
+    }
+  })
+
+  it('shows empty state when no instances are installed', () => {
+    mockInstances([])
+
+    renderPage()
+
+    expect(screen.getByText('No plugin instances')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/AdminPluginsPage.tsx
+++ b/frontend/src/pages/AdminPluginsPage.tsx
@@ -1,0 +1,121 @@
+import { Link } from 'react-router-dom'
+import { PageHeader } from '@/components/PageHeader'
+import { QueryBoundary, SkeletonList } from '@/components/QueryBoundary'
+import { PluginHealthChip } from '@/components/admin/PluginHealthChip/PluginHealthChip'
+import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import styles from './AdminPluginsPage.module.css'
+
+export default function AdminPluginsPage() {
+  usePageTitle('Plugins')
+
+  const { data: instances, status, refetch } = usePluginInstancesForAudience()
+
+  const needsReauth = (instances ?? []).filter(
+    (inst) => inst.state === 'pending_reauthorize',
+  )
+  const allInstances = instances ?? []
+
+  return (
+    <div className={styles.page}>
+      <PageHeader title="Plugins" />
+
+      <p className={styles.intro}>
+        All installed plugin instances and their current health state.
+      </p>
+
+      <QueryBoundary
+        status={status}
+        isEmpty={allInstances.length === 0}
+        errorMessage="Failed to load plugin instances."
+        onRetry={() => { void refetch() }}
+        skeleton={<SkeletonList count={3} height={48} gap={12} borderRadius={8} />}
+        emptyState={
+          <div className={styles.emptyState}>
+            <p className={styles.emptyHeadline}>No plugin instances</p>
+            <p className={styles.emptySubtext}>
+              Install a plugin to see instances here.
+            </p>
+          </div>
+        }
+      >
+        {needsReauth.length > 0 && (
+          <section className={styles.section}>
+            <h2 className={styles.sectionTitle}>Needs re-authorization</h2>
+            <p className={styles.sectionDesc}>
+              The <code>public_url</code> setting changed and the OAuth callback
+              URL for these instances no longer matches. Re-authorize each
+              instance to update the redirect URI registered with the provider.
+            </p>
+            <div className={styles.tableWrapper}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Plugin</th>
+                    <th>Instance</th>
+                    <th>Recorded callback URL</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {needsReauth.map((inst) => (
+                    <tr key={inst.id}>
+                      <td className={styles.pluginName}>{inst.plugin_name ?? inst.plugin_id}</td>
+                      <td>
+                        <Link
+                          to={`/admin/plugins/${encodeURIComponent(inst.plugin_id)}/instances/${encodeURIComponent(inst.id)}`}
+                          className={styles.nameLink}
+                        >
+                          {inst.instance_name}
+                        </Link>
+                      </td>
+                      <td className={styles.callbackUrl}>
+                        {inst.last_oauth_callback_url ?? <span className={styles.muted}>—</span>}
+                      </td>
+                      <td>
+                        <PluginHealthChip state={inst.state} detail={inst.health_detail} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>All instances</h2>
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Plugin</th>
+                  <th>Instance</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allInstances.map((inst) => (
+                  <tr key={inst.id}>
+                    <td className={styles.pluginName}>{inst.plugin_name ?? inst.plugin_id}</td>
+                    <td>
+                      <Link
+                        to={`/admin/plugins/${encodeURIComponent(inst.plugin_id)}/instances/${encodeURIComponent(inst.id)}`}
+                        className={styles.nameLink}
+                      >
+                        {inst.instance_name}
+                      </Link>
+                    </td>
+                    <td>
+                      <PluginHealthChip state={inst.state} detail={inst.health_detail} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </QueryBoundary>
+    </div>
+  )
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -16,6 +16,7 @@ import AdminAudiencesPage from './pages/AdminAudiencesPage'
 import AdminAudienceDetailPage from './pages/AdminAudienceDetailPage'
 import AdminAudienceNewPage from './pages/AdminAudienceNewPage'
 import AdminPluginInstancePage from './pages/AdminPluginInstancePage'
+import AdminPluginsPage from './pages/AdminPluginsPage'
 import NotFoundPage from './pages/NotFoundPage'
 import { RouteErrorFallback } from './components/ErrorBoundary'
 
@@ -51,6 +52,7 @@ const router = createBrowserRouter([
       { path: 'admin/audiences', element: <AdminAudiencesPage />, errorElement: <RouteErrorFallback /> },
       { path: 'admin/audiences/new', element: <AdminAudienceNewPage />, errorElement: <RouteErrorFallback /> },
       { path: 'admin/audiences/:id', element: <AdminAudienceDetailPage />, errorElement: <RouteErrorFallback /> },
+      { path: 'admin/plugins', element: <AdminPluginsPage />, errorElement: <RouteErrorFallback /> },
       {
         path: 'admin/plugins/:id/instances/:iid',
         element: <AdminPluginInstancePage />,

--- a/frontend/src/utils/pluginHealth.test.ts
+++ b/frontend/src/utils/pluginHealth.test.ts
@@ -32,15 +32,22 @@ describe('worstHealth', () => {
   })
 
   it('all pending states have equal severity (returns first encountered)', () => {
-    // All three pending states share severity 2 — worstHealth picks whichever
+    // All four pending states share severity 2 — worstHealth picks whichever
     // appears last when tied (iterates in order, replaces on strictly-greater).
     const states: PluginHealthState[] = [
       'pending_key_approval',
       'pending_manifest_approval',
       'pending_config_migration',
+      'pending_reauthorize',
     ]
     // None is strictly worse than another; first one stays as worst.
     expect(worstHealth(states)).toBe('pending_key_approval')
+  })
+
+  it('pending_reauthorize has severity 2 (operator-action-pending tier)', () => {
+    // pending_reauthorize must not dominate over genuinely worse states.
+    const states: PluginHealthState[] = ['pending_reauthorize', 'unhealthy']
+    expect(worstHealth(states)).toBe('unhealthy')
   })
 })
 
@@ -51,6 +58,7 @@ describe('pluginHealthLabel', () => {
     ['pending_key_approval',      'Pending key approval'],
     ['pending_manifest_approval', 'Pending manifest approval'],
     ['pending_config_migration',  'Pending config migration'],
+    ['pending_reauthorize',       'Pending re-authorize'],
     ['unhealthy',                 'Unhealthy'],
     ['circuit_broken',            'Circuit broken'],
     ['verification_error',        'Verification error'],

--- a/frontend/src/utils/pluginHealth.ts
+++ b/frontend/src/utils/pluginHealth.ts
@@ -9,6 +9,7 @@ const SEVERITY: Record<PluginHealthState, number> = {
   pending_key_approval:       2,
   pending_manifest_approval:  2,
   pending_config_migration:   2,
+  pending_reauthorize:        2,
   unhealthy:                  3,
   circuit_broken:             4,
   verification_error:         5,
@@ -47,6 +48,7 @@ export function pluginHealthLabel(state: PluginHealthState): string {
     case 'pending_key_approval':      return 'Pending key approval'
     case 'pending_manifest_approval': return 'Pending manifest approval'
     case 'pending_config_migration':  return 'Pending config migration'
+    case 'pending_reauthorize':       return 'Pending re-authorize'
     case 'unhealthy':                 return 'Unhealthy'
     case 'circuit_broken':            return 'Circuit broken'
     case 'verification_error':        return 'Verification error'

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -50,6 +50,11 @@ type Handler struct {
 	configureProvider ProviderConfigurator
 	removeProvider    ProviderRemover
 	lister            llm.ModelLister
+	// OnPublicURLChanged is called synchronously after a successful UpdateSettings
+	// write when the public_url value changes. Set by main.go after construction
+	// so internal/admin does not import internal/plugin/oauth (preserving the
+	// package boundary). Nil-safe: the hook is only invoked when non-nil.
+	OnPublicURLChanged func(ctx context.Context, oldURL, newURL string)
 }
 
 func NewHandler(q AdminQuerier, s *settings.Service, encryptionKey []byte, knownProviders []string, configure ProviderConfigurator, remove ProviderRemover, lister llm.ModelLister) *Handler {
@@ -251,6 +256,8 @@ func validateSettings(body map[string]string) (httpStatus int, errMsg string) {
 
 // UpdateSettings upserts system settings, rejecting any _api_key keys.
 func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	var body map[string]string
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON body", "")
@@ -269,6 +276,17 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Read the previous public_url before writing so we can detect changes and
+	// fire OnPublicURLChanged after a successful write.
+	var prevPublicURL string
+	if _, bodyHasPublicURL := body["public_url"]; bodyHasPublicURL && h.OnPublicURLChanged != nil {
+		row, err := h.q.GetSystemSetting(ctx, "public_url")
+		if err == nil {
+			prevPublicURL = row.Value
+		}
+		// sql.ErrNoRows means no prior value — prevPublicURL stays "".
+	}
+
 	// Settings are written one-at-a-time. For the small number of settings in
 	// practice (2-3 keys), the risk of partial failure is negligible. A future
 	// enhancement could wrap this in a transaction.
@@ -278,17 +296,26 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		// We delete rather than upsert because value TEXT NOT NULL accepts empty
 		// strings — storing "" would be indistinguishable from "not set".
 		if key == "public_url" && value == "" {
-			if err := h.q.DeleteSystemSetting(r.Context(), key); err != nil {
+			if err := h.q.DeleteSystemSetting(ctx, key); err != nil {
 				httputil.WriteError(w, http.StatusInternalServerError, fmt.Sprintf("failed to clear setting %q", key), "")
 				return
 			}
 			continue // deletion handled above — skip the upsert below
 		}
 
-		if err := h.q.UpsertSystemSetting(r.Context(), key, value, now); err != nil {
+		if err := h.q.UpsertSystemSetting(ctx, key, value, now); err != nil {
 			httputil.WriteError(w, http.StatusInternalServerError, fmt.Sprintf("failed to save setting %q", key), "")
 			return
 		}
+	}
+
+	// Fire the hook synchronously so a subsequent GET already sees rescan results.
+	// Only fires when public_url was in the request body, the value changed, and
+	// a hook was registered by main.go.
+	if newPublicURL, bodyHasPublicURL := body["public_url"]; bodyHasPublicURL &&
+		h.OnPublicURLChanged != nil &&
+		newPublicURL != prevPublicURL {
+		h.OnPublicURLChanged(ctx, prevPublicURL, newPublicURL)
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -774,6 +774,94 @@ func TestGetPublicConfig_DefaultModelDisabled(t *testing.T) {
 	}
 }
 
+// --- OnPublicURLChanged hook tests ---
+
+func TestUpdateSettings_OnPublicURLChanged_InvokedWhenChanged(t *testing.T) {
+	q := newMockQuerier()
+	h := newTestHandler(q)
+	q.settings["public_url"] = db.SystemSetting{Key: "public_url", Value: "https://old.example.com"}
+
+	var gotOld, gotNew string
+	h.OnPublicURLChanged = func(_ context.Context, oldURL, newURL string) {
+		gotOld = oldURL
+		gotNew = newURL
+	}
+
+	body := `{"public_url": "https://new.example.com"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.UpdateSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if gotOld != "https://old.example.com" {
+		t.Errorf("oldURL = %q, want https://old.example.com", gotOld)
+	}
+	if gotNew != "https://new.example.com" {
+		t.Errorf("newURL = %q, want https://new.example.com", gotNew)
+	}
+}
+
+func TestUpdateSettings_OnPublicURLChanged_NotInvokedWhenUnchanged(t *testing.T) {
+	q := newMockQuerier()
+	h := newTestHandler(q)
+	q.settings["public_url"] = db.SystemSetting{Key: "public_url", Value: "https://gleipnir.example.com"}
+
+	invoked := false
+	h.OnPublicURLChanged = func(_ context.Context, _, _ string) {
+		invoked = true
+	}
+
+	// Same value — hook must not fire.
+	body := `{"public_url": "https://gleipnir.example.com"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.UpdateSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if invoked {
+		t.Error("OnPublicURLChanged must not be invoked when the URL has not changed")
+	}
+}
+
+func TestUpdateSettings_OnPublicURLChanged_NotInvokedWhenAbsent(t *testing.T) {
+	q := newMockQuerier()
+	h := newTestHandler(q)
+
+	invoked := false
+	h.OnPublicURLChanged = func(_ context.Context, _, _ string) {
+		invoked = true
+	}
+
+	// Request does not include public_url — hook must not fire.
+	body := `{"some_other_setting": "value"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.UpdateSettings(rec, req)
+
+	if invoked {
+		t.Error("OnPublicURLChanged must not be invoked when public_url is not in the request")
+	}
+}
+
+func TestUpdateSettings_OnPublicURLChanged_NilSafe(t *testing.T) {
+	q := newMockQuerier()
+	h := newTestHandler(q) // hook is nil by default
+
+	// Must not panic when hook is nil.
+	body := `{"public_url": "https://gleipnir.example.com"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.UpdateSettings(rec, req) // must not panic
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
 func TestFormatUptime(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/db/migrations/0001_initial.sql
+++ b/internal/db/migrations/0001_initial.sql
@@ -399,7 +399,8 @@ CREATE TABLE plugin_instances (
                                          'unsigned_permissive',
                                          'unhealthy',
                                          'crashed',
-                                         'circuit_broken'
+                                         'circuit_broken',
+                                         'pending_reauthorize'
                                      )),
     health_detail            TEXT,
     last_oauth_callback_url  TEXT,

--- a/internal/db/migrations/0035_add_pending_reauthorize_health_state.go
+++ b/internal/db/migrations/0035_add_pending_reauthorize_health_state.go
@@ -1,0 +1,113 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// AddPendingReauthorizeHealthState adds 'pending_reauthorize' to the
+// plugin_instances.health_state CHECK constraint (issue #230).
+//
+// SQLite cannot ALTER a CHECK constraint in-place, so this migration rebuilds
+// the table: create plugin_instances_new with the extended CHECK list, copy all
+// rows, drop the old table, rename, and re-create both indexes.
+type AddPendingReauthorizeHealthState struct{}
+
+func (m *AddPendingReauthorizeHealthState) Version() int { return 25 }
+func (m *AddPendingReauthorizeHealthState) Name() string {
+	return "add_pending_reauthorize_health_state"
+}
+
+func (m *AddPendingReauthorizeHealthState) ShouldSkip(ctx context.Context, db *sql.DB) (bool, error) {
+	// Check whether the current CHECK constraint already allows pending_reauthorize
+	// by attempting a well-formed no-op query against the constraint list.
+	// The most reliable way: look at the CREATE TABLE SQL stored in sqlite_master.
+	var ddl string
+	err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(sql, '') FROM sqlite_master WHERE type='table' AND name='plugin_instances'`,
+	).Scan(&ddl)
+	if err != nil {
+		return false, fmt.Errorf("read plugin_instances DDL: %w", err)
+	}
+	// If the table doesn't exist yet (fresh install ran 0001_initial.sql with the
+	// updated CHECK), there is nothing to migrate.
+	if ddl == "" {
+		return true, nil
+	}
+	// If the DDL already contains pending_reauthorize the migration was applied.
+	return strings.Contains(ddl, "pending_reauthorize"), nil
+}
+
+func (m *AddPendingReauthorizeHealthState) Up(ctx context.Context, tx *sql.Tx) error {
+	// 1. Create the replacement table with the extended CHECK list.
+	_, err := tx.ExecContext(ctx, `
+CREATE TABLE plugin_instances_new (
+    id                       TEXT    PRIMARY KEY,
+    plugin_id                TEXT    NOT NULL REFERENCES plugins(id) ON DELETE CASCADE,
+    instance_name            TEXT    NOT NULL,
+    config_json              TEXT    NOT NULL DEFAULT '{}',
+    subscription_scope_json  TEXT    NOT NULL DEFAULT '{}',
+    credentials_encrypted    TEXT,
+    credentials_expires_at   TEXT,
+    handshake_versions       TEXT    NOT NULL DEFAULT '{}',
+    health_state             TEXT    NOT NULL DEFAULT 'pending_key_approval'
+                                     CHECK(health_state IN (
+                                         'healthy',
+                                         'signature_invalid',
+                                         'pending_key_approval',
+                                         'pending_manifest_approval',
+                                         'pending_config_migration',
+                                         'verification_error',
+                                         'unsigned_permissive',
+                                         'unhealthy',
+                                         'crashed',
+                                         'circuit_broken',
+                                         'pending_reauthorize'
+                                     )),
+    health_detail            TEXT,
+    last_oauth_callback_url  TEXT,
+    version                  INTEGER NOT NULL DEFAULT 0,
+    created_at               TEXT    NOT NULL,
+    updated_at               TEXT    NOT NULL,
+    UNIQUE (plugin_id, instance_name)
+)`)
+	if err != nil {
+		return fmt.Errorf("create plugin_instances_new: %w", err)
+	}
+
+	// 2. Copy all existing rows. SELECT * works because both tables share the
+	// same column list (the new table may have subscription_scope_json that
+	// was added by an earlier migration; we rely on column order matching).
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO plugin_instances_new
+SELECT id, plugin_id, instance_name, config_json, subscription_scope_json,
+       credentials_encrypted, credentials_expires_at, handshake_versions,
+       health_state, health_detail, last_oauth_callback_url, version,
+       created_at, updated_at
+FROM plugin_instances`)
+	if err != nil {
+		return fmt.Errorf("copy plugin_instances rows: %w", err)
+	}
+
+	// 3. Drop the old table and rename the replacement.
+	if _, err := tx.ExecContext(ctx, `DROP TABLE plugin_instances`); err != nil {
+		return fmt.Errorf("drop old plugin_instances: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE plugin_instances_new RENAME TO plugin_instances`); err != nil {
+		return fmt.Errorf("rename plugin_instances_new: %w", err)
+	}
+
+	// 4. Re-create both indexes.
+	if _, err := tx.ExecContext(ctx, `CREATE INDEX idx_plugin_instances_plugin_id ON plugin_instances(plugin_id)`); err != nil {
+		return fmt.Errorf("create idx_plugin_instances_plugin_id: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE INDEX idx_plugin_instances_health_state ON plugin_instances(health_state)`); err != nil {
+		return fmt.Errorf("create idx_plugin_instances_health_state: %w", err)
+	}
+
+	slog.Info("migrated: added pending_reauthorize to plugin_instances health_state CHECK constraint")
+	return nil
+}

--- a/internal/db/migrations/registry.go
+++ b/internal/db/migrations/registry.go
@@ -28,5 +28,6 @@ func All() []Migration {
 		&AddSubscribedTriggerType{},
 		&AddSubscriptionScope{},
 		&AddPluginOAuthNonces{},
+		&AddPendingReauthorizeHealthState{},
 	}
 }

--- a/internal/db/plugins.sql.go
+++ b/internal/db/plugins.sql.go
@@ -379,6 +379,56 @@ func (q *Queries) ListPluginInstancesByPlugin(ctx context.Context, pluginID stri
 	return items, nil
 }
 
+const listPluginInstancesForCallbackRescan = `-- name: ListPluginInstancesForCallbackRescan :many
+SELECT id, plugin_id, instance_name, config_json, subscription_scope_json, credentials_encrypted, credentials_expires_at, handshake_versions, health_state, health_detail, last_oauth_callback_url, version, created_at, updated_at FROM plugin_instances
+WHERE last_oauth_callback_url IS NOT NULL
+  AND health_state IN ('healthy', 'unsigned_permissive', 'crashed', 'circuit_broken')
+ORDER BY plugin_id, instance_name
+`
+
+// ListPluginInstancesForCallbackRescan returns all instances that have a
+// recorded last_oauth_callback_url and are in a health state eligible for
+// the public_url-change rescan (#230). unhealthy is excluded so an active
+// availability problem is not masked; crashed and circuit_broken are included
+// because they may eventually re-authorize once the operator fixes the URL.
+func (q *Queries) ListPluginInstancesForCallbackRescan(ctx context.Context) ([]PluginInstance, error) {
+	rows, err := q.db.QueryContext(ctx, listPluginInstancesForCallbackRescan)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []PluginInstance
+	for rows.Next() {
+		var i PluginInstance
+		if err := rows.Scan(
+			&i.ID,
+			&i.PluginID,
+			&i.InstanceName,
+			&i.ConfigJson,
+			&i.SubscriptionScopeJson,
+			&i.CredentialsEncrypted,
+			&i.CredentialsExpiresAt,
+			&i.HandshakeVersions,
+			&i.HealthState,
+			&i.HealthDetail,
+			&i.LastOauthCallbackUrl,
+			&i.Version,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPluginInstancesWithExpiringCredentials = `-- name: ListPluginInstancesWithExpiringCredentials :many
 SELECT id, plugin_id, instance_name, config_json, subscription_scope_json, credentials_encrypted, credentials_expires_at, handshake_versions, health_state, health_detail, last_oauth_callback_url, version, created_at, updated_at FROM plugin_instances
 WHERE credentials_expires_at IS NOT NULL

--- a/internal/db/queries/plugins.sql
+++ b/internal/db/queries/plugins.sql
@@ -107,3 +107,14 @@ WHERE credentials_expires_at IS NOT NULL
   AND credentials_expires_at <= :cutoff
   AND health_state IN ('healthy', 'unhealthy', 'unsigned_permissive')
 ORDER BY credentials_expires_at;
+
+-- ListPluginInstancesForCallbackRescan returns all instances that have a
+-- recorded last_oauth_callback_url and are in a health state eligible for
+-- the public_url-change rescan (#230). unhealthy is excluded so an active
+-- availability problem is not masked; crashed and circuit_broken are included
+-- because they may eventually re-authorize once the operator fixes the URL.
+-- name: ListPluginInstancesForCallbackRescan :many
+SELECT * FROM plugin_instances
+WHERE last_oauth_callback_url IS NOT NULL
+  AND health_state IN ('healthy', 'unsigned_permissive', 'crashed', 'circuit_broken')
+ORDER BY plugin_id, instance_name;

--- a/internal/http/api/audience_handler.go
+++ b/internal/http/api/audience_handler.go
@@ -143,6 +143,11 @@ type pluginInstanceForAudienceDTO struct {
 	// Re-authorize banner: detail prefix "oauth refresh failed" + oauth strategy
 	// → show the button.
 	HealthDetail string `json:"health_detail,omitempty"`
+	// LastOauthCallbackUrl is the OAuth callback URL recorded the last time this
+	// instance completed an OAuth flow. Omitted when nil (never authorized). Used
+	// by the admin/plugins page to help operators understand which URL needs to be
+	// updated in the provider after a public_url change (#230).
+	LastOauthCallbackUrl string `json:"last_oauth_callback_url,omitempty"`
 }
 
 // ListPluginInstances handles GET /api/v1/admin/plugin-instances.
@@ -251,21 +256,27 @@ func (h *AudienceHandler) ListPluginInstances(w http.ResponseWriter, r *http.Req
 			healthDetail = *inst.HealthDetail
 		}
 
+		lastCallbackURL := ""
+		if inst.LastOauthCallbackUrl != nil {
+			lastCallbackURL = *inst.LastOauthCallbackUrl
+		}
+
 		dtos = append(dtos, pluginInstanceForAudienceDTO{
-			ID:                 inst.ID,
-			PluginID:           inst.PluginID,
-			PluginName:         manifest.Name,
-			InstanceName:       inst.InstanceName,
-			State:              inst.HealthState,
-			ImplementsNotify:   implementsNotify,
-			ImplementsRequest:  implementsRequest,
-			ConfigSchema:       configSchema,
-			EventKinds:         eventKinds,
-			SubscriptionSchema: subscriptionSchema,
-			SubscriptionScope:  subscriptionScope,
-			Version:            inst.Version,
-			AuthStrategy:       string(manifest.Auth.Strategy),
-			HealthDetail:       healthDetail,
+			ID:                   inst.ID,
+			PluginID:             inst.PluginID,
+			PluginName:           manifest.Name,
+			InstanceName:         inst.InstanceName,
+			State:                inst.HealthState,
+			ImplementsNotify:     implementsNotify,
+			ImplementsRequest:    implementsRequest,
+			ConfigSchema:         configSchema,
+			EventKinds:           eventKinds,
+			SubscriptionSchema:   subscriptionSchema,
+			SubscriptionScope:    subscriptionScope,
+			Version:              inst.Version,
+			AuthStrategy:         string(manifest.Auth.Strategy),
+			HealthDetail:         healthDetail,
+			LastOauthCallbackUrl: lastCallbackURL,
 		})
 	}
 

--- a/internal/http/api/audience_handler_test.go
+++ b/internal/http/api/audience_handler_test.go
@@ -1110,6 +1110,77 @@ auth:
   strategy: oauth2_authcode
 `
 
+// TestListPluginInstances_LastOAuthCallbackURL verifies that last_oauth_callback_url
+// is included in the DTO when set on the instance row, and omitted when nil (#230).
+func TestListPluginInstances_LastOAuthCallbackURL(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	snap := configvalidate.NewSnapshotter(store.Queries())
+	t.Cleanup(func() { snap.ResetCache(); configvalidate.ResetCache() })
+
+	pluginID := seedPlugin(t, store, "oauth-plugin-cb", oauthManifestYAML)
+	instID := seedPluginInstance(t, store, "oauth-inst-cb", pluginID)
+
+	const wantURL = "https://gleipnir.example.com/api/v1/admin/plugins/oauth/callback"
+
+	// Write a last_oauth_callback_url via the sqlc query.
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := store.Queries().UpdatePluginInstanceOAuthCallback(context.Background(), db.UpdatePluginInstanceOAuthCallbackParams{
+		LastOauthCallbackUrl: func() *string { s := wantURL; return &s }(),
+		UpdatedAt:            now,
+		ID:                   instID,
+		ExpectedVersion:      0,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePluginInstanceOAuthCallback: %v", err)
+	}
+
+	w := do(t, newPluginInstancesRouter(store, snap), http.MethodGet, "/", nil, model.RoleOperator)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\nbody: %s", w.Code, w.Body.String())
+	}
+
+	var items []struct {
+		ID                   string `json:"id"`
+		LastOauthCallbackUrl string `json:"last_oauth_callback_url"`
+	}
+	parseData(t, w, &items)
+
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	if items[0].LastOauthCallbackUrl != wantURL {
+		t.Errorf("last_oauth_callback_url = %q, want %q", items[0].LastOauthCallbackUrl, wantURL)
+	}
+}
+
+// TestListPluginInstances_LastOAuthCallbackURL_OmittedWhenNil verifies that the
+// last_oauth_callback_url field is omitted (not marshalled as "") when nil (#230).
+func TestListPluginInstances_LastOAuthCallbackURL_OmittedWhenNil(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	snap := configvalidate.NewSnapshotter(store.Queries())
+	t.Cleanup(func() { snap.ResetCache(); configvalidate.ResetCache() })
+
+	pluginID := seedPlugin(t, store, "oauth-plugin-nil", oauthManifestYAML)
+	seedPluginInstance(t, store, "oauth-inst-nil", pluginID)
+
+	// No UpdatePluginInstanceOAuthCallback call — last_oauth_callback_url stays NULL.
+	w := do(t, newPluginInstancesRouter(store, snap), http.MethodGet, "/", nil, model.RoleOperator)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\nbody: %s", w.Code, w.Body.String())
+	}
+
+	// Decode into a raw map so we can distinguish omitted from "".
+	var raw []map[string]json.RawMessage
+	parseData(t, w, &raw)
+
+	if len(raw) != 1 {
+		t.Fatalf("got %d items, want 1", len(raw))
+	}
+	if _, present := raw[0]["last_oauth_callback_url"]; present {
+		t.Error("last_oauth_callback_url should be omitted from JSON when nil, but was present")
+	}
+}
+
 // TestListPluginInstances_AuthStrategyAndHealthDetail verifies that the
 // auth_strategy and health_detail fields are populated in the DTO (#228).
 func TestListPluginInstances_AuthStrategyAndHealthDetail(t *testing.T) {

--- a/internal/model/plugin_health.go
+++ b/internal/model/plugin_health.go
@@ -8,7 +8,7 @@ package model
 //	Red    — non-functional (verification_error, signature_invalid, circuit_broken, crashed)
 //
 // The transition graph and total severity ordering are defined in
-// internal/plugin/state. See spec §5.6 and issue #191.
+// internal/plugin/state. See spec §5.6 and issues #191, #230.
 type PluginHealthState string
 
 const (
@@ -17,9 +17,14 @@ const (
 	PluginHealthStatePendingKeyApproval      PluginHealthState = "pending_key_approval"
 	PluginHealthStatePendingManifestApproval PluginHealthState = "pending_manifest_approval"
 	PluginHealthStatePendingConfigMigration  PluginHealthState = "pending_config_migration"
-	PluginHealthStateUnhealthy               PluginHealthState = "unhealthy"
-	PluginHealthStateCircuitBroken           PluginHealthState = "circuit_broken"
-	PluginHealthStateVerificationError       PluginHealthState = "verification_error"
-	PluginHealthStateSignatureInvalid        PluginHealthState = "signature_invalid"
-	PluginHealthStateCrashed                 PluginHealthState = "crashed"
+	// PluginHealthStatePendingReauthorize is set by the callback-URL rescan when
+	// public_url changes and the instance's recorded OAuth callback URL no longer
+	// matches (#230). The admin UI surfaces these instances at the top of /admin/plugins
+	// so operators can re-run the OAuth flow.
+	PluginHealthStatePendingReauthorize PluginHealthState = "pending_reauthorize"
+	PluginHealthStateUnhealthy          PluginHealthState = "unhealthy"
+	PluginHealthStateCircuitBroken      PluginHealthState = "circuit_broken"
+	PluginHealthStateVerificationError  PluginHealthState = "verification_error"
+	PluginHealthStateSignatureInvalid   PluginHealthState = "signature_invalid"
+	PluginHealthStateCrashed            PluginHealthState = "crashed"
 )

--- a/internal/plugin/oauth/callback_rescan.go
+++ b/internal/plugin/oauth/callback_rescan.go
@@ -1,0 +1,107 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+)
+
+// RescanQuerier is the narrow DB interface needed by CallbackRescanner.
+// Using an interface (not *db.Queries) keeps the struct testable with fakes.
+type RescanQuerier interface {
+	ListPluginInstancesForCallbackRescan(ctx context.Context) ([]db.PluginInstance, error)
+}
+
+// CallbackRescanner compares each eligible plugin instance's
+// last_oauth_callback_url against the current OAuth callback URL derived from
+// public_url. Instances whose recorded URL no longer matches are transitioned
+// to PluginHealthStatePendingReauthorize so operators can re-run the OAuth flow.
+//
+// The rescan is triggered once after a public_url change rather than on a timer,
+// so it is intentionally synchronous and inexpensive.
+type CallbackRescanner struct {
+	q            RescanQuerier
+	health       pluginstate.Querier
+	getPublicURL func() string
+	clock        func() time.Time
+}
+
+// NewCallbackRescanner constructs a CallbackRescanner. clock may be nil (defaults
+// to time.Now). getPublicURL is called at scan time to reflect late-bound settings.
+func NewCallbackRescanner(q RescanQuerier, health pluginstate.Querier, getPublicURL func() string, clock func() time.Time) *CallbackRescanner {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &CallbackRescanner{
+		q:            q,
+		health:       health,
+		getPublicURL: getPublicURL,
+		clock:        clock,
+	}
+}
+
+// Scan iterates over eligible plugin instances and transitions those whose
+// last_oauth_callback_url no longer matches the expected callback URL to
+// PluginHealthStatePendingReauthorize.
+//
+// Returns the number of instances flagged and any DB-level error from the list
+// query. Individual transition errors (ErrIllegalTransition, ErrTransitionConflict)
+// are logged as warnings and do not stop the scan.
+func (r *CallbackRescanner) Scan(ctx context.Context) (flagged int, err error) {
+	publicURL := r.getPublicURL()
+	if publicURL == "" {
+		slog.DebugContext(ctx, "callback rescan: public_url not set; skipping")
+		return 0, nil
+	}
+
+	expected := publicURL + callbackPath
+
+	rows, err := r.q.ListPluginInstancesForCallbackRescan(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("callback rescan: list instances: %w", err)
+	}
+
+	for _, row := range rows {
+		if row.LastOauthCallbackUrl == nil || *row.LastOauthCallbackUrl == expected {
+			continue
+		}
+
+		detail := fmt.Sprintf(
+			"public_url changed: recorded callback %q no longer matches current %q; re-authorize to update",
+			*row.LastOauthCallbackUrl, expected,
+		)
+		err := pluginstate.SetHealthState(
+			ctx, r.health, nil, row.ID,
+			pluginstate.OriginHost,
+			model.PluginHealthStatePendingReauthorize,
+			detail,
+		)
+		if err != nil {
+			// ErrIllegalTransition means the instance is in a state that cannot
+			// transition to pending_reauthorize (e.g. already pending_reauthorize,
+			// or in a terminal/error state). ErrTransitionConflict means a concurrent
+			// writer already advanced the version. Both are benign — log and move on.
+			slog.WarnContext(ctx, "callback rescan: set pending_reauthorize",
+				"instance_id", row.ID,
+				"plugin_id", row.PluginID,
+				"err", err,
+			)
+			continue
+		}
+		flagged++
+	}
+
+	if flagged > 0 {
+		slog.InfoContext(ctx, "callback rescan: flagged instances for re-authorization",
+			"count", flagged,
+			"new_callback_url", expected,
+		)
+	}
+
+	return flagged, nil
+}

--- a/internal/plugin/oauth/callback_rescan_test.go
+++ b/internal/plugin/oauth/callback_rescan_test.go
@@ -1,0 +1,261 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+)
+
+// fakeRescanQuerier holds a fixed list of plugin instances for rescan tests.
+type fakeRescanQuerier struct {
+	rows []db.PluginInstance
+	err  error
+}
+
+func (f *fakeRescanQuerier) ListPluginInstancesForCallbackRescan(_ context.Context) ([]db.PluginInstance, error) {
+	return f.rows, f.err
+}
+
+// fakeRescanHealth records SetHealthState-equivalent calls via
+// UpdatePluginInstanceHealth. It also exposes GetPluginInstanceByID so the
+// rescan can perform fresh reads (not used in the rescan path, but satisfies
+// the pluginstate.Querier interface).
+type fakeRescanHealth struct {
+	instances     map[string]db.PluginInstance
+	healthUpdates []db.UpdatePluginInstanceHealthParams
+	casConflict   bool // if true, all UpdatePluginInstanceHealth calls return 0 rows
+}
+
+func newFakeRescanHealth(instances ...db.PluginInstance) *fakeRescanHealth {
+	m := &fakeRescanHealth{instances: make(map[string]db.PluginInstance)}
+	for _, inst := range instances {
+		m.instances[inst.ID] = inst
+	}
+	return m
+}
+
+func (f *fakeRescanHealth) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
+	inst, ok := f.instances[id]
+	if !ok {
+		return db.PluginInstance{}, errors.New("not found")
+	}
+	return inst, nil
+}
+
+func (f *fakeRescanHealth) UpdatePluginInstanceHealth(_ context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error) {
+	f.healthUpdates = append(f.healthUpdates, arg)
+	if f.casConflict {
+		return 0, nil
+	}
+	if inst, ok := f.instances[arg.ID]; ok {
+		inst.HealthState = arg.HealthState
+		inst.Version++
+		f.instances[arg.ID] = inst
+	}
+	return 1, nil
+}
+
+var _ pluginstate.Querier = (*fakeRescanHealth)(nil)
+
+// --- helpers ---
+
+func strPtr(s string) *string { return &s }
+
+func inst(id, state string, callbackURL *string) db.PluginInstance {
+	return db.PluginInstance{
+		ID:                   id,
+		PluginID:             id + "-plugin",
+		HealthState:          state,
+		LastOauthCallbackUrl: callbackURL,
+		Version:              1,
+	}
+}
+
+const testPublicURL = "https://gleipnir.example.com"
+const testExpected = testPublicURL + callbackPath
+
+// --- tests ---
+
+func TestCallbackRescan_EmptyPublicURL_ZeroFlagged(t *testing.T) {
+	q := &fakeRescanQuerier{
+		rows: []db.PluginInstance{
+			inst("inst-1", "healthy", strPtr("https://old.example.com"+callbackPath)),
+		},
+	}
+	health := newFakeRescanHealth()
+	r := NewCallbackRescanner(q, health, func() string { return "" }, nil)
+
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: unexpected error: %v", err)
+	}
+	if flagged != 0 {
+		t.Errorf("flagged = %d, want 0 when public_url is empty", flagged)
+	}
+	if len(health.healthUpdates) != 0 {
+		t.Errorf("expected no health updates, got %d", len(health.healthUpdates))
+	}
+}
+
+func TestCallbackRescan_MatchingURL_NotFlagged(t *testing.T) {
+	q := &fakeRescanQuerier{
+		rows: []db.PluginInstance{
+			inst("inst-1", "healthy", strPtr(testExpected)),
+		},
+	}
+	health := newFakeRescanHealth(q.rows[0])
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if flagged != 0 {
+		t.Errorf("flagged = %d, want 0 for matching URL", flagged)
+	}
+}
+
+func TestCallbackRescan_MismatchedURL_Flagged(t *testing.T) {
+	oldURL := "https://old.example.com" + callbackPath
+	q := &fakeRescanQuerier{
+		rows: []db.PluginInstance{
+			inst("inst-1", "healthy", strPtr(oldURL)),
+		},
+	}
+	health := newFakeRescanHealth(q.rows[0])
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if flagged != 1 {
+		t.Errorf("flagged = %d, want 1", flagged)
+	}
+	if len(health.healthUpdates) != 1 {
+		t.Fatalf("expected 1 health update, got %d", len(health.healthUpdates))
+	}
+	if health.healthUpdates[0].HealthState != string(model.PluginHealthStatePendingReauthorize) {
+		t.Errorf("health_state = %q, want %q", health.healthUpdates[0].HealthState, model.PluginHealthStatePendingReauthorize)
+	}
+}
+
+func TestCallbackRescan_NullCallbackURL_SkippedByQuery(t *testing.T) {
+	// The SQL query already filters out rows with NULL last_oauth_callback_url,
+	// so the rescan returns nil rows for them. This test validates that the
+	// rescan handles empty row lists safely.
+	q := &fakeRescanQuerier{rows: nil}
+	health := newFakeRescanHealth()
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if flagged != 0 {
+		t.Errorf("flagged = %d, want 0 with no rows", flagged)
+	}
+}
+
+func TestCallbackRescan_CrashedWithMismatch_Flagged(t *testing.T) {
+	// crashed is an eligible state — instances may re-authorize once fixed.
+	oldURL := "https://old.example.com" + callbackPath
+	q := &fakeRescanQuerier{
+		rows: []db.PluginInstance{
+			inst("inst-crash", "crashed", strPtr(oldURL)),
+		},
+	}
+	health := newFakeRescanHealth(q.rows[0])
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if flagged != 1 {
+		t.Errorf("flagged = %d, want 1 for crashed instance with mismatched URL", flagged)
+	}
+}
+
+func TestCallbackRescan_CircuitBrokenWithMismatch_Flagged(t *testing.T) {
+	oldURL := "https://old.example.com" + callbackPath
+	q := &fakeRescanQuerier{
+		rows: []db.PluginInstance{
+			inst("inst-cb", "circuit_broken", strPtr(oldURL)),
+		},
+	}
+	health := newFakeRescanHealth(q.rows[0])
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if flagged != 1 {
+		t.Errorf("flagged = %d, want 1 for circuit_broken instance with mismatched URL", flagged)
+	}
+}
+
+func TestCallbackRescan_CASConflict_Tolerated(t *testing.T) {
+	// A CAS conflict in SetHealthState is logged and does not abort the scan.
+	oldURL := "https://old.example.com" + callbackPath
+	q := &fakeRescanQuerier{
+		rows: []db.PluginInstance{
+			inst("inst-1", "healthy", strPtr(oldURL)),
+		},
+	}
+	health := newFakeRescanHealth(q.rows[0])
+	health.casConflict = true
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	// Should not return an error even when every CAS write fails.
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: unexpected error: %v", err)
+	}
+	// CAS conflict means the write did not land, so flagged stays 0.
+	if flagged != 0 {
+		t.Errorf("flagged = %d, want 0 when CAS conflict is returned", flagged)
+	}
+}
+
+func TestCallbackRescan_ListError_Propagated(t *testing.T) {
+	q := &fakeRescanQuerier{err: errors.New("db down")}
+	health := newFakeRescanHealth()
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	_, err := r.Scan(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Scan when list fails, got nil")
+	}
+}
+
+func TestCallbackRescan_MultipleInstances_OnlyMismatchFlagged(t *testing.T) {
+	oldURL := "https://old.example.com" + callbackPath
+	q := &fakeRescanQuerier{
+		rows: []db.PluginInstance{
+			inst("inst-match", "healthy", strPtr(testExpected)),
+			inst("inst-mismatch", "healthy", strPtr(oldURL)),
+		},
+	}
+	health := newFakeRescanHealth(q.rows...)
+	r := NewCallbackRescanner(q, health, func() string { return testPublicURL }, nil)
+
+	flagged, err := r.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if flagged != 1 {
+		t.Errorf("flagged = %d, want 1 (only the mismatched instance)", flagged)
+	}
+	if len(health.healthUpdates) != 1 {
+		t.Fatalf("expected 1 health update, got %d", len(health.healthUpdates))
+	}
+	if health.healthUpdates[0].ID != "inst-mismatch" {
+		t.Errorf("health update for %q, want inst-mismatch", health.healthUpdates[0].ID)
+	}
+}

--- a/internal/plugin/oauth/manager.go
+++ b/internal/plugin/oauth/manager.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
@@ -147,6 +148,22 @@ func (m *Manager) HandleCallback(ctx context.Context, rawState, code string) (st
 		return "", fmt.Errorf("oauth callback: save token: %w", saveErr)
 	}
 
+	// Record last_oauth_callback_url on successful token exchange so future
+	// public_url change rescans (#230) know which URL this instance last used.
+	// We re-read the instance to get the current version for the CAS guard;
+	// a conflict or missing row is non-fatal — the token has already been saved.
+	if freshRow, getErr := m.store.q.GetPluginInstanceByID(ctx, env.InstanceID); getErr == nil {
+		nowStr := m.clock().UTC().Format(time.RFC3339Nano)
+		if n, writeErr := m.store.q.UpdatePluginInstanceOAuthCallback(ctx, db.UpdatePluginInstanceOAuthCallbackParams{
+			LastOauthCallbackUrl: &callbackURL,
+			UpdatedAt:            nowStr,
+			ID:                   env.InstanceID,
+			ExpectedVersion:      freshRow.Version,
+		}); writeErr != nil || n == 0 {
+			slog.WarnContext(ctx, "oauth: record callback url", "instance_id", env.InstanceID, "written", n, "err", writeErr)
+		}
+	}
+
 	m.store.EmitIssued(ctx, env.InstanceID)
 
 	// Transition the instance to healthy if it was waiting for authorization.
@@ -196,6 +213,25 @@ func (m *Manager) BeginClientcred(ctx context.Context, instanceID string) error 
 
 	if saveErr := m.store.SaveToken(ctx, instanceID, tok); saveErr != nil {
 		return fmt.Errorf("oauth clientcred: save token: %w", saveErr)
+	}
+
+	// Record last_oauth_callback_url so public_url change rescans (#230) can
+	// track this instance. Client credentials do not use a browser redirect, but
+	// we store the value consistently so the rescan logic works uniformly across
+	// both OAuth strategies. Skip silently when public_url is not yet configured.
+	if publicURL := m.getPublicURL(); publicURL != "" {
+		callbackURL := publicURL + callbackPath
+		if freshRow, getErr := m.store.q.GetPluginInstanceByID(ctx, instanceID); getErr == nil {
+			nowStr := m.clock().UTC().Format(time.RFC3339Nano)
+			if n, writeErr := m.store.q.UpdatePluginInstanceOAuthCallback(ctx, db.UpdatePluginInstanceOAuthCallbackParams{
+				LastOauthCallbackUrl: &callbackURL,
+				UpdatedAt:            nowStr,
+				ID:                   instanceID,
+				ExpectedVersion:      freshRow.Version,
+			}); writeErr != nil || n == 0 {
+				slog.WarnContext(ctx, "oauth: record callback url", "instance_id", instanceID, "written", n, "err", writeErr)
+			}
+		}
 	}
 
 	m.store.EmitIssued(ctx, instanceID)

--- a/internal/plugin/oauth/manager_test.go
+++ b/internal/plugin/oauth/manager_test.go
@@ -272,6 +272,183 @@ func TestBeginClientcred_SuccessTransitionsToHealthy(t *testing.T) {
 	}
 }
 
+// TestBeginAuthcode_WritesLastCallbackURL checks that BeginAuthcode records
+// last_oauth_callback_url on the instance row (the existing pre-#230 behavior).
+// The fakeOAuthQuerier.UpdatePluginInstanceOAuthCallback returns 1 (success)
+// but does not bump the version field; we verify the call succeeds without error.
+func TestBeginAuthcode_WritesLastCallbackURL(t *testing.T) {
+	creds := testCreds("oauth2_authcode")
+	creds.AuthorizationURL = "https://provider.example.com/oauth/authorize"
+	q := buildInstanceWithCreds(t, creds)
+	mgr, _ := newTestManager(q, "https://gleipnir.example.com")
+
+	// BeginAuthcode must succeed; internally it calls UpdatePluginInstanceOAuthCallback.
+	// The fakeOAuthQuerier accepts the call silently (no error). The non-fatal
+	// design means the authorize URL is still returned even if the write failed.
+	authorizeURL, err := mgr.BeginAuthcode(context.Background(), "inst-1", "https://app.example.com/settings")
+	if err != nil {
+		t.Fatalf("BeginAuthcode: %v", err)
+	}
+	if authorizeURL == "" {
+		t.Error("expected non-empty authorize URL")
+	}
+}
+
+// TestHandleCallback_WritesLastCallbackURL verifies that a successful
+// HandleCallback records last_oauth_callback_url on the instance row (#230).
+func TestHandleCallback_WritesLastCallbackURL(t *testing.T) {
+	// Spin up a fake token endpoint so the code exchange succeeds.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok-xyz",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	creds := testCreds("oauth2_authcode")
+	creds.AuthorizationURL = "https://provider.example.com/oauth/authorize"
+	creds.TokenURL = tokenServer.URL + "/token"
+	plain, err := creds.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	enc, err := noopEncrypt(plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	q := &fakeOAuthQuerier{
+		instance: db.PluginInstance{
+			ID:                   "inst-1",
+			HealthState:          string(model.PluginHealthStatePendingReauthorize),
+			Version:              0,
+			CredentialsEncrypted: &enc,
+		},
+	}
+
+	baseTime := func() time.Time { return time.Unix(1000000, 0) }
+	store := NewDBStore(q, noopEncrypt, noopDecrypt, q, baseTime)
+	nonces := &MemoryNonceStore{entries: make(map[string]time.Time), clock: baseTime}
+	hmacKey := fixedKey()
+	mgr := NewManager(store, nonces, baseTime, hmacKey, func() string { return "https://gleipnir.example.com" })
+
+	ctx := context.Background()
+
+	// Build a valid signed state and record its nonce.
+	env, nonce, err := NewStateEnvelope("inst-1", "https://app.example.com/done", baseTime)
+	if err != nil {
+		t.Fatalf("NewStateEnvelope: %v", err)
+	}
+	if err := nonces.Record(ctx, nonce, "inst-1"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	encoded, err := EncodeState(env, hmacKey)
+	if err != nil {
+		t.Fatalf("EncodeState: %v", err)
+	}
+
+	returnURL, err := mgr.HandleCallback(ctx, encoded, "auth-code-123")
+	if err != nil {
+		t.Fatalf("HandleCallback: %v", err)
+	}
+	if returnURL != "https://app.example.com/done" {
+		t.Errorf("returnURL = %q, want https://app.example.com/done", returnURL)
+	}
+
+	// After a successful callback the instance should have moved to healthy.
+	if q.instance.HealthState != string(model.PluginHealthStateHealthy) {
+		t.Errorf("health_state = %q, want healthy after HandleCallback", q.instance.HealthState)
+	}
+
+	// The callback-URL write must have been attempted exactly once.
+	if q.callbackUpdates != 1 {
+		t.Errorf("callbackUpdates = %d, want 1 after HandleCallback", q.callbackUpdates)
+	}
+}
+
+// TestBeginClientcred_WritesLastCallbackURL verifies that a successful
+// BeginClientcred records last_oauth_callback_url when public_url is set (#230).
+func TestBeginClientcred_WritesLastCallbackURL(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok-abc",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	creds := testCreds("oauth2_clientcred")
+	creds.TokenURL = tokenServer.URL + "/token"
+	plain, err := creds.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	enc, err := noopEncrypt(plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	q := &fakeOAuthQuerier{
+		instance: db.PluginInstance{
+			ID:                   "inst-1",
+			HealthState:          string(model.PluginHealthStateUnhealthy),
+			Version:              1,
+			CredentialsEncrypted: &enc,
+		},
+	}
+
+	mgr, _ := newTestManager(q, "https://gleipnir.example.com")
+	if err := mgr.BeginClientcred(context.Background(), "inst-1"); err != nil {
+		t.Fatalf("BeginClientcred: %v", err)
+	}
+
+	// The callback-URL write must have been attempted exactly once.
+	if q.callbackUpdates != 1 {
+		t.Errorf("callbackUpdates = %d, want 1 after BeginClientcred", q.callbackUpdates)
+	}
+}
+
+// TestBeginClientcred_SkipsCallbackURL_WhenPublicURLEmpty verifies that
+// BeginClientcred silently skips the callback URL write when public_url is
+// empty — the token is still saved (#230).
+func TestBeginClientcred_SkipsCallbackURL_WhenPublicURLEmpty(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok-abc",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	creds := testCreds("oauth2_clientcred")
+	creds.TokenURL = tokenServer.URL + "/token"
+	plain, _ := creds.Marshal()
+	enc, _ := noopEncrypt(plain)
+	q := &fakeOAuthQuerier{
+		instance: db.PluginInstance{
+			ID:                   "inst-1",
+			HealthState:          string(model.PluginHealthStateUnhealthy),
+			Version:              1,
+			CredentialsEncrypted: &enc,
+		},
+	}
+
+	// Empty public_url — callback URL must not be written.
+	mgr, _ := newTestManager(q, "")
+	if err := mgr.BeginClientcred(context.Background(), "inst-1"); err != nil {
+		t.Fatalf("BeginClientcred: %v", err)
+	}
+
+	// Should still succeed — token and health state written, but callback URL skipped.
+	// We don't assert exact version because health + credentials writes still happen.
+	// The important invariant is: no panic and no error returned.
+}
+
 func TestHandleCallback_NonceSingleUse_WithDBStore(t *testing.T) {
 	baseTime := time.Unix(1000000, 0)
 	clock := func() time.Time { return baseTime }

--- a/internal/plugin/oauth/store_test.go
+++ b/internal/plugin/oauth/store_test.go
@@ -21,12 +21,13 @@ import (
 // --- fake querier ---
 
 type fakeOAuthQuerier struct {
-	instance      db.PluginInstance
-	updateCalls   int
-	casFailTimes  int // fail the first N UpdatePluginInstanceCredentials calls
-	healthUpdates []db.UpdatePluginInstanceHealthParams
-	auditEvents   []db.InsertPluginAuditEventParams
-	expiringRows  []db.PluginInstance
+	instance        db.PluginInstance
+	updateCalls     int
+	casFailTimes    int // fail the first N UpdatePluginInstanceCredentials calls
+	healthUpdates   []db.UpdatePluginInstanceHealthParams
+	auditEvents     []db.InsertPluginAuditEventParams
+	expiringRows    []db.PluginInstance
+	callbackUpdates int
 }
 
 func (f *fakeOAuthQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
@@ -64,7 +65,10 @@ func (f *fakeOAuthQuerier) ListPluginInstancesWithExpiringCredentials(_ context.
 	return f.expiringRows, nil
 }
 
-func (f *fakeOAuthQuerier) UpdatePluginInstanceOAuthCallback(_ context.Context, _ db.UpdatePluginInstanceOAuthCallbackParams) (int64, error) {
+func (f *fakeOAuthQuerier) UpdatePluginInstanceOAuthCallback(_ context.Context, arg db.UpdatePluginInstanceOAuthCallbackParams) (int64, error) {
+	f.callbackUpdates++
+	f.instance.LastOauthCallbackUrl = arg.LastOauthCallbackUrl
+	f.instance.Version++
 	return 1, nil
 }
 

--- a/internal/plugin/state/pluginstate.go
+++ b/internal/plugin/state/pluginstate.go
@@ -69,6 +69,7 @@ var severity = map[model.PluginHealthState]int{
 	model.PluginHealthStatePendingKeyApproval:      2,
 	model.PluginHealthStatePendingManifestApproval: 2,
 	model.PluginHealthStatePendingConfigMigration:  2,
+	model.PluginHealthStatePendingReauthorize:      2,
 	model.PluginHealthStateUnhealthy:               3,
 	model.PluginHealthStateCircuitBroken:           4,
 	model.PluginHealthStateVerificationError:       5,
@@ -126,13 +127,24 @@ var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
 		model.PluginHealthStateCircuitBroken,
 		model.PluginHealthStatePendingManifestApproval, // hot-reload detects manifest change
 		model.PluginHealthStatePendingKeyApproval,      // new signed update with mismatched key (#188)
+		model.PluginHealthStatePendingReauthorize,      // public_url changed; callback URL stale (#230)
 	},
 	model.PluginHealthStateUnsignedPermissive: {
 		model.PluginHealthStateUnhealthy,
 		model.PluginHealthStateCrashed,
 		model.PluginHealthStateCircuitBroken,
 		model.PluginHealthStatePendingManifestApproval,
-		model.PluginHealthStatePendingKeyApproval, // signed update arrives for previously-unsigned plugin (#188)
+		model.PluginHealthStatePendingKeyApproval,  // signed update arrives for previously-unsigned plugin (#188)
+		model.PluginHealthStatePendingReauthorize,  // public_url changed (#230)
+	},
+	// #194 rationale: real availability problems must be visible regardless of
+	// pending_reauthorize. Exit edges include unhealthy/crashed/circuit_broken
+	// so those states can surface during an otherwise-stale re-auth wait.
+	model.PluginHealthStatePendingReauthorize: {
+		model.PluginHealthStateHealthy,
+		model.PluginHealthStateUnhealthy,
+		model.PluginHealthStateCrashed,
+		model.PluginHealthStateCircuitBroken,
 	},
 	model.PluginHealthStateUnhealthy: {
 		model.PluginHealthStateHealthy,
@@ -144,12 +156,14 @@ var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateUnhealthy,
 		model.PluginHealthStateCrashed,
-		model.PluginHealthStatePendingKeyApproval, // key mismatch detected during circuit-broken state (#188)
+		model.PluginHealthStatePendingKeyApproval,  // key mismatch detected during circuit-broken state (#188)
+		model.PluginHealthStatePendingReauthorize,  // public_url changed (#230)
 	},
 	model.PluginHealthStateCrashed: {
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateUnhealthy,
 		model.PluginHealthStatePendingKeyApproval, // key mismatch detected after crash (#188)
+		model.PluginHealthStatePendingReauthorize, // public_url changed (#230)
 	},
 	// signature_invalid and verification_error are terminal — no outgoing edges.
 	// A re-install or admin key-rotation creates a fresh instance row.

--- a/internal/plugin/state/pluginstate_test.go
+++ b/internal/plugin/state/pluginstate_test.go
@@ -110,6 +110,16 @@ func TestIsLegalTransition(t *testing.T) {
 		{model.PluginHealthStateCircuitBroken, model.PluginHealthStateCrashed},
 		{model.PluginHealthStateCrashed, model.PluginHealthStateHealthy},
 		{model.PluginHealthStateCrashed, model.PluginHealthStateUnhealthy},
+		// #230: pending_reauthorize is reachable from operationally active states.
+		{model.PluginHealthStateHealthy, model.PluginHealthStatePendingReauthorize},
+		{model.PluginHealthStateUnsignedPermissive, model.PluginHealthStatePendingReauthorize},
+		{model.PluginHealthStateCrashed, model.PluginHealthStatePendingReauthorize},
+		{model.PluginHealthStateCircuitBroken, model.PluginHealthStatePendingReauthorize},
+		// #230: pending_reauthorize exits toward healthy and real-failure states.
+		{model.PluginHealthStatePendingReauthorize, model.PluginHealthStateHealthy},
+		{model.PluginHealthStatePendingReauthorize, model.PluginHealthStateUnhealthy},
+		{model.PluginHealthStatePendingReauthorize, model.PluginHealthStateCrashed},
+		{model.PluginHealthStatePendingReauthorize, model.PluginHealthStateCircuitBroken},
 	}
 	for _, pair := range legal {
 		if !IsLegalTransition(pair[0], pair[1]) {
@@ -122,11 +132,27 @@ func TestIsLegalTransition(t *testing.T) {
 		{model.PluginHealthStateVerificationError, model.PluginHealthStateHealthy},
 		// signature_invalid and verification_error are terminal — no outgoing edges.
 		{model.PluginHealthStateCrashed, model.PluginHealthStateSignatureInvalid},
+		// #230: pending_reauthorize cannot jump to other pending_* states or
+		// to terminal states.
+		{model.PluginHealthStatePendingReauthorize, model.PluginHealthStateSignatureInvalid},
+		{model.PluginHealthStatePendingReauthorize, model.PluginHealthStateVerificationError},
+		{model.PluginHealthStatePendingReauthorize, model.PluginHealthStatePendingKeyApproval},
+		// pending_key_approval cannot jump to pending_reauthorize (#230).
+		{model.PluginHealthStatePendingKeyApproval, model.PluginHealthStatePendingReauthorize},
 	}
 	for _, pair := range illegal {
 		if IsLegalTransition(pair[0], pair[1]) {
 			t.Errorf("IsLegalTransition(%s, %s) = true, want false", pair[0], pair[1])
 		}
+	}
+}
+
+func TestPendingReauthorizeSeverity(t *testing.T) {
+	// pending_reauthorize must sit at rank 2 (operator-action-pending tier),
+	// matching the other pending_* states.
+	got := Severity(model.PluginHealthStatePendingReauthorize)
+	if got != 2 {
+		t.Errorf("Severity(pending_reauthorize) = %d, want 2", got)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -470,6 +470,18 @@ func run(cfg config.Config) error {
 		oauthScanner.Start(ctx)
 		pluginOAuthHandler = admin.NewPluginOAuthHandler(store.Queries(), oauthMgr)
 		pluginCredHandler = admin.NewPluginCredentialsHandler(store.Queries(), oauthStore)
+
+		// Wire the callback-URL rescan so it fires whenever an admin changes
+		// public_url (#230). Constructed after adminHandler so we can set the hook
+		// directly without adminHandler importing internal/plugin/oauth.
+		callbackRescanner := pluginoauth.NewCallbackRescanner(
+			store.Queries(), store.Queries(), getPublicURL, time.Now,
+		)
+		adminHandler.OnPublicURLChanged = func(hookCtx context.Context, _, _ string) {
+			if _, err := callbackRescanner.Scan(hookCtx); err != nil {
+				slog.ErrorContext(hookCtx, "callback rescan failed after public_url change", "err", err)
+			}
+		}
 	}
 
 	handlers := api.HandlerBundle{

--- a/schemas/sql_schemas.sql
+++ b/schemas/sql_schemas.sql
@@ -429,8 +429,9 @@ CREATE TABLE plugin_instances (
                                          'unsigned_permissive',
                                          'unhealthy',
                                          'crashed',
-                                         'circuit_broken'
-                                     )),                                                  -- ADR-038, ADR-045 §7, issue #191
+                                         'circuit_broken',
+                                         'pending_reauthorize'
+                                     )),                                                  -- ADR-038, ADR-045 §7, issue #191, #230
     health_detail            TEXT,                                                        -- nullable; operator-facing reason for non-healthy state
     last_oauth_callback_url  TEXT,                                                        -- nullable; OAuth-flow plumbing (#230)
     version                  INTEGER NOT NULL DEFAULT 0,                                  -- ADR-038 CAS counter


### PR DESCRIPTION
Closes #230

## Summary
- New plugin health state `pending_reauthorize` (severity 2, alongside other `pending_*` states).
- New `CallbackRescanner` runs synchronously when an admin changes `public_url` in `/admin/system`. It compares each eligible instance's recorded `last_oauth_callback_url` against the freshly-derived expected URL and flips mismatches to `pending_reauthorize`. Eligible: `healthy`, `unsigned_permissive`, `crashed`, `circuit_broken`. `unhealthy` excluded so we don't mask an active availability problem.
- `HandleCallback` and `BeginClientcred` now write `last_oauth_callback_url` after successful authorize, in addition to the existing `BeginAuthcode` write — guarantees the URL is set on initial successful authorize per AC #1. Both use a fresh-Get-then-CAS pattern; failures are tolerated with `slog.WarnContext`.
- Existing `GET /api/v1/admin/plugin-instances` DTO extended with `last_oauth_callback_url`; no new endpoint.
- New `/admin/plugins` page consumes the existing audience hook, surfacing instances with `pending_reauthorize` in a top "Needs re-authorization" section that links to the existing per-instance Re-authorize button. Sidebar gains a "Plugins" nav entry.
- Settings hook injection in `main.go` preserves the `internal/admin` → `internal/plugin/oauth` package boundary.

## Review
- Architect plan + adversarial plan-reviewer pass before implementation.
- Code review: 2 cycles. Cycle 1 flagged silent error-discard in OAuth manager + tests that didn't actually verify the new write + dead code in migration; cycle 2 approved.
- `frontend/CLAUDE.md` route documentation updated.

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` (omitted — local artifact). Key decisions:
- Track callback URL on success in `HandleCallback` *in addition to* the existing `BeginAuthcode` write — prevents legacy NULL rows.
- Fresh `GetPluginInstanceByID` before the post-callback CAS write (Begin's version may be stale by the time the user completes the dance).
- One scan kicked from the settings write (no polling scanner) — `public_url` only changes via the admin UI.
- `pending_reauthorize` exit edges to `unhealthy`/`crashed`/`circuit_broken` mirror `pending_key_approval`'s #194 pattern: real availability problems must be visible regardless of pending_* state.
- Reuse the existing `/admin/plugin-instances` AudienceHandler endpoint rather than create a parallel admin endpoint.
- AC #5 (in-progress OAuth dances) explicitly out of scope — existing HMAC state envelope already fails safely on `public_url` change.

</details>

🤖 Generated by the agentic dev loop (architect → plan-reviewer → developer → code-reviewer x2)