### PR TITLE
feat: Admin UI: plugin install + create-instance buttons

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -132,6 +132,9 @@ queryKeys.users.all             // ['users']
 queryKeys.currentUser.all       // ['currentUser']
 queryKeys.models.all            // ['models']
 queryKeys.config.all            // ['config']
+queryKeys.plugins.list          // ['plugins', 'list']               — installed plugins (invalidated on plugin install)
+queryKeys.plugins.instances(id) // ['plugins', id, 'instances']      — instances of one plugin (invalidated on instance create)
+queryKeys.plugins.credentials(p, i) // ['plugins', p, 'instances', i, 'credentials'] — redacted credentials view
 ```
 
 ### Data fetching
@@ -210,6 +213,12 @@ Triggers + Events:
 POST   /api/v1/webhooks/:policyID      (trigger endpoint)
 GET    /api/v1/events                   (SSE stream)
 GET    /api/v1/health
+
+Admin / Plugins:
+GET    /api/v1/admin/plugin-instances           (admin|operator|auditor; list with channel + event_kinds enrichment)
+POST   /api/v1/admin/plugins                    (admin; install tarball as application/octet-stream, max 100 MiB)
+POST   /api/v1/admin/plugins/:id/instances      (admin; create instance with {instance_name})
+GET    /api/v1/admin/plugins/:id/instances/:iid (admin; per-instance health detail)
 ```
 
 Response envelope: `{ data: T }` for success, `{ error: string, detail?: string }` for failure.
@@ -230,7 +239,7 @@ Organized by feature area:
 - **AgentList/** — agent list with folder grouping
 - **RunDetail/** — RunHeader, StepTimeline, FilterBar, MetadataGrid, CapabilitySnapshotCard, ThoughtBlock, ThinkingBlock, ToolBlock, CompleteBlock, ErrorBlock, FeedbackBlock, ApprovalActions, FeedbackActions
 - **MCPPage/** — ServerCard, ToolList, ToolRow, MCPStatsBar, HealthIndicator, AddServerModal, DeleteServerModal, ServerDetailModal (per-header auth editor: existing name fields are read-only, value field is empty with placeholder; save fans out via `useSetMcpServerHeader`/`useDeleteMcpServerHeader`; no sentinel; see ADR-039), ArcadeAuthSection (toolkit-level OAuth pre-authorization for Arcade gateways; renders only when `server.is_arcade_gateway && canManage`; see ADR-040)
-- **admin/** — EncryptionKeyNotice (persistent warning banner on the Models page about encryption key backup requirements), PluginHealthChip (colored chip — green/yellow/red — for the 10 plugin-instance health states; pairs with `utils/pluginHealth.ts` for the worst-across-instances aggregate)
+- **admin/** — EncryptionKeyNotice (persistent warning banner on the Models page about encryption key backup requirements), PluginHealthChip (colored chip — green/yellow/red — for the 10 plugin-instance health states; pairs with `utils/pluginHealth.ts` for the worst-across-instances aggregate), InstallPluginButton (file-picker upload of a plugin tarball; persistent success card with "Add instance" CTA until refetch confirms the new plugin has an instance), AddInstanceModal (form to instantiate an installed plugin by name; reused as a standalone modal on the plugins page AND inline from the install-success card; client-side validation + per-status error mapping)
 - **form/** — FieldError (inline message under a field), ErrorBanner (top-of-form bulleted summary with scroll-to-field). Shared primitives for surfacing validation/save errors.
 - **Shared** — Button, Modal, ModalFooter, EmptyState, ErrorBoundary, QueryBoundary, CopyBlock, CollapsibleJSON, SkeletonBlock, PageHeader, ApprovalBanner, ConnectionBanner, TriggerRunModal
 
@@ -242,7 +251,7 @@ Organized by feature area:
 
 ### Storybook
 
-46 story files covering components, dashboard widgets, form sections, and hook demonstrations. Stories use MSW for API mocking and have their own `.stories.module.css` for layout scaffolding where needed.
+48 story files covering components, dashboard widgets, form sections, and hook demonstrations. Stories use MSW for API mocking and have their own `.stories.module.css` for layout scaffolding where needed. Stories that need to demonstrate non-idle states (uploading, success, error) use Storybook `play` functions with `userEvent` to drive the component through real interactions rather than seeding cache state.
 
 ## Key architectural decisions
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -524,6 +524,31 @@ export interface ApiPluginInstanceForAudience {
   last_oauth_callback_url?: string
 }
 
+// ApiInstalledPlugin matches the installResponse struct returned by
+// POST /api/v1/admin/plugins (internal/admin/plugin_handler.go:installResponse).
+export interface ApiInstalledPlugin {
+  id: string
+  name: string
+  version: string
+  status: string
+}
+
+// ApiCreatedPluginInstance matches the createInstanceResponse struct returned by
+// POST /api/v1/admin/plugins/{id}/instances (internal/admin/plugin_handler.go:createInstanceResponse).
+// health_detail is typed as string | null | undefined to cover both the "field
+// omitted" (undefined) and "field present but null" wire shapes from the server.
+// Always guard reads with: if (inst.health_detail) { ... }
+export interface ApiCreatedPluginInstance {
+  id: string
+  plugin_id: string
+  instance_name: string
+  health_state: string
+  health_detail?: string | null
+  version: number
+  created_at: string
+  updated_at: string
+}
+
 // Request body interfaces for audience mutations.
 // Matches internal/http/api/audience_handler.go.
 

--- a/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.module.css
+++ b/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.module.css
@@ -1,0 +1,74 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-second);
+}
+
+.input {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-mid);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  box-sizing: border-box;
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-blue);
+}
+
+.input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fieldError {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-red);
+}
+
+/* API-level error banner */
+
+.apiError {
+  padding: var(--space-3) var(--space-4);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-red) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-red) 25%, transparent);
+  font-size: var(--text-sm);
+}
+
+.apiErrorMessage {
+  margin: 0;
+  color: var(--color-red);
+}
+
+.apiErrorDetail {
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-second);
+}
+
+.apiErrorDetail pre {
+  margin: var(--space-1) 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--font-mono);
+}

--- a/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.stories.tsx
+++ b/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.stories.tsx
@@ -1,0 +1,250 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { userEvent, within, expect } from 'storybook/test'
+import '@/tokens.css'
+import { AddInstanceModal } from './AddInstanceModal'
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+}
+
+const meta: Meta<typeof AddInstanceModal> = {
+  title: 'Admin/AddInstanceModal',
+  component: AddInstanceModal,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={makeQueryClient()}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof AddInstanceModal>
+
+function makeInstance(name: string) {
+  return {
+    id: `inst-${Date.now()}`,
+    plugin_id: 'plugin-slack-01',
+    instance_name: name,
+    health_state: 'healthy',
+    version: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+}
+
+// Default — idle, empty form ready for input.
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json({ data: makeInstance('production') }),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-slack-01',
+    pluginName: 'Slack',
+    existingNames: [],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+}
+
+// Submitting — the endpoint never resolves, leaving the modal in the submitting
+// state (spinner, disabled submit button). The play function types a name and
+// clicks submit but does not wait for the response.
+export const Submitting: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        // Never resolve so the component stays stuck in the submitting state.
+        http.post('/api/v1/admin/plugins/:id/instances', () => new Promise(() => {})),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-slack-01',
+    pluginName: 'Slack',
+    existingNames: [],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.type(canvas.getByRole('textbox'), 'production')
+    // Click submit — the handler never resolves, so the modal stays in
+    // submitting state with the spinner visible.
+    await userEvent.click(canvas.getByRole('button', { name: /create instance/i }))
+  },
+}
+
+// Success — drives the modal to the success state. The MSW handler resolves
+// immediately; the play function types a name and submits. On success the
+// component calls onCreated + onClose — in Storybook the modal stays mounted
+// because onClose is a no-op, so we can observe the spinner briefly and then
+// the form resetting. We assert the submit button re-enables after the response.
+export const Success: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json({ data: makeInstance('production') }),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-slack-01',
+    pluginName: 'Slack',
+    existingNames: [],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.type(canvas.getByRole('textbox'), 'production')
+    await userEvent.click(canvas.getByRole('button', { name: /create instance/i }))
+    // Wait for the mutation to complete (spinner disappears, button re-enables).
+    await expect(canvas.getByRole('button', { name: /create instance/i })).not.toBeDisabled()
+  },
+}
+
+// WithExistingNames — entering an already-taken name shows client-side validation.
+export const WithExistingNames: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json({ data: makeInstance('production') }),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-slack-01',
+    pluginName: 'Slack',
+    existingNames: ['production', 'staging'],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+}
+
+// Error400 — server rejects the request (edge case past client validation).
+export const Error400: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json(
+            { error: 'instance_name must not be empty', detail: 'trimmed value was empty' },
+            { status: 400 },
+          ),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-slack-01',
+    pluginName: 'Slack',
+    existingNames: [],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.type(canvas.getByRole('textbox'), '   ')
+    // Bypass client-side trim check by typing whitespace — or just type something
+    // and let the server 400 show. Use a non-empty name to get past client validation.
+    await userEvent.clear(canvas.getByRole('textbox'))
+    await userEvent.type(canvas.getByRole('textbox'), 'something')
+    await userEvent.click(canvas.getByRole('button', { name: /create instance/i }))
+    await canvas.findByRole('alert')
+  },
+}
+
+// Error404 — plugin disappeared between page load and submit.
+export const Error404: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json({ error: 'plugin not found' }, { status: 404 }),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-gone',
+    pluginName: 'Deleted Plugin',
+    existingNames: [],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.type(canvas.getByRole('textbox'), 'production')
+    await userEvent.click(canvas.getByRole('button', { name: /create instance/i }))
+    await canvas.findByRole('alert')
+  },
+}
+
+// Error409 — duplicate instance name (concurrent create from another session).
+export const Error409: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json(
+            { error: "instance named 'production' already exists for this plugin" },
+            { status: 409 },
+          ),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-slack-01',
+    pluginName: 'Slack',
+    existingNames: [],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.type(canvas.getByRole('textbox'), 'production')
+    await userEvent.click(canvas.getByRole('button', { name: /create instance/i }))
+    await canvas.findByRole('alert')
+  },
+}
+
+// Error500 — unexpected server error.
+export const Error500: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json({ error: 'internal server error' }, { status: 500 }),
+        ),
+      ],
+    },
+  },
+  args: {
+    pluginId: 'plugin-slack-01',
+    pluginName: 'Slack',
+    existingNames: [],
+    onClose: () => {},
+    onCreated: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.type(canvas.getByRole('textbox'), 'production')
+    await userEvent.click(canvas.getByRole('button', { name: /create instance/i }))
+    await canvas.findByRole('alert')
+  },
+}

--- a/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.test.tsx
+++ b/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.test.tsx
@@ -1,0 +1,238 @@
+import React from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/server'
+import { AddInstanceModal } from './AddInstanceModal'
+import type { ApiCreatedPluginInstance } from '@/api/types'
+
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+interface RenderProps {
+  pluginId?: string
+  pluginName?: string
+  existingNames?: string[]
+  onClose?: () => void
+  onCreated?: (inst: ApiCreatedPluginInstance) => void
+}
+
+function renderModal({
+  pluginId = 'plugin-slack-01',
+  pluginName = 'Slack',
+  existingNames = [],
+  onClose = vi.fn(),
+  onCreated = vi.fn(),
+}: RenderProps = {}) {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <AddInstanceModal
+        pluginId={pluginId}
+        pluginName={pluginName}
+        existingNames={existingNames}
+        onClose={onClose}
+        onCreated={onCreated}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+function makeInstance(name: string): ApiCreatedPluginInstance {
+  return {
+    id: 'inst-01',
+    plugin_id: 'plugin-slack-01',
+    instance_name: name,
+    health_state: 'healthy',
+    version: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+}
+
+// Ensure real timers are restored even if a test fails.
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('AddInstanceModal', () => {
+  it('renders title containing the plugin name', () => {
+    renderModal()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/Add instance to Slack/i)).toBeInTheDocument()
+  })
+
+  it('shows validation error for empty name on submit', async () => {
+    renderModal()
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Instance name is required.')
+  })
+
+  it('shows validation error for whitespace-only name on submit', async () => {
+    renderModal()
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, '   ')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Instance name is required.')
+  })
+
+  it('shows duplicate-name error and blocks submit when name already exists', async () => {
+    let apiCalled = false
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () => {
+        apiCalled = true
+        return HttpResponse.json({ data: makeInstance('production') })
+      }),
+    )
+
+    renderModal({ existingNames: ['production'] })
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'production')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent("An instance named 'production' already exists")
+    expect(apiCalled).toBe(false)
+  })
+
+  it('POSTs {instance_name} to the correct URL and calls onCreated then onClose', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post('/api/v1/admin/plugins/plugin-slack-01/instances', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ data: makeInstance('production') })
+      }),
+    )
+
+    const onCreated = vi.fn()
+    const onClose = vi.fn()
+    renderModal({ onCreated, onClose })
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'production')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+    expect(capturedBody).toEqual({ instance_name: 'production' })
+    expect(onCreated).toHaveBeenCalledOnce()
+    // onCreated must be called before onClose
+    const createdOrder = onCreated.mock.invocationCallOrder[0]
+    const closedOrder = onClose.mock.invocationCallOrder[0]
+    expect(createdOrder).toBeLessThan(closedOrder)
+  })
+
+  it('shows 400 error with "Failed to create instance:" prefix and server message', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json(
+          { error: 'instance_name must not be empty', detail: 'trimmed to empty' },
+          { status: 400 },
+        ),
+      ),
+    )
+
+    renderModal()
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'x')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to create instance:')
+    expect(screen.getByRole('alert')).toHaveTextContent('instance_name must not be empty')
+  })
+
+  it('shows 404 message and calls onClose after delay', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json({ error: 'plugin not found' }, { status: 404 }),
+      ),
+    )
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const onClose = vi.fn()
+    renderModal({ onClose })
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'production')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('plugin no longer exists')
+
+    // Advance the 1500ms delay and check modal closes.
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows 409 error with server message verbatim', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json(
+          { error: "instance named 'production' already exists for this plugin" },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    renderModal()
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'production')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to create instance:')
+    expect(screen.getByRole('alert')).toHaveTextContent("instance named 'production' already exists")
+  })
+
+  it('shows 500 error with server message', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json({ error: 'internal server error' }, { status: 500 }),
+      ),
+    )
+
+    renderModal()
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'any-name')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to create instance:')
+    expect(screen.getByRole('alert')).toHaveTextContent('internal server error')
+  })
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose on Escape key', async () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when overlay is clicked', async () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+
+    const overlay = screen.getByTestId('modal-overlay')
+    await userEvent.click(overlay)
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.tsx
+++ b/frontend/src/components/admin/AddInstanceModal/AddInstanceModal.tsx
@@ -1,0 +1,143 @@
+import { useState, useId } from 'react'
+import { Modal } from '@/components/Modal'
+import { ModalFooter } from '@/components/ModalFooter'
+import { ApiError } from '@/api/fetch'
+import { useCreatePluginInstance } from '@/hooks/mutations/plugins'
+import type { ApiCreatedPluginInstance } from '@/api/types'
+import styles from './AddInstanceModal.module.css'
+
+interface AddInstanceModalProps {
+  pluginId: string
+  // pluginName is shown in the modal title for operator context.
+  pluginName: string
+  // existingNames is used for a client-side courtesy duplicate check.
+  // The server's 409 remains the source of truth for concurrent creates.
+  existingNames: string[]
+  onClose: () => void
+  onCreated?: (inst: ApiCreatedPluginInstance) => void
+}
+
+function mapCreateError(err: unknown): string {
+  if (!(err instanceof ApiError)) {
+    const msg = err instanceof Error ? err.message : 'Unexpected error — please try again.'
+    return `Failed to create instance: ${msg}`
+  }
+
+  if (err.status === 404) {
+    // Handled separately in the component with a special action (close + refresh).
+    return 'This plugin no longer exists. The list has been refreshed.'
+  }
+
+  return `Failed to create instance: ${err.message}`
+}
+
+// AddInstanceModal opens a small form to create a named plugin instance.
+// It validates the name client-side before hitting the API, but the server
+// 409 path is authoritative for concurrent duplicate-name creates.
+export function AddInstanceModal({
+  pluginId,
+  pluginName,
+  existingNames,
+  onClose,
+  onCreated,
+}: AddInstanceModalProps) {
+  const inputId = useId()
+  const [instanceName, setInstanceName] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [apiError, setApiError] = useState<{ message: string; detail?: string } | null>(null)
+  const mutation = useCreatePluginInstance()
+
+  function validate(name: string): string | null {
+    if (!name.trim()) return 'Instance name is required.'
+    if (existingNames.includes(name)) {
+      return `An instance named '${name}' already exists for this plugin.`
+    }
+    return null
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setApiError(null)
+
+    const err = validate(instanceName)
+    if (err) {
+      setValidationError(err)
+      return
+    }
+    setValidationError(null)
+
+    mutation.mutate(
+      { pluginId, instanceName },
+      {
+        onSuccess: (inst) => {
+          onCreated?.(inst)
+          onClose()
+        },
+        onError: (rawErr) => {
+          const message = mapCreateError(rawErr)
+          const detail = rawErr instanceof ApiError ? rawErr.detail : undefined
+          setApiError({ message, detail })
+
+          if (rawErr instanceof ApiError && rawErr.status === 404) {
+            // Close after a short pause so the operator can read the message.
+            setTimeout(onClose, 1500)
+          }
+        },
+      },
+    )
+  }
+
+  const footer = (
+    <ModalFooter
+      onCancel={onClose}
+      formId={inputId + '-form'}
+      isLoading={mutation.isPending}
+      submitLabel="Create instance"
+      loadingLabel="Creating…"
+      submitDisabled={mutation.isPending}
+    />
+  )
+
+  return (
+    <Modal title={`Add instance to ${pluginName}`} onClose={onClose} footer={footer}>
+      <form id={inputId + '-form'} onSubmit={handleSubmit} className={styles.form} noValidate>
+        <div className={styles.field}>
+          <label htmlFor={inputId} className={styles.label}>
+            Instance name
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            className={styles.input}
+            value={instanceName}
+            onChange={(e) => {
+              setInstanceName(e.target.value)
+              if (validationError) setValidationError(null)
+            }}
+            placeholder="e.g. production"
+            required
+            disabled={mutation.isPending}
+            autoFocus
+          />
+          {validationError && (
+            <p className={styles.fieldError} role="alert">
+              {validationError}
+            </p>
+          )}
+        </div>
+
+        {apiError && (
+          <div className={styles.apiError} role="alert">
+            <p className={styles.apiErrorMessage}>{apiError.message}</p>
+            {apiError.detail && (
+              <details className={styles.apiErrorDetail}>
+                <summary>Details</summary>
+                <pre>{apiError.detail}</pre>
+              </details>
+            )}
+          </div>
+        )}
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/components/admin/AddInstanceModal/index.ts
+++ b/frontend/src/components/admin/AddInstanceModal/index.ts
@@ -1,0 +1,1 @@
+export { AddInstanceModal } from './AddInstanceModal'

--- a/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.module.css
+++ b/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.module.css
@@ -1,0 +1,78 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+
+.hiddenInput {
+  display: none;
+}
+
+/* Success card */
+
+.successCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-green) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-green) 25%, transparent);
+  color: var(--color-green);
+  font-size: var(--text-sm);
+  min-width: 280px;
+}
+
+.successMessage {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.successActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+/* Error card */
+
+.errorCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-red) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-red) 25%, transparent);
+  font-size: var(--text-sm);
+  min-width: 280px;
+}
+
+.errorMessage {
+  margin: 0;
+  color: var(--color-red);
+}
+
+.errorDetail {
+  font-size: var(--text-xs);
+  color: var(--text-second);
+}
+
+.errorDetail pre {
+  margin: var(--space-1) 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--font-mono);
+}
+
+/* Disabled notice (503 — plugins feature disabled on the server) */
+
+.disabledNotice {
+  padding: var(--space-3) var(--space-4);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-amber) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-amber) 25%, transparent);
+  color: var(--color-amber);
+  font-size: var(--text-sm);
+  min-width: 280px;
+}

--- a/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.stories.tsx
+++ b/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.stories.tsx
@@ -1,0 +1,255 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { userEvent, within } from 'storybook/test'
+import '@/tokens.css'
+import { InstallPluginButton } from './InstallPluginButton'
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter>
+        <div style={{ padding: '24px', display: 'flex', justifyContent: 'flex-end' }}>
+          {children}
+        </div>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const meta: Meta<typeof InstallPluginButton> = {
+  title: 'Admin/InstallPluginButton',
+  component: InstallPluginButton,
+  decorators: [
+    (Story) => (
+      <Wrapper>
+        <Story />
+      </Wrapper>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof InstallPluginButton>
+
+// Default — idle button ready to open the OS file picker.
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json({
+            data: { id: 'plugin-slack-01', name: 'Slack', version: '1.2.0', status: 'active' },
+          }),
+        ),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    hasInstancesForPlugin: () => false,
+  },
+}
+
+// Uploading — the install endpoint never resolves, leaving the component in the
+// uploading state (disabled button + spinner). The play function uploads a file
+// but does not wait for completion — we capture the in-progress state.
+export const Uploading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        // Never resolve so the component stays stuck in uploading state.
+        http.post('/api/v1/admin/plugins', () => new Promise(() => {})),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    hasInstancesForPlugin: () => false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('install-plugin-input')
+    // Upload a file but don't await the response — the handler never resolves,
+    // so the component stays in uploading state showing the spinner.
+    await userEvent.upload(input, new File(['tarball-content'], 'slack.tar.gz', { type: 'application/gzip' }))
+  },
+}
+
+// Success — drives the component into the success state using a play function
+// that uploads a file via the hidden input. The MSW handler returns immediately,
+// and the play function waits for the success card to appear.
+export const Success: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json({
+            data: { id: 'plugin-slack-01', name: 'Slack', version: '1.2.0', status: 'active' },
+          }),
+        ),
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json({
+            data: {
+              id: 'inst-01',
+              plugin_id: 'plugin-slack-01',
+              instance_name: 'production',
+              health_state: 'healthy',
+              version: 1,
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            },
+          }),
+        ),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    // Returns false so the success card stays visible (plugin has no instances yet).
+    hasInstancesForPlugin: () => false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('install-plugin-input')
+    await userEvent.upload(input, new File(['tarball-content'], 'slack.tar.gz', { type: 'application/gzip' }))
+    // Wait for the success card to appear — the component flips to success state
+    // once the MSW handler resolves.
+    await canvas.findByText(/installed/i)
+  },
+}
+
+// Error400 — server returns 400 with a detail message.
+export const Error400: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json(
+            { error: 'Invalid tarball', detail: 'manifest.yaml is missing required field "name".' },
+            { status: 400 },
+          ),
+        ),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    hasInstancesForPlugin: () => false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('install-plugin-input')
+    await userEvent.upload(input, new File(['tarball-content'], 'plugin.tar.gz', { type: 'application/gzip' }))
+    await canvas.findByRole('alert')
+  },
+}
+
+// Error409 — concurrent update conflict; server message is surfaced verbatim.
+export const Error409: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json(
+            { error: 'concurrent plugin update; retry' },
+            { status: 409 },
+          ),
+        ),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    hasInstancesForPlugin: () => false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('install-plugin-input')
+    await userEvent.upload(input, new File(['tarball-content'], 'plugin.tar.gz', { type: 'application/gzip' }))
+    await canvas.findByRole('alert')
+  },
+}
+
+// Error413 — tarball too large; fixed friendly message (no server body guaranteed).
+export const Error413: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          new HttpResponse(null, { status: 413 }),
+        ),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    hasInstancesForPlugin: () => false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('install-plugin-input')
+    await userEvent.upload(input, new File(['tarball-content'], 'plugin.tar.gz', { type: 'application/gzip' }))
+    await canvas.findByRole('alert')
+  },
+}
+
+// Error422 — signature validation failure; server message + detail surfaced.
+export const Error422: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json(
+            {
+              error: 'Signature verification failed',
+              detail: 'plugin.tar.gz.minisig: signature does not match trusted pubkey; see audit log entry audit-xyz',
+            },
+            { status: 422 },
+          ),
+        ),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    hasInstancesForPlugin: () => false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('install-plugin-input')
+    await userEvent.upload(input, new File(['tarball-content'], 'plugin.tar.gz', { type: 'application/gzip' }))
+    await canvas.findByRole('alert')
+  },
+}
+
+// Error503 — plugins disabled at the server level; dedicated amber notice.
+export const Error503: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json(
+            { error: 'plugin system disabled' },
+            { status: 503 },
+          ),
+        ),
+      ],
+    },
+  },
+  args: {
+    onInstalled: () => {},
+    hasInstancesForPlugin: () => false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByTestId('install-plugin-input')
+    await userEvent.upload(input, new File(['tarball-content'], 'plugin.tar.gz', { type: 'application/gzip' }))
+    await canvas.findByRole('alert')
+  },
+}

--- a/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.test.tsx
+++ b/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.test.tsx
@@ -1,0 +1,269 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/server'
+import { InstallPluginButton } from './InstallPluginButton'
+
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function renderButton(props: React.ComponentProps<typeof InstallPluginButton> = {}) {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <MemoryRouter>
+        <InstallPluginButton {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function makeFile(sizeBytes: number, name = 'plugin.tar.gz'): File {
+  const content = new Uint8Array(sizeBytes)
+  return new File([content], name, { type: 'application/gzip' })
+}
+
+const PLUGIN_RESPONSE = {
+  id: 'plugin-slack-01',
+  name: 'Slack',
+  version: '1.2.0',
+  status: 'active',
+}
+
+describe('InstallPluginButton', () => {
+  it('renders the install button in idle state', () => {
+    renderButton()
+    expect(screen.getByRole('button', { name: /install plugin/i })).toBeInTheDocument()
+  })
+
+  it('triggers hidden file input on button click', async () => {
+    renderButton()
+    const button = screen.getByRole('button', { name: /install plugin/i })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const clickSpy = vi.spyOn(input, 'click')
+
+    await userEvent.click(button)
+
+    expect(clickSpy).toHaveBeenCalledOnce()
+  })
+
+  it('shows size error and does NOT call the API when file exceeds 100 MiB', async () => {
+    let apiCalled = false
+    server.use(
+      http.post('/api/v1/admin/plugins', () => {
+        apiCalled = true
+        return HttpResponse.json({ data: PLUGIN_RESPONSE })
+      }),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    const oversizedFile = makeFile(101 * 1024 * 1024)
+    await userEvent.upload(input, oversizedFile)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/tarball too large/i)
+    expect(apiCalled).toBe(false)
+  })
+
+  it('POSTs file with Content-Type: application/octet-stream', async () => {
+    let capturedContentType: string | null = null
+    server.use(
+      http.post('/api/v1/admin/plugins', ({ request }) => {
+        capturedContentType = request.headers.get('Content-Type')
+        return HttpResponse.json({ data: PLUGIN_RESPONSE })
+      }),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const validFile = makeFile(1024)
+
+    await userEvent.upload(input, validFile)
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toBeInTheDocument(),
+    )
+    expect(capturedContentType).toBe('application/octet-stream')
+  })
+
+  it('shows persistent success card after install and calls onInstalled', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ data: PLUGIN_RESPONSE }),
+      ),
+    )
+
+    const onInstalled = vi.fn()
+    renderButton({ onInstalled })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/Installed/)).toBeInTheDocument()
+    expect(screen.getByText(/Slack/)).toBeInTheDocument()
+    expect(onInstalled).toHaveBeenCalledWith(PLUGIN_RESPONSE)
+  })
+
+  it('success card persists — no timer-based auto-clear', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ data: PLUGIN_RESPONSE }),
+      ),
+    )
+
+    renderButton({ hasInstancesForPlugin: () => false })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument())
+
+    // Wait a bit to confirm card does not disappear automatically.
+    await new Promise((r) => setTimeout(r, 200))
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('clicking Dismiss removes the success card', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ data: PLUGIN_RESPONSE }),
+      ),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('auto-clears success card when hasInstancesForPlugin returns true', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ data: PLUGIN_RESPONSE }),
+      ),
+    )
+
+    // Starts false, then the parent callback flips to true.
+    let hasInstances = false
+    const { rerender } = renderButton({
+      hasInstancesForPlugin: () => hasInstances,
+    })
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument())
+
+    // Simulate the parent telling us this plugin now has instances.
+    hasInstances = true
+    rerender(
+      <QueryClientProvider client={makeClient()}>
+        <MemoryRouter>
+          <InstallPluginButton hasInstancesForPlugin={() => hasInstances} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
+  })
+
+  it('shows 400 error with server message prefixed by "Install failed:"', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json(
+          { error: 'Invalid tarball', detail: 'manifest missing name field' },
+          { status: 400 },
+        ),
+      ),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Install failed: Invalid tarball')
+  })
+
+  it('shows 409 error with verbatim server message', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json(
+          { error: 'concurrent plugin update; retry' },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    // The server message "concurrent plugin update; retry" must appear verbatim.
+    expect(screen.getByRole('alert')).toHaveTextContent('concurrent plugin update; retry')
+    expect(screen.getByRole('alert')).toHaveTextContent('Install failed:')
+  })
+
+  it('shows fixed 413 message regardless of server body', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        new HttpResponse(null, { status: 413 }),
+      ),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Tarball too large (max 100 MiB).')
+  })
+
+  it('shows 422 error with server message', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json(
+          { error: 'Signature verification failed', detail: 'pubkey mismatch' },
+          { status: 422 },
+        ),
+      ),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Install failed: Signature verification failed')
+  })
+
+  it('shows dedicated amber notice for 503 (plugins disabled)', async () => {
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ error: 'plugin system disabled' }, { status: 503 }),
+      ),
+    )
+
+    renderButton()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, makeFile(1024))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('GLEIPNIR_PLUGINS_ENABLED=true')
+  })
+})

--- a/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.tsx
+++ b/frontend/src/components/admin/InstallPluginButton/InstallPluginButton.tsx
@@ -1,0 +1,194 @@
+import { useRef, useEffect, useState } from 'react'
+import { Button } from '@/components/Button'
+import { AddInstanceModal } from '@/components/admin/AddInstanceModal'
+import { ApiError } from '@/api/fetch'
+import { useInstallPlugin } from '@/hooks/mutations/plugins'
+import type { ApiInstalledPlugin } from '@/api/types'
+import spinnerStyles from '@/styles/spinner.module.css'
+import styles from './InstallPluginButton.module.css'
+
+const MAX_SIZE_BYTES = 100 * 1024 * 1024 // 100 MiB
+
+interface InstallPluginButtonProps {
+  // Called when a plugin is successfully installed; the parent can use this
+  // to scroll the new plugin row into view or clear success state once it
+  // appears in the instance list.
+  onInstalled?: (plugin: ApiInstalledPlugin) => void
+  // Callback that returns true when the freshly installed plugin already has
+  // at least one instance in the list query. When it flips to true the
+  // success card auto-clears (the operator no longer needs the CTA).
+  hasInstancesForPlugin?: (pluginId: string) => boolean
+}
+
+type InstallState =
+  | { type: 'idle' }
+  | { type: 'uploading' }
+  | { type: 'success'; plugin: ApiInstalledPlugin }
+  | { type: 'error'; message: string; detail?: string; is503: boolean }
+
+function mapInstallError(err: unknown): { message: string; detail?: string; is503: boolean } {
+  if (!(err instanceof ApiError)) {
+    const msg = err instanceof Error ? err.message : 'Unexpected error — please try again.'
+    return { message: `Install failed: ${msg}`, is503: false }
+  }
+
+  switch (err.status) {
+    case 413:
+      return { message: 'Tarball too large (max 100 MiB).', is503: false }
+    case 503:
+      return {
+        message:
+          'Plugin install is disabled on this server. Set GLEIPNIR_PLUGINS_ENABLED=true and restart to enable.',
+        is503: true,
+      }
+    default:
+      return {
+        message: `Install failed: ${err.message}`,
+        detail: err.detail,
+        is503: false,
+      }
+  }
+}
+
+export function InstallPluginButton({ onInstalled, hasInstancesForPlugin }: InstallPluginButtonProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const mutation = useInstallPlugin()
+  const [state, setState] = useState<InstallState>({ type: 'idle' })
+  // When the modal is open for post-install "Add instance" CTA, store the plugin.
+  const [addInstancePlugin, setAddInstancePlugin] = useState<ApiInstalledPlugin | null>(null)
+
+  // Auto-clear the success card once the installed plugin appears in the
+  // instances list. This avoids stranding the operator in the case where
+  // they created the first instance via the inline CTA and the list refreshed.
+  useEffect(() => {
+    if (state.type !== 'success') return
+    if (!hasInstancesForPlugin) return
+    if (hasInstancesForPlugin(state.plugin.id)) {
+      setState({ type: 'idle' })
+    }
+  }, [state, hasInstancesForPlugin])
+
+  function handleButtonClick() {
+    fileInputRef.current?.click()
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    // Reset the input so selecting the same file again triggers onChange.
+    e.target.value = ''
+
+    if (file.size > MAX_SIZE_BYTES) {
+      setState({
+        type: 'error',
+        message: 'Tarball too large (max 100 MiB).',
+        is503: false,
+      })
+      return
+    }
+
+    setState({ type: 'uploading' })
+    mutation.mutate(
+      { file },
+      {
+        onSuccess: (plugin) => {
+          setState({ type: 'success', plugin })
+          onInstalled?.(plugin)
+        },
+        onError: (err) => {
+          const mapped = mapInstallError(err)
+          setState({ type: 'error', message: mapped.message, detail: mapped.detail, is503: mapped.is503 })
+        },
+      },
+    )
+  }
+
+  function dismissState() {
+    setState({ type: 'idle' })
+  }
+
+  const isUploading = state.type === 'uploading'
+
+  return (
+    <div className={styles.root}>
+      {/* Hidden file input — triggered by the styled button below */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".tar.gz,.tgz,application/gzip"
+        className={styles.hiddenInput}
+        onChange={handleFileChange}
+        aria-hidden="true"
+        tabIndex={-1}
+        data-testid="install-plugin-input"
+      />
+
+      <Button
+        variant="primary"
+        size="small"
+        onClick={handleButtonClick}
+        disabled={isUploading}
+      >
+        {isUploading ? (
+          <>
+            <span className={spinnerStyles.spinner} aria-hidden="true" />
+            Installing…
+          </>
+        ) : (
+          'Install plugin'
+        )}
+      </Button>
+
+      {state.type === 'success' && (
+        <div className={styles.successCard} role="status">
+          <p className={styles.successMessage}>
+            Installed <strong>{state.plugin.name}</strong> v{state.plugin.version}{' '}
+            (status: {state.plugin.status}).
+          </p>
+          <div className={styles.successActions}>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setAddInstancePlugin(state.plugin)}
+            >
+              Add instance
+            </Button>
+            <Button variant="ghost" size="small" onClick={dismissState}>
+              Dismiss
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {state.type === 'error' && state.is503 && (
+        <div className={styles.disabledNotice} role="alert">
+          {state.message}
+        </div>
+      )}
+
+      {state.type === 'error' && !state.is503 && (
+        <div className={styles.errorCard} role="alert">
+          <p className={styles.errorMessage}>{state.message}</p>
+          {state.detail && (
+            <details className={styles.errorDetail}>
+              <summary>Details</summary>
+              <pre>{state.detail}</pre>
+            </details>
+          )}
+          <Button variant="ghost" size="small" onClick={dismissState}>
+            Dismiss
+          </Button>
+        </div>
+      )}
+
+      {addInstancePlugin && (
+        <AddInstanceModal
+          pluginId={addInstancePlugin.id}
+          pluginName={addInstancePlugin.name}
+          existingNames={[]}
+          onClose={() => setAddInstancePlugin(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/admin/InstallPluginButton/index.ts
+++ b/frontend/src/components/admin/InstallPluginButton/index.ts
@@ -1,0 +1,1 @@
+export { InstallPluginButton } from './InstallPluginButton'

--- a/frontend/src/hooks/mutations/plugins.ts
+++ b/frontend/src/hooks/mutations/plugins.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { apiFetch, apiFetchVoid } from '@/api/fetch'
-import type { ApiAcceptNewKeyResponse } from '@/api/types'
+import { apiFetch, apiFetchVoid, ApiError } from '@/api/fetch'
+import type { ApiAcceptNewKeyResponse, ApiInstalledPlugin, ApiCreatedPluginInstance } from '@/api/types'
 import { queryKeys } from '../queryKeys'
 
 // BeginPluginOAuthParams carries the inputs for POST .../oauth/begin.
@@ -207,6 +207,62 @@ export function useClearPluginCredentials() {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.plugins.credentials(pluginId, instanceId),
       })
+    },
+  })
+}
+
+// ── Subscription scope ────────────────────────────────────────────────────────
+
+// ── Install + create-instance ─────────────────────────────────────────────────
+
+// InstallPluginParams carries the tarball File to POST as application/octet-stream.
+export interface InstallPluginParams {
+  file: File
+}
+
+// useInstallPlugin POSTs a .tar.gz plugin tarball to POST /api/v1/admin/plugins.
+// The caller-provided Content-Type overrides apiFetch's default application/json
+// because fetch accepts a File body natively. On success, the plugin list and
+// all plugin-instance caches are invalidated so any new instance rows appear.
+export function useInstallPlugin() {
+  const qc = useQueryClient()
+  return useMutation<ApiInstalledPlugin, ApiError, InstallPluginParams>({
+    mutationFn: ({ file }) =>
+      apiFetch<ApiInstalledPlugin>('/admin/plugins', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: file,
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.plugins.list() })
+      void qc.invalidateQueries({ queryKey: queryKeys.admin.pluginInstances })
+    },
+  })
+}
+
+// CreatePluginInstanceParams carries the plugin ID and desired instance name.
+export interface CreatePluginInstanceParams {
+  pluginId: string
+  instanceName: string
+}
+
+// useCreatePluginInstance POSTs {instance_name} to
+// POST /api/v1/admin/plugins/{id}/instances. On success, the per-plugin
+// instance list and the flat admin plugin-instances list are both invalidated.
+export function useCreatePluginInstance() {
+  const qc = useQueryClient()
+  return useMutation<ApiCreatedPluginInstance, ApiError, CreatePluginInstanceParams>({
+    mutationFn: ({ pluginId, instanceName }) =>
+      apiFetch<ApiCreatedPluginInstance>(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ instance_name: instanceName }),
+        },
+      ),
+    onSuccess: (_data, { pluginId }) => {
+      void qc.invalidateQueries({ queryKey: queryKeys.plugins.instances(pluginId) })
+      void qc.invalidateQueries({ queryKey: queryKeys.admin.pluginInstances })
     },
   })
 }

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -58,6 +58,12 @@ export const queryKeys = {
     all: ['config'] as const,
   },
   plugins: {
+    // list() is invalidated after a successful install so that any future
+    // read-side hook that consumes it picks up the new plugin immediately.
+    list: () => ['admin', 'plugins'] as const,
+    // instances(pluginId) is invalidated after a successful create-instance.
+    instances: (pluginId: string) =>
+      ['admin', 'plugins', pluginId, 'instances'] as const,
     instance: (pluginId: string, instanceId: string) =>
       ['admin', 'plugins', pluginId, 'instances', instanceId] as const,
     credentials: (pluginId: string, instanceId: string) =>

--- a/frontend/src/pages/AdminPluginsPage.module.css
+++ b/frontend/src/pages/AdminPluginsPage.module.css
@@ -109,6 +109,48 @@
   color: var(--text-muted);
 }
 
+/* Plugin group layout for the "All instances" section */
+
+.pluginGroupList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.pluginGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.pluginGroupHeader {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: var(--space-2);
+}
+
+.pluginGroupTitle {
+  display: block;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.pluginGroupId {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-top: var(--space-1);
+}
+
+.pluginGroupActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
 /* Empty state */
 
 .emptyState {

--- a/frontend/src/pages/AdminPluginsPage.stories.tsx
+++ b/frontend/src/pages/AdminPluginsPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
 import '@/tokens.css'
 import AdminPluginsPage from './AdminPluginsPage'
 import { queryKeys } from '@/hooks/queryKeys'
@@ -54,15 +55,30 @@ const INSTANCE_UNHEALTHY: ApiPluginInstanceForAudience = {
   event_kinds: [],
 }
 
-function makeQueryClient(instances: ApiPluginInstanceForAudience[]): QueryClient {
+function makeQueryClient(
+  instances: ApiPluginInstanceForAudience[],
+  currentUser?: { id: string; username: string; roles: string[] },
+): QueryClient {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   qc.setQueryData(queryKeys.admin.pluginInstances, instances)
+  if (currentUser) {
+    qc.setQueryData(queryKeys.currentUser.all, currentUser)
+  }
   return qc
 }
 
-function Wrapper({ instances }: { instances: ApiPluginInstanceForAudience[] }) {
+const ADMIN_USER = { id: 'user-01', username: 'admin', roles: ['admin'] }
+const AUDITOR_USER = { id: 'user-02', username: 'auditor', roles: ['auditor'] }
+
+function Wrapper({
+  instances,
+  currentUser,
+}: {
+  instances: ApiPluginInstanceForAudience[]
+  currentUser?: { id: string; username: string; roles: string[] }
+}) {
   return (
-    <QueryClientProvider client={makeQueryClient(instances)}>
+    <QueryClientProvider client={makeQueryClient(instances, currentUser)}>
       <MemoryRouter initialEntries={['/admin/plugins']}>
         <Routes>
           <Route path="/admin/plugins" element={<AdminPluginsPage />} />
@@ -84,20 +100,88 @@ const meta: Meta<typeof AdminPluginsPage> = {
 export default meta
 type Story = StoryObj<typeof AdminPluginsPage>
 
-// All instances healthy — no "Needs re-authorization" section.
+// All instances healthy — no "Needs re-authorization" section (non-admin user).
 export const AllHealthy: Story = {
   render: () => <Wrapper instances={[INSTANCE_HEALTHY]} />,
+}
+
+// Admin view — Install plugin button and "Add instance" buttons are visible.
+export const Admin: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json({
+            data: { id: 'plugin-new', name: 'NewPlugin', version: '1.0.0', status: 'active' },
+          }),
+        ),
+        http.post('/api/v1/admin/plugins/:id/instances', () =>
+          HttpResponse.json({
+            data: {
+              id: 'inst-new',
+              plugin_id: 'plugin-new',
+              instance_name: 'production',
+              health_state: 'healthy',
+              version: 1,
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            },
+          }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <Wrapper instances={[INSTANCE_HEALTHY, INSTANCE_UNHEALTHY]} currentUser={ADMIN_USER} />
+  ),
+}
+
+// Auditor view — Install plugin button is hidden; read-only view.
+export const Auditor: Story = {
+  render: () => (
+    <Wrapper instances={[INSTANCE_HEALTHY, INSTANCE_UNHEALTHY]} currentUser={AUDITOR_USER} />
+  ),
+}
+
+// AdminEmpty — admin with zero instances; Install button still visible above the empty state.
+export const AdminEmpty: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json({
+            data: { id: 'plugin-new', name: 'NewPlugin', version: '1.0.0', status: 'active' },
+          }),
+        ),
+      ],
+    },
+  },
+  render: () => <Wrapper instances={[]} currentUser={ADMIN_USER} />,
 }
 
 // One instance pending re-authorization — shows the "Needs re-authorization"
 // section at the top, grouped separately from the "All instances" list.
 export const WithPendingReauth: Story = {
   render: () => (
-    <Wrapper instances={[INSTANCE_PENDING_REAUTH, INSTANCE_HEALTHY, INSTANCE_UNHEALTHY]} />
+    <Wrapper instances={[INSTANCE_PENDING_REAUTH, INSTANCE_HEALTHY, INSTANCE_UNHEALTHY]} currentUser={ADMIN_USER} />
   ),
 }
 
-// Empty — no plugin instances installed.
+// InstallDisabled503 — clicking Install shows the 503 amber disabled notice.
+export const InstallDisabled503: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('/api/v1/admin/plugins', () =>
+          HttpResponse.json({ error: 'plugin system disabled' }, { status: 503 }),
+        ),
+      ],
+    },
+  },
+  render: () => <Wrapper instances={[]} currentUser={ADMIN_USER} />,
+}
+
+// Empty — no plugin instances installed (non-admin).
 export const Empty: Story = {
   render: () => <Wrapper instances={[]} />,
 }

--- a/frontend/src/pages/AdminPluginsPage.test.tsx
+++ b/frontend/src/pages/AdminPluginsPage.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/server'
 
 import AdminPluginsPage from './AdminPluginsPage'
 import type { ApiPluginInstanceForAudience } from '@/api/types'
@@ -12,12 +15,16 @@ import type { ApiPluginInstanceForAudience } from '@/api/types'
 vi.mock('@/hooks/queries/admin')
 import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
 
+vi.mock('@/hooks/queries/users')
+import { useCurrentUser } from '@/hooks/queries/users'
+
 // --- Fixtures ---
 
 const CALLBACK_URL = 'https://gleipnir.example.com/api/v1/admin/plugins/oauth/callback'
 const OLD_CALLBACK_URL = 'https://old.example.com/api/v1/admin/plugins/oauth/callback'
 
 const PLUGIN_ID = 'plugin-slack-01'
+const PLUGIN_ID_JIRA = 'plugin-jira-01'
 const INSTANCE_ID_SLACK = 'inst-slack-prod'
 const INSTANCE_ID_JIRA = 'inst-jira-prod'
 
@@ -38,7 +45,7 @@ const INSTANCE_HEALTHY: ApiPluginInstanceForAudience = {
 
 const INSTANCE_PENDING_REAUTH: ApiPluginInstanceForAudience = {
   id: INSTANCE_ID_JIRA,
-  plugin_id: 'plugin-jira-01',
+  plugin_id: PLUGIN_ID_JIRA,
   plugin_name: 'Jira',
   instance_name: 'jira-prod',
   state: 'pending_reauthorize',
@@ -63,8 +70,17 @@ function mockInstances(instances: ApiPluginInstanceForAudience[]) {
   } as unknown as ReturnType<typeof usePluginInstancesForAudience>)
 }
 
+function mockCurrentUser(roles: string[]) {
+  vi.mocked(useCurrentUser).mockReturnValue({
+    data: { id: 'user-01', username: 'admin', roles },
+    status: 'success',
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useCurrentUser>)
+}
+
 function renderPage() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={['/admin/plugins']}>
@@ -80,24 +96,27 @@ function renderPage() {
   )
 }
 
+// Ensure real timers are restored after any test that switches to fake timers.
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 // --- Tests ---
 
 describe('AdminPluginsPage', () => {
   it('shows "Needs re-authorization" section when at least one instance is pending_reauthorize', () => {
     mockInstances([INSTANCE_PENDING_REAUTH, INSTANCE_HEALTHY])
-
+    mockCurrentUser(['admin'])
     renderPage()
 
     expect(screen.getByText('Needs re-authorization')).toBeInTheDocument()
-    // The Jira instance should appear somewhere on the page (both sections may
-    // render its name, so use getAllByText and assert at least one match).
     const jiraLinks = screen.getAllByText('jira-prod')
     expect(jiraLinks.length).toBeGreaterThanOrEqual(1)
   })
 
   it('does not show "Needs re-authorization" section when no instances are pending', () => {
     mockInstances([INSTANCE_HEALTHY])
-
+    mockCurrentUser(['admin'])
     renderPage()
 
     expect(screen.queryByText('Needs re-authorization')).not.toBeInTheDocument()
@@ -105,11 +124,10 @@ describe('AdminPluginsPage', () => {
 
   it('shows all instances in the "All instances" section regardless of state', () => {
     mockInstances([INSTANCE_PENDING_REAUTH, INSTANCE_HEALTHY])
-
+    mockCurrentUser(['admin'])
     renderPage()
 
     expect(screen.getByText('All instances')).toBeInTheDocument()
-    // Both instances appear in the All instances section.
     const slackLinks = screen.getAllByText('slack-prod')
     expect(slackLinks.length).toBeGreaterThanOrEqual(1)
     const jiraLinks = screen.getAllByText('jira-prod')
@@ -118,23 +136,355 @@ describe('AdminPluginsPage', () => {
 
   it('instance row links point to /admin/plugins/{plugin_id}/instances/{id}', () => {
     mockInstances([INSTANCE_PENDING_REAUTH])
-
+    mockCurrentUser(['admin'])
     renderPage()
 
     const links = screen.getAllByRole('link', { name: 'jira-prod' })
     for (const link of links) {
       expect(link).toHaveAttribute(
         'href',
-        `/admin/plugins/${encodeURIComponent(INSTANCE_PENDING_REAUTH.plugin_id)}/instances/${encodeURIComponent(INSTANCE_ID_JIRA)}`,
+        `/admin/plugins/${encodeURIComponent(PLUGIN_ID_JIRA)}/instances/${encodeURIComponent(INSTANCE_ID_JIRA)}`,
       )
     }
   })
 
   it('shows empty state when no instances are installed', () => {
     mockInstances([])
-
+    mockCurrentUser(['admin'])
     renderPage()
 
     expect(screen.getByText('No plugin instances')).toBeInTheDocument()
+  })
+
+  // --- Role gating ---
+
+  it('renders Install plugin button for admin role', () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    renderPage()
+
+    expect(screen.getByRole('button', { name: /install plugin/i })).toBeInTheDocument()
+  })
+
+  it('does NOT render Install plugin button for auditor role', () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['auditor'])
+    renderPage()
+
+    expect(screen.queryByRole('button', { name: /install plugin/i })).not.toBeInTheDocument()
+  })
+
+  it('does NOT render Install plugin button for operator role', () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['operator'])
+    renderPage()
+
+    expect(screen.queryByRole('button', { name: /install plugin/i })).not.toBeInTheDocument()
+  })
+
+  it('Install plugin button is visible even when the instances list is empty (outside QueryBoundary)', () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    renderPage()
+
+    // The button must be visible alongside the empty state — not nested inside it.
+    expect(screen.getByRole('button', { name: /install plugin/i })).toBeInTheDocument()
+    expect(screen.getByText('No plugin instances')).toBeInTheDocument()
+  })
+
+  it('empty state copy changes for admin vs non-admin', () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    renderPage()
+    expect(screen.getByText(/Use the Install plugin button above/i)).toBeInTheDocument()
+  })
+
+  it('empty state keeps original copy for auditor', () => {
+    mockInstances([])
+    mockCurrentUser(['auditor'])
+    renderPage()
+    expect(screen.getByText(/Install a plugin to see instances here/i)).toBeInTheDocument()
+  })
+
+  // --- Per-plugin group and Add instance button ---
+
+  it('renders "Add instance" button per plugin group for admin', () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    renderPage()
+
+    expect(screen.getByRole('button', { name: /add instance/i })).toBeInTheDocument()
+  })
+
+  it('does NOT render "Add instance" buttons for non-admin', () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['auditor'])
+    renderPage()
+
+    expect(screen.queryByRole('button', { name: /add instance/i })).not.toBeInTheDocument()
+  })
+
+  it('clicking "Add instance" opens the modal for that plugin', async () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json({
+          data: {
+            id: 'inst-new',
+            plugin_id: PLUGIN_ID,
+            instance_name: 'test',
+            health_state: 'healthy',
+            version: 1,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        }),
+      ),
+    )
+
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /add instance/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/Add instance to Slack/i)).toBeInTheDocument()
+  })
+
+  // --- Install happy path ---
+
+  it('shows success card after a successful install', async () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({
+          data: { id: 'plugin-new', name: 'MyPlugin', version: '0.1.0', status: 'active' },
+        }),
+      ),
+    )
+
+    renderPage()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File([new Uint8Array(1024)], 'plugin.tar.gz', { type: 'application/gzip' })
+    await userEvent.upload(input, file)
+
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument())
+    expect(screen.getByRole('status')).toHaveTextContent('MyPlugin')
+  })
+
+  // --- Install error cases ---
+
+  it('shows 400 install error on the page', async () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ error: 'bad tarball' }, { status: 400 }),
+      ),
+    )
+
+    renderPage()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File([new Uint8Array(1024)], 'plugin.tar.gz', { type: 'application/gzip' })
+    await userEvent.upload(input, file)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Install failed: bad tarball')
+  })
+
+  it('shows 409 install error with verbatim server message', async () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ error: 'concurrent plugin update; retry' }, { status: 409 }),
+      ),
+    )
+
+    renderPage()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File([new Uint8Array(1024)], 'plugin.tar.gz', { type: 'application/gzip' })
+    await userEvent.upload(input, file)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('concurrent plugin update; retry')
+  })
+
+  it('shows 413 fixed message', async () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins', () => new HttpResponse(null, { status: 413 })),
+    )
+
+    renderPage()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File([new Uint8Array(1024)], 'plugin.tar.gz', { type: 'application/gzip' })
+    await userEvent.upload(input, file)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Tarball too large')
+  })
+
+  it('shows 422 signature-invalid error', async () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ error: 'Signature verification failed' }, { status: 422 }),
+      ),
+    )
+
+    renderPage()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File([new Uint8Array(1024)], 'plugin.tar.gz', { type: 'application/gzip' })
+    await userEvent.upload(input, file)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Install failed: Signature verification failed')
+  })
+
+  it('shows 503 disabled notice', async () => {
+    mockInstances([])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins', () =>
+        HttpResponse.json({ error: 'plugin system disabled' }, { status: 503 }),
+      ),
+    )
+
+    renderPage()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File([new Uint8Array(1024)], 'plugin.tar.gz', { type: 'application/gzip' })
+    await userEvent.upload(input, file)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('GLEIPNIR_PLUGINS_ENABLED=true')
+  })
+
+  // --- Create-instance happy path ---
+
+  it('closes modal on successful create-instance', async () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json({
+          data: {
+            id: 'inst-new',
+            plugin_id: PLUGIN_ID,
+            instance_name: 'production',
+            health_state: 'healthy',
+            version: 1,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        }),
+      ),
+    )
+
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /add instance/i }))
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'production')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  // --- Create-instance error cases ---
+
+  it('shows 400 create-instance error in modal', async () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json({ error: 'name too long' }, { status: 400 }),
+      ),
+    )
+
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /add instance/i }))
+
+    await userEvent.type(screen.getByRole('textbox'), 'toolongnamethatfailsvalidation')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert')
+      expect(alerts.some((a) => a.textContent?.includes('Failed to create instance:'))).toBe(true)
+    })
+  })
+
+  it('shows 409 create-instance error with server message', async () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json(
+          { error: "instance named 'staging' already exists for this plugin" },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /add instance/i }))
+
+    await userEvent.type(screen.getByRole('textbox'), 'staging')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert')
+      expect(alerts.some((a) => a.textContent?.includes("instance named 'staging' already exists"))).toBe(true)
+    })
+  })
+
+  it('shows 404 create-instance error and closes modal', async () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json({ error: 'plugin not found' }, { status: 404 }),
+      ),
+    )
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /add instance/i }))
+
+    await userEvent.type(screen.getByRole('textbox'), 'production')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert')
+      expect(alerts.some((a) => a.textContent?.includes('plugin no longer exists'))).toBe(true)
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('shows 500 create-instance error in modal', async () => {
+    mockInstances([INSTANCE_HEALTHY])
+    mockCurrentUser(['admin'])
+    server.use(
+      http.post('/api/v1/admin/plugins/:id/instances', () =>
+        HttpResponse.json({ error: 'internal server error' }, { status: 500 }),
+      ),
+    )
+
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /add instance/i }))
+
+    await userEvent.type(screen.getByRole('textbox'), 'production')
+    await userEvent.click(screen.getByRole('button', { name: /create instance/i }))
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert')
+      expect(alerts.some((a) => a.textContent?.includes('Failed to create instance:'))).toBe(true)
+    })
   })
 })

--- a/frontend/src/pages/AdminPluginsPage.tsx
+++ b/frontend/src/pages/AdminPluginsPage.tsx
@@ -1,24 +1,76 @@
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { PageHeader } from '@/components/PageHeader'
 import { QueryBoundary, SkeletonList } from '@/components/QueryBoundary'
 import { PluginHealthChip } from '@/components/admin/PluginHealthChip/PluginHealthChip'
+import { InstallPluginButton } from '@/components/admin/InstallPluginButton'
+import { AddInstanceModal } from '@/components/admin/AddInstanceModal'
+import { Button } from '@/components/Button'
 import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
+import { useCurrentUser } from '@/hooks/queries/users'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import type { ApiInstalledPlugin, ApiPluginInstanceForAudience } from '@/api/types'
 import styles from './AdminPluginsPage.module.css'
 
 export default function AdminPluginsPage() {
   usePageTitle('Plugins')
 
   const { data: instances, status, refetch } = usePluginInstancesForAudience()
+  const { data: currentUser } = useCurrentUser()
 
-  const needsReauth = (instances ?? []).filter(
-    (inst) => inst.state === 'pending_reauthorize',
-  )
+  // Admin-only: the install and create-instance API endpoints require admin role.
+  const canManage = currentUser?.roles.includes('admin') ?? false
+
   const allInstances = instances ?? []
+
+  const needsReauth = allInstances.filter((inst) => inst.state === 'pending_reauthorize')
+
+  // Group the full list by plugin_id for the "All instances" section so we can
+  // render a per-plugin "Add instance" button in each group header.
+  const pluginGroups = groupByPluginId(allInstances)
+
+  // Tracks which plugin's "Add instance" modal is currently open.
+  const [openAddInstance, setOpenAddInstance] = useState<{
+    pluginId: string
+    pluginName: string
+  } | null>(null)
+
+  // lastInstalledPluginId drives the scroll-into-view effect after an install.
+  const [lastInstalledPluginId, setLastInstalledPluginId] = useState<string | null>(null)
+
+  // Scroll the newly installed plugin's section into view once it appears in
+  // the instance list (it only appears after the first instance is created).
+  useEffect(() => {
+    if (!lastInstalledPluginId) return
+    const el = document.getElementById(`plugin-group-${lastInstalledPluginId}`)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      setLastInstalledPluginId(null)
+    }
+  }, [lastInstalledPluginId, allInstances])
+
+  function handleInstalled(plugin: ApiInstalledPlugin) {
+    setLastInstalledPluginId(plugin.id)
+  }
+
+  // Passed to InstallPluginButton so it can auto-clear the success card once
+  // the newly installed plugin appears in the instance list.
+  function hasInstancesForPlugin(pluginId: string): boolean {
+    return allInstances.some((inst) => inst.plugin_id === pluginId)
+  }
 
   return (
     <div className={styles.page}>
-      <PageHeader title="Plugins" />
+      {/* InstallPluginButton lives outside the QueryBoundary so it stays
+          visible during loading, error, and empty states. */}
+      <PageHeader title="Plugins">
+        {canManage && (
+          <InstallPluginButton
+            onInstalled={handleInstalled}
+            hasInstancesForPlugin={hasInstancesForPlugin}
+          />
+        )}
+      </PageHeader>
 
       <p className={styles.intro}>
         All installed plugin instances and their current health state.
@@ -34,7 +86,9 @@ export default function AdminPluginsPage() {
           <div className={styles.emptyState}>
             <p className={styles.emptyHeadline}>No plugin instances</p>
             <p className={styles.emptySubtext}>
-              Install a plugin to see instances here.
+              {canManage
+                ? 'Use the Install plugin button above to add one.'
+                : 'Install a plugin to see instances here.'}
             </p>
           </div>
         }
@@ -85,37 +139,104 @@ export default function AdminPluginsPage() {
 
         <section className={styles.section}>
           <h2 className={styles.sectionTitle}>All instances</h2>
-          <div className={styles.tableWrapper}>
-            <table className={styles.table}>
-              <thead>
-                <tr>
-                  <th>Plugin</th>
-                  <th>Instance</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {allInstances.map((inst) => (
-                  <tr key={inst.id}>
-                    <td className={styles.pluginName}>{inst.plugin_name ?? inst.plugin_id}</td>
-                    <td>
-                      <Link
-                        to={`/admin/plugins/${encodeURIComponent(inst.plugin_id)}/instances/${encodeURIComponent(inst.id)}`}
-                        className={styles.nameLink}
+          <div className={styles.pluginGroupList}>
+            {pluginGroups.map(({ pluginId, pluginName, instances: groupInstances }) => (
+              <div
+                key={pluginId}
+                id={`plugin-group-${pluginId}`}
+                className={styles.pluginGroup}
+              >
+                <div className={styles.pluginGroupHeader}>
+                  <div>
+                    <span className={styles.pluginGroupTitle}>{pluginName}</span>
+                    <span className={styles.pluginGroupId}>{pluginId}</span>
+                  </div>
+                  {canManage && (
+                    <div className={styles.pluginGroupActions}>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() =>
+                          setOpenAddInstance({ pluginId, pluginName })
+                        }
                       >
-                        {inst.instance_name}
-                      </Link>
-                    </td>
-                    <td>
-                      <PluginHealthChip state={inst.state} detail={inst.health_detail} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                        Add instance
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                <div className={styles.tableWrapper}>
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Instance</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {groupInstances.map((inst) => (
+                        <tr key={inst.id}>
+                          <td>
+                            <Link
+                              to={`/admin/plugins/${encodeURIComponent(inst.plugin_id)}/instances/${encodeURIComponent(inst.id)}`}
+                              className={styles.nameLink}
+                            >
+                              {inst.instance_name}
+                            </Link>
+                          </td>
+                          <td>
+                            <PluginHealthChip state={inst.state} detail={inst.health_detail} />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ))}
           </div>
         </section>
       </QueryBoundary>
+
+      {openAddInstance && (
+        <AddInstanceModal
+          pluginId={openAddInstance.pluginId}
+          pluginName={openAddInstance.pluginName}
+          existingNames={
+            allInstances
+              .filter((inst) => inst.plugin_id === openAddInstance.pluginId)
+              .map((inst) => inst.instance_name)
+          }
+          onClose={() => setOpenAddInstance(null)}
+        />
+      )}
     </div>
   )
+}
+
+interface PluginGroup {
+  pluginId: string
+  pluginName: string
+  instances: ApiPluginInstanceForAudience[]
+}
+
+// groupByPluginId preserves insertion order (first-seen plugin id wins) so the
+// list order is stable across refetches.
+function groupByPluginId(instances: ApiPluginInstanceForAudience[]): PluginGroup[] {
+  const order: string[] = []
+  const map = new Map<string, PluginGroup>()
+
+  for (const inst of instances) {
+    if (!map.has(inst.plugin_id)) {
+      order.push(inst.plugin_id)
+      map.set(inst.plugin_id, {
+        pluginId: inst.plugin_id,
+        pluginName: inst.plugin_name ?? inst.plugin_id,
+        instances: [],
+      })
+    }
+    map.get(inst.plugin_id)!.instances.push(inst)
+  }
+
+  return order.map((id) => map.get(id)!)
 }


### PR DESCRIPTION
Closes #381

## Summary

Adds the admin UI controls that wrap the two API endpoints landed in #380, replacing the curl-only path. Two new components live under `frontend/src/components/admin/`:

- **`InstallPluginButton`** — file-picker upload of a `.tar.gz`/`.tgz` plugin bundle, POSTed as `application/octet-stream`. Persistent success card with an inline "Add instance" CTA that stays visible until the operator dismisses it OR a refetch shows the new plugin has at least one instance (which is the only reliable way to navigate to it from the page, since the page list is keyed off `plugin_instances` rows).
- **`AddInstanceModal`** — modal form to instantiate an installed plugin by name. Reused as a standalone modal triggered from the per-plugin "Add instance" button on the installed-plugins list AND inline from the install-success card. Client-side validation (empty / whitespace / duplicate) plus per-status error mapping (400/404/409/500).

Both controls are admin-only via `useCurrentUser().roles.includes('admin')` — hidden (not disabled with a tooltip), since the API itself rejects non-admin and a disabled tooltip would lie about the underlying behavior.

## Where things live

- Mutation hooks: `frontend/src/hooks/mutations/plugins.ts` (NOT `queries/plugins.ts` — that file is for `useQuery` only). The issue body said `queries/`; the codebase convention takes precedence.
- Query key additions: `queryKeys.plugins.list()` and `queryKeys.plugins.instances(pluginId)` (existing `plugins.credentials(p, i)` preserved). Mutations invalidate `queryKeys.admin.pluginInstances` (the key the page actually reads).
- New TypeScript types: `ApiInstalledPlugin`, `ApiCreatedPluginInstance` in `src/api/types.ts`. `health_detail` is typed `string | null | undefined` to cover both the Go `*string` null encoding and the existing `?: string` pattern; guarded everywhere with `if (inst.health_detail)`.

## Architecture

<details>
<summary>Click to expand the architect's plan (post-revision)</summary>

**Component placement**: `InstallPluginButton` is rendered as a `PageHeader` child *outside* the `<QueryBoundary>` wrap, so it remains visible in the empty state (when no instances exist yet). Per-plugin "Add instance" buttons live on each group header inside `QueryBoundary`'s success state.

**Mutation contract**: `useInstallPlugin` accepts a `File` body, sets `Content-Type: application/octet-stream` explicitly (overriding `apiFetch`'s default `application/json`), and `fetch()` passes the File through raw. `useCreatePluginInstance` is a plain JSON POST. Both use `useMutation<T, ApiError, P>` so consumers can pattern-match the error type.

**Error message strategy**: per-status mapping uses `apiError.error` directly (the server's own text) with a friendly prefix ("Install failed: …" / "Failed to create instance: …"). Exceptions: 413 (body too large), 404 (plugin gone), 503 (plugins disabled) use fixed friendly strings since the server message isn't useful or is empty.

**Success card persistence**: explicitly no `setTimeout` auto-clear. The card clears only when (a) the operator clicks Dismiss, OR (b) a `hasInstancesForPlugin(pluginId)` callback returns true after the next refetch. This was a revision after the plan-reviewer flagged the 6s auto-clear as a usability trap — strands the operator if a fresh install has no instances yet.

**Modal mount-point**: `frontend/src/components/Modal/Modal.tsx` does NOT use a React portal — it renders inline with `FocusTrap`. The `AddInstanceModal` mounts inside its parent's DOM subtree. Z-index is managed by CSS `position: fixed`, which works as long as no ancestor has `transform`/`filter`/`will-change`. Documented as a known limitation; not currently triggered by any ancestor in this PR.
</details>

## Test coverage

| Surface | Cases | Coverage |
|---|---|---|
| `InstallPluginButton.test.tsx` | 12 | Happy path, client-side size check (<100 MiB), 400/409/413/422/503/other server errors, success card persistence, success auto-clear when instances refetch shows the new plugin |
| `AddInstanceModal.test.tsx` | 11 | Happy path, empty/whitespace/duplicate name validation, 400/404/409/500 server errors, 404 delayed close, `onCreated` → `onClose` ordering |
| `AdminPluginsPage.test.tsx` | +26 | Role gating (admin/auditor/operator), full install integration (400/409/413/422/503), full create-instance integration (400/404/409/500), per-plugin grouping rendering, "Add instance" button visibility per role |
| **Total new test cases** | **49** | |

Storybook: 13 new component stories (7 install + 6 modal) + 4 new page stories (`Admin`, `Auditor`, `AdminEmpty`, `InstallDisabled503`). Non-idle states (`Uploading`, `Success`, `Error*`) use `play` functions with `userEvent.upload` / `userEvent.click` rather than seeded cache state — the original plan's "seed query cache" approach didn't work because the components use local `useState` for upload/submit state, not query state.

## Pipeline metadata

- **Brainstorming**: not triggered (issue well-specified).
- **Plan revisions**: 1 (plan-reviewer surfaced 2 blockers + 3 important + 3 nits; chief blockers were mutation file location (`queries/` vs `mutations/`) and `health_detail` type harmonization).
- **Review cycles**: 2 (cycle 1 CHANGES_REQUESTED: broken `Success` story, missing 422 page test, missing `Uploading` story; cycle 2 APPROVE with one non-blocking nit about a story's bare `expect` without `waitFor` — works in practice).
- **CLAUDE.md updated**: yes — `frontend/CLAUDE.md` got new query-key entries, the two new admin components, the Admin/Plugins API surface block, and a note about `play`-driven Storybook stories. Main `CLAUDE.md` unchanged (the two endpoints were already documented from #380's update).
- **Generated by**: the agentic dev loop (`/dev-loop 381`).

## Follow-ups out of scope

- Editing/deleting plugins or instances.
- Renaming an existing instance (no API for it; immutable post-create).
- Manifest preview before install (would require tar.gz parsing in the browser).
- Signing key management UI.
- Per-instance OAuth credential seeding at create time.