### PR TITLE
feat: Credentials tab driven by manifest auth strategy

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -36,7 +36,7 @@ npm run build-storybook  # static Storybook build
 /admin/audiences/new → create audience (admin|operator)
 /admin/audiences/:id → audience detail/editor (admin|operator: edit; auditor: read-only)
 /admin/plugins      → plugin instance list (admin); groups instances pending re-authorization at top after a public_url change (#230)
-/admin/plugins/:id/instances/:iid → plugin instance editor (admin); Subscriptions tab edits coarse watch scope (#223), Config and Credentials tabs are placeholders for #241/#242
+/admin/plugins/:id/instances/:iid → plugin instance editor (admin); Subscriptions tab edits coarse watch scope (#223), Credentials tab renders per the manifest's auth strategy (write-only static API key / header set / basic auth; Authorize / Re-authorize for OAuth — #231), Config tab is a placeholder for #241
 *                   → 404 not found
 ```
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -562,3 +562,44 @@ export interface ApiBindingTestRequest {
 export interface ApiBindingTestResponse {
   results: { match: boolean; error?: string }[]
 }
+
+// PluginAuthStrategy mirrors the AuthStrategy* constants in plugin-sdk/manifest.
+// Used to type-narrow credential form rendering in CredentialsTab.
+export type PluginAuthStrategy =
+  | 'none'
+  | 'static_api_key'
+  | 'header_set'
+  | 'basic_auth'
+  | 'oauth2_authcode'
+  | 'oauth2_clientcred'
+
+// ApiRedactedCredentials mirrors internal/plugin/oauth.RedactedCredentials
+// (internal/plugin/oauth/credentials.go). Secret values are NEVER present —
+// only presence flags (has_api_key, has_password, has_client_secret, has_token)
+// and non-secret metadata.
+export interface ApiRedactedCredentials {
+  strategy: string
+
+  // static_api_key fields
+  header_name?: string
+  scheme?: string
+  has_api_key?: boolean
+
+  // header_set fields
+  header_names?: string[]
+
+  // basic_auth fields
+  username?: string
+  has_password?: boolean
+
+  // oauth2_* fields
+  client_id?: string
+  has_client_secret?: boolean
+  authorization_url?: string
+  token_url?: string
+  scopes?: string[]
+  has_token?: boolean
+  // token_expires_at is an RFC3339Nano UTC timestamp. Absent when the token is
+  // missing or has a zero expiry.
+  token_expires_at?: string
+}

--- a/frontend/src/components/admin/CredentialsTab/CredentialsTab.module.css
+++ b/frontend/src/components/admin/CredentialsTab/CredentialsTab.module.css
@@ -1,0 +1,181 @@
+.tab {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+/* Field rows */
+
+.fieldRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.fieldLabel {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+.optional {
+  font-weight: var(--weight-normal);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.writeOnlyNote {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.input {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-mid);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-blue);
+  outline-offset: 1px;
+}
+
+.input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Header set */
+
+.headerList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.headerItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+}
+
+.headerName {
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+.sectionLabel {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-second);
+}
+
+.addHeaderRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: var(--space-2);
+  align-items: start;
+}
+
+/* OAuth metadata grid */
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--space-2) var(--space-4);
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+.metaGrid dt {
+  color: var(--text-second);
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+}
+
+.metaGrid dd {
+  margin: 0;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.metaUrl {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+/* Action / save rows */
+
+.actionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.savedConfirm {
+  font-size: var(--text-sm);
+  color: var(--color-green);
+}
+
+/* Clear credentials (destructive) */
+
+.clearSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* Messages */
+
+.errorMsg {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-red);
+}
+
+.emptyMsg {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.loading {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+/* Strategy mismatch warning — amber tint matching the re-auth banner */
+.mismatchWarning {
+  padding: var(--space-3) var(--space-4);
+  background: rgba(240, 200, 48, 0.12);
+  border: 1px solid rgba(240, 200, 48, 0.3);
+  border-radius: 4px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}

--- a/frontend/src/components/admin/CredentialsTab/CredentialsTab.stories.tsx
+++ b/frontend/src/components/admin/CredentialsTab/CredentialsTab.stories.tsx
@@ -1,0 +1,350 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import '@/tokens.css'
+import { CredentialsTab } from './CredentialsTab'
+import { queryKeys } from '@/hooks/queryKeys'
+import type { ApiRedactedCredentials } from '@/api/types'
+import { RefreshFailureDetailPrefix } from '@/utils/pluginHealth'
+
+const PLUGIN_ID = 'plugin-test-01'
+const INSTANCE_ID = 'inst-test-prod'
+
+const CREDS_URL = `/api/v1/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}/credentials`
+
+function makeQueryClient(creds: ApiRedactedCredentials): QueryClient {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  qc.setQueryData(queryKeys.plugins.credentials(PLUGIN_ID, INSTANCE_ID), creds)
+  return qc
+}
+
+function Wrapper({
+  creds,
+  children,
+}: {
+  creds: ApiRedactedCredentials
+  children: React.ReactNode
+}) {
+  return (
+    <QueryClientProvider client={makeQueryClient(creds)}>
+      <div style={{ maxWidth: 640, padding: 24 }}>{children}</div>
+    </QueryClientProvider>
+  )
+}
+
+const meta: Meta<typeof CredentialsTab> = {
+  title: 'Admin/CredentialsTab',
+  component: CredentialsTab,
+}
+
+export default meta
+type Story = StoryObj<typeof CredentialsTab>
+
+// ── none ──────────────────────────────────────────────────────────────────────
+
+export const None: Story = {
+  render: () => (
+    <Wrapper creds={{ strategy: 'none' }}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="none"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+// ── static_api_key ────────────────────────────────────────────────────────────
+
+const STATIC_API_KEY_CREDS: ApiRedactedCredentials = {
+  strategy: 'static_api_key',
+  header_name: 'X-API-Key',
+  scheme: 'Bearer',
+  has_api_key: true,
+}
+
+export const StaticAPIKey: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.put(CREDS_URL + '/static-api-key', () =>
+          HttpResponse.json({ data: {} }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <Wrapper creds={STATIC_API_KEY_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="static_api_key"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+export const StaticAPIKeyAuditor: Story = {
+  render: () => (
+    <Wrapper creds={STATIC_API_KEY_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="static_api_key"
+        canManage={false}
+      />
+    </Wrapper>
+  ),
+}
+
+// ── header_set ────────────────────────────────────────────────────────────────
+
+const HEADER_SET_CREDS: ApiRedactedCredentials = {
+  strategy: 'header_set',
+  header_names: ['X-Custom-Auth', 'X-Tenant-ID'],
+}
+
+export const HeaderSet: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.put(CREDS_URL + '/headers/:name', () =>
+          HttpResponse.json({ data: {} }),
+        ),
+        http.delete(CREDS_URL + '/headers/:name', () =>
+          HttpResponse.json({ data: {} }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <Wrapper creds={HEADER_SET_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="header_set"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+export const HeaderSetEmpty: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.put(CREDS_URL + '/headers/:name', () =>
+          HttpResponse.json({ data: {} }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <Wrapper creds={{ strategy: 'header_set', header_names: [] }}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="header_set"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+export const HeaderSetAuditor: Story = {
+  render: () => (
+    <Wrapper creds={HEADER_SET_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="header_set"
+        canManage={false}
+      />
+    </Wrapper>
+  ),
+}
+
+// ── basic_auth ────────────────────────────────────────────────────────────────
+
+const BASIC_AUTH_CREDS: ApiRedactedCredentials = {
+  strategy: 'basic_auth',
+  username: 'service-account',
+  has_password: true,
+}
+
+export const BasicAuth: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.put(CREDS_URL + '/basic-auth', () =>
+          HttpResponse.json({ data: {} }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <Wrapper creds={BASIC_AUTH_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="basic_auth"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+// ── oauth2_authcode — no token yet ────────────────────────────────────────────
+
+const OAUTH_NO_TOKEN_CREDS: ApiRedactedCredentials = {
+  strategy: 'oauth2_authcode',
+  client_id: 'my-client-id',
+  has_client_secret: true,
+  authorization_url: 'https://provider.example.com/authorize',
+  token_url: 'https://provider.example.com/token',
+  scopes: ['read', 'write'],
+  has_token: false,
+}
+
+export const OAuth2AuthcodeNoToken: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(
+          `/api/v1/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}/oauth/begin`,
+          () =>
+            HttpResponse.json({
+              data: { authorize_url: 'https://provider.example.com/authorize?state=xyz' },
+            }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <Wrapper creds={OAUTH_NO_TOKEN_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="oauth2_authcode"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+// ── oauth2_authcode — token present, healthy ──────────────────────────────────
+
+const OAUTH_WITH_TOKEN_CREDS: ApiRedactedCredentials = {
+  strategy: 'oauth2_authcode',
+  client_id: 'my-client-id',
+  has_client_secret: true,
+  authorization_url: 'https://provider.example.com/authorize',
+  token_url: 'https://provider.example.com/token',
+  scopes: ['read', 'write'],
+  has_token: true,
+  token_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+}
+
+export const OAuth2AuthcodeHealthy: Story = {
+  render: () => (
+    <Wrapper creds={OAUTH_WITH_TOKEN_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="oauth2_authcode"
+        healthState="healthy"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+// ── oauth2_authcode — refresh failed (Re-authorize CTA) ──────────────────────
+
+export const OAuth2AuthcodeRefreshFailed: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(
+          `/api/v1/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}/oauth/begin`,
+          () =>
+            HttpResponse.json({
+              data: { authorize_url: 'https://provider.example.com/authorize?state=xyz' },
+            }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <Wrapper creds={OAUTH_WITH_TOKEN_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="oauth2_authcode"
+        healthState="unhealthy"
+        healthDetail={`${RefreshFailureDetailPrefix}: token expired`}
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+// ── oauth2_clientcred ─────────────────────────────────────────────────────────
+
+const OAUTH_CLIENTCRED_CREDS: ApiRedactedCredentials = {
+  strategy: 'oauth2_clientcred',
+  client_id: 'service-app',
+  has_client_secret: true,
+  token_url: 'https://auth.example.com/token',
+  scopes: ['api.read'],
+  has_token: true,
+}
+
+export const OAuth2Clientcred: Story = {
+  render: () => (
+    <Wrapper creds={OAUTH_CLIENTCRED_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="oauth2_clientcred"
+        healthState="healthy"
+        canManage
+      />
+    </Wrapper>
+  ),
+}
+
+// ── Auditor read-only (OAuth) ─────────────────────────────────────────────────
+
+export const AuditorReadOnly: Story = {
+  render: () => (
+    <Wrapper creds={OAUTH_WITH_TOKEN_CREDS}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="oauth2_authcode"
+        healthState="healthy"
+        canManage={false}
+      />
+    </Wrapper>
+  ),
+}
+
+// ── Strategy mismatch warning ─────────────────────────────────────────────────
+
+// Server returns basic_auth, but manifest now declares static_api_key.
+// This can happen briefly during a hot-reload before the credential row is migrated.
+export const StrategyMismatch: Story = {
+  render: () => (
+    <Wrapper creds={{ strategy: 'basic_auth', username: 'admin', has_password: true }}>
+      <CredentialsTab
+        pluginId={PLUGIN_ID}
+        instanceId={INSTANCE_ID}
+        strategy="static_api_key"
+        canManage
+      />
+    </Wrapper>
+  ),
+}

--- a/frontend/src/components/admin/CredentialsTab/CredentialsTab.test.tsx
+++ b/frontend/src/components/admin/CredentialsTab/CredentialsTab.test.tsx
@@ -1,0 +1,475 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/server'
+import { CredentialsTab } from './CredentialsTab'
+import { queryKeys } from '@/hooks/queryKeys'
+import type { ApiRedactedCredentials } from '@/api/types'
+import { RefreshFailureDetailPrefix } from '@/utils/pluginHealth'
+
+const PLUGIN_ID = 'plug-1'
+const INSTANCE_ID = 'inst-1'
+
+const BASE_URL = `/api/v1/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}/credentials`
+
+// Install a fallback GET /credentials handler before every test so that when
+// a mutation's onSuccess calls invalidateQueries → re-fetch, the GET returns
+// the pre-seeded data rather than failing with a network error.
+// This is a no-op for tests that pre-seed the QueryClient and don't trigger
+// mutations (those tests never hit the network at all with staleTime: Infinity).
+beforeEach(() => {
+  server.use(
+    http.get(BASE_URL, () => HttpResponse.json({ data: { strategy: 'none' } })),
+  )
+})
+
+function makeClient(creds?: ApiRedactedCredentials): QueryClient {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        // staleTime: Infinity prevents background refetches from clobbering
+        // pre-seeded test data with a failed network call.
+        staleTime: Infinity,
+      },
+      mutations: { retry: false },
+    },
+  })
+  if (creds) {
+    qc.setQueryData(queryKeys.plugins.credentials(PLUGIN_ID, INSTANCE_ID), creds)
+  }
+  return qc
+}
+
+function renderTab(
+  props: Partial<React.ComponentProps<typeof CredentialsTab>> & {
+    creds?: ApiRedactedCredentials
+  },
+) {
+  const { creds, ...rest } = props
+  const qc = makeClient(creds)
+  return {
+    qc,
+    ...render(
+      <QueryClientProvider client={qc}>
+        <CredentialsTab
+          pluginId={PLUGIN_ID}
+          instanceId={INSTANCE_ID}
+          strategy="none"
+          canManage={true}
+          {...rest}
+        />
+      </QueryClientProvider>,
+    ),
+  }
+}
+
+// ── strategy: none ────────────────────────────────────────────────────────────
+
+describe('strategy: none', () => {
+  it('renders the no-authentication placeholder', () => {
+    renderTab({ creds: { strategy: 'none' }, strategy: 'none' })
+    expect(screen.getByText(/no authentication credentials/i)).toBeInTheDocument()
+  })
+})
+
+// ── strategy: static_api_key ──────────────────────────────────────────────────
+
+describe('strategy: static_api_key', () => {
+  const creds: ApiRedactedCredentials = {
+    strategy: 'static_api_key',
+    header_name: 'X-API-Key',
+    scheme: 'Bearer',
+    has_api_key: true,
+  }
+
+  it('renders header name and scheme pre-populated from creds', () => {
+    renderTab({ creds, strategy: 'static_api_key' })
+    expect(screen.getByDisplayValue('X-API-Key')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Bearer')).toBeInTheDocument()
+  })
+
+  it('sends the correct PUT body on save', async () => {
+    let captured: unknown
+    server.use(
+      http.put(BASE_URL + '/static-api-key', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json({ data: {} })
+      }),
+    )
+
+    renderTab({ creds, strategy: 'static_api_key' })
+
+    const apiKeyInput = screen.getByLabelText(/api key/i)
+    await userEvent.type(apiKeyInput, 'secret-value')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(captured).toMatchObject({
+        header_name: 'X-API-Key',
+        scheme: 'Bearer',
+        api_key: 'secret-value',
+      })
+    })
+  })
+
+  it('shows a validation error when api key is empty', async () => {
+    renderTab({ creds, strategy: 'static_api_key' })
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/api key is required/i)
+  })
+
+  it('shows saved confirmation after a successful save', async () => {
+    server.use(
+      http.put(BASE_URL + '/static-api-key', () =>
+        HttpResponse.json({ data: {} }),
+      ),
+    )
+    renderTab({ creds, strategy: 'static_api_key' })
+    const apiKeyInput = screen.getByLabelText(/api key/i)
+    await userEvent.type(apiKeyInput, 'my-key')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    await waitFor(() => expect(screen.getByText('Saved.')).toBeInTheDocument())
+  })
+
+  it('auditor: inputs are disabled and save button hidden', () => {
+    renderTab({ creds, strategy: 'static_api_key', canManage: false })
+    const inputs = screen.getAllByRole('textbox')
+    inputs.forEach((input) => expect(input).toBeDisabled())
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
+  })
+})
+
+// ── strategy: header_set ──────────────────────────────────────────────────────
+
+describe('strategy: header_set', () => {
+  const creds: ApiRedactedCredentials = {
+    strategy: 'header_set',
+    header_names: ['X-Auth', 'X-Tenant'],
+  }
+
+  it('renders existing header names', () => {
+    renderTab({ creds, strategy: 'header_set' })
+    expect(screen.getByText('X-Auth')).toBeInTheDocument()
+    expect(screen.getByText('X-Tenant')).toBeInTheDocument()
+  })
+
+  it('sends DELETE on header delete click', async () => {
+    let deletedName = ''
+    server.use(
+      http.delete(BASE_URL + '/headers/:name', ({ params }) => {
+        deletedName = params.name as string
+        return HttpResponse.json({ data: {} })
+      }),
+    )
+    renderTab({ creds, strategy: 'header_set' })
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
+    await userEvent.click(deleteButtons[0])
+    await waitFor(() => expect(deletedName).toBe('X-Auth'))
+  })
+
+  it('sends PUT on add header with valid name and value', async () => {
+    let captured: unknown
+    server.use(
+      http.put(BASE_URL + '/headers/X-New-Header', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json({ data: {} })
+      }),
+    )
+    renderTab({ creds: { strategy: 'header_set', header_names: [] }, strategy: 'header_set' })
+    await userEvent.type(screen.getByLabelText(/new header name/i), 'X-New-Header')
+    await userEvent.type(screen.getByLabelText(/new header value/i), 'my-value')
+    await userEvent.click(screen.getByRole('button', { name: /add/i }))
+    await waitFor(() => expect(captured).toEqual({ value: 'my-value' }))
+  })
+
+  it('rejects reserved header names client-side', async () => {
+    renderTab({ creds: { strategy: 'header_set', header_names: [] }, strategy: 'header_set' })
+    await userEvent.type(screen.getByLabelText(/new header name/i), 'Content-Type')
+    await userEvent.type(screen.getByLabelText(/new header value/i), 'anything')
+    await userEvent.click(screen.getByRole('button', { name: /add/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/reserved header name/i)
+  })
+
+  it('rejects Mcp-Session-Id as a reserved header', async () => {
+    renderTab({ creds: { strategy: 'header_set', header_names: [] }, strategy: 'header_set' })
+    await userEvent.type(screen.getByLabelText(/new header name/i), 'Mcp-Session-Id')
+    await userEvent.type(screen.getByLabelText(/new header value/i), 'anything')
+    await userEvent.click(screen.getByRole('button', { name: /add/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/reserved header name/i)
+  })
+
+  it('auditor: add row is hidden', () => {
+    renderTab({ creds, strategy: 'header_set', canManage: false })
+    expect(screen.queryByLabelText(/new header name/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument()
+  })
+})
+
+// ── strategy: basic_auth ──────────────────────────────────────────────────────
+
+describe('strategy: basic_auth', () => {
+  const creds: ApiRedactedCredentials = {
+    strategy: 'basic_auth',
+    username: 'admin',
+    has_password: true,
+  }
+
+  it('renders the pre-populated username', () => {
+    renderTab({ creds, strategy: 'basic_auth' })
+    expect(screen.getByDisplayValue('admin')).toBeInTheDocument()
+  })
+
+  it('sends the correct PUT body on save', async () => {
+    let captured: unknown
+    server.use(
+      http.put(BASE_URL + '/basic-auth', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json({ data: {} })
+      }),
+    )
+    renderTab({ creds, strategy: 'basic_auth' })
+    const passwordInput = screen.getByLabelText(/password/i)
+    await userEvent.type(passwordInput, 'newpass')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    await waitFor(() =>
+      expect(captured).toMatchObject({ username: 'admin', password: 'newpass' }),
+    )
+  })
+
+  it('shows a validation error when password is empty', async () => {
+    renderTab({ creds, strategy: 'basic_auth' })
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/password is required/i)
+  })
+})
+
+// ── strategy: oauth2_authcode ─────────────────────────────────────────────────
+
+describe('strategy: oauth2_authcode', () => {
+  const credsNoToken: ApiRedactedCredentials = {
+    strategy: 'oauth2_authcode',
+    client_id: 'cid',
+    has_client_secret: true,
+    authorization_url: 'https://provider.test/authorize',
+    token_url: 'https://provider.test/token',
+    scopes: ['read'],
+    has_token: false,
+  }
+
+  const credsWithToken: ApiRedactedCredentials = {
+    ...credsNoToken,
+    has_token: true,
+    token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  }
+
+  it('shows "Authorize" button when no token', () => {
+    renderTab({ creds: credsNoToken, strategy: 'oauth2_authcode' })
+    expect(screen.getByRole('button', { name: /^authorize$/i })).toBeInTheDocument()
+  })
+
+  it('shows metadata rows (client_id, scopes, token present)', () => {
+    renderTab({ creds: credsWithToken, strategy: 'oauth2_authcode', healthState: 'healthy' })
+    expect(screen.getByText('cid')).toBeInTheDocument()
+    expect(screen.getByText('read')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('shows "Re-authorize" when token present but refresh failed', () => {
+    renderTab({
+      creds: credsWithToken,
+      strategy: 'oauth2_authcode',
+      healthState: 'unhealthy',
+      healthDetail: `${RefreshFailureDetailPrefix}: server 401`,
+    })
+    expect(screen.getByRole('button', { name: /re-authorize/i })).toBeInTheDocument()
+  })
+
+  it('shows no oauth button when token present and healthy', () => {
+    renderTab({ creds: credsWithToken, strategy: 'oauth2_authcode', healthState: 'healthy' })
+    expect(screen.queryByRole('button', { name: /authorize/i })).not.toBeInTheDocument()
+  })
+
+  it('auditor: no authorize button even when no token', () => {
+    renderTab({ creds: credsNoToken, strategy: 'oauth2_authcode', canManage: false })
+    expect(screen.queryByRole('button', { name: /authorize/i })).not.toBeInTheDocument()
+  })
+})
+
+// ── strategy: oauth2_clientcred ───────────────────────────────────────────────
+
+describe('strategy: oauth2_clientcred', () => {
+  const creds: ApiRedactedCredentials = {
+    strategy: 'oauth2_clientcred',
+    client_id: 'svc',
+    has_client_secret: true,
+    token_url: 'https://auth.test/token',
+    has_token: false,
+  }
+
+  it('renders "Authorize" button when no token', () => {
+    renderTab({ creds, strategy: 'oauth2_clientcred' })
+    expect(screen.getByRole('button', { name: /^authorize$/i })).toBeInTheDocument()
+  })
+})
+
+// ── strategy mismatch ─────────────────────────────────────────────────────────
+
+describe('strategy mismatch', () => {
+  it('shows a mismatch warning when server strategy differs from prop strategy', () => {
+    renderTab({
+      creds: { strategy: 'basic_auth', username: 'admin' },
+      strategy: 'static_api_key',
+    })
+    expect(screen.getByRole('alert')).toHaveTextContent(/strategy mismatch/i)
+  })
+})
+
+// ── error state ───────────────────────────────────────────────────────────────
+
+describe('error state', () => {
+  it('shows error message when credentials fetch fails', async () => {
+    // No pre-seeded data; server returns 500 so useQuery transitions to error.
+    server.use(
+      http.get(BASE_URL, () =>
+        HttpResponse.json({ error: 'Internal error' }, { status: 500 }),
+      ),
+    )
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    render(
+      <QueryClientProvider client={qc}>
+        <CredentialsTab
+          pluginId={PLUGIN_ID}
+          instanceId={INSTANCE_ID}
+          strategy="static_api_key"
+          canManage
+        />
+      </QueryClientProvider>,
+    )
+    await waitFor(() =>
+      expect(screen.getByText(/could not load credentials/i)).toBeInTheDocument(),
+    )
+  })
+})
+
+// ── clear credentials ─────────────────────────────────────────────────────────
+
+describe('clear credentials', () => {
+  it('shows Clear button when something is set and canManage=true', () => {
+    renderTab({
+      creds: { strategy: 'static_api_key', has_api_key: true },
+      strategy: 'static_api_key',
+    })
+    expect(screen.getByRole('button', { name: /clear credentials/i })).toBeInTheDocument()
+  })
+
+  it('calls DELETE /credentials on clear', async () => {
+    let called = false
+    server.use(
+      http.delete(BASE_URL, () => {
+        called = true
+        return HttpResponse.json({ data: {} })
+      }),
+    )
+    renderTab({
+      creds: { strategy: 'static_api_key', has_api_key: true },
+      strategy: 'static_api_key',
+    })
+    await userEvent.click(screen.getByRole('button', { name: /clear credentials/i }))
+    await waitFor(() => expect(called).toBe(true))
+  })
+
+  it('auditor: Clear button is hidden', () => {
+    renderTab({
+      creds: { strategy: 'static_api_key', has_api_key: true },
+      strategy: 'static_api_key',
+      canManage: false,
+    })
+    expect(screen.queryByRole('button', { name: /clear credentials/i })).not.toBeInTheDocument()
+  })
+
+  it('hides Clear button when nothing is set', () => {
+    renderTab({
+      creds: { strategy: 'static_api_key', has_api_key: false },
+      strategy: 'static_api_key',
+    })
+    expect(screen.queryByRole('button', { name: /clear credentials/i })).not.toBeInTheDocument()
+  })
+})
+
+// ── API error surfacing ───────────────────────────────────────────────────────
+
+describe('mutation error surfacing', () => {
+  it('shows inline error when PUT static-api-key fails', async () => {
+    server.use(
+      http.put(BASE_URL + '/static-api-key', () =>
+        HttpResponse.json({ error: 'Strategy mismatch', detail: 'Cannot set static_api_key on a basic_auth instance.' }, { status: 400 }),
+      ),
+    )
+    renderTab({
+      creds: { strategy: 'static_api_key', header_name: 'X-Key', has_api_key: false },
+      strategy: 'static_api_key',
+    })
+    // header_name is already populated; just fill api_key
+    await userEvent.type(screen.getByLabelText(/api key/i), 'bad-key')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    // errMessage returns the detail field first, then falls back to error
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/cannot set static_api_key/i)
+    })
+  })
+
+  it('shows inline error when PUT header fails', async () => {
+    server.use(
+      http.put(BASE_URL + '/headers/:name', () =>
+        HttpResponse.json({ error: 'Reserved header', detail: 'Mcp-Session-Id is reserved.' }, { status: 400 }),
+      ),
+    )
+    renderTab({ creds: { strategy: 'header_set', header_names: [] }, strategy: 'header_set' })
+    await userEvent.type(screen.getByLabelText(/new header name/i), 'X-Fine')
+    await userEvent.type(screen.getByLabelText(/new header value/i), 'val')
+    await userEvent.click(screen.getByRole('button', { name: /add/i }))
+    // errMessage returns the detail field first, then falls back to error
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/mcp-session-id is reserved/i)
+    })
+  })
+})
+
+// ── mock vi.fn for window.location.href ──────────────────────────────────────
+
+// The Authorize button mutates window.location.href on success. We don't need
+// to assert against that here (ReauthorizeButton tests cover it); just verify
+// the mutation is triggered.
+describe('authorize button calls oauth/begin', () => {
+  it('clicks Authorize and posts to oauth/begin', async () => {
+    let called = false
+    server.use(
+      http.post(
+        `/api/v1/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}/oauth/begin`,
+        () => {
+          called = true
+          // Return without authorize_url → clientcred-like path (no redirect)
+          return HttpResponse.json({ data: { status: 'ok' } })
+        },
+      ),
+    )
+    // Also need pluginInstances invalidation path — set a no-op handler
+    renderTab({
+      creds: { strategy: 'oauth2_authcode', has_token: false, client_id: 'c', token_url: 't' },
+      strategy: 'oauth2_authcode',
+    })
+    await userEvent.click(screen.getByRole('button', { name: /^authorize$/i }))
+    await waitFor(() => expect(called).toBe(true))
+  })
+})
+
+// Note: tests that assert window.location.href (e.g. authorize button test) do
+// not need a stub here because the mock server returns status:'ok' without
+// authorize_url, so ReauthorizeButton.onSuccess skips the href assignment.

--- a/frontend/src/components/admin/CredentialsTab/CredentialsTab.tsx
+++ b/frontend/src/components/admin/CredentialsTab/CredentialsTab.tsx
@@ -1,0 +1,624 @@
+import { useState } from 'react'
+import { Button } from '@/components/Button'
+import { ReauthorizeButton } from '@/components/admin/ReauthorizeButton/ReauthorizeButton'
+import { usePluginInstanceCredentials } from '@/hooks/queries/plugins'
+import {
+  useSetPluginStaticAPIKey,
+  useSetPluginHeader,
+  useDeletePluginHeader,
+  useSetPluginBasicAuth,
+  useClearPluginCredentials,
+} from '@/hooks/mutations/plugins'
+import { isOAuthRefreshFailure } from '@/utils/pluginHealth'
+import { formatTimestamp } from '@/utils/format'
+import type { ApiError } from '@/api/fetch'
+import type { PluginAuthStrategy } from '@/api/types'
+import styles from './CredentialsTab.module.css'
+
+// errMessage extracts a human-readable error message from a TanStack Query
+// onError callback value. TanStack Query types error as `unknown`; ApiError
+// carries `.message` and `.detail`; fall back to a generic string.
+function errMessage(err: unknown, fallback: string): string {
+  const apiErr = err as ApiError
+  return apiErr?.detail ?? apiErr?.message ?? fallback
+}
+
+// Reserved header names mirroring internal/infra/headervalidate.go.
+// Rejecting these client-side gives immediate feedback; the server also rejects them.
+const RESERVED_HEADERS = new Set([
+  'Mcp-Session-Id',
+  'Content-Type',
+  'Accept',
+  'Content-Length',
+  'Host',
+])
+
+function isReservedHeader(name: string): boolean {
+  // Case-insensitive check to match RFC 7230 header name comparison.
+  const normalised = name.toLowerCase()
+  for (const reserved of RESERVED_HEADERS) {
+    if (reserved.toLowerCase() === normalised) return true
+  }
+  return false
+}
+
+// ── StaticAPIKeyForm ──────────────────────────────────────────────────────────
+
+interface StaticAPIKeyFormProps {
+  pluginId: string
+  instanceId: string
+  initialHeaderName: string
+  initialScheme: string
+  canManage: boolean
+}
+
+function StaticAPIKeyForm({
+  pluginId,
+  instanceId,
+  initialHeaderName,
+  initialScheme,
+  canManage,
+}: StaticAPIKeyFormProps) {
+  const [headerName, setHeaderName] = useState(initialHeaderName)
+  const [scheme, setScheme] = useState(initialScheme)
+  const [apiKey, setApiKey] = useState('')
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useSetPluginStaticAPIKey()
+
+  function handleSave() {
+    setSaved(false)
+    setError(null)
+    if (!headerName.trim()) {
+      setError('Header name is required.')
+      return
+    }
+    if (!apiKey.trim()) {
+      setError('API key is required.')
+      return
+    }
+    mutation.mutate(
+      { pluginId, instanceId, header_name: headerName.trim(), scheme: scheme.trim() || undefined, api_key: apiKey },
+      {
+        onSuccess: () => {
+          setSaved(true)
+          setApiKey('')
+        },
+        onError: (err) => {
+          setError(errMessage(err, 'Save failed.'))
+        },
+      },
+    )
+  }
+
+  return (
+    <div className={styles.form}>
+      <div className={styles.fieldRow}>
+        <label htmlFor="static-header-name" className={styles.fieldLabel}>
+          Header name
+        </label>
+        <input
+          id="static-header-name"
+          type="text"
+          className={styles.input}
+          value={headerName}
+          onChange={(e) => setHeaderName(e.target.value)}
+          placeholder="e.g. X-API-Key"
+          disabled={!canManage}
+        />
+      </div>
+
+      <div className={styles.fieldRow}>
+        <label htmlFor="static-scheme" className={styles.fieldLabel}>
+          Scheme <span className={styles.optional}>(optional)</span>
+        </label>
+        <input
+          id="static-scheme"
+          type="text"
+          className={styles.input}
+          value={scheme}
+          onChange={(e) => setScheme(e.target.value)}
+          placeholder="e.g. Bearer"
+          disabled={!canManage}
+        />
+      </div>
+
+      <div className={styles.fieldRow}>
+        <label htmlFor="static-api-key" className={styles.fieldLabel}>
+          API key
+        </label>
+        <p className={styles.writeOnlyNote}>Write-only — enter a new value to replace.</p>
+        <input
+          id="static-api-key"
+          type="password"
+          className={styles.input}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          autoComplete="new-password"
+          disabled={!canManage}
+        />
+      </div>
+
+      {error && <p className={styles.errorMsg} role="alert">{error}</p>}
+
+      {canManage && (
+        <div className={styles.actionRow}>
+          <Button
+            type="button"
+            variant="primary"
+            size="small"
+            onClick={handleSave}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+          {saved && !mutation.isPending && (
+            <span className={styles.savedConfirm}>Saved.</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── HeaderSetForm ─────────────────────────────────────────────────────────────
+
+interface HeaderSetFormProps {
+  pluginId: string
+  instanceId: string
+  headerNames: string[]
+  canManage: boolean
+}
+
+function HeaderSetForm({ pluginId, instanceId, headerNames, canManage }: HeaderSetFormProps) {
+  const [newName, setNewName] = useState('')
+  const [newValue, setNewValue] = useState('')
+  const [addError, setAddError] = useState<string | null>(null)
+  const [addSaved, setAddSaved] = useState(false)
+
+  const setMutation = useSetPluginHeader()
+  const deleteMutation = useDeletePluginHeader()
+
+  function handleAdd() {
+    setAddError(null)
+    setAddSaved(false)
+    const trimmedName = newName.trim()
+    if (!trimmedName) {
+      setAddError('Header name is required.')
+      return
+    }
+    if (isReservedHeader(trimmedName)) {
+      // Client-side guard matching internal/infra/headervalidate reserved-header blocklist.
+      setAddError(`"${trimmedName}" is a reserved header name and cannot be used.`)
+      return
+    }
+    if (!newValue.trim()) {
+      setAddError('Header value is required.')
+      return
+    }
+    setMutation.mutate(
+      { pluginId, instanceId, name: trimmedName, value: newValue },
+      {
+        onSuccess: () => {
+          setNewName('')
+          setNewValue('')
+          setAddSaved(true)
+        },
+        onError: (err) => {
+          setAddError(errMessage(err, 'Save failed.'))
+        },
+      },
+    )
+  }
+
+  function handleDelete(name: string) {
+    deleteMutation.mutate(
+      { pluginId, instanceId, name },
+      {
+        onError: (err) => {
+          setAddError(errMessage(err, 'Delete failed.'))
+        },
+      },
+    )
+  }
+
+  return (
+    <div className={styles.form}>
+      {headerNames.length === 0 ? (
+        <p className={styles.emptyMsg}>No headers set.</p>
+      ) : (
+        <ul className={styles.headerList}>
+          {headerNames.map((name) => (
+            <li key={name} className={styles.headerItem}>
+              <span className={styles.headerName}>{name}</span>
+              {canManage && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="small"
+                  onClick={() => handleDelete(name)}
+                  disabled={deleteMutation.isPending}
+                >
+                  Delete
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {canManage && (
+        <>
+          <p className={styles.sectionLabel}>Add header</p>
+          <div className={styles.addHeaderRow}>
+            <input
+              type="text"
+              className={styles.input}
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Header name"
+              aria-label="New header name"
+            />
+            <input
+              type="password"
+              className={styles.input}
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+              placeholder="Value"
+              aria-label="New header value"
+              autoComplete="new-password"
+            />
+            <Button
+              type="button"
+              variant="primary"
+              size="small"
+              onClick={handleAdd}
+              disabled={setMutation.isPending}
+            >
+              {setMutation.isPending ? 'Adding…' : 'Add'}
+            </Button>
+          </div>
+
+          {addError && <p className={styles.errorMsg} role="alert">{addError}</p>}
+          {addSaved && !setMutation.isPending && (
+            <p className={styles.savedConfirm}>Header added.</p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── BasicAuthForm ─────────────────────────────────────────────────────────────
+
+interface BasicAuthFormProps {
+  pluginId: string
+  instanceId: string
+  initialUsername: string
+  canManage: boolean
+}
+
+function BasicAuthForm({ pluginId, instanceId, initialUsername, canManage }: BasicAuthFormProps) {
+  const [username, setUsername] = useState(initialUsername)
+  const [password, setPassword] = useState('')
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useSetPluginBasicAuth()
+
+  function handleSave() {
+    setSaved(false)
+    setError(null)
+    if (!username.trim()) {
+      setError('Username is required.')
+      return
+    }
+    if (!password.trim()) {
+      setError('Password is required.')
+      return
+    }
+    mutation.mutate(
+      { pluginId, instanceId, username: username.trim(), password },
+      {
+        onSuccess: () => {
+          setSaved(true)
+          setPassword('')
+        },
+        onError: (err) => {
+          setError(errMessage(err, 'Save failed.'))
+        },
+      },
+    )
+  }
+
+  return (
+    <div className={styles.form}>
+      <div className={styles.fieldRow}>
+        <label htmlFor="basic-username" className={styles.fieldLabel}>
+          Username
+        </label>
+        <input
+          id="basic-username"
+          type="text"
+          className={styles.input}
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          disabled={!canManage}
+        />
+      </div>
+
+      <div className={styles.fieldRow}>
+        <label htmlFor="basic-password" className={styles.fieldLabel}>
+          Password
+        </label>
+        <p className={styles.writeOnlyNote}>Write-only — enter a new value to replace.</p>
+        <input
+          id="basic-password"
+          type="password"
+          className={styles.input}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="new-password"
+          disabled={!canManage}
+        />
+      </div>
+
+      {error && <p className={styles.errorMsg} role="alert">{error}</p>}
+
+      {canManage && (
+        <div className={styles.actionRow}>
+          <Button
+            type="button"
+            variant="primary"
+            size="small"
+            onClick={handleSave}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+          {saved && !mutation.isPending && (
+            <span className={styles.savedConfirm}>Saved.</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── OAuthSection ──────────────────────────────────────────────────────────────
+
+interface OAuthSectionProps {
+  pluginId: string
+  instanceId: string
+  strategy: string
+  clientId?: string
+  authorizationUrl?: string
+  tokenUrl?: string
+  scopes?: string[]
+  hasToken: boolean
+  tokenExpiresAt?: string
+  healthState?: string
+  healthDetail?: string
+  canManage: boolean
+}
+
+function OAuthSection({
+  pluginId,
+  instanceId,
+  strategy,
+  clientId,
+  authorizationUrl,
+  tokenUrl,
+  scopes,
+  hasToken,
+  tokenExpiresAt,
+  healthState,
+  healthDetail,
+  canManage,
+}: OAuthSectionProps) {
+  const isRefreshFailed = isOAuthRefreshFailure(healthState ?? '', healthDetail)
+
+  return (
+    <div className={styles.form}>
+      <dl className={styles.metaGrid}>
+        {clientId && (
+          <>
+            <dt>Client ID</dt>
+            <dd>{clientId}</dd>
+          </>
+        )}
+        {authorizationUrl && (
+          <>
+            <dt>Authorization URL</dt>
+            <dd className={styles.metaUrl}>{authorizationUrl}</dd>
+          </>
+        )}
+        {tokenUrl && (
+          <>
+            <dt>Token URL</dt>
+            <dd className={styles.metaUrl}>{tokenUrl}</dd>
+          </>
+        )}
+        {scopes && scopes.length > 0 && (
+          <>
+            <dt>Scopes</dt>
+            <dd>{scopes.join(', ')}</dd>
+          </>
+        )}
+        <dt>Token present</dt>
+        <dd>{hasToken ? 'Yes' : 'No'}</dd>
+        {hasToken && tokenExpiresAt && (
+          <>
+            <dt>Token expires</dt>
+            <dd>{formatTimestamp(tokenExpiresAt)}</dd>
+          </>
+        )}
+      </dl>
+
+      {canManage && (
+        <div className={styles.actionRow}>
+          {!hasToken && (
+            // No token yet — show the initial "Authorize" CTA.
+            <ReauthorizeButton
+              pluginId={pluginId}
+              instanceId={instanceId}
+              strategy={strategy}
+              label="Authorize"
+              pendingLabel="Authorizing…"
+            />
+          )}
+          {hasToken && isRefreshFailed && (
+            // Token present but refresh failed — Re-authorize is the primary CTA.
+            // The page-level banner already shows this; we surface it here too so
+            // the operator can act from the Credentials tab without scrolling up.
+            <ReauthorizeButton
+              pluginId={pluginId}
+              instanceId={instanceId}
+              strategy={strategy}
+              label="Re-authorize"
+              pendingLabel="Starting…"
+            />
+          )}
+          {/* When has_token && !isRefreshFailed: no button — avoid duplicating
+              the page-level banner CTA. Operator can clear + re-authorize if needed. */}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── CredentialsTab ────────────────────────────────────────────────────────────
+
+export interface CredentialsTabProps {
+  pluginId: string
+  instanceId: string
+  // strategy is derived from instance.auth_strategy (manifest snapshot). The
+  // tab fetches the server-side redacted view and warns when they disagree.
+  strategy: PluginAuthStrategy
+  canManage: boolean
+  healthState?: string
+  healthDetail?: string
+}
+
+export function CredentialsTab({
+  pluginId,
+  instanceId,
+  strategy,
+  canManage,
+  healthState,
+  healthDetail,
+}: CredentialsTabProps) {
+  const { data: creds, status } = usePluginInstanceCredentials(pluginId, instanceId)
+  const clearMutation = useClearPluginCredentials()
+  const [clearError, setClearError] = useState<string | null>(null)
+
+  function handleClear() {
+    setClearError(null)
+    clearMutation.mutate(
+      { pluginId, instanceId },
+      {
+        onError: (err) => {
+          setClearError(errMessage(err, 'Clear failed.'))
+        },
+      },
+    )
+  }
+
+  if (status === 'pending') {
+    return <p className={styles.loading}>Loading credentials…</p>
+  }
+  if (status === 'error') {
+    return <p className={styles.errorMsg}>Could not load credentials.</p>
+  }
+
+  // Warn when the manifest strategy (prop) disagrees with the server-side
+  // strategy stored in the credential blob. This can happen briefly after a
+  // manifest hot-reload if the backend has not yet migrated the credential row.
+  const serverStrategy = creds?.strategy
+  const strategyMismatch = serverStrategy && serverStrategy !== strategy
+
+  const isSet = (
+    creds?.has_api_key ||
+    (creds?.header_names && creds.header_names.length > 0) ||
+    creds?.has_password ||
+    creds?.has_token
+  )
+
+  return (
+    <div className={styles.tab}>
+      {strategyMismatch && (
+        <div className={styles.mismatchWarning} role="alert">
+          Strategy mismatch: manifest declares <strong>{strategy}</strong>, but stored
+          credentials use <strong>{serverStrategy}</strong>. Contact your plugin administrator.
+        </div>
+      )}
+
+      {strategy === 'none' && (
+        <p className={styles.emptyMsg}>
+          This plugin instance uses no authentication credentials.
+        </p>
+      )}
+
+      {strategy === 'static_api_key' && (
+        <StaticAPIKeyForm
+          pluginId={pluginId}
+          instanceId={instanceId}
+          initialHeaderName={creds?.header_name ?? ''}
+          initialScheme={creds?.scheme ?? ''}
+          canManage={canManage}
+        />
+      )}
+
+      {strategy === 'header_set' && (
+        <HeaderSetForm
+          pluginId={pluginId}
+          instanceId={instanceId}
+          headerNames={creds?.header_names ?? []}
+          canManage={canManage}
+        />
+      )}
+
+      {strategy === 'basic_auth' && (
+        <BasicAuthForm
+          pluginId={pluginId}
+          instanceId={instanceId}
+          initialUsername={creds?.username ?? ''}
+          canManage={canManage}
+        />
+      )}
+
+      {(strategy === 'oauth2_authcode' || strategy === 'oauth2_clientcred') && (
+        <OAuthSection
+          pluginId={pluginId}
+          instanceId={instanceId}
+          strategy={strategy}
+          clientId={creds?.client_id}
+          authorizationUrl={creds?.authorization_url}
+          tokenUrl={creds?.token_url}
+          scopes={creds?.scopes}
+          hasToken={creds?.has_token ?? false}
+          tokenExpiresAt={creds?.token_expires_at}
+          healthState={healthState}
+          healthDetail={healthDetail}
+          canManage={canManage}
+        />
+      )}
+
+      {canManage && strategy !== 'none' && isSet && (
+        <div className={styles.clearSection}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="small"
+            onClick={handleClear}
+            disabled={clearMutation.isPending}
+          >
+            {clearMutation.isPending ? 'Clearing…' : 'Clear credentials'}
+          </Button>
+          {clearError && <p className={styles.errorMsg} role="alert">{clearError}</p>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.tsx
+++ b/frontend/src/components/admin/ReauthorizeButton/ReauthorizeButton.tsx
@@ -5,6 +5,11 @@ interface ReauthorizeButtonProps {
   pluginId: string
   instanceId: string
   strategy: string
+  // label and pendingLabel allow callers to customise the button text.
+  // Defaults preserve the original "Re-authorize" / "Starting…" strings so
+  // the existing page-level banner is unaffected.
+  label?: string
+  pendingLabel?: string
 }
 
 const OAUTH_STRATEGIES = ['oauth2_authcode', 'oauth2_clientcred']
@@ -13,7 +18,16 @@ const OAUTH_STRATEGIES = ['oauth2_authcode', 'oauth2_clientcred']
 // an instance whose token refresh has failed (#228). It only renders for OAuth
 // strategies; calling it on a non-OAuth instance is a no-op by design so it
 // can safely be dropped into surfaces that may not gate strategy up-front.
-export function ReauthorizeButton({ pluginId, instanceId, strategy }: ReauthorizeButtonProps) {
+//
+// The optional `label` and `pendingLabel` props allow CredentialsTab to reuse
+// this button for the initial "Authorize" CTA without a separate component.
+export function ReauthorizeButton({
+  pluginId,
+  instanceId,
+  strategy,
+  label = 'Re-authorize',
+  pendingLabel = 'Starting…',
+}: ReauthorizeButtonProps) {
   const mutation = useBeginPluginOAuth()
 
   // Defense-in-depth: only OAuth strategies need re-authorization. The page
@@ -47,7 +61,7 @@ export function ReauthorizeButton({ pluginId, instanceId, strategy }: Reauthoriz
       onClick={handleClick}
       disabled={mutation.isPending}
     >
-      {mutation.isPending ? 'Starting…' : 'Re-authorize'}
+      {mutation.isPending ? pendingLabel : label}
     </Button>
   )
 }

--- a/frontend/src/hooks/mutations/plugins.ts
+++ b/frontend/src/hooks/mutations/plugins.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { apiFetch } from '@/api/fetch'
+import { apiFetch, apiFetchVoid } from '@/api/fetch'
 import type { ApiAcceptNewKeyResponse } from '@/api/types'
 import { queryKeys } from '../queryKeys'
 
@@ -80,6 +80,138 @@ export function useAcceptPluginNewKey() {
     },
   })
 }
+
+// ── Credential mutations ──────────────────────────────────────────────────────
+//
+// All five mutations invalidate queryKeys.plugins.credentials(...) so the
+// CredentialsTab re-fetches the updated redacted view. They do NOT invalidate
+// admin.pluginInstances — credentials do not change instance health state.
+
+interface PluginInstanceRef {
+  pluginId: string
+  instanceId: string
+}
+
+// useSetPluginStaticAPIKey writes the static_api_key credential blob.
+// PUT /api/v1/admin/plugins/{id}/instances/{iid}/credentials/static-api-key
+export function useSetPluginStaticAPIKey() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      pluginId,
+      instanceId,
+      header_name,
+      scheme,
+      api_key,
+    }: PluginInstanceRef & { header_name: string; scheme?: string; api_key: string }) =>
+      apiFetchVoid(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances/${encodeURIComponent(instanceId)}/credentials/static-api-key`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ header_name, scheme, api_key }),
+        },
+      ),
+    onSuccess: (_data, { pluginId, instanceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.plugins.credentials(pluginId, instanceId),
+      })
+    },
+  })
+}
+
+// useSetPluginHeader writes a single named header for the header_set strategy.
+// PUT /api/v1/admin/plugins/{id}/instances/{iid}/credentials/headers/{name}
+export function useSetPluginHeader() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      pluginId,
+      instanceId,
+      name,
+      value,
+    }: PluginInstanceRef & { name: string; value: string }) =>
+      apiFetchVoid(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances/${encodeURIComponent(instanceId)}/credentials/headers/${encodeURIComponent(name)}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ value }),
+        },
+      ),
+    onSuccess: (_data, { pluginId, instanceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.plugins.credentials(pluginId, instanceId),
+      })
+    },
+  })
+}
+
+// useDeletePluginHeader removes a single named header from the header_set credential blob.
+// DELETE /api/v1/admin/plugins/{id}/instances/{iid}/credentials/headers/{name}
+export function useDeletePluginHeader() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      pluginId,
+      instanceId,
+      name,
+    }: PluginInstanceRef & { name: string }) =>
+      apiFetchVoid(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances/${encodeURIComponent(instanceId)}/credentials/headers/${encodeURIComponent(name)}`,
+        { method: 'DELETE' },
+      ),
+    onSuccess: (_data, { pluginId, instanceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.plugins.credentials(pluginId, instanceId),
+      })
+    },
+  })
+}
+
+// useSetPluginBasicAuth writes the basic_auth credential blob.
+// PUT /api/v1/admin/plugins/{id}/instances/{iid}/credentials/basic-auth
+export function useSetPluginBasicAuth() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      pluginId,
+      instanceId,
+      username,
+      password,
+    }: PluginInstanceRef & { username: string; password: string }) =>
+      apiFetchVoid(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances/${encodeURIComponent(instanceId)}/credentials/basic-auth`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ username, password }),
+        },
+      ),
+    onSuccess: (_data, { pluginId, instanceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.plugins.credentials(pluginId, instanceId),
+      })
+    },
+  })
+}
+
+// useClearPluginCredentials wipes the credential blob while preserving Strategy.
+// DELETE /api/v1/admin/plugins/{id}/instances/{iid}/credentials
+export function useClearPluginCredentials() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ pluginId, instanceId }: PluginInstanceRef) =>
+      apiFetchVoid(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances/${encodeURIComponent(instanceId)}/credentials`,
+        { method: 'DELETE' },
+      ),
+    onSuccess: (_data, { pluginId, instanceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.plugins.credentials(pluginId, instanceId),
+      })
+    },
+  })
+}
+
+// ── Subscription scope ────────────────────────────────────────────────────────
 
 // useSetInstanceSubscriptionScope submits a new subscription scope for a plugin
 // instance. On success it invalidates the plugin-instances list so the audience

--- a/frontend/src/hooks/queries/plugins.ts
+++ b/frontend/src/hooks/queries/plugins.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/api/fetch'
+import type { ApiRedactedCredentials } from '@/api/types'
+import { queryKeys } from '../queryKeys'
+
+// usePluginInstanceCredentials fetches the redacted credential view for a
+// plugin instance. Secret values are never included — only presence flags and
+// non-secret metadata (see ApiRedactedCredentials / oauth.RedactedCredentials).
+export function usePluginInstanceCredentials(
+  pluginId: string | undefined,
+  instanceId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.plugins.credentials(pluginId ?? '', instanceId ?? ''),
+    queryFn: () =>
+      apiFetch<ApiRedactedCredentials>(
+        `/admin/plugins/${encodeURIComponent(pluginId!)}/instances/${encodeURIComponent(instanceId!)}/credentials`,
+      ),
+    enabled: !!pluginId && !!instanceId,
+  })
+}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -60,5 +60,7 @@ export const queryKeys = {
   plugins: {
     instance: (pluginId: string, instanceId: string) =>
       ['admin', 'plugins', pluginId, 'instances', instanceId] as const,
+    credentials: (pluginId: string, instanceId: string) =>
+      ['admin', 'plugins', pluginId, 'instances', instanceId, 'credentials'] as const,
   },
 } as const

--- a/frontend/src/pages/AdminPluginInstancePage.stories.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
 import '@/tokens.css'
 import AdminPluginInstancePage from './AdminPluginInstancePage'
 import { queryKeys } from '@/hooks/queryKeys'
-import type { ApiPluginInstanceForAudience } from '@/api/types'
+import type { ApiPluginInstanceForAudience, ApiRedactedCredentials } from '@/api/types'
 import { RefreshFailureDetailPrefix } from '@/utils/pluginHealth'
 
 const PLUGIN_ID = 'plugin-slack-01'
@@ -93,6 +94,43 @@ const FIXTURE_OAUTH_REFRESH_FAILED_CLIENTCRED: ApiPluginInstanceForAudience = {
   event_kinds: [],
 }
 
+// Default redacted credentials fixture — used by MSW to respond to GET /credentials.
+// Seeded so the CredentialsTab shows meaningful content in stories.
+const FIXTURE_CREDENTIALS_OAUTH: ApiRedactedCredentials = {
+  strategy: 'oauth2_authcode',
+  client_id: 'story-client-id',
+  has_client_secret: true,
+  authorization_url: 'https://provider.example.com/authorize',
+  token_url: 'https://provider.example.com/token',
+  scopes: ['read', 'write'],
+  has_token: true,
+  token_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+}
+
+const FIXTURE_CREDENTIALS_NONE: ApiRedactedCredentials = { strategy: 'none' }
+
+// MSW handlers for the credentials endpoint so the CredentialsTab renders in
+// all existing stories without needing a running backend.
+const CREDENTIALS_HANDLERS = [
+  http.get(
+    `/api/v1/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}/credentials`,
+    () => HttpResponse.json({ data: FIXTURE_CREDENTIALS_OAUTH }),
+  ),
+]
+
+const CREDENTIALS_HANDLERS_NONE = [
+  http.get(
+    `/api/v1/admin/plugins/${PLUGIN_ID}/instances/${INSTANCE_ID}/credentials`,
+    () => HttpResponse.json({ data: FIXTURE_CREDENTIALS_NONE }),
+  ),
+]
+
+// currentUser stub — stories render as admin so write controls are shown.
+const CURRENT_USER_HANDLER = http.get(
+  '/api/v1/auth/me',
+  () => HttpResponse.json({ data: { id: 'u1', username: 'admin', roles: ['admin'] } }),
+)
+
 function makeQueryClient(instances: ApiPluginInstanceForAudience[]): QueryClient {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   qc.setQueryData(queryKeys.admin.pluginInstances, instances)
@@ -126,11 +164,17 @@ type Story = StoryObj<typeof AdminPluginInstancePage>
 
 // Renders the Subscriptions tab because the fixture has subscription_schema.
 export const WithSubscriptionSchema: Story = {
+  parameters: {
+    msw: { handlers: [...CREDENTIALS_HANDLERS, CURRENT_USER_HANDLER] },
+  },
   render: () => <Wrapper instances={[FIXTURE_WITH_SCHEMA]} />,
 }
 
 // No subscription_schema → Subscriptions tab is hidden; defaults to Config tab.
 export const NoSubscriptionSchema: Story = {
+  parameters: {
+    msw: { handlers: [...CREDENTIALS_HANDLERS_NONE, CURRENT_USER_HANDLER] },
+  },
   render: () => <Wrapper instances={[FIXTURE_NO_SCHEMA]} />,
 }
 
@@ -156,11 +200,17 @@ export const Loading: Story = {
 // oauth2_authcode strategy instance. Clicking Re-authorize would navigate
 // to the provider's authorization page.
 export const OAuthRefreshFailedAuthcode: Story = {
+  parameters: {
+    msw: { handlers: [...CREDENTIALS_HANDLERS, CURRENT_USER_HANDLER] },
+  },
   render: () => <Wrapper instances={[FIXTURE_OAUTH_REFRESH_FAILED_AUTHCODE]} />,
 }
 
 // OAuth refresh failed (clientcred) — same banner, but Re-authorize performs
 // the client credentials exchange synchronously (no browser redirect).
 export const OAuthRefreshFailedClientcred: Story = {
+  parameters: {
+    msw: { handlers: [...CREDENTIALS_HANDLERS, CURRENT_USER_HANDLER] },
+  },
   render: () => <Wrapper instances={[FIXTURE_OAUTH_REFRESH_FAILED_CLIENTCRED]} />,
 }

--- a/frontend/src/pages/AdminPluginInstancePage.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.tsx
@@ -6,10 +6,13 @@ import { PageHeader } from '@/components/PageHeader'
 import { Button } from '@/components/Button'
 import { FieldError } from '@/components/form/FieldError/FieldError'
 import { ReauthorizeButton } from '@/components/admin/ReauthorizeButton/ReauthorizeButton'
+import { CredentialsTab } from '@/components/admin/CredentialsTab/CredentialsTab'
 import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
+import { useCurrentUser } from '@/hooks/queries/users'
 import { useSetInstanceSubscriptionScope } from '@/hooks/mutations/plugins'
 import { isOAuthRefreshFailure } from '@/utils/pluginHealth'
 import { queryKeys } from '@/hooks/queryKeys'
+import type { PluginAuthStrategy } from '@/api/types'
 import type { ApiError } from '@/api/fetch'
 import styles from './AdminPluginInstancePage.module.css'
 
@@ -253,6 +256,11 @@ export default function AdminPluginInstancePage() {
   const queryClient = useQueryClient()
 
   const { data: allInstances, status } = usePluginInstancesForAudience()
+  const { data: currentUser } = useCurrentUser()
+
+  // The backend gates all credentials endpoints with RequireRole(admin).
+  // canManage matches that exactly so write controls are only shown to admins.
+  const canManage = currentUser?.roles.includes('admin') ?? false
 
   const instance = allInstances?.find((inst) => inst.id === instanceId && inst.plugin_id === pluginId)
 
@@ -267,12 +275,18 @@ export default function AdminPluginInstancePage() {
   }, [status, hasSubscriptionSchema, activeTab])
 
   // After a successful OAuth authcode round-trip the callback handler redirects
-  // the browser back here with ?oauth_ok=1. Invalidate the instance list so the
-  // Re-authorize banner clears without requiring a manual refresh.
+  // the browser back here with ?oauth_ok=1. Invalidate the instance list and
+  // credentials cache so the Re-authorize banner clears and has_token flips
+  // without requiring a manual refresh.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     if (params.get('oauth_ok') === '1') {
       void queryClient.invalidateQueries({ queryKey: queryKeys.admin.pluginInstances })
+      if (pluginId && instanceId) {
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.plugins.credentials(pluginId, instanceId),
+        })
+      }
     }
   // Run once on mount; queryClient reference is stable.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -310,8 +324,14 @@ export default function AdminPluginInstancePage() {
     if (activeTab === 'credentials') {
       return (
         <div className={styles.tabContent}>
-          {/* TODO #242: render credentials form */}
-          <p className={styles.placeholder}>Credentials management — coming in #242.</p>
+          <CredentialsTab
+            pluginId={pluginId!}
+            instanceId={instanceId!}
+            strategy={(instance.auth_strategy ?? 'none') as PluginAuthStrategy}
+            canManage={canManage}
+            healthState={instance.state}
+            healthDetail={instance.health_detail}
+          />
         </div>
       )
     }


### PR DESCRIPTION
Closes #231

## Summary
- New `CredentialsTab` component (under `frontend/src/components/admin/CredentialsTab/`) replaces the placeholder in `AdminPluginInstancePage`. It branches on the instance's manifest auth strategy:
  - `static_api_key` / `header_set` / `basic_auth` → write-only input forms. GET returns key names + `has_*` presence flags only (ADR-039).
  - `oauth2_authcode` / `oauth2_clientcred` → read-only metadata, token-expiry row, and an "Authorize" button when `!has_token` or a "Re-authorize" button when token present + refresh failed.
  - `none` → empty-state copy.
- Role gating: `canManage = roles.includes('admin')` to match backend `RequireRole(admin)`. Auditors see field names + presence; inputs disabled, no submit/delete buttons.
- `<ReauthorizeButton>` extended with optional `label` / `pendingLabel` props (defaults preserve existing banner behavior).
- New hook `usePluginInstanceCredentials`; new mutations `useSetPluginStaticAPIKey`, `useSetPluginHeader`, `useDeletePluginHeader`, `useSetPluginBasicAuth`, `useClearPluginCredentials` (each invalidates only `plugins.credentials(...)`).
- `?oauth_ok=1` mount-effect now also invalidates the credentials cache so `has_token` / `token_expires_at` flips immediately after the OAuth dance.
- Reserved-header client-side blocklist mirrors `internal/infra/headervalidate`.
- 12 Storybook stories (per strategy + auditor + OAuth-refresh-failed + strategy-mismatch). 30 new Vitest tests, all passing.
- `frontend/CLAUDE.md` route comment updated.

## Test plan
- [ ] `cd frontend && npx vitest run src/components/admin/CredentialsTab` — 30 tests pass
- [ ] `cd frontend && npm run build` — clean
- [ ] `cd frontend && npm run storybook` — visit each `CredentialsTab` story, confirm per-strategy rendering, auditor read-only, OAuth-refresh-failed banner
- [ ] In a running stack, open an instance edit page and confirm each strategy form submits to the right endpoint and the page refreshes credential state

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` (not committed). High points:
- Strategy source = manifest snapshot (`instance.auth_strategy`), not the GET-credentials payload; surface mismatch warning when they disagree.
- "Last-refresh" rendered as `Token expires` (closest backend signal — `token_expires_at`).
- Reuse `<ReauthorizeButton>` for both first-time Authorize and Re-authorize via a label prop.
- Credential mutations do NOT invalidate `admin.pluginInstances` (credentials don't affect instance health).
- CSS Modules + 4px spacing, no inline styles.
</details>

## Pipeline notes
- Generated by the agentic dev-loop. 1 plan-review cycle (REVISE → revised inline). 1 code-review cycle (APPROVE, 3 non-blocking suggestions noted in review).
- `frontend/CLAUDE.md` updated.
- Targeting `plugin-architecture` per the dev-loop invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)