### PR TITLE
feat: Slack TriggerService — channel_message via Socket Mode

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -41,6 +41,7 @@ github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/goccmack/gocc v0.0.0-20230228185258-2292f9e40198/go.mod h1:DTh/Y2+NbnOVVoypCCQrovMPDKUGp4yZpSbWg5D0XIM=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -1,9 +1,9 @@
 # slack
 
-**Status: scaffold only.** This plugin compiles and passes `gleipnir-plugin validate`, but all service methods return "not implemented" errors. Subsequent issues fill in real Slack API behavior:
+**Status: TriggerService implemented (#234).** ToolService is implemented (#233). ChannelService is still a stub.
 
-- [#233](https://github.com/felag-engineering/gleipnir/issues/233) — ToolService: `send_message`, `list_channels`
-- [#234](https://github.com/felag-engineering/gleipnir/issues/234) — TriggerService: `channel_message` event stream (Slack Events API)
+Remaining issues:
+
 - [#235](https://github.com/felag-engineering/gleipnir/issues/235) — ChannelService: `Notify` and `Request` via Slack DMs / posts
 - [#236](https://github.com/felag-engineering/gleipnir/issues/236) — Instance config schema, OAuth wiring
 - [#237](https://github.com/felag-engineering/gleipnir/issues/237) — End-to-end test, packaging, signing
@@ -13,7 +13,7 @@ Parent tracking issue: [#162](https://github.com/felag-engineering/gleipnir/issu
 ## What this plugin declares
 
 - **ToolService v1** — `post_message`, `list_channels`, `search_messages`, `react`, `set_topic` (implemented by #233)
-- **TriggerService v1** — `channel_message` event kind (stub; populated by #234)
+- **TriggerService v1** — `channel_message` event kind via Slack Socket Mode (#234). Note: subscription-scope channel filtering matches by **channel ID** only (e.g. `C012ABCDEF`); name-based filtering (e.g. `#incidents`) silently does not match because Socket Mode events carry only IDs. Resolving names is future work.
 - **ChannelService v1** — `Notify` and `Request` (stubs; populated by #235)
 - **Auth strategy** — `oauth2_authcode` with Slack's authorization and token endpoints
 
@@ -22,11 +22,16 @@ Parent tracking issue: [#162](https://github.com/felag-engineering/gleipnir/issu
 ```
 slack/
   main.go            — calls serve.Serve() with all three service factories
-  service.go         — stub implementations of ToolService, TriggerService, ChannelService
+  service.go         — ToolService (#233) + TriggerService (#234) implementations; ChannelService still stub
+  tools.go           — typed tool params + handlers (#233)
+  translator.go      — pure functions translating Socket Mode events to channel_message payloads (#234)
+  scope.go           — SlackSubscriptionScope decode + matches helpers (#234)
   manifest.go        — pluginManifest variable (source of truth for metadata + event kinds)
   manifest.yaml      — canonical YAML projection of manifest.go (generated)
   manifest_test.go   — TestManifestYAMLIsCanonical: round-trip + Go-source equality
-  service_test.go    — stub behavior assertions (not-implemented errors, ListTools empty, etc.)
+  service_test.go    — service-level behavior assertions (tool calls, trigger lifecycle)
+  translator_test.go — pure translator unit tests (#234)
+  scope_test.go      — subscription-scope matching unit tests (#234)
   Makefile           — build / test / manifest / validate / clean targets
   .gitignore         — excludes the compiled binary and signing artifacts
   go.mod             — per-plugin module; resolved by the repo-root go.work
@@ -50,6 +55,31 @@ Default OAuth endpoints baked into the manifest:
 - Authorization URL: `https://slack.com/oauth/v2/authorize`
 - Token URL: `https://slack.com/api/oauth.v2.access`
 - Default scopes: `channels:read`, `chat:write`, `im:write`, `users:read`
+
+### App-level token (xapp-)
+
+TriggerService uses Slack's Socket Mode transport, which requires an additional
+**app-level token** (prefix `xapp-`) separate from the OAuth bot token. Socket
+Mode is homelab-friendly because it does not require a public webhook endpoint.
+
+To generate the token:
+
+1. Open your Slack app settings at [api.slack.com/apps](https://api.slack.com/apps).
+2. Select your app → **Settings → Socket Mode**.
+3. Enable Socket Mode if not already enabled.
+4. Under **App-Level Tokens**, click **Generate Token and Scopes**.
+5. Give the token a name (e.g. `gleipnir-socket-mode`) and add the scope `connections:write`.
+6. Click **Generate** and copy the token (it starts with `xapp-`).
+7. In the Gleipnir admin UI, navigate to the Slack plugin instance config and
+   paste the token into the `app_level_token` field.
+
+The full end-to-end setup (including connecting the Slack app to your workspace
+and wiring the Gleipnir trigger) is documented in [#237](https://github.com/felag-engineering/gleipnir/issues/237).
+
+> **Note:** The `app_level_token` field is stored as plain text in instance
+> config in this release. A follow-up issue will add `gleipnir-secret` format
+> annotation so the admin GET endpoint redacts the value to `"***"` (mirroring
+> the ADR-039 pattern for auth headers).
 
 ## Build
 
@@ -81,7 +111,16 @@ The broader `go test ./plugins/...` does not work, because each first-party plug
 |------|-----------------|
 | `TestManifestYAMLIsCanonical` | `manifest.yaml` round-trips and matches `manifest.go` |
 | `TestStubsReturnNotImplemented` | `Channel.Notify`, `Channel.Request` return `ERROR_CODE_INTERNAL` in-band |
-| `TestTriggerStartReturnsUnimplemented` | `TriggerService.Start` returns `codes.Unimplemented` on first `Recv` |
+| `TestTriggerStartFailedPreconditionWithoutToken` | Missing `app_level_token` → `FailedPrecondition` + UNHEALTHY/config_missing |
+| `TestTriggerStartEmitsEventOnFakeSocketModeMessage` | Fake runner delivers event → `EmitEvent` called with correct kind/id/payload, Ack called once |
+| `TestTriggerStartHonorsSubscriptionScopeChannels` | Excluded channel → zero `EmitEvent`, Ack still called |
+| `TestTriggerStartHealthUnhealthyOnInvalidAuth` | Runner returns `invalid_auth` → `Unauthenticated` + UNHEALTHY/auth_expired |
+| `TestTranslate` | Table-driven: MessageEvent, AppMentionEvent, subtypes, nil data, malformed ts |
+| `TestDeriveEventIDIsDeterministic` | Same (channelID, ts) → same ULID across two calls |
+| `TestDeriveEventIDDiffersForDifferentInputs` | Different inputs → different ULIDs |
+| `TestParseSlackTS` | Valid ts parses correctly; malformed ts falls back to now |
+| `TestSlackSubscriptionScopeMatches` | Table-driven scope matching: by-id, by-name, mention-only, composed |
+| `TestDecodeSubscriptionScope` | Empty/`{}` → zero value; malformed → error |
 | `TestToolListToolsAdvertisesAll` | `ListTools` returns exactly 5 tools with valid JSON-Schema InputSchema |
 | `TestToolCancelIsNoOp` | `Cancel` returns an empty response with no error |
 | `TestToolCalls` | Table-driven: happy path × 5 tools, error cases, auth failures, unknown tool |

--- a/plugins/slack/go.mod
+++ b/plugins/slack/go.mod
@@ -5,6 +5,7 @@ go 1.25.10
 require (
 	github.com/felag-engineering/gleipnir/plugin-sdk v0.0.0
 	github.com/invopop/jsonschema v0.13.0
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/slack-go/slack v0.17.3
 	google.golang.org/grpc v1.79.3
 	gopkg.in/yaml.v3 v3.0.1

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -45,8 +45,20 @@ var pluginManifest = manifest.Manifest{
 		},
 	},
 	Tools: buildToolDecls(),
-	// ConfigSchema is omitted for this scaffold. Instance-level config
-	// (workspace ID, default channel, etc.) lands in #236 with OAuth wiring.
+	// ConfigSchema declares required instance-level config. The app_level_token
+	// (xapp- prefix) is the Socket Mode token used by TriggerService; it is
+	// separate from the OAuth bot token stored in credentials_encrypted.
+	// Phase-7 follow-up (#xxx): mark this field as gleipnir-secret so GET
+	// /api/v1/admin/plugin-instances/{iid} redacts it to "***".
+	ConfigSchema: mustParseYAML(`
+type: object
+required:
+  - app_level_token
+properties:
+  app_level_token:
+    type: string
+    description: 'Slack app-level token (xapp- prefix) for Socket Mode. Generate in Slack admin: Settings → Socket Mode → Generate token with scope connections:write.'
+`),
 	Channels: []manifest.ChannelDecl{
 		{
 			ImplementsNotify:  true,
@@ -105,16 +117,66 @@ func buildToolDecls() []manifest.ToolDecl {
 	}
 }
 
+// SlackSubscriptionScope is the instance-level coarse subscription filter sent
+// in TriggerService.Start as watch_scope_json. It limits which channels the
+// plugin watches across ALL policies on this instance, reducing noise from
+// high-traffic channels like #general.
+//
+// Distinct from SlackChannelMessageBinding (per-policy event filter): scope is
+// configured once on the instance; binding is configured per-policy.
+type SlackSubscriptionScope struct {
+	// Channels is a list of channel names or IDs to watch (e.g. "#incidents",
+	// "C01ABC"). Empty means watch all channels the bot is a member of.
+	Channels []string `json:"channels,omitempty" jsonschema:"title=Channels,description=Channel names or IDs (e.g. #incidents\\, C01ABC). Empty = watch all."`
+	// MentionOnly limits delivery to messages where the bot is mentioned.
+	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Only emit when bot is mentioned."`
+}
+
 // SlackChannelMessageBinding is the per-policy binding struct for the
 // channel_message event kind. Fields drive the binding_schema shown in the
-// policy trigger editor. #234 fills in the matching TriggerService.Start logic.
+// policy trigger editor.
 type SlackChannelMessageBinding struct {
-	// Channel is a glob pattern matched against the Slack channel name. Use
-	// GlobField so the binding evaluator selects OpGlob at runtime.
-	Channel manifest.GlobField `json:"channel,omitempty" jsonschema:"title=Channel,description=Glob pattern matched against the Slack channel name (e.g. #incidents-*)"`
-	// Text is a substring matched against the message text. Use ContainsField so
-	// the binding evaluator selects OpContains at runtime.
+	// Channel is a substring matched against the Slack channel name or ID.
+	// ContainsField is used here rather than GlobField: the host binding evaluator
+	// rejects format:glob (binding.go:230), but accepts format:contains.
+	Channel manifest.ContainsField `json:"channel,omitempty" jsonschema:"title=Channel,description=Substring matched against the Slack channel name or ID (e.g. #incidents)"`
+	// Text is a substring matched against the message text.
 	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Substring matched against the message text"`
+	// MentionOnly restricts the policy to events where the bot was mentioned.
+	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Only trigger when the bot is mentioned in the message"`
+	// User restricts the policy to messages from a specific Slack user ID.
+	User manifest.EqualsField `json:"user,omitempty" jsonschema:"title=User,description=Slack user ID to match (e.g. U012AB3CD). Leave empty to match all users."`
+}
+
+// SlackChannelMessagePayload is the JSON payload emitted for each channel_message
+// event. The host binding evaluator matches policy bindings against these fields.
+// Fields marked omitempty are absent when the Slack event does not include them.
+//
+// yaml tags mirror the json tags so that yaml.Marshal (used for manifest examples)
+// produces underscore-separated keys matching the JSON wire format. Without explicit
+// yaml tags, yaml.v3 would use all-lowercase camelCase (e.g. "channelid" instead
+// of "channel_id"), making examples misleading in the admin UI.
+type SlackChannelMessagePayload struct {
+	// Channel is the display name (best-effort) or channel ID when the name is unknown.
+	Channel string `json:"channel" yaml:"channel" jsonschema:"title=Channel,description=Channel display name (e.g. #incidents) or channel ID when the name is unknown"`
+	// ChannelID is the stable Slack channel identifier (always present).
+	ChannelID string `json:"channel_id" yaml:"channel_id" jsonschema:"title=Channel ID,description=Stable Slack channel identifier (e.g. C01ABC)"`
+	// Text is the plain-text message body.
+	Text string `json:"text" yaml:"text" jsonschema:"title=Text,description=Plain-text message body"`
+	// User is the Slack user ID of the sender (empty for bot/system messages).
+	User string `json:"user,omitempty" yaml:"user,omitempty" jsonschema:"title=User,description=Slack user ID of the sender (empty for bot/system messages)"`
+	// Ts is the Slack message timestamp (uniquely identifies the message within a channel).
+	Ts string `json:"ts" yaml:"ts" jsonschema:"title=Timestamp,description=Slack message timestamp (uniquely identifies the message within a channel)"`
+	// ThreadTs is the parent thread timestamp (present only for threaded replies).
+	ThreadTs string `json:"thread_ts,omitempty" yaml:"thread_ts,omitempty" jsonschema:"title=Thread timestamp,description=Parent thread timestamp (present only for threaded replies)"`
+	// EventTs is the timestamp of the event itself.
+	EventTs string `json:"event_ts" yaml:"event_ts" jsonschema:"title=Event timestamp,description=Timestamp of the event itself"`
+	// TeamID is the Slack workspace (team) ID (best-effort; may be empty for some event shapes).
+	TeamID string `json:"team_id,omitempty" yaml:"team_id,omitempty" jsonschema:"title=Team ID,description=Slack workspace ID (best-effort; may be empty for some event shapes)"`
+	// ChannelType indicates the channel kind (channel, group, im, mim).
+	ChannelType string `json:"channel_type" yaml:"channel_type" jsonschema:"title=Channel type,description=Slack channel kind: channel (public)\\, group (private)\\, im (DM)\\, mim (multi-DM)"`
+	// Mentioned is true when the bot was mentioned in the message (app_mention event).
+	Mentioned bool `json:"mentioned" yaml:"mentioned" jsonschema:"title=Mentioned,description=True when the bot was explicitly mentioned in the message"`
 }
 
 // SlackChannelEntryConfig documents the Go-side shape of the per-audience-entry
@@ -127,15 +189,63 @@ type SlackChannelEntryConfig struct {
 }
 
 func init() {
+	// SubscriptionSchema defines the instance-level coarse filter passed in
+	// TriggerService.Start as watch_scope_json. Operators configure this once
+	// per plugin instance to limit which channels are watched.
+	pluginManifest.SubscriptionSchema = manifest.MustReflectSchema(SlackSubscriptionScope{})
+
 	// channel_message is the event kind emitted whenever a message is posted to
-	// a watched Slack channel. The binding_schema is derived by reflection from
-	// SlackChannelMessageBinding so the policy editor renders the GlobField and
-	// ContainsField correctly. #234 implements the matching TriggerService.Start.
-	pluginManifest.MustAddEventKind(
+	// a watched Slack channel. The binding_schema and payload_schema are derived
+	// by reflection so the policy editor renders the fields correctly.
+	// Three example payloads are provided for the "Test against sample" UI (spec §7.5).
+	pluginManifest.MustAddEventKindWithExamples(
 		"channel_message",
 		"A message was posted to a Slack channel",
 		SlackChannelMessageBinding{},
-		nil, // payloadSchema: #234 will add a typed payload schema
+		manifest.MustReflectSchema(SlackChannelMessagePayload{}),
+		manifest.Example{
+			Name: "Plain channel message",
+			Payload: SlackChannelMessagePayload{
+				Channel:     "#general",
+				ChannelID:   "C012ABCDEF",
+				Text:        "Lunch order is in.",
+				User:        "U01USER001",
+				Ts:          "1700000001.000100",
+				EventTs:     "1700000001.000100",
+				TeamID:      "T03TEAM001",
+				ChannelType: "channel",
+				Mentioned:   false,
+			},
+		},
+		manifest.Example{
+			Name: "Bot mention in incidents channel",
+			Payload: SlackChannelMessagePayload{
+				Channel:     "#incidents",
+				ChannelID:   "C09INCIDENT",
+				Text:        "<@U07BOTUSER> the database is degraded",
+				User:        "U01USER002",
+				Ts:          "1700001000.000200",
+				EventTs:     "1700001000.000200",
+				TeamID:      "T03TEAM001",
+				ChannelType: "channel",
+				Mentioned:   true,
+			},
+		},
+		manifest.Example{
+			Name: "Threaded reply",
+			Payload: SlackChannelMessagePayload{
+				Channel:     "#ops",
+				ChannelID:   "C09OPSCHAN",
+				Text:        "Rolled back the deployment, monitoring now.",
+				User:        "U01USER003",
+				Ts:          "1700002000.000300",
+				ThreadTs:    "1700002000.000100",
+				EventTs:     "1700002000.000300",
+				TeamID:      "T03TEAM001",
+				ChannelType: "channel",
+				Mentioned:   false,
+			},
+		},
 	)
 }
 

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -26,30 +26,147 @@ channels:
       type: object
     implements_notify: true
     implements_request: true
+config_schema:
+  properties:
+    app_level_token:
+      description: 'Slack app-level token (xapp- prefix) for Socket Mode. Generate in Slack admin: Settings → Socket Mode → Generate token with scope connections:write.'
+      type: string
+  required:
+    - app_level_token
+  type: object
 description: 'Slack integration: tools (send/list channels), triggers (channel messages), and channels (notify/request via Slack DMs and posts).'
 event_kinds:
   - binding_schema:
       additionalProperties: false
       properties:
         channel:
-          description: 'Glob pattern matched against the Slack channel name (e.g. #incidents-*)'
-          format: glob
+          description: 'Substring matched against the Slack channel name or ID (e.g. #incidents)'
+          format: contains
           title: Channel
           type: string
+        mention_only:
+          description: Only trigger when the bot is mentioned in the message
+          title: Mention-only
+          type: boolean
         text:
           description: Substring matched against the message text
           format: contains
           title: Text contains
           type: string
+        user:
+          description: Slack user ID to match (e.g. U012AB3CD). Leave empty to match all users.
+          title: User
+          type: string
       type: object
     description: A message was posted to a Slack channel
+    examples:
+      - name: Plain channel message
+        payload:
+          channel: '#general'
+          channel_id: C012ABCDEF
+          channel_type: channel
+          event_ts: "1700000001.000100"
+          mentioned: false
+          team_id: T03TEAM001
+          text: Lunch order is in.
+          ts: "1700000001.000100"
+          user: U01USER001
+      - name: Bot mention in incidents channel
+        payload:
+          channel: '#incidents'
+          channel_id: C09INCIDENT
+          channel_type: channel
+          event_ts: "1700001000.000200"
+          mentioned: true
+          team_id: T03TEAM001
+          text: <@U07BOTUSER> the database is degraded
+          ts: "1700001000.000200"
+          user: U01USER002
+      - name: Threaded reply
+        payload:
+          channel: '#ops'
+          channel_id: C09OPSCHAN
+          channel_type: channel
+          event_ts: "1700002000.000300"
+          mentioned: false
+          team_id: T03TEAM001
+          text: Rolled back the deployment, monitoring now.
+          thread_ts: "1700002000.000100"
+          ts: "1700002000.000300"
+          user: U01USER003
     kind: channel_message
+    payload_schema:
+      additionalProperties: false
+      properties:
+        channel:
+          description: 'Channel display name (e.g. #incidents) or channel ID when the name is unknown'
+          title: Channel
+          type: string
+        channel_id:
+          description: Stable Slack channel identifier (e.g. C01ABC)
+          title: Channel ID
+          type: string
+        channel_type:
+          description: 'Slack channel kind: channel (public), group (private), im (DM), mim (multi-DM)'
+          title: Channel type
+          type: string
+        event_ts:
+          description: Timestamp of the event itself
+          title: Event timestamp
+          type: string
+        mentioned:
+          description: True when the bot was explicitly mentioned in the message
+          title: Mentioned
+          type: boolean
+        team_id:
+          description: Slack workspace ID (best-effort; may be empty for some event shapes)
+          title: Team ID
+          type: string
+        text:
+          description: Plain-text message body
+          title: Text
+          type: string
+        thread_ts:
+          description: Parent thread timestamp (present only for threaded replies)
+          title: Thread timestamp
+          type: string
+        ts:
+          description: Slack message timestamp (uniquely identifies the message within a channel)
+          title: Timestamp
+          type: string
+        user:
+          description: Slack user ID of the sender (empty for bot/system messages)
+          title: User
+          type: string
+      required:
+        - channel
+        - channel_id
+        - text
+        - ts
+        - event_ts
+        - channel_type
+        - mentioned
+      type: object
 name: slack
 schema_version: v1
 services:
   channel: v1
   tool: v1
   trigger: v1
+subscription_schema:
+  additionalProperties: false
+  properties:
+    channels:
+      description: 'Channel names or IDs (e.g. #incidents, C01ABC). Empty = watch all.'
+      items:
+        type: string
+      title: Channels
+      type: array
+    mention_only:
+      description: Only emit when bot is mentioned.
+      title: Mention-only
+      type: boolean
+  type: object
 tools:
   - description: Post a plain-text message to a Slack channel or DM.
     input_schema:

--- a/plugins/slack/scope.go
+++ b/plugins/slack/scope.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// decodeSubscriptionScope parses watch_scope_json into a SlackSubscriptionScope.
+// An empty string or "{}" decodes to the zero value (matches everything).
+// Returns an error if the JSON is present but malformed.
+func decodeSubscriptionScope(jsonStr string) (SlackSubscriptionScope, error) {
+	if jsonStr == "" || jsonStr == "{}" {
+		return SlackSubscriptionScope{}, nil
+	}
+	var s SlackSubscriptionScope
+	if err := json.Unmarshal([]byte(jsonStr), &s); err != nil {
+		return SlackSubscriptionScope{}, err
+	}
+	return s, nil
+}
+
+// matches reports whether an event for the given channel should be delivered
+// to a subscriber with this scope.
+//
+// Rules:
+//   - If Channels is non-empty, the event's channelID or channelName must
+//     appear in the list. Channel names may be specified with or without the
+//     leading "#" — both forms are accepted.
+//   - If MentionOnly is true, isMention must be true for the event to match.
+//   - An empty scope (zero value) matches all events.
+func (s SlackSubscriptionScope) matches(channelID, channelName string, isMention bool) bool {
+	if s.MentionOnly && !isMention {
+		return false
+	}
+	if len(s.Channels) == 0 {
+		return true
+	}
+	// Normalize the channel name by stripping a leading "#" so operators can
+	// write either "incidents" or "#incidents" in the scope config.
+	normalizedName := strings.TrimPrefix(channelName, "#")
+
+	for _, allowed := range s.Channels {
+		normalized := strings.TrimPrefix(allowed, "#")
+		if normalized == channelID || normalized == normalizedName {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/slack/scope_test.go
+++ b/plugins/slack/scope_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestDecodeSubscriptionScope checks that empty/minimal JSON decodes correctly.
+func TestDecodeSubscriptionScope(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		check   func(t *testing.T, s SlackSubscriptionScope)
+	}{
+		{
+			name:  "empty string returns zero value",
+			input: "",
+			check: func(t *testing.T, s SlackSubscriptionScope) {
+				t.Helper()
+				if len(s.Channels) != 0 {
+					t.Errorf("channels: want empty, got %v", s.Channels)
+				}
+				if s.MentionOnly {
+					t.Error("mention_only: want false")
+				}
+			},
+		},
+		{
+			name:  "empty object returns zero value",
+			input: "{}",
+			check: func(t *testing.T, s SlackSubscriptionScope) {
+				t.Helper()
+				if len(s.Channels) != 0 {
+					t.Errorf("channels: want empty, got %v", s.Channels)
+				}
+			},
+		},
+		{
+			name:  "channels list decoded correctly",
+			input: `{"channels":["#incidents","C01ABC"]}`,
+			check: func(t *testing.T, s SlackSubscriptionScope) {
+				t.Helper()
+				if len(s.Channels) != 2 {
+					t.Fatalf("channels: want 2, got %d", len(s.Channels))
+				}
+			},
+		},
+		{
+			name:  "mention_only decoded correctly",
+			input: `{"mention_only":true}`,
+			check: func(t *testing.T, s SlackSubscriptionScope) {
+				t.Helper()
+				if !s.MentionOnly {
+					t.Error("mention_only: want true")
+				}
+			},
+		},
+		{
+			name:    "malformed JSON returns error",
+			input:   `{not-valid`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := decodeSubscriptionScope(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tc.wantErr && tc.check != nil {
+				tc.check(t, s)
+			}
+		})
+	}
+}
+
+// TestSlackSubscriptionScopeMatches is a table-driven test for the matches method.
+func TestSlackSubscriptionScopeMatches(t *testing.T) {
+	cases := []struct {
+		name        string
+		scope       SlackSubscriptionScope
+		channelID   string
+		channelName string
+		isMention   bool
+		want        bool
+	}{
+		{
+			name:        "empty scope matches everything",
+			scope:       SlackSubscriptionScope{},
+			channelID:   "C01ANY",
+			channelName: "anything",
+			isMention:   false,
+			want:        true,
+		},
+		{
+			name:        "empty scope matches mention too",
+			scope:       SlackSubscriptionScope{},
+			channelID:   "C01ANY",
+			channelName: "anything",
+			isMention:   true,
+			want:        true,
+		},
+		{
+			name:        "channel matched by ID",
+			scope:       SlackSubscriptionScope{Channels: []string{"C01ALLOWED"}},
+			channelID:   "C01ALLOWED",
+			channelName: "some-channel",
+			isMention:   false,
+			want:        true,
+		},
+		{
+			name:        "channel matched by name without hash",
+			scope:       SlackSubscriptionScope{Channels: []string{"incidents"}},
+			channelID:   "C01ANY",
+			channelName: "incidents",
+			isMention:   false,
+			want:        true,
+		},
+		{
+			name:        "channel matched by name with hash in scope",
+			scope:       SlackSubscriptionScope{Channels: []string{"#incidents"}},
+			channelID:   "C01ANY",
+			channelName: "incidents",
+			isMention:   false,
+			want:        true,
+		},
+		{
+			name:        "channel matched by name with hash in both",
+			scope:       SlackSubscriptionScope{Channels: []string{"#incidents"}},
+			channelID:   "C01ANY",
+			channelName: "#incidents",
+			isMention:   false,
+			want:        true,
+		},
+		{
+			name:        "channel not in scope",
+			scope:       SlackSubscriptionScope{Channels: []string{"#incidents"}},
+			channelID:   "C99OTHER",
+			channelName: "general",
+			isMention:   false,
+			want:        false,
+		},
+		{
+			name:        "mention_only=true with non-mention",
+			scope:       SlackSubscriptionScope{MentionOnly: true},
+			channelID:   "C01ANY",
+			channelName: "general",
+			isMention:   false,
+			want:        false,
+		},
+		{
+			name:        "mention_only=true with mention",
+			scope:       SlackSubscriptionScope{MentionOnly: true},
+			channelID:   "C01ANY",
+			channelName: "general",
+			isMention:   true,
+			want:        true,
+		},
+		{
+			name: "mention_only + channel filter both satisfied",
+			scope: SlackSubscriptionScope{
+				MentionOnly: true,
+				Channels:    []string{"#incidents"},
+			},
+			channelID:   "C01INC",
+			channelName: "incidents",
+			isMention:   true,
+			want:        true,
+		},
+		{
+			name: "mention_only + channel filter: channel fails",
+			scope: SlackSubscriptionScope{
+				MentionOnly: true,
+				Channels:    []string{"#incidents"},
+			},
+			channelID:   "C99OTHER",
+			channelName: "general",
+			isMention:   true,
+			want:        false,
+		},
+		{
+			name: "mention_only + channel filter: mention fails",
+			scope: SlackSubscriptionScope{
+				MentionOnly: true,
+				Channels:    []string{"#incidents"},
+			},
+			channelID:   "C01INC",
+			channelName: "incidents",
+			isMention:   false,
+			want:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.scope.matches(tc.channelID, tc.channelName, tc.isMention)
+			if got != tc.want {
+				t.Errorf("matches(%q, %q, %v): want %v, got %v",
+					tc.channelID, tc.channelName, tc.isMention, tc.want, got)
+			}
+		})
+	}
+}

--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -13,6 +16,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
 
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
@@ -236,24 +241,276 @@ func errorResponse(code commonv1.ErrorCode, message string) *toolv1.CallResponse
 
 // ── TriggerService ────────────────────────────────────────────────────────────
 
-// TriggerService implements triggerv1.TriggerServiceServer with a stub Start.
-// #234 will implement Start to subscribe to the Slack Events API and emit
-// channel_message events matching the policy's binding config.
+// socketModeRunner abstracts socketmode.Client for testability.
+//
+// Concurrency contract: implementors MUST consume events from a SINGLE goroutine
+// and call onEvent sequentially. Per-stream ordering is part of the trigger
+// contract (issue #234 AC); concurrent dispatch is forbidden.
+type socketModeRunner interface {
+	// Run opens the Socket Mode WebSocket connection, calls onEvent for each
+	// incoming event, and blocks until ctx is cancelled or a fatal error occurs.
+	// Returns context.Canceled on clean shutdown, or an error string containing
+	// "invalid_auth" / "account_inactive" / "not_authed" / "token_revoked" on
+	// auth failure (per socket_mode_managed_conn.go:188-249).
+	Run(ctx context.Context, onEvent func(socketmode.Event)) error
+
+	// Ack acknowledges a Slack EventsAPI envelope. Must be called within 3 seconds
+	// of receiving the event or Slack will redeliver it.
+	Ack(req socketmode.Request)
+}
+
+// socketModeFactory creates a socketModeRunner from an app-level (xapp-) token.
+type socketModeFactory func(xappToken string) (socketModeRunner, error)
+
+// productionSocketModeRunner wraps socketmode.Client to satisfy the socketModeRunner
+// interface with a single-goroutine fanout — events are delivered sequentially
+// to preserve per-stream ordering.
+type productionSocketModeRunner struct {
+	client *socketmode.Client
+}
+
+// Run opens the Socket Mode connection. A single goroutine ranges over
+// client.Events and calls onEvent sequentially (preserving ordering). Run then
+// calls client.RunContext(ctx) and waits for the fanout goroutine to drain
+// before returning, so the caller never observes partial shutdown.
+func (r *productionSocketModeRunner) Run(ctx context.Context, onEvent func(socketmode.Event)) error {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ev := range r.client.Events {
+			onEvent(ev)
+		}
+	}()
+
+	err := r.client.RunContext(ctx)
+	// Wait for the fanout goroutine to finish draining the Events channel.
+	// RunContext closes client.Events on return, so the goroutine exits promptly.
+	wg.Wait()
+	return err
+}
+
+// Ack delegates to the underlying socketmode.Client.
+func (r *productionSocketModeRunner) Ack(req socketmode.Request) {
+	r.client.Ack(req)
+}
+
+// defaultSocketModeFactory constructs a productionSocketModeRunner using the
+// provided xapp- token. The bot token slot is left empty ("") because Socket
+// Mode only requires the app-level token; the bot token is used only for API
+// calls (which go through ToolService, not TriggerService).
+func defaultSocketModeFactory(xappToken string) (socketModeRunner, error) {
+	api := slack.New("", slack.OptionAppLevelToken(xappToken))
+	client := socketmode.New(api)
+	return &productionSocketModeRunner{client: client}, nil
+}
+
+// TriggerService implements triggerv1.TriggerServiceServer. It opens a Slack
+// Socket Mode WebSocket connection, receives message and app_mention events,
+// translates them to SlackChannelMessagePayload JSON, applies the instance-level
+// subscription scope, and emits matching events to the host via EmitEvent.
 type TriggerService struct {
 	triggerv1.UnimplementedTriggerServiceServer
-	host hostv1.HostServiceClient
+	host              hostv1.HostServiceClient
+	socketModeFactory socketModeFactory
 }
 
 // NewTriggerService creates a TriggerService that uses hostClient for host RPCs.
+// The production socketmode.Client factory is used for the real Slack connection.
+// Signature is intentionally stable — mirrors how NewToolService stayed stable
+// across #366.
 func NewTriggerService(hostClient hostv1.HostServiceClient) *TriggerService {
-	return &TriggerService{host: hostClient}
+	return &TriggerService{
+		host:              hostClient,
+		socketModeFactory: defaultSocketModeFactory,
+	}
 }
 
-// Start is a server-streaming RPC. There is no response slot before the first
-// event, so a top-level gRPC error is the only way to signal failure here.
-// #234 replaces this with the Slack Events API subscription loop.
-func (s *TriggerService) Start(_ *triggerv1.StartRequest, _ grpc.ServerStreamingServer[triggerv1.StartResponse]) error {
-	return status.Error(codes.Unimplemented, "slack TriggerService.Start: not implemented")
+// newTriggerServiceWithFactory is an internal constructor for tests that need
+// to inject a fake socketModeRunner instead of a real Slack connection.
+func newTriggerServiceWithFactory(hostClient hostv1.HostServiceClient, factory socketModeFactory) *TriggerService {
+	return &TriggerService{
+		host:              hostClient,
+		socketModeFactory: factory,
+	}
+}
+
+// Start is a server-streaming RPC that opens a Slack Socket Mode connection and
+// emits channel_message events to the host. It blocks until the stream context
+// is cancelled (clean shutdown) or a fatal Slack error occurs (auth failure,
+// misconfiguration). The stream itself carries no StartResponse messages —
+// canonical event delivery goes through HostService.EmitEvent (spec §4.3).
+func (s *TriggerService) Start(req *triggerv1.StartRequest, stream grpc.ServerStreamingServer[triggerv1.StartResponse]) error {
+	// Propagate the host-injected call ID so SetHealthState and EmitEvent can
+	// be correlated back to this trigger stream by the host.
+	hostCtx := serve.WithCallContext(stream.Context())
+
+	// Fetch the app-level (xapp-) token from instance config. This token is
+	// separate from the OAuth bot token — it is required for Socket Mode.
+	cfgResp, err := s.host.GetInstanceConfig(hostCtx, &hostv1.GetInstanceConfigRequest{})
+	if err != nil {
+		return status.Errorf(codes.Internal, "GetInstanceConfig: %v", err)
+	}
+	token, err := extractAppLevelToken(cfgResp.GetConfigJson())
+	if err != nil || token == "" {
+		s.setTriggerHealth(hostCtx, healthConfigMissing)
+		return status.Error(codes.FailedPrecondition, "app_level_token is required in instance config but was not set; configure it in the admin UI")
+	}
+
+	// Parse the instance-level coarse subscription scope from the request.
+	// An empty or missing scope matches all channels.
+	scope, err := decodeSubscriptionScope(req.GetWatchScopeJson())
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid watch_scope_json: %v", err)
+	}
+
+	// Build the Socket Mode runner using the factory (real or fake in tests).
+	runner, err := s.socketModeFactory(token)
+	if err != nil {
+		return status.Errorf(codes.Internal, "create socket mode runner: %v", err)
+	}
+
+	// onEvent is called sequentially by the runner's single fanout goroutine.
+	// Per the socketModeRunner contract, this function is never called concurrently.
+	onEvent := func(evt socketmode.Event) {
+		if evt.Type != socketmode.EventTypeEventsAPI {
+			s.handleNonEventsAPI(hostCtx, evt)
+			return
+		}
+
+		// Ack FIRST, synchronously, unconditionally — beats Slack's 3-second
+		// redelivery window even if translate or EmitEvent stalls later.
+		// A deferred Ack would run AFTER EmitEvent and could miss the window
+		// under host backpressure (blocking #3 from plan review).
+		if evt.Request != nil {
+			runner.Ack(*evt.Request)
+		}
+
+		eventsAPIEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
+		if !ok {
+			return
+		}
+
+		kind, eventID, payload, emit, err := translate(eventsAPIEvent.InnerEvent, eventsAPIEvent.TeamID)
+		if err != nil {
+			log.Printf("slack: translate error: %v", err)
+			return
+		}
+		if !emit {
+			return
+		}
+
+		// Extract channelID and mentioned from the decoded payload to evaluate
+		// the subscription scope. We unmarshal into SlackChannelMessagePayload
+		// because translate already serialized all the fields there.
+		var p SlackChannelMessagePayload
+		if jsonErr := json.Unmarshal(payload, &p); jsonErr != nil {
+			log.Printf("slack: scope check unmarshal: %v", jsonErr)
+			return
+		}
+		// p.ChannelID is the real Slack channel ID (e.g. C012ABCDEF). p.Channel
+		// currently also holds the ID — Socket Mode message events don't include
+		// resolved channel names. As a result, operator subscription scopes
+		// containing entries like "#incidents" won't match; only ID-form entries
+		// like "C012ABCDEF" do. Future work: cache an ID→name map via
+		// conversations.info so name-form scopes work.
+		if !scope.matches(p.ChannelID, p.Channel, p.Mentioned) {
+			return
+		}
+
+		if _, err := s.host.EmitEvent(hostCtx, &hostv1.EmitEventRequest{
+			EventKind: kind,
+			EventId:   eventID,
+			// PayloadJson carries the JSON bytes as a string on the wire.
+			PayloadJson: string(payload),
+		}); err != nil {
+			// EmitEvent failure is non-fatal — don't tear down the stream.
+			log.Printf("slack: EmitEvent failed: %v", err)
+		}
+	}
+
+	// Run blocks until ctx is cancelled or a fatal Slack error occurs.
+	runErr := runner.Run(stream.Context(), onEvent)
+
+	// Clean shutdown: context was cancelled by the host (supervisor restart, etc.)
+	// or the stream context expired. Return nil so the supervisor can re-call Start.
+	if errors.Is(runErr, context.Canceled) || stream.Context().Err() != nil {
+		return nil
+	}
+
+	// Auth failure: the 4 named Slack auth-fatal strings surface via RunContext's
+	// return value (not via EventTypeInvalidAuth — that fires only on HTTP 404
+	// from connect(), per socket_mode_managed_conn.go:235-249).
+	if runErr != nil {
+		errStr := runErr.Error()
+		for _, fatal := range []string{"invalid_auth", "account_inactive", "not_authed", "token_revoked"} {
+			if strings.Contains(errStr, fatal) {
+				s.setTriggerHealth(hostCtx, healthAuthExpired)
+				return status.Error(codes.Unauthenticated, errStr)
+			}
+		}
+		log.Printf("slack: socket mode exited with unexpected error: %v", runErr)
+		return status.Error(codes.Unavailable, runErr.Error())
+	}
+
+	return nil
+}
+
+// handleNonEventsAPI logs diagnostic information for non-message socketmode events
+// and updates health state when Slack signals an auth problem at the connection
+// level (EventTypeInvalidAuth fires only on HTTP 404 from connect()).
+func (s *TriggerService) handleNonEventsAPI(ctx context.Context, evt socketmode.Event) {
+	switch evt.Type {
+	case socketmode.EventTypeConnected:
+		log.Printf("slack: socket mode connected")
+	case socketmode.EventTypeHello:
+		log.Printf("slack: socket mode hello received")
+	case socketmode.EventTypeDisconnect:
+		// socketmode auto-reconnects; log informational only.
+		log.Printf("slack: socket mode disconnected (will reconnect)")
+	case socketmode.EventTypeConnectionError:
+		log.Printf("slack: socket mode connection error (will reconnect): %v", evt.Data)
+	case socketmode.EventTypeInvalidAuth:
+		// Fires ONLY on HTTP 404 from connect() — not the common auth-failure path.
+		// The 4 named auth strings (invalid_auth etc.) come back via RunContext's
+		// return value. Log + mark unhealthy but do NOT return from Start: RunContext
+		// will surface its own error which the post-Run classifier handles.
+		log.Printf("slack: socket mode invalid_auth event (HTTP 404 from connect)")
+		s.setTriggerHealth(ctx, healthAuthExpired)
+	}
+}
+
+// setTriggerHealth updates the plugin health state. It is called for persistent
+// failures that require operator intervention (missing config, auth expiry).
+func (s *TriggerService) setTriggerHealth(ctx context.Context, h healthHint) {
+	var detail string
+	switch h {
+	case healthAuthExpired:
+		detail = "auth_expired"
+	case healthConfigMissing:
+		detail = "config_missing"
+	default:
+		return
+	}
+	_, _ = s.host.SetHealthState(ctx, &hostv1.SetHealthStateRequest{
+		State:  hostv1.PluginHealthState_PLUGIN_HEALTH_STATE_UNHEALTHY,
+		Detail: detail,
+	})
+}
+
+// extractAppLevelToken parses the instance config JSON and returns the
+// app_level_token value. Returns ("", nil) when the field is absent or empty.
+func extractAppLevelToken(configJSON string) (string, error) {
+	if configJSON == "" || configJSON == "{}" {
+		return "", nil
+	}
+	var cfg struct {
+		AppLevelToken string `json:"app_level_token"`
+	}
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		return "", fmt.Errorf("parse instance config: %w", err)
+	}
+	return cfg.AppLevelToken, nil
 }
 
 // ── ChannelService ────────────────────────────────────────────────────────────

--- a/plugins/slack/service_test.go
+++ b/plugins/slack/service_test.go
@@ -3,15 +3,21 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
 
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
@@ -130,6 +136,420 @@ func setupAll(t *testing.T, slackBackend *httptest.Server, hostOpts ...plugintes
 	return svcs, cleanup
 }
 
+// ── fakeSocketModeRunner ─────────────────────────────────────────────────────
+
+// fakeSocketModeRunner is a test double for socketModeRunner. It plays back
+// a configured slice of events sequentially (preserving ordering), then blocks
+// on ctx.Done() and returns ctx.Err() — or returns runErr immediately without
+// playing any events when runErr is non-nil.
+//
+// Ack records every call so tests can assert that acknowledgement happened.
+type fakeSocketModeRunner struct {
+	events []socketmode.Event
+	runErr error
+
+	mu   sync.Mutex
+	acks []socketmode.Request
+}
+
+// Run plays back configured events sequentially, then blocks until ctx is done.
+// If runErr is set, it returns runErr immediately (no events played).
+func (f *fakeSocketModeRunner) Run(ctx context.Context, onEvent func(socketmode.Event)) error {
+	if f.runErr != nil {
+		return f.runErr
+	}
+	for _, ev := range f.events {
+		onEvent(ev)
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Ack records the acknowledged request for later assertion.
+func (f *fakeSocketModeRunner) Ack(req socketmode.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acks = append(f.acks, req)
+}
+
+// AckCount returns the number of times Ack was called.
+func (f *fakeSocketModeRunner) AckCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.acks)
+}
+
+// ── setupAllWithFactory ──────────────────────────────────────────────────────
+
+// setupAllWithFactory starts a TriggerService gRPC server using an injected
+// socketModeFactory (for testing without a real Slack connection) backed by a
+// FakeHost configured to return cfgJSON from GetInstanceConfig.
+// It returns the services client, the FakeHost for health/event assertions,
+// and a cleanup function.
+func setupAllWithFactory(t *testing.T, factory socketModeFactory, cfgJSON string) (*services, *plugintest.FakeHost, func()) {
+	t.Helper()
+
+	host := plugintest.NewFakeHost(
+		plugintest.WithInstanceConfigJSON(cfgJSON),
+	)
+
+	hostLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for host: %v", err)
+	}
+	hostSrv := grpc.NewServer()
+	host.Register(hostSrv)
+	go func() { _ = hostSrv.Serve(hostLis) }()
+
+	hostConn, err := grpc.NewClient(hostLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial host: %v", err)
+	}
+	hostClient := hostv1.NewHostServiceClient(hostConn)
+
+	triggerLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for trigger: %v", err)
+	}
+	triggerSrv := grpc.NewServer()
+	triggerSvc := newTriggerServiceWithFactory(hostClient, factory)
+	triggerv1.RegisterTriggerServiceServer(triggerSrv, triggerSvc)
+	go func() { _ = triggerSrv.Serve(triggerLis) }()
+
+	triggerConn, err := grpc.NewClient(triggerLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial trigger: %v", err)
+	}
+
+	svcs := &services{
+		trigger: triggerv1.NewTriggerServiceClient(triggerConn),
+	}
+	cleanup := func() {
+		triggerConn.Close()
+		triggerSrv.Stop()
+		hostConn.Close()
+		hostSrv.Stop()
+	}
+	return svcs, host, cleanup
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// eventsAPISocketEvent builds a socketmode.Event of type EventTypeEventsAPI
+// wrapping a slackevents.EventsAPIEvent whose InnerEvent.Data is a pointer
+// (mirroring what slackevents.ParseEvent produces via reflect.New).
+func eventsAPISocketEvent(channelID, channelType, user, text, ts, teamID string) socketmode.Event {
+	inner := slackevents.EventsAPIInnerEvent{
+		Type: "message",
+		Data: &slackevents.MessageEvent{
+			Channel:        channelID,
+			ChannelType:    channelType,
+			User:           user,
+			Text:           text,
+			TimeStamp:      ts,
+			EventTimeStamp: ts,
+		},
+	}
+	outerEvt := slackevents.EventsAPIEvent{
+		TeamID:     teamID,
+		InnerEvent: inner,
+	}
+	return socketmode.Event{
+		Type:    socketmode.EventTypeEventsAPI,
+		Data:    outerEvt,
+		Request: &socketmode.Request{EnvelopeID: "env-" + ts},
+	}
+}
+
+// startTriggerInBackground calls svcs.trigger.Start in a goroutine and
+// returns a channel that receives the first Recv error (or nil on clean EOF).
+// The cancel function should be called to shut down the trigger stream.
+func startTriggerInBackground(t *testing.T, svcs *services, scopeJSON string) (cancel func(), done <-chan error) {
+	t.Helper()
+	ctx, cancelFn := context.WithCancel(context.Background())
+	ch := make(chan error, 1)
+	go func() {
+		stream, err := svcs.trigger.Start(ctx, &triggerv1.StartRequest{
+			WatchScopeJson: scopeJSON,
+		})
+		if err != nil {
+			ch <- err
+			return
+		}
+		_, recvErr := stream.Recv()
+		ch <- recvErr
+	}()
+	return cancelFn, ch
+}
+
+// ── New trigger tests ─────────────────────────────────────────────────────────
+
+// TestTriggerStartFailedPreconditionWithoutToken asserts that Start returns
+// codes.FailedPrecondition when the instance config carries no app_level_token,
+// and that the FakeHost records UNHEALTHY/config_missing.
+func TestTriggerStartFailedPreconditionWithoutToken(t *testing.T) {
+	svcs, host, cleanup := setupAllWithFactory(t,
+		func(_ string) (socketModeRunner, error) {
+			t.Fatal("socketModeFactory should not be called when token is missing")
+			return nil, nil
+		},
+		`{}`, // no app_level_token
+	)
+	defer cleanup()
+
+	stream, err := svcs.trigger.Start(context.Background(), &triggerv1.StartRequest{})
+	if err != nil {
+		t.Fatalf("Start open: %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error from Recv, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("code: want FailedPrecondition, got %v", st.Code())
+	}
+
+	healthState, detail, healthOK := host.Health()
+	if !healthOK {
+		t.Fatal("expected health state to be set")
+	}
+	if healthState != plugintest.HealthStateUnhealthy {
+		t.Errorf("health state: want Unhealthy, got %v", healthState)
+	}
+	if detail != "config_missing" {
+		t.Errorf("health detail: want %q, got %q", "config_missing", detail)
+	}
+}
+
+// TestTriggerStartEmitsEventOnFakeSocketModeMessage asserts that a fake
+// socketmode.Event of type EventTypeEventsAPI causes Start to call
+// host.EmitEvent with kind=channel_message, a non-empty deterministic event_id,
+// the correct payload, and that Ack is called exactly once for that event.
+func TestTriggerStartEmitsEventOnFakeSocketModeMessage(t *testing.T) {
+	const (
+		channelID = "C01TESTEMIT"
+		ts        = "1700010000.000100"
+		teamID    = "T01TEAM"
+		userID    = "U01USER"
+		msgText   = "hello from trigger test"
+	)
+
+	fake := &fakeSocketModeRunner{
+		events: []socketmode.Event{
+			eventsAPISocketEvent(channelID, "channel", userID, msgText, ts, teamID),
+		},
+	}
+
+	// emitCh receives the event the moment EmitEvent completes on the host.
+	// Buffer size 1 so the callback never blocks even if the consumer is slow.
+	emitCh := make(chan plugintest.Event, 1)
+
+	host := plugintest.NewFakeHost(
+		plugintest.WithInstanceConfigJSON(`{"app_level_token":"xapp-test-token"}`),
+		plugintest.OnEmitEvent(func(ev plugintest.Event) {
+			select {
+			case emitCh <- ev:
+			default:
+			}
+		}),
+	)
+
+	hostLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for host: %v", err)
+	}
+	hostSrv := grpc.NewServer()
+	host.Register(hostSrv)
+	go func() { _ = hostSrv.Serve(hostLis) }()
+	t.Cleanup(hostSrv.Stop)
+
+	hostConn, err := grpc.NewClient(hostLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial host: %v", err)
+	}
+	t.Cleanup(func() { hostConn.Close() })
+	hostClient := hostv1.NewHostServiceClient(hostConn)
+
+	triggerLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for trigger: %v", err)
+	}
+	triggerSrv := grpc.NewServer()
+	triggerv1.RegisterTriggerServiceServer(triggerSrv,
+		newTriggerServiceWithFactory(hostClient, func(_ string) (socketModeRunner, error) {
+			return fake, nil
+		}))
+	go func() { _ = triggerSrv.Serve(triggerLis) }()
+	t.Cleanup(triggerSrv.Stop)
+
+	triggerConn, err := grpc.NewClient(triggerLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial trigger: %v", err)
+	}
+	t.Cleanup(func() { triggerConn.Close() })
+
+	svcs := &services{trigger: triggerv1.NewTriggerServiceClient(triggerConn)}
+	cancel, done := startTriggerInBackground(t, svcs, `{}`)
+
+	// Wait for EmitEvent to complete on the host side before cancelling the
+	// context. hostCtx is derived from stream.Context(), so cancelling before
+	// EmitEvent finishes would cause the RPC to fail with codes.Canceled.
+	var ev plugintest.Event
+	select {
+	case ev = <-emitCh:
+		// EmitEvent returned successfully.
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("timed out waiting for EmitEvent")
+	}
+	cancel()
+	<-done // wait for Start to return
+
+	// Ack must have been called exactly once (fires before EmitEvent in onEvent).
+	if n := fake.AckCount(); n != 1 {
+		t.Errorf("Ack call count: want 1, got %d", n)
+	}
+
+	if ev.EventKind != "channel_message" {
+		t.Errorf("event kind: want channel_message, got %q", ev.EventKind)
+	}
+	if ev.EventID == "" {
+		t.Error("event_id: want non-empty ULID string, got empty")
+	}
+
+	// Verify the event_id is deterministic: same inputs produce the same ULID.
+	wantID := deriveEventID(channelID, ts)
+	if ev.EventID != wantID {
+		t.Errorf("event_id: want %q (deterministic), got %q", wantID, ev.EventID)
+	}
+
+	// Verify key payload fields.
+	var p SlackChannelMessagePayload
+	if err := json.Unmarshal([]byte(ev.PayloadJSON), &p); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if p.ChannelID != channelID {
+		t.Errorf("payload channel_id: want %q, got %q", channelID, p.ChannelID)
+	}
+	if p.User != userID {
+		t.Errorf("payload user: want %q, got %q", userID, p.User)
+	}
+	if p.Text != msgText {
+		t.Errorf("payload text: want %q, got %q", msgText, p.Text)
+	}
+	if p.TeamID != teamID {
+		t.Errorf("payload team_id: want %q, got %q", teamID, p.TeamID)
+	}
+	if p.Mentioned {
+		t.Error("payload mentioned: want false for plain message event")
+	}
+}
+
+// TestTriggerStartHonorsSubscriptionScopeChannels asserts that when the
+// subscription scope restricts channels to a list that excludes the incoming
+// event's channel, no EmitEvent is recorded — but Ack is still called (because
+// Ack happens before the scope filter, per the synchronous-Ack requirement).
+func TestTriggerStartHonorsSubscriptionScopeChannels(t *testing.T) {
+	const (
+		channelID = "C99EXCLUDED"
+		ts        = "1700020000.000200"
+	)
+
+	fake := &fakeSocketModeRunner{
+		events: []socketmode.Event{
+			eventsAPISocketEvent(channelID, "channel", "U01USER", "filtered out", ts, "T01TEAM"),
+		},
+	}
+
+	cfgJSON := `{"app_level_token":"xapp-test-token"}`
+	// Scope only allows "#incidents", which excludes C99EXCLUDED.
+	scopeJSON := `{"channels":["#incidents"]}`
+
+	svcs, host, cleanup := setupAllWithFactory(t,
+		func(_ string) (socketModeRunner, error) { return fake, nil },
+		cfgJSON,
+	)
+	defer cleanup()
+
+	cancel, done := startTriggerInBackground(t, svcs, scopeJSON)
+
+	// Poll until Ack is recorded (Ack fires before scope check).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && fake.AckCount() < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	// Ack still fires even though the event is scope-filtered.
+	if n := fake.AckCount(); n != 1 {
+		t.Errorf("Ack call count: want 1 (ack precedes scope filter), got %d", n)
+	}
+
+	// No EmitEvent should have been recorded.
+	events := host.Events()
+	if len(events) != 0 {
+		t.Errorf("EmitEvent call count: want 0 (scope filtered), got %d", len(events))
+	}
+}
+
+// TestTriggerStartHealthUnhealthyOnInvalidAuth drives the RunContext-return
+// auth-failure path: the fake runner's Run returns errors.New("invalid_auth")
+// immediately (no events played). The test asserts codes.Unauthenticated and
+// that the FakeHost records UNHEALTHY/auth_expired.
+func TestTriggerStartHealthUnhealthyOnInvalidAuth(t *testing.T) {
+	fake := &fakeSocketModeRunner{
+		runErr: errors.New("invalid_auth"),
+	}
+
+	cfgJSON := `{"app_level_token":"xapp-test-token"}`
+	svcs, host, cleanup := setupAllWithFactory(t,
+		func(_ string) (socketModeRunner, error) { return fake, nil },
+		cfgJSON,
+	)
+	defer cleanup()
+
+	stream, err := svcs.trigger.Start(context.Background(), &triggerv1.StartRequest{})
+	if err != nil {
+		t.Fatalf("Start open: %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error from Recv, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("code: want Unauthenticated, got %v", st.Code())
+	}
+
+	healthState, detail, healthOK := host.Health()
+	if !healthOK {
+		t.Fatal("expected health state to be set")
+	}
+	if healthState != plugintest.HealthStateUnhealthy {
+		t.Errorf("health state: want Unhealthy, got %v", healthState)
+	}
+	if detail != "auth_expired" {
+		t.Errorf("health detail: want %q, got %q", "auth_expired", detail)
+	}
+}
+
+// ── Existing tests ────────────────────────────────────────────────────────────
+
 // TestStubsReturnNotImplemented asserts that Channel.Notify and Channel.Request
 // return an in-band ErrorEnvelope with ERROR_CODE_INTERNAL and a non-empty
 // message containing "not implemented". The gRPC call itself must succeed (nil
@@ -184,31 +604,6 @@ func TestStubsReturnNotImplemented(t *testing.T) {
 				t.Error("expected non-empty error message")
 			}
 		})
-	}
-}
-
-// TestTriggerStartReturnsUnimplemented asserts that TriggerService.Start
-// immediately returns a gRPC-level codes.Unimplemented error. Start is a
-// server-streaming RPC, so the only way to surface an error before emitting
-// any events is via a top-level gRPC status. #234 replaces this stub.
-func TestTriggerStartReturnsUnimplemented(t *testing.T) {
-	svcs, cleanup := setupAll(t, nil)
-	defer cleanup()
-
-	stream, err := svcs.trigger.Start(context.Background(), &triggerv1.StartRequest{})
-	if err != nil {
-		t.Fatalf("Start open: %v", err)
-	}
-	_, err = stream.Recv()
-	if err == nil {
-		t.Fatal("expected error from Recv, got nil")
-	}
-	st, ok := status.FromError(err)
-	if !ok {
-		t.Fatalf("expected gRPC status error, got: %v", err)
-	}
-	if st.Code() != codes.Unimplemented {
-		t.Errorf("code: want Unimplemented, got %v", st.Code())
 	}
 }
 

--- a/plugins/slack/tools.go
+++ b/plugins/slack/tools.go
@@ -93,9 +93,10 @@ type slackCreds struct {
 type healthHint int
 
 const (
-	healthNone        healthHint = iota // transient or caller error — no health update
-	healthAuthExpired                   // persistent auth failure — set UNHEALTHY
-	healthAuthMissing                   // no credentials configured — set UNHEALTHY
+	healthNone          healthHint = iota // transient or caller error — no health update
+	healthAuthExpired                     // persistent auth failure — set UNHEALTHY
+	healthAuthMissing                     // no credentials configured — set UNHEALTHY
+	healthConfigMissing                   // required instance config field missing — set UNHEALTHY
 )
 
 // mapErr maps a Slack API error to an ErrorCode and optional health hint.

--- a/plugins/slack/translator.go
+++ b/plugins/slack/translator.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/slack-go/slack/slackevents"
+)
+
+// parseSlackTS parses a Slack message timestamp of the form "1700000000.123456"
+// into a time.Time. Falls back to time.Now() on parse error so callers always
+// get a valid timestamp for ULID generation.
+func parseSlackTS(ts string) time.Time {
+	parts := strings.SplitN(ts, ".", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return time.Now()
+	}
+	sec, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return time.Now()
+	}
+	return time.Unix(sec, 0)
+}
+
+// deriveEventID produces a stable, time-sortable event ID from a Slack channel
+// ID and message timestamp. The same (channelID, ts) pair always produces the
+// same ULID, which lets the host deduplicate redelivered events within its
+// 1-hour dedup window (spec §4.3.2).
+//
+// Implementation: SHA-256 of "channelID:ts" provides 32 bytes of deterministic
+// entropy; we take the first 10 bytes as the ULID entropy source. The ULID
+// timestamp component is derived from parseSlackTS(ts).
+func deriveEventID(channelID, ts string) string {
+	h := sha256.Sum256([]byte(channelID + ":" + ts))
+	entropy := bytes.NewReader(h[:10])
+	id := ulid.MustNew(ulid.Timestamp(parseSlackTS(ts)), entropy)
+	return id.String()
+}
+
+// translate converts a Slack EventsAPIInnerEvent into a channel_message payload.
+// Returns emit=false (with no error) for events that should be silently dropped:
+// non-message/mention inner event types, and message events with a non-empty
+// SubType (bot_message, message_changed, etc.).
+//
+// The teamID parameter is sourced from the outer EventsAPIEvent.TeamID and is
+// best-effort — it may be empty for some Slack event shapes.
+//
+// IMPORTANT: slackevents.ParseEvent populates InnerEvent.Data via reflect.New,
+// which returns a pointer. The type switch MUST use pointer cases (*MessageEvent,
+// *AppMentionEvent) or the default case will always match.
+func translate(inner slackevents.EventsAPIInnerEvent, teamID string) (kind, eventID string, payload []byte, emit bool, err error) {
+	switch ev := inner.Data.(type) {
+	case *slackevents.MessageEvent:
+		// Drop subtypes: bot_message, message_changed, message_deleted, etc.
+		// Only plain human-authored new messages (SubType == "") are emitted.
+		if ev.SubType != "" {
+			return "", "", nil, false, nil
+		}
+		p := SlackChannelMessagePayload{
+			Channel:     ev.Channel,
+			ChannelID:   ev.Channel, // MessageEvent has no separate channel_id field
+			Text:        ev.Text,
+			User:        ev.User,
+			Ts:          ev.TimeStamp,
+			ThreadTs:    ev.ThreadTimeStamp,
+			EventTs:     ev.EventTimeStamp,
+			TeamID:      teamID,
+			ChannelType: ev.ChannelType,
+			Mentioned:   false,
+		}
+		b, err := json.Marshal(p)
+		if err != nil {
+			return "", "", nil, false, fmt.Errorf("translate: marshal message payload: %w", err)
+		}
+		return "channel_message", deriveEventID(ev.Channel, ev.TimeStamp), b, true, nil
+
+	case *slackevents.AppMentionEvent:
+		p := SlackChannelMessagePayload{
+			Channel:     ev.Channel,
+			ChannelID:   ev.Channel, // AppMentionEvent has no separate channel_id field
+			Text:        ev.Text,
+			User:        ev.User,
+			Ts:          ev.TimeStamp,
+			ThreadTs:    ev.ThreadTimeStamp,
+			EventTs:     ev.EventTimeStamp,
+			TeamID:      teamID,
+			ChannelType: "channel", // app_mention only fires in channels
+			Mentioned:   true,
+		}
+		b, err := json.Marshal(p)
+		if err != nil {
+			return "", "", nil, false, fmt.Errorf("translate: marshal mention payload: %w", err)
+		}
+		return "channel_message", deriveEventID(ev.Channel, ev.TimeStamp), b, true, nil
+
+	default:
+		// All other inner event types (reactions, channel events, etc.) are
+		// not subscribed to by this plugin version. Drop silently.
+		return "", "", nil, false, nil
+	}
+}

--- a/plugins/slack/translator_test.go
+++ b/plugins/slack/translator_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack/slackevents"
+)
+
+// TestTranslate is a table-driven test for the translate() pure function.
+// All inner.Data values are POINTER types to match what slackevents.ParseEvent
+// produces at runtime via reflect.New (see slackevents/parsers.go:122-143).
+func TestTranslate(t *testing.T) {
+	cases := []struct {
+		name     string
+		inner    slackevents.EventsAPIInnerEvent
+		teamID   string
+		wantEmit bool
+		wantKind string
+		wantErr  bool
+		// checkPayload is called when wantEmit=true to assert specific payload fields.
+		checkPayload func(t *testing.T, payload []byte)
+	}{
+		{
+			name: "plain MessageEvent emits channel_message",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "message",
+				Data: &slackevents.MessageEvent{
+					Channel:        "C01ABC",
+					ChannelType:    "channel",
+					User:           "U01USER",
+					Text:           "hello world",
+					TimeStamp:      "1700000000.123456",
+					EventTimeStamp: "1700000000.234567",
+				},
+			},
+			teamID:   "T01TEAM",
+			wantEmit: true,
+			wantKind: "channel_message",
+			checkPayload: func(t *testing.T, payload []byte) {
+				t.Helper()
+				var p SlackChannelMessagePayload
+				if err := json.Unmarshal(payload, &p); err != nil {
+					t.Fatalf("unmarshal payload: %v", err)
+				}
+				if p.ChannelID != "C01ABC" {
+					t.Errorf("channel_id: want C01ABC, got %q", p.ChannelID)
+				}
+				if p.User != "U01USER" {
+					t.Errorf("user: want U01USER, got %q", p.User)
+				}
+				if p.Text != "hello world" {
+					t.Errorf("text: want %q, got %q", "hello world", p.Text)
+				}
+				if p.TeamID != "T01TEAM" {
+					t.Errorf("team_id: want T01TEAM, got %q", p.TeamID)
+				}
+				if p.Mentioned {
+					t.Error("mentioned: want false for plain message")
+				}
+			},
+		},
+		{
+			name: "AppMentionEvent sets mentioned=true",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "app_mention",
+				Data: &slackevents.AppMentionEvent{
+					Channel:        "C09INCIDENT",
+					User:           "U01USER",
+					Text:           "<@U07BOT> help",
+					TimeStamp:      "1700001000.000100",
+					EventTimeStamp: "1700001000.000100",
+				},
+			},
+			teamID:   "T01TEAM",
+			wantEmit: true,
+			wantKind: "channel_message",
+			checkPayload: func(t *testing.T, payload []byte) {
+				t.Helper()
+				var p SlackChannelMessagePayload
+				if err := json.Unmarshal(payload, &p); err != nil {
+					t.Fatalf("unmarshal payload: %v", err)
+				}
+				if !p.Mentioned {
+					t.Error("mentioned: want true for app_mention")
+				}
+				if p.ChannelType != "channel" {
+					t.Errorf("channel_type: want channel, got %q", p.ChannelType)
+				}
+			},
+		},
+		{
+			name: "threaded reply includes thread_ts",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "message",
+				Data: &slackevents.MessageEvent{
+					Channel:         "C09OPS",
+					ChannelType:     "channel",
+					User:            "U01USER",
+					Text:            "rolling back now",
+					TimeStamp:       "1700002000.000300",
+					ThreadTimeStamp: "1700002000.000100",
+					EventTimeStamp:  "1700002000.000300",
+				},
+			},
+			teamID:   "T01TEAM",
+			wantEmit: true,
+			wantKind: "channel_message",
+			checkPayload: func(t *testing.T, payload []byte) {
+				t.Helper()
+				var p SlackChannelMessagePayload
+				if err := json.Unmarshal(payload, &p); err != nil {
+					t.Fatalf("unmarshal payload: %v", err)
+				}
+				if p.ThreadTs != "1700002000.000100" {
+					t.Errorf("thread_ts: want 1700002000.000100, got %q", p.ThreadTs)
+				}
+			},
+		},
+		{
+			name: "SubType bot_message is dropped",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "message",
+				Data: &slackevents.MessageEvent{
+					Channel:        "C01ABC",
+					User:           "U01USER",
+					Text:           "bot says hi",
+					TimeStamp:      "1700003000.000001",
+					EventTimeStamp: "1700003000.000001",
+					SubType:        "bot_message",
+				},
+			},
+			teamID:   "T01TEAM",
+			wantEmit: false,
+		},
+		{
+			name: "SubType message_changed is dropped",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "message",
+				Data: &slackevents.MessageEvent{
+					Channel:        "C01ABC",
+					User:           "U01USER",
+					Text:           "edited message",
+					TimeStamp:      "1700004000.000001",
+					EventTimeStamp: "1700004000.000001",
+					SubType:        "message_changed",
+				},
+			},
+			teamID:   "T01TEAM",
+			wantEmit: false,
+		},
+		{
+			name: "nil inner Data is dropped",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "message",
+				Data: nil,
+			},
+			teamID:   "T01TEAM",
+			wantEmit: false,
+		},
+		{
+			name: "malformed ts falls back gracefully (no error)",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "message",
+				Data: &slackevents.MessageEvent{
+					Channel:        "C01ABC",
+					ChannelType:    "channel",
+					User:           "U01USER",
+					Text:           "hi",
+					TimeStamp:      "not-a-ts",
+					EventTimeStamp: "not-a-ts",
+				},
+			},
+			teamID:   "T01TEAM",
+			wantEmit: true,
+			wantKind: "channel_message",
+			// No specific payload check; we just confirm no error and emit=true.
+		},
+		{
+			name: "unknown inner event type is dropped",
+			inner: slackevents.EventsAPIInnerEvent{
+				Type: "reaction_added",
+				// reaction_added events come back as a different concrete type;
+				// using a string pointer here ensures the default case matches.
+				Data: new(string),
+			},
+			teamID:   "T01TEAM",
+			wantEmit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, eventID, payload, emit, err := translate(tc.inner, tc.teamID)
+
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if emit != tc.wantEmit {
+				t.Errorf("emit: want %v, got %v", tc.wantEmit, emit)
+			}
+			if !emit {
+				return
+			}
+
+			if kind != tc.wantKind {
+				t.Errorf("kind: want %q, got %q", tc.wantKind, kind)
+			}
+			if eventID == "" {
+				t.Error("eventID: want non-empty ULID string")
+			}
+			if len(payload) == 0 {
+				t.Error("payload: want non-empty bytes")
+			}
+
+			if tc.checkPayload != nil {
+				tc.checkPayload(t, payload)
+			}
+		})
+	}
+}
+
+// TestDeriveEventIDIsDeterministic asserts that the same (channelID, ts) pair
+// always produces the same ULID across two independent calls. This is the
+// property that enables host-side deduplication of Slack's at-least-once delivery.
+func TestDeriveEventIDIsDeterministic(t *testing.T) {
+	channelID := "C01DEDUP"
+	ts := "1700000000.123456"
+
+	id1 := deriveEventID(channelID, ts)
+	id2 := deriveEventID(channelID, ts)
+
+	if id1 != id2 {
+		t.Errorf("deriveEventID not deterministic: got %q then %q", id1, id2)
+	}
+	if id1 == "" {
+		t.Error("deriveEventID returned empty string")
+	}
+}
+
+// TestDeriveEventIDDiffersForDifferentInputs ensures distinct (channelID, ts)
+// pairs produce distinct IDs, ruling out a constant or trivially broken hash.
+func TestDeriveEventIDDiffersForDifferentInputs(t *testing.T) {
+	id1 := deriveEventID("C01ABC", "1700000000.000001")
+	id2 := deriveEventID("C01ABC", "1700000000.000002")
+	id3 := deriveEventID("C02DEF", "1700000000.000001")
+
+	if id1 == id2 {
+		t.Error("same channel, different ts: IDs should differ")
+	}
+	if id1 == id3 {
+		t.Error("different channel, same ts: IDs should differ")
+	}
+}
+
+// TestParseSlackTS covers the happy path and the fallback behaviour.
+func TestParseSlackTS(t *testing.T) {
+	t.Run("valid unix seconds", func(t *testing.T) {
+		got := parseSlackTS("1700000000.123456")
+		want := time.Unix(1700000000, 0)
+		if !got.Equal(want) {
+			t.Errorf("want %v, got %v", want, got)
+		}
+	})
+
+	t.Run("malformed falls back to now", func(t *testing.T) {
+		before := time.Now().Add(-time.Second)
+		got := parseSlackTS("not-a-number")
+		after := time.Now().Add(time.Second)
+		if got.Before(before) || got.After(after) {
+			t.Errorf("expected fallback to time.Now(), got %v", got)
+		}
+	})
+
+	t.Run("empty string falls back to now", func(t *testing.T) {
+		before := time.Now().Add(-time.Second)
+		got := parseSlackTS("")
+		after := time.Now().Add(time.Second)
+		if got.Before(before) || got.After(after) {
+			t.Errorf("expected fallback to time.Now(), got %v", got)
+		}
+	})
+}
+
+// TestTranslateEventIDMatchesDeriveEventID verifies that the event_id embedded
+// in the translate() output is consistent with a direct call to deriveEventID
+// using the same inputs.
+func TestTranslateEventIDMatchesDeriveEventID(t *testing.T) {
+	channelID := "C01MATCH"
+	ts := "1700005000.000500"
+
+	inner := slackevents.EventsAPIInnerEvent{
+		Type: "message",
+		Data: &slackevents.MessageEvent{
+			Channel:        channelID,
+			ChannelType:    "channel",
+			User:           "U01USER",
+			Text:           "consistency check",
+			TimeStamp:      ts,
+			EventTimeStamp: ts,
+		},
+	}
+
+	_, eventID, _, emit, err := translate(inner, "T01TEAM")
+	if err != nil || !emit {
+		t.Fatalf("translate: emit=%v err=%v", emit, err)
+	}
+
+	want := deriveEventID(channelID, ts)
+	if eventID != want {
+		t.Errorf("event_id mismatch: translate produced %q, deriveEventID produced %q", eventID, want)
+	}
+}
+
+// TestTranslatePayloadChannelForMessage verifies the channel field in the payload
+// for a MessageEvent matches the channel from the event (MessageEvent has no
+// separate channel_id field so Channel is used for both).
+func TestTranslatePayloadChannelForMessage(t *testing.T) {
+	inner := slackevents.EventsAPIInnerEvent{
+		Type: "message",
+		Data: &slackevents.MessageEvent{
+			Channel:        "CMYCHAN",
+			ChannelType:    "channel",
+			Text:           "hello",
+			TimeStamp:      "1700000000.000001",
+			EventTimeStamp: "1700000000.000001",
+		},
+	}
+	_, _, payload, emit, err := translate(inner, "")
+	if err != nil || !emit {
+		t.Fatalf("translate: emit=%v err=%v", emit, err)
+	}
+	// Verify channel_id appears in the payload JSON.
+	if !strings.Contains(string(payload), `"CMYCHAN"`) {
+		t.Errorf("payload should contain channel ID CMYCHAN: %s", payload)
+	}
+}


### PR DESCRIPTION
Closes #234 — sub-issue 3 of 7 under tracking issue #162 (Phase 8: Slack plugin).

## Summary

Replaces the stub `TriggerService.Start` from #232/#365 with a real Socket Mode WebSocket loop. The plugin subscribes to Slack `message` and `app_mention` events, translates each one into a `channel_message` payload, and emits it to the host via `HostService.EmitEvent`. Per-instance subscription scope (channels + mention-only filter) is applied at the message-handler level.

## Non-obvious implementation choices (and why)

- **xapp- app-level token lives in `config_json`, not `StoredCredentials`.** Adding a parallel slot to host-side credentials would have been a cross-cutting change touching `internal/plugin/oauth/credentials.go`. Storing in `config_json` keeps the same encryption-at-rest guarantees, fits the existing manifest-schema-validation path, and avoids touching `internal/*` (the lint forbids it). A Phase-7 follow-up should add per-instance config-field secret redaction on `GET /api/v1/admin/plugin-instances/{iid}` mirroring `auth_headers_encrypted` from ADR-039.
- **`EmitEvent` is the canonical delivery path.** `Start` blocks until ctx cancelled and never sends `StartResponse`. Matches spec §4.3 and the host supervisor's wiring at `internal/plugin/trigger/supervisor.go:435-450`. One goroutine in the plugin.
- **POINTER cases in the translator type switch.** `slackevents.ParseEvent` populates `InnerEvent.Data` via `reflect.New(t)` which returns `*T`. A value-typed `case slackevents.MessageEvent:` would have silently never matched.
- **Synchronous Ack BEFORE translate/EmitEvent.** Slack requires ack within 3 seconds. A deferred ack would fire AFTER `EmitEvent` and could miss the window under host backpressure → Slack redelivers. So `runner.Ack(*evt.Request)` happens first, unconditionally, in the `onEvent` closure.
- **`event_id` is a ULID** derived from `sha256(channel_id + ":" + ts)` with `ulid.Timestamp(parseSlackTS(ts))` as the time component. Same `(channel_id, ts)` → same ULID, so the host's 1-hour dedup window drops duplicates from reconnect / network retry.
- **`SlackChannelMessageBinding.Channel` swapped from `GlobField` → `ContainsField`.** The host's binding evaluator (`internal/plugin/binding/binding.go:230`) rejects `format:glob` with `ErrUnsupportedOperator` — the original `GlobField` declaration from #232's scaffold would have silently never fired even after this PR. `ContainsField` (format:contains) is supported end-to-end. Plan-reviewer caught this; the fix is bundled here since it's required for the feature to work.
- **`RunContext` returns `context.Canceled` on clean shutdown, not nil.** The post-Run handler explicitly checks `errors.Is(runErr, context.Canceled) || stream.Context().Err() != nil` BEFORE classifying auth-fatal strings, so clean shutdown maps to a nil Start return.
- **`EventTypeInvalidAuth` events-loop handler is HTTP-404-only.** The 4 named auth-fatal strings (`invalid_auth`, `account_inactive`, `not_authed`, `token_revoked`) come back via `RunContext`'s return value, NOT through the Events channel. The post-Run classifier is the primary auth-failure path; the events-loop handler is a best-effort guard for the HTTP-404 edge case where Slack rejects the connection request itself.

## Known limitation (documented in README)

Subscription-scope channel filtering matches by **channel ID** only (e.g. `C012ABCDEF`). Name-based filtering (e.g. `#incidents`) silently does not match because Socket Mode message events carry only IDs, not resolved names. Caching a channel-id→name map via `conversations.info` is future work.

## Verification

| Check | Result |
|---|---|
| `go test -race -count=1 ./plugins/slack/...` (24 tests) | ✅ |
| Manifest re-gen × 2, `git diff --exit-code` | ✅ byte-identical |
| `make lint-plugins` (no `internal/*` imports) | ✅ |
| `make lint-plugins-self-test` | ✅ |
| Workspace `go build ./...` | ✅ |

## Process

<details>
<summary>Architecture plan + review cycles</summary>

Generated via the agentic dev-loop:
- **Architect** produced a 10-file plan with a 10-question pre-investigation (Socket Mode lifecycle, xapp- token storage, TriggerService.Start contract, generation interaction, payload schema, dedup-key derivation, subscription scope, sample payloads, error handling, test strategy).
- **Plan reviewer** flagged 5 blocking correctness bugs:
  1. Type switch needed POINTER cases (`*slackevents.MessageEvent`) — `slackevents.ParseEvent` uses `reflect.New`
  2. `EventTypeInvalidAuth` events-loop handler is HTTP-404-only, not the common auth-failure path — needed explicit documentation
  3. Defer-style Ack would miss Slack's 3s window — must be synchronous before translate
  4. `socketModeRunner` interface needed `Ack` method (companion to #3)
  5. `RunContext` returns `context.Canceled` on clean shutdown, not nil — needed explicit mapping
- **Plan revised** to address all 5 + suggestions (per-stream ordering guarantee in interface doc, team_id may-be-empty caveat, test-only constructor pattern).
- **Code review**: 1 cycle. APPROVED with 2 non-blocking suggestions (stale "stub" text in README; channel-name filter silent failure needed a comment). Both fixed surgically before commit.

</details>

## Documentation

No `CLAUDE.md` changes needed — host-side `EmitEvent`/`GetInstanceConfig`/`SetHealthState` semantics are already documented at lines 152-158. `frontend/CLAUDE.md` not relevant (pure backend/plugin work).

## Follow-ups (NOT in this PR)

- **Phase-7 issue:** "Per-instance config field marked `secret` is redacted on GET /api/v1/admin/plugin-instances/{iid}" — add `format: gleipnir-secret` JSON Schema annotation; redact admin GET; write-only PUT mirrors ADR-039.
- **Channel-name resolution** for subscription scope (cache `conversations.info` results).
- **Block Kit / interactive callbacks** — comes with #235 ChannelService since it's shared infrastructure.

---
🤖 Generated with the agentic dev-loop