### PR TITLE
feat: Slack OAuth authcode flow integration

### DIFF
--- a/docs/developer/manual-testing.md
+++ b/docs/developer/manual-testing.md
@@ -188,3 +188,117 @@ agent:
 6. **Full reasoning trace** — for any completed run, open the run detail in the UI. **Pass:** the trace shows all step types — agent thinking steps, tool call inputs, tool call results, and (where applicable) approval events. All are visible in the correct order.
 
 7. **Re-discovery** — tag a Todoist tool that was previously untagged, then click Discover again on the Todoist server. **Pass:** tool count and tag assignments are updated in the UI without needing to re-register the server.
+
+## Slack plugin (OAuth authcode)
+
+End-to-end manual QA for the Slack plugin OAuth authorization code flow. This
+section is not part of the automated test suite — it requires a real Slack
+workspace, a publicly-reachable Gleipnir instance, and a Slack app registered
+at [api.slack.com/apps](https://api.slack.com/apps).
+
+### Prerequisites
+
+- A Slack workspace where you have permission to install custom apps.
+- A Gleipnir instance reachable from the public internet (or at least from
+  Slack's servers for OAuth redirect). `localhost` will not work because Slack's
+  OAuth callback cannot reach it.
+- `public_url` configured in **Admin → System** before starting the OAuth flow.
+  `BeginAuthcode` returns an error if `public_url` is empty (see
+  `internal/plugin/oauth/manager.go`). Set it to e.g.
+  `https://gleipnir.example.com`.
+
+### Step 1 — Create the Slack app
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click
+   **Create New App → From a manifest**.
+2. Paste the YAML from `plugins/slack/README.md §"Slack app manifest (one-click)"`,
+   replacing `<your-public-url>` with your Gleipnir public URL.
+3. Click **Create**.
+4. Confirm the redirect URL under **OAuth & Permissions → Redirect URLs** shows:
+   ```
+   https://<your-public-url>/api/v1/admin/plugins/oauth/callback
+   ```
+
+### Step 2 — Build and install the plugin
+
+Follow the steps in `plugins/slack/README.md §"Install and audience setup flow"`:
+
+```sh
+# From the repo root
+cd plugins/slack
+make build
+gleipnir-plugin keygen --out slack.key
+gleipnir-plugin sign    --binary ./slack --manifest manifest.yaml --key slack.key
+gleipnir-plugin package --binary ./slack --manifest manifest.yaml --sig slack.sig --out slack.tar.gz
+```
+
+Then upload `slack.tar.gz` via **Admin → Plugins → Install plugin**.
+
+### Step 3 — Configure credentials and app-level token
+
+1. In Slack app settings → **Basic Information → App Credentials**, copy the
+   **Client ID** and **Client Secret**.
+2. In Gleipnir **Admin → Plugins → Slack → your instance → Credentials**, paste
+   both values and save.
+3. In Slack app settings → **Settings → Socket Mode → App-Level Tokens**, generate
+   a token with scope `connections:write`. Copy the `xapp-` token.
+4. In Gleipnir **Admin → Plugins → Slack → your instance → Instance Config**,
+   set `app_level_token` to the `xapp-` token and save.
+
+### Step 4 — Authorize with Slack
+
+1. Click **Authorize with Slack** in the Gleipnir admin UI.
+2. Your browser redirects to Slack's OAuth consent screen. Click **Allow**.
+3. Slack redirects back to Gleipnir's callback URL.
+4. The admin UI reloads with `?oauth_ok=1`. **Pass:** the plugin instance health
+   is now **Healthy**.
+
+### Step 5 — Smoke test: post a message
+
+Create a policy with a `manual` trigger and a single capability:
+
+```yaml
+name: slack-smoke
+trigger:
+  type: manual
+capabilities:
+  tools:
+    - tool: <instance-name>.post_message
+agent:
+  task: "Post 'Hello from Gleipnir smoke test' to the #test channel."
+  limits:
+    max_tokens_per_run: 5000
+    max_tool_calls_per_run: 5
+  concurrency: skip
+```
+
+Fire the policy via **Admin → Policies → slack-smoke → Trigger**.
+
+**Pass criteria:**
+- (a) The message appears in the `#test` Slack channel.
+- (b) The plugin instance remains **Healthy** after the run.
+- (c) Fire the policy a second time. On the second invocation, `auth.test` is
+  NOT called again (the `verifiedToken` short-circuit skips it). Confirm by
+  checking Slack's API call log or by counting the requests hitting your test
+  backend — the `POST /auth.test` count stays at 1.
+
+### Step 6 — Negative path: revoked token
+
+1. In the Slack workspace admin panel, go to **Installed Apps → Gleipnir →
+   Remove app** (or revoke the bot token directly).
+2. Fire the `slack-smoke` policy again.
+
+**Pass criteria:**
+- The run returns a `PERMISSION` error with a message containing `auth.test failed`.
+- The plugin instance transitions to **UNHEALTHY** with detail `auth_expired`.
+- The operator UI shows the unhealthy state in the Plugins dashboard.
+
+### Step 7 — Re-authorize
+
+1. Re-install the Slack app in the workspace (or generate a new bot token and
+   update it via the admin UI).
+2. Click **Authorize with Slack** again.
+3. Fire the smoke-test policy.
+
+**Pass:** Run completes successfully; instance health returns to **Healthy**;
+message appears in Slack.

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -1,11 +1,9 @@
 # slack
 
-**Status: TriggerService implemented (#234).** ToolService is implemented (#233). ChannelService is still a stub.
+**Status: All three services implemented (#233, #234, #235).** OAuth authcode integration documented in #236.
 
 Remaining issues:
 
-- [#235](https://github.com/felag-engineering/gleipnir/issues/235) — ChannelService: `Notify` and `Request` via Slack DMs / posts
-- [#236](https://github.com/felag-engineering/gleipnir/issues/236) — Instance config schema, OAuth wiring
 - [#237](https://github.com/felag-engineering/gleipnir/issues/237) — End-to-end test, packaging, signing
 
 Parent tracking issue: [#162](https://github.com/felag-engineering/gleipnir/issues/162)
@@ -14,7 +12,7 @@ Parent tracking issue: [#162](https://github.com/felag-engineering/gleipnir/issu
 
 - **ToolService v1** — `post_message`, `list_channels`, `search_messages`, `react`, `set_topic` (implemented by #233)
 - **TriggerService v1** — `channel_message` event kind via Slack Socket Mode (#234). Note: subscription-scope channel filtering matches by **channel ID** only (e.g. `C012ABCDEF`); name-based filtering (e.g. `#incidents`) silently does not match because Socket Mode events carry only IDs. Resolving names is future work.
-- **ChannelService v1** — `Notify` and `Request` (stubs; populated by #235)
+- **ChannelService v1** — `Notify` and `Request` via Slack DMs and posts (#235)
 - **Auth strategy** — `oauth2_authcode` with Slack's authorization and token endpoints
 
 ## Layout
@@ -22,7 +20,7 @@ Parent tracking issue: [#162](https://github.com/felag-engineering/gleipnir/issu
 ```
 slack/
   main.go            — calls serve.Serve() with all three service factories
-  service.go         — ToolService (#233) + TriggerService (#234) implementations; ChannelService still stub
+  service.go         — ToolService, TriggerService, ChannelService implementations
   tools.go           — typed tool params + handlers (#233)
   translator.go      — pure functions translating Socket Mode events to channel_message payloads (#234)
   scope.go           — SlackSubscriptionScope decode + matches helpers (#234)
@@ -39,22 +37,108 @@ slack/
 
 ## Channel (per-audience) config schema
 
-| Field     | Required | Description |
-|-----------|----------|-------------|
-| `channel` | yes      | Slack channel or user DM target (e.g. `#general` or `@username`) |
-| `mention` | no       | Slack user or group to mention in the message (e.g. `@oncall`) |
+| Field              | Required | Description |
+|--------------------|----------|-------------|
+| `channel`          | yes      | Slack channel or user DM target (e.g. `#general` or `@username`) |
+| `mention`          | no       | Slack user or group to mention in the message (e.g. `@oncall`) |
+| `response_buttons` | no       | Custom button options for `Request` messages (defaults to Approve/Reject) |
 
 ## Auth
 
 This plugin uses `oauth2_authcode`. The host runs the OAuth 2.0 authorization
-code flow on behalf of the plugin and stores the resulting access + refresh
-token in encrypted credentials. A `client_id` and `client_secret` must be
-configured at install time by an admin.
+code flow on behalf of the plugin and stores the resulting access token in
+encrypted credentials. A `client_id` and `client_secret` must be configured
+per-instance by an admin — there are no baked-in defaults (Option A per #236;
+see §"Configure OAuth credentials" below).
 
-Default OAuth endpoints baked into the manifest:
+Default OAuth endpoints declared in the manifest:
 - Authorization URL: `https://slack.com/oauth/v2/authorize`
 - Token URL: `https://slack.com/api/oauth.v2.access`
-- Default scopes: `channels:read`, `chat:write`, `im:write`, `users:read`
+
+### Configure OAuth credentials
+
+#### Step 1 — Create your Slack app
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App**.
+2. Choose **From a manifest** to use the one-click YAML below (see
+   §"Slack app manifest (one-click)"), or choose **From scratch** and configure
+   scopes manually.
+3. Select your workspace and confirm.
+
+#### Step 2 — Add the Gleipnir redirect URL
+
+1. In your new Slack app's settings, go to **OAuth & Permissions**.
+2. Under **Redirect URLs**, click **Add New Redirect URL** and enter:
+   ```
+   https://<your-gleipnir-public-url>/api/v1/admin/plugins/oauth/callback
+   ```
+   Replace `<your-gleipnir-public-url>` with the value you configured in
+   Gleipnir Admin → System → Public URL.
+3. Click **Save URLs**.
+
+#### Step 3 — Copy credentials from Slack
+
+1. In your Slack app's settings, go to **Basic Information**.
+2. Under **App Credentials**, copy the **Client ID** and **Client Secret**.
+
+#### Step 4 — Paste credentials into Gleipnir
+
+1. Open Gleipnir Admin → Plugins → Slack → your plugin instance.
+2. In the **Credentials** section, paste the **Client ID** and **Client Secret**.
+3. Save.
+
+#### Step 5 — Authorize
+
+1. Click **Authorize with Slack** in the Gleipnir admin UI.
+2. Your browser redirects to Slack's OAuth consent screen.
+3. Click **Allow**.
+4. Slack redirects back to Gleipnir's callback URL.
+5. The admin UI reloads with `?oauth_ok=1` and the plugin instance transitions
+   to **healthy**.
+6. The first tool call runs `auth.test` as a final verification gate.
+
+### Slack app manifest (one-click)
+
+Paste this YAML into Slack's "Create from manifest" flow. Replace
+`<your-public-url>` with your Gleipnir instance's public URL.
+
+```yaml
+display_information:
+  name: Gleipnir
+  description: Gleipnir homelab agent orchestrator
+features:
+  bot_user:
+    display_name: Gleipnir
+    always_online: false
+  socket_mode_enabled: true
+oauth_config:
+  redirect_urls:
+    - https://<your-public-url>/api/v1/admin/plugins/oauth/callback
+  scopes:
+    bot:
+      - channels:history
+      - channels:read
+      - chat:write
+      - groups:history
+      - im:history
+      - im:write
+      - mpim:history
+      - search:read
+      - users:read
+settings:
+  event_subscriptions:
+    bot_events:
+      - message.channels
+      - message.groups
+      - message.im
+      - message.mpim
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
 
 ### App-level token (xapp-)
 
@@ -72,9 +156,6 @@ To generate the token:
 6. Click **Generate** and copy the token (it starts with `xapp-`).
 7. In the Gleipnir admin UI, navigate to the Slack plugin instance config and
    paste the token into the `app_level_token` field.
-
-The full end-to-end setup (including connecting the Slack app to your workspace
-and wiring the Gleipnir trigger) is documented in [#237](https://github.com/felag-engineering/gleipnir/issues/237).
 
 > **Note:** The `app_level_token` field is stored as plain text in instance
 > config in this release. A follow-up issue will add `gleipnir-secret` format
@@ -110,7 +191,6 @@ The broader `go test ./plugins/...` does not work, because each first-party plug
 | Test | What it asserts |
 |------|-----------------|
 | `TestManifestYAMLIsCanonical` | `manifest.yaml` round-trips and matches `manifest.go` |
-| `TestStubsReturnNotImplemented` | `Channel.Notify`, `Channel.Request` return `ERROR_CODE_INTERNAL` in-band |
 | `TestTriggerStartFailedPreconditionWithoutToken` | Missing `app_level_token` → `FailedPrecondition` + UNHEALTHY/config_missing |
 | `TestTriggerStartEmitsEventOnFakeSocketModeMessage` | Fake runner delivers event → `EmitEvent` called with correct kind/id/payload, Ack called once |
 | `TestTriggerStartHonorsSubscriptionScopeChannels` | Excluded channel → zero `EmitEvent`, Ack still called |
@@ -127,6 +207,9 @@ The broader `go test ./plugins/...` does not work, because each first-party plug
 | `TestToolCallMetricOutcomeLabel` | Metric `outcome` label is `"ok"` on success and `"error"` on error |
 | `TestToolCallCtxCancel` | Cancelled context surfaces as `UNAVAILABLE` |
 | `TestMapErr` | Slack error-code strings map to the correct `ErrorCode` + health hint |
+| `TestToolService_Call_AuthTestFails_SetsUnhealthy` | auth.test → invalid_auth → PERMISSION + UNHEALTHY/auth_expired, tool not called |
+| `TestToolService_Call_AuthTestOnce_SkippedOnSubsequentCalls` | Same token → auth.test called once; verifiedToken short-circuit skips second |
+| `TestToolService_Call_AuthTestReruns_OnTokenRotation` | Token changes between calls → auth.test called twice (one per distinct token) |
 
 ## Manifest
 
@@ -163,9 +246,7 @@ Then run `go test ./...` to confirm `TestManifestYAMLIsCanonical` still passes.
 4. **Install** via the Gleipnir admin UI at `/admin/plugins` → "Install plugin"
    → upload `slack.tar.gz`.
 
-5. **Configure OAuth credentials** in the plugin credentials screen:
-   - Enter your Slack app's `client_id` and `client_secret`.
-   - Complete the OAuth authorization flow.
+5. **Configure OAuth credentials** — follow the steps in §"Configure OAuth credentials" above.
 
 6. **Add an audience entry** to a policy:
    - Select the Slack plugin as the channel.
@@ -309,13 +390,29 @@ The following OAuth 2.0 bot token scopes must be granted when installing the
 Slack app. These are declared in `manifest.go`'s `OAuthDefaults.Scopes` list
 and shown in the admin UI during install.
 
-| Scope | Used by |
-|-------|---------|
-| `channels:read` | `list_channels` (public channels) |
-| `chat:write` | `post_message` |
-| `im:write` | `post_message` to DMs |
-| `users:read` | user lookup in various responses |
-| `search:read` | `search_messages` |
+| Scope             | Used by |
+|-------------------|---------|
+| `channels:history` | **Reserved; no current tool uses it** |
+| `channels:read`   | `list_channels` (public channels) |
+| `chat:write`      | `post_message` |
+| `groups:history`  | **Reserved; no current tool uses it** |
+| `im:history`      | **Reserved; no current tool uses it** |
+| `im:write`        | `post_message` to DMs |
+| `mpim:history`    | **Reserved; no current tool uses it** |
+| `search:read`     | `search_messages` |
+| `users:read`      | user lookup in various responses |
+
+> **Note on `*:history` scopes:** The four `*:history` scopes (`channels:history`,
+> `groups:history`, `im:history`, `mpim:history`) are reserved for future
+> history-reading tools (e.g., a `read_recent_messages` tool that calls
+> `conversations.history`). The current plugin code does **not** call these
+> endpoints at runtime. Socket Mode event delivery (TriggerService) uses the
+> app-level `xapp-` token and does **not** require these bot-token scopes.
+> Operators who decline these scopes at OAuth time will still get a working
+> installation for the currently-implemented tools (`post_message`,
+> `list_channels`, `search_messages`, `react`, `set_topic`) and the
+> `channel_message` trigger; they are requested up-front per the issue AC so the
+> same OAuth grant covers planned tools without a re-authorize round trip.
 
 **Note on `search:read`:** This scope is available for bot tokens but may not
 be granted during OAuth if the Slack app was configured before `search:read`
@@ -324,3 +421,14 @@ was added. Bot-only installs that are missing this scope will see a runtime
 plugin will be set to `UNHEALTHY` with detail `auth_expired` in the operator
 UI. To resolve: grant `search:read` in the Slack app settings and re-authorize
 the plugin instance.
+
+## Token refresh
+
+Slack v2 bot tokens (`xoxb-` prefix) do not expire under normal circumstances
+— they remain valid indefinitely unless explicitly revoked by a workspace admin
+or the app is uninstalled. As a result, the Phase-7 credential refresh scanner
+has nothing to refresh for Slack in the steady state. The `auth_expired` health
+transition fires only when a token is revoked: the next `ToolService.Call`
+invocation runs `auth.test`, receives `invalid_auth` or `token_revoked`, and
+sets the plugin to `UNHEALTHY`. The operator then re-authorizes via the admin UI
+to restore the healthy state.

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -22,26 +22,45 @@ var pluginManifest = manifest.Manifest{
 	// oauth2_authcode strategy: the host runs the OAuth2 authorization code flow
 	// on behalf of the plugin and stores the resulting access + refresh token pair
 	// in credentials_encrypted (spec §9.2).
-	//
-	// HasClientID and HasClientSecret are presence booleans, not values — setting
-	// either to true makes the key appear in the YAML (omitempty suppresses false).
-	// Setting both true advertises that this strategy requires a client_id and
-	// client_secret to be populated at install time by an admin. The actual
-	// credentials live in encrypted storage, never in the manifest file.
 	Auth: manifest.AuthDecl{
 		Mode:     "instance_credentials",
 		Strategy: manifest.AuthStrategyOAuth2Authcode,
 		OAuthDefaults: &manifest.OAuthDefaultsDecl{
 			AuthorizationURL: "https://slack.com/oauth/v2/authorize",
 			TokenURL:         "https://slack.com/api/oauth.v2.access",
-			// search:read is required by search_messages. Bot-only installs that
-			// are not granted this scope will see a runtime PERMISSION error
-			// (missing_scope → ERROR_CODE_PERMISSION + SetHealthState UNHEALTHY
-			// "auth_expired") visible in the operator UI. Operators must grant
-			// the scope in the Slack app settings and re-authorize.
-			Scopes:          []string{"channels:read", "chat:write", "im:write", "users:read", "search:read"},
-			HasClientID:     true,
-			HasClientSecret: true,
+			// Sequences are NOT sorted by manifest.Marshal (yaml.go:85-89);
+			// declare in alphabetical order to keep manifest.yaml byte-stable for
+			// TestManifestYAMLIsCanonical.
+			//
+			// The four *:history scopes (channels:history, groups:history,
+			// im:history, mpim:history) are reserved for future history-reading
+			// tools (e.g. conversations.history). The current plugin code does NOT
+			// call these endpoints. Socket Mode delivery (TriggerService) uses the
+			// app-level xapp- token and does NOT require these bot-token scopes.
+			// They are requested up-front so the same OAuth grant covers planned
+			// tools without a re-authorize round trip.
+			Scopes: []string{
+				"channels:history",
+				"channels:read",
+				"chat:write",
+				"groups:history",
+				"im:history",
+				"im:write",
+				"mpim:history",
+				"search:read",
+				"users:read",
+			},
+			// HasClientID and HasClientSecret describe whether the manifest carries
+			// default values. OAuthDefaultsDecl has no string fields for those
+			// (plugin-sdk/manifest/manifest.go:208-224). Per PR #236 (user
+			// Option A), we intentionally ship no defaults — operators register
+			// their own Slack app and supply client_id/client_secret per-instance
+			// via the admin UI (consumed by oauth.Resolve via InstanceConfigOverride
+			// at internal/plugin/oauth/credentials.go:201-238). Setting these
+			// honestly to false reflects the SDK's documented semantic; no host
+			// behavior depends on the values.
+			HasClientID:     false,
+			HasClientSecret: false,
 		},
 	},
 	Tools: buildToolDecls(),

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -2,14 +2,16 @@ auth:
   mode: instance_credentials
   oauth_defaults:
     authorization_url: https://slack.com/oauth/v2/authorize
-    has_client_id: true
-    has_client_secret: true
     scopes:
+      - channels:history
       - channels:read
       - chat:write
+      - groups:history
+      - im:history
       - im:write
-      - users:read
+      - mpim:history
       - search:read
+      - users:read
     token_url: https://slack.com/api/oauth.v2.access
   strategy: oauth2_authcode
 channels:

--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc"
@@ -38,6 +39,13 @@ type ToolService struct {
 	host       hostv1.HostServiceClient
 	httpClient *http.Client
 	apiURL     string // empty = Slack production default; tests pass httptest.Server URL + "/"
+
+	// verifiedToken holds the last access_token that passed auth.test.
+	// Concurrent first-calls may race: both may observe nil and both run
+	// auth.test against Slack. Acceptable: correctness preserved (second
+	// Store wins; both runs see a verified token). atomic.Pointer gives
+	// a lock-free fast path on Call() after the first verification.
+	verifiedToken atomic.Pointer[string]
 }
 
 // NewToolService creates a ToolService using hostClient for host RPCs,
@@ -137,8 +145,8 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 	toolName := req.GetToolName()
 
 	// Guard against unknown tool names before touching the Slack API.
-	// Unknown tools return INVALID_ARG without emitting a metric or hitting
-	// the Slack API, matching the minimal-tool dispatch pattern
+	// Unknown tools return INVALID_ARG without emitting a metric or running
+	// auth.test, matching the minimal-tool dispatch pattern
 	// (plugin-sdk/examples/minimal-tool/service.go:62-69).
 	switch toolName {
 	case "post_message", "list_channels", "search_messages", "react", "set_topic":
@@ -146,6 +154,27 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 	default:
 		return errorResponse(commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
 			fmt.Sprintf("unknown tool: %q", toolName)), nil
+	}
+
+	// Verify the token against Slack's auth.test endpoint on first use and
+	// whenever the token changes (e.g. after re-authorization). This is a
+	// lazy security gate: it catches revoked tokens before the tool call
+	// executes and transitions the plugin to UNHEALTHY so the operator sees
+	// a clear signal in the admin UI.
+	if prior := s.verifiedToken.Load(); prior == nil || *prior != creds.Token.AccessToken {
+		if _, authErr := sc.AuthTestContext(ctx); authErr != nil {
+			code, hint := mapErr(authErr)
+			if hint != healthNone {
+				s.setHealth(hostCtx, hint)
+			}
+			return errorResponse(code, "auth.test failed: "+authErr.Error()), nil
+		}
+		// Store address of a fresh local copy. Storing &creds.Token.AccessToken
+		// would persist a pointer into the just-fetched StoredCredentials
+		// value, which is harmless today (string compare by value) but
+		// fragile and non-obvious.
+		tok := creds.Token.AccessToken
+		s.verifiedToken.Store(&tok)
 	}
 
 	// Dispatch and measure.

--- a/plugins/slack/service_test.go
+++ b/plugins/slack/service_test.go
@@ -359,6 +359,28 @@ func setupChannelServiceWithRunner(
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
+// authTestHandler returns an http.HandlerFunc that responds to Slack's auth.test
+// endpoint. When ok is true it returns a successful auth.test response; when ok
+// is false it returns an invalid_auth error.
+func authTestHandler(ok bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if ok {
+			_, _ = w.Write([]byte(`{"ok":true,"url":"https://example.slack.com/","team":"T","user":"U","team_id":"T","user_id":"U"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+	}
+}
+
+// newSlackMux returns an *http.ServeMux with /auth.test pre-registered.
+// Callers register per-path handlers on the returned mux.
+func newSlackMux(authTestOK bool) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth.test", authTestHandler(authTestOK))
+	return mux
+}
+
 // eventsAPISocketEvent builds a socketmode.Event of type EventTypeEventsAPI.
 func eventsAPISocketEvent(channelID, channelType, user, text, ts, teamID string) socketmode.Event {
 	inner := slackevents.EventsAPIInnerEvent{
@@ -1390,3 +1412,244 @@ func (h *lateAuditHost) WriteAuditStep(_ context.Context, req *hostv1.WriteAudit
 	return &hostv1.WriteAuditStepResponse{Ok: true}, nil
 }
 
+// ── credentialRotatingHost ────────────────────────────────────────────────────
+
+// credentialRotatingHost is an inline hostv1.HostServiceServer that returns
+// tokenA on the first GetCredentials call and tokenB on all subsequent calls.
+// It mirrors the lateAuditHost pattern so tests can exercise the verifiedToken
+// short-circuit by swapping the token between two Call() invocations without
+// needing a FakeHost credential mutation API (which doesn't exist).
+type credentialRotatingHost struct {
+	hostv1.UnimplementedHostServiceServer
+	callCount      atomic.Int32
+	tokenA, tokenB string
+	setHealthCalls atomic.Int32
+}
+
+func (h *credentialRotatingHost) GetCredentials(_ context.Context, _ *hostv1.GetCredentialsRequest) (*hostv1.GetCredentialsResponse, error) {
+	n := h.callCount.Add(1)
+	tok := h.tokenA
+	if n > 1 {
+		tok = h.tokenB
+	}
+	return &hostv1.GetCredentialsResponse{
+		CredentialsJson: fmt.Sprintf(`{"strategy":"oauth2_authcode","token":{"access_token":%q}}`, tok),
+	}, nil
+}
+
+func (h *credentialRotatingHost) GetInstanceConfig(_ context.Context, _ *hostv1.GetInstanceConfigRequest) (*hostv1.GetInstanceConfigResponse, error) {
+	return &hostv1.GetInstanceConfigResponse{ConfigJson: "{}"}, nil
+}
+
+func (h *credentialRotatingHost) SetHealthState(_ context.Context, _ *hostv1.SetHealthStateRequest) (*hostv1.SetHealthStateResponse, error) {
+	h.setHealthCalls.Add(1)
+	return &hostv1.SetHealthStateResponse{}, nil
+}
+
+func (h *credentialRotatingHost) EmitMetric(_ context.Context, _ *hostv1.EmitMetricRequest) (*hostv1.EmitMetricResponse, error) {
+	return &hostv1.EmitMetricResponse{}, nil
+}
+
+// ── Auth.test verification tests ─────────────────────────────────────────────
+
+// TestToolService_Call_AuthTestFails_SetsUnhealthy asserts that when auth.test
+// returns invalid_auth, Call returns a PERMISSION error envelope, the plugin
+// transitions to UNHEALTHY/auth_expired, and the tool handler is never called.
+func TestToolService_Call_AuthTestFails_SetsUnhealthy(t *testing.T) {
+	var toolCallCount atomic.Int32
+	mux := newSlackMux(false) // auth.test returns invalid_auth
+	mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		toolCallCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1.0"}`))
+	})
+
+	backend := httptest.NewServer(mux)
+	defer backend.Close()
+
+	host := plugintest.NewFakeHost(
+		plugintest.WithCredentialsJSON(`{"strategy":"oauth2_authcode","token":{"access_token":"xoxb-test"}}`),
+	)
+	svcs, cleanup := setupAllWithHost(t, host, backend)
+	defer cleanup()
+
+	resp, err := svcs.tool.Call(context.Background(), &toolv1.CallRequest{
+		ToolName:  "post_message",
+		InputJson: `{"channel":"C123","text":"hello"}`,
+	})
+	if err != nil {
+		t.Fatalf("Call RPC error: %v", err)
+	}
+
+	env := resp.GetError()
+	if env == nil {
+		t.Fatal("expected error envelope, got success")
+	}
+	if env.GetCode() != commonv1.ErrorCode_ERROR_CODE_PERMISSION {
+		t.Errorf("error code: want PERMISSION, got %v", env.GetCode())
+	}
+	if !strings.Contains(env.GetMessage(), "auth.test failed") {
+		t.Errorf("message should mention auth.test failed, got: %q", env.GetMessage())
+	}
+
+	state, detail, ok := host.Health()
+	if !ok {
+		t.Fatal("expected SetHealthState to be called, but no health state recorded")
+	}
+	if state != plugintest.HealthStateUnhealthy {
+		t.Errorf("health state: want Unhealthy, got %v", state)
+	}
+	if detail != "auth_expired" {
+		t.Errorf("health detail: want auth_expired, got %q", detail)
+	}
+
+	if n := toolCallCount.Load(); n != 0 {
+		t.Errorf("/chat.postMessage hit count: want 0 (tool not called on auth failure), got %d", n)
+	}
+}
+
+// TestToolService_Call_AuthTestOnce_SkippedOnSubsequentCalls asserts that
+// auth.test is called exactly once when the same token is used for two
+// consecutive Call() invocations. The verifiedToken short-circuit prevents the
+// second auth.test round-trip.
+func TestToolService_Call_AuthTestOnce_SkippedOnSubsequentCalls(t *testing.T) {
+	var authTestCount atomic.Int32
+	// Build the mux manually (not via newSlackMux) so we can wrap /auth.test
+	// with a counter without registering the pattern twice (Go 1.22+ panics
+	// on duplicate registrations in the same mux).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth.test", func(w http.ResponseWriter, r *http.Request) {
+		authTestCount.Add(1)
+		authTestHandler(true)(w, r)
+	})
+	mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1.0"}`))
+	})
+
+	backend := httptest.NewServer(mux)
+	defer backend.Close()
+
+	host := plugintest.NewFakeHost(
+		plugintest.WithCredentialsJSON(`{"strategy":"oauth2_authcode","token":{"access_token":"xoxb-same-token"}}`),
+	)
+	svcs, cleanup := setupAllWithHost(t, host, backend)
+	defer cleanup()
+
+	callReq := &toolv1.CallRequest{
+		ToolName:  "post_message",
+		InputJson: `{"channel":"C123","text":"hello"}`,
+	}
+
+	resp, err := svcs.tool.Call(context.Background(), callReq)
+	if err != nil {
+		t.Fatalf("first Call RPC error: %v", err)
+	}
+	if resp.GetError() != nil {
+		t.Fatalf("first Call: expected success, got error: %v", resp.GetError().GetMessage())
+	}
+
+	resp, err = svcs.tool.Call(context.Background(), callReq)
+	if err != nil {
+		t.Fatalf("second Call RPC error: %v", err)
+	}
+	if resp.GetError() != nil {
+		t.Fatalf("second Call: expected success, got error: %v", resp.GetError().GetMessage())
+	}
+
+	if n := authTestCount.Load(); n != 1 {
+		t.Errorf("auth.test hit count: want 1 (short-circuit on second call), got %d", n)
+	}
+}
+
+// TestToolService_Call_AuthTestReruns_OnTokenRotation asserts that auth.test
+// runs again when the access token changes between Call() invocations. A custom
+// credentialRotatingHost is used because FakeHost's WithCredentialsJSON is
+// constructor-only (no setter to mutate between calls).
+func TestToolService_Call_AuthTestReruns_OnTokenRotation(t *testing.T) {
+	var authTestCount atomic.Int32
+	// Build the mux manually (not via newSlackMux) so we can wrap /auth.test
+	// with a counter without registering the pattern twice (Go 1.22+ panics
+	// on duplicate registrations in the same mux).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth.test", func(w http.ResponseWriter, r *http.Request) {
+		authTestCount.Add(1)
+		authTestHandler(true)(w, r)
+	})
+	mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1.0"}`))
+	})
+
+	backend := httptest.NewServer(mux)
+	defer backend.Close()
+
+	rotatingHost := &credentialRotatingHost{
+		tokenA: "xoxb-token-a",
+		tokenB: "xoxb-token-b",
+	}
+
+	hostLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen host: %v", err)
+	}
+	hostSrv := grpc.NewServer()
+	hostv1.RegisterHostServiceServer(hostSrv, rotatingHost)
+	go func() { _ = hostSrv.Serve(hostLis) }()
+	defer hostSrv.Stop()
+
+	hostConn, err := grpc.NewClient(hostLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial host: %v", err)
+	}
+	defer hostConn.Close()
+	hostClient := hostv1.NewHostServiceClient(hostConn)
+
+	toolSvc := NewToolService(hostClient, backend.Client(), backend.URL+"/")
+
+	toolLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tool: %v", err)
+	}
+	toolSrv := grpc.NewServer()
+	toolv1.RegisterToolServiceServer(toolSrv, toolSvc)
+	go func() { _ = toolSrv.Serve(toolLis) }()
+	defer toolSrv.Stop()
+
+	toolConn, err := grpc.NewClient(toolLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial tool: %v", err)
+	}
+	defer toolConn.Close()
+	toolClient := toolv1.NewToolServiceClient(toolConn)
+
+	callReq := &toolv1.CallRequest{
+		ToolName:  "post_message",
+		InputJson: `{"channel":"C123","text":"hello"}`,
+	}
+
+	// First call: uses tokenA → auth.test fires (count becomes 1).
+	resp, err := toolClient.Call(context.Background(), callReq)
+	if err != nil {
+		t.Fatalf("first Call RPC error: %v", err)
+	}
+	if resp.GetError() != nil {
+		t.Fatalf("first Call: expected success, got error: %v", resp.GetError().GetMessage())
+	}
+
+	// Second call: credentialRotatingHost returns tokenB → verifiedToken mismatch
+	// → auth.test fires again (count becomes 2).
+	resp, err = toolClient.Call(context.Background(), callReq)
+	if err != nil {
+		t.Fatalf("second Call RPC error: %v", err)
+	}
+	if resp.GetError() != nil {
+		t.Fatalf("second Call: expected success, got error: %v", resp.GetError().GetMessage())
+	}
+
+	if n := authTestCount.Load(); n != 2 {
+		t.Errorf("auth.test hit count: want 2 (one per distinct token), got %d", n)
+	}
+}

--- a/plugins/slack/tools_test.go
+++ b/plugins/slack/tools_test.go
@@ -286,11 +286,12 @@ func toolCases(t *testing.T) []toolCallCase {
 
 // TestPostMessageRateLimit verifies that callWithRetry retries once on a 429
 // with Retry-After: 0 and that the tool ultimately succeeds. Exactly 2 requests
-// must hit the fake Slack backend.
+// must hit the fake Slack backend for /chat.postMessage (auth.test is excluded).
 func TestPostMessageRateLimit(t *testing.T) {
-	var calls int32
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&calls, 1)
+	var postCalls int32
+	mux := newSlackMux(true)
+	mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&postCalls, 1)
 		if n == 1 {
 			// First request: 429 with Retry-After: 0 so RetryAfter == 0 and fits any budget.
 			w.Header().Set("Retry-After", "0")
@@ -300,7 +301,8 @@ func TestPostMessageRateLimit(t *testing.T) {
 		// Second request: success.
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, `{"ok":true,"channel":"C123","ts":"1.234"}`)
-	}))
+	})
+	backend := httptest.NewServer(mux)
 	defer backend.Close()
 
 	host := plugintest.NewFakeHost(plugintest.WithCredentialsJSON(credsJSON))
@@ -330,9 +332,10 @@ func TestPostMessageRateLimit(t *testing.T) {
 		t.Errorf("output JSON missing key %q; got: %s", "ts", resp.GetOutputJson())
 	}
 
-	// Exactly 2 requests must have hit the backend (initial + 1 retry).
-	if n := atomic.LoadInt32(&calls); n != 2 {
-		t.Errorf("expected exactly 2 requests to fake backend, got %d", n)
+	// Exactly 2 /chat.postMessage requests: initial 429 + 1 retry. auth.test
+	// is not counted because it hits a separate mux entry.
+	if n := atomic.LoadInt32(&postCalls); n != 2 {
+		t.Errorf("expected exactly 2 /chat.postMessage requests to fake backend, got %d", n)
 	}
 }
 
@@ -346,12 +349,16 @@ func TestToolCalls(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Optionally start a fake Slack API server.
+			// Optionally start a fake Slack API server. Use newSlackMux so the
+			// auth.test gate introduced in Call() always has a valid /auth.test
+			// route; the per-case handler is registered at "/" (catch-all).
 			var backend *httptest.Server
 			if tc.handler != nil {
-				backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mux := newSlackMux(true)
+				mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					tc.handler(t, w, r)
 				}))
+				backend = httptest.NewServer(mux)
 				defer backend.Close()
 			}
 
@@ -452,10 +459,12 @@ func TestToolCalls(t *testing.T) {
 // success and "error" on failure, using post_message as the representative tool.
 func TestToolCallMetricOutcomeLabel(t *testing.T) {
 	t.Run("success_outcome_ok", func(t *testing.T) {
-		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mux := newSlackMux(true)
+		mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(slackOKResponse(map[string]any{"channel": "C1", "ts": "1.0"}))
-		}))
+		})
+		backend := httptest.NewServer(mux)
 		defer backend.Close()
 
 		host := plugintest.NewFakeHost(plugintest.WithCredentialsJSON(credsJSON))
@@ -477,10 +486,12 @@ func TestToolCallMetricOutcomeLabel(t *testing.T) {
 	})
 
 	t.Run("error_outcome_error", func(t *testing.T) {
-		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mux := newSlackMux(true)
+		mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(slackErrResponse("channel_not_found"))
-		}))
+		})
+		backend := httptest.NewServer(mux)
 		defer backend.Close()
 
 		host := plugintest.NewFakeHost(plugintest.WithCredentialsJSON(credsJSON))
@@ -506,12 +517,17 @@ func TestToolCallMetricOutcomeLabel(t *testing.T) {
 // from the tool call. We cancel immediately before the Call to ensure the Slack
 // HTTP client sees a canceled context.
 func TestToolCallCtxCancel(t *testing.T) {
-	// Backend that blocks until the request context is done.
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Backend that blocks until the request context is done. /auth.test gets
+	// its own route via newSlackMux so the gate isn't what blocks; the
+	// cancellation surfaces either at the gRPC layer or from the context-
+	// aware HTTP call in auth.test or in the tool dispatch's PostMessage.
+	mux := newSlackMux(true)
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(slackErrResponse("context_canceled"))
 	}))
+	backend := httptest.NewServer(mux)
 	defer backend.Close()
 
 	host := plugintest.NewFakeHost(plugintest.WithCredentialsJSON(credsJSON))


### PR DESCRIPTION
Closes #236 — sub-issue 5 of 7 under tracking issue #162 (Phase 8: Slack plugin).

## Summary

Completes the Slack OAuth authcode integration started in #232. The plugin's manifest gains the four `*:history` scopes from the AC; ToolService gains a lazy `auth.test` verification gate; the README ships a one-click Slack-app manifest YAML so homelab operators can go from zero to authorized in ~60 seconds; and `docs/developer/manual-testing.md` documents the end-to-end operator recipe for #237 to consume.

## Per-user direction: Option A (users own their data)

**No baked-in `client_id`/`client_secret` defaults.** Every Gleipnir installation owns its own Slack app and credentials. This preserves the "users own their data" principle and avoids the security anti-pattern of embedding a `client_secret` in a distributable plugin binary (anyone with the `.tar.gz` could `strings | grep` it and impersonate the app). A "Felag Hosted OAuth" infrastructure is deferred to a Phase 9+ discussion that would require Felag-the-project to commit to operating a callback service.

The "homelab convenience" intent is preserved via the one-click Slack-app manifest YAML in the README — paste into Slack's "Create from manifest" flow, get a working app in ~60 seconds.

## Non-obvious design choices

- **`auth.test` runs lazily on the first ToolService.Call** after a token change, gated by an `atomic.Pointer[string]` `verifiedToken` field. The host already transitions to healthy on successful HandleCallback (`internal/plugin/oauth/manager.go:169-176`); the plugin adds a final gate so tokens that were issued but lack expected scopes (or were immediately revoked) fail fast with `PERMISSION + UNHEALTHY/auth_expired` before any tool runs.
- **ChannelService and TriggerService are NOT instrumented** — their first-call paths already detect auth failures via the existing `mapErr` classifier. Concentrating verification in ToolService avoids duplicate `auth.test` calls.
- **`tok := creds.Token.AccessToken; s.verifiedToken.Store(&tok)`** — store address of a fresh local copy rather than `&creds.Token.AccessToken`. Storing the struct-field address works (string compare is by value) but persists a pointer into the just-fetched StoredCredentials, which is fragile and non-obvious.
- **The first-call race on `verifiedToken` is benign and documented.** Two concurrent first-calls may both observe nil and both run `auth.test` — second Store wins; correctness preserved.
- **Four `*:history` scopes are added per AC but currently UNUSED at runtime.** Socket Mode event delivery (TriggerService) uses the `xapp-` app-level token and does NOT need these bot-token scopes. They're requested up-front so the same OAuth grant covers planned history-reading tools without a re-authorize round trip. README clearly marks them "Reserved; no current tool uses it."
- **`HasClientID`/`HasClientSecret` flipped from `true` to `false`.** The SDK's documented semantic (`plugin-sdk/manifest/manifest.go:218`: "true when the manifest includes a default") makes `false` the literal-correct value under Option A. Investigation confirmed NO host code reads these for behavior — only `internal/plugin/manifest/diff.go:231-237` emits change records on flip.
- **Sequence ordering is declaration-sensitive in canonical YAML.** `manifest.Marshal` sorts mapping keys but does NOT sort sequence nodes (`yaml.go:85-89`). Scopes declared alphabetically in Go source with a code comment so future maintainers don't assume Marshal will sort.
- **`TestToolService_Call_AuthTestReruns_OnTokenRotation` cannot use FakeHost.** `WithCredentialsJSON` is a constructor-only option with no setter to mutate credentials between calls. Used a custom `credentialRotatingHost` mirroring the `lateAuditHost` pattern from #235.
- **The existing test handler pattern (single `http.Handler` returning `{"ok":true}` for any path) accidentally passed the new `auth.test` gate** because slack-go's `AuthTestContext` parses any `{"ok":true}` as success. Removed this fragility via `newSlackMux(authTestOK bool)` + per-path `HandleFunc` registration. Existing tests migrated.
- **Slack v2 bot tokens (xoxb-) do NOT expire absent revocation** — the Phase-7 refresh scanner has nothing to refresh for Slack. `auth_expired` fires only on revoke. Documented in README §"Token refresh".

## Verification

| Check | Result |
|---|---|
| `cd plugins/slack && go test -race -count=1 ./...` (3 new + 4 migrated) | ✅ |
| `make manifest` × 2 with `git diff`: byte-stable | ✅ |
| `make lint-plugins` (no `internal/*` imports) | ✅ |
| `make lint-plugins-self-test` | ✅ |
| Workspace `go build ./...` | ✅ |

## Process

<details>
<summary>Architecture plan + review cycles</summary>

Generated via the agentic dev-loop:
- **Architect** surfaced a load-bearing interpretation conflict: the issue AC's "Default client_id/client_secret baked in" cannot be satisfied with the current SDK (`OAuthDefaultsDecl` has presence booleans only — no value fields) AND embedding a `client_secret` in a distributable binary is a security anti-pattern. Paused for user input.
- **User chose Option A** — operator registers their own Slack app; no baked-in defaults. Preserves "users own their data."
- **Plan reviewer** verified all SDK fact-claims but flagged 3 blocking issues:
  1. Sequence order in canonical YAML is declaration-sensitive (Marshal doesn't sort sequences) — needs explicit code comment
  2. `TestToolService_Call_AuthTestReruns_OnTokenRotation` can't use FakeHost (no credential setter) — needs custom `credentialRotatingHost`
  3. `atomic.Pointer.Store(&creds.Token.AccessToken)` stores address of struct field — should store address of fresh copy
  Plus 4 suggestions (per-path mux, race documentation, scope rationale fix, HasClientID/HasClientSecret semantics).
- **Architect revision** addressed all 7 + investigated `HasClientID`/`HasClientSecret` usage across the codebase, confirming no host behavior depends on the values (only `diff.go` reports flips).
- **Code review**: 1 cycle. APPROVED with 2 non-blocking suggestions (misleading test comment, grammar nit) — both fixed surgically.

</details>

## Documentation

No `CLAUDE.md` updates needed — host-side OAuth orchestration (`internal/plugin/oauth/`) is already fully documented at line 158. `frontend/CLAUDE.md` not relevant (pure backend/plugin work). README and manual-testing.md updates are in-PR.

## Follow-ups (NOT in this PR)

- **Phase 9+ discussion:** Felag Hosted OAuth infrastructure — requires Felag-the-project to commit to operating a callback service. Deferred per user direction.
- **Future history-reading tool** (`read_recent_messages` calling `conversations.history`) — the four `*:history` scopes are reserved for this; sub-issue not yet filed.
- **#368 (already filed):** Per-instance config field secret redaction. The Slack plugin's `app_level_token` (added in #234) will benefit when that lands.

---
🤖 Generated with the agentic dev-loop