### PR TITLE
feat: persist plugin binary path and wire subprocess spawn (#386)

### DIFF
--- a/conn_factory_test.go
+++ b/conn_factory_test.go
@@ -152,6 +152,9 @@ func (q *connFactoryFakeQuerier) ListPluginsByStatus(_ context.Context, _ string
 func (q *connFactoryFakeQuerier) ListPluginInstancesByPlugin(_ context.Context, _ string) ([]db.PluginInstance, error) {
 	return nil, nil
 }
+func (q *connFactoryFakeQuerier) GetPluginByID(_ context.Context, _ string) (db.Plugin, error) {
+	return db.Plugin{}, errors.New("not found")
+}
 func (q *connFactoryFakeQuerier) GetPluginInstanceByID(_ context.Context, _ string) (db.PluginInstance, error) {
 	return db.PluginInstance{}, errors.New("not found")
 }

--- a/internal/db/migrations/0001_initial.sql
+++ b/internal/db/migrations/0001_initial.sql
@@ -372,6 +372,7 @@ CREATE TABLE plugins (
     manifest_snapshot  TEXT    NOT NULL,
     trusted_pubkey     TEXT    NOT NULL,
     status             TEXT    NOT NULL CHECK(status IN ('pending_review','active','removed')),
+    binary_path        TEXT,                   -- absolute path to extracted plugin executable (#386); NULL on legacy rows
     version            INTEGER NOT NULL DEFAULT 0,
     created_at         TEXT    NOT NULL,
     updated_at         TEXT    NOT NULL

--- a/internal/db/migrations/0036_add_plugin_binary_path.go
+++ b/internal/db/migrations/0036_add_plugin_binary_path.go
@@ -1,0 +1,55 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// AddPluginBinaryPath adds the binary_path column to the plugins table on
+// existing deployments. New deployments get it from the schema; this migration
+// is a no-op for them (ShouldSkip returns true when the column is already present).
+//
+// The column is nullable so existing rows survive without a backfill — NULL means
+// "no binary path persisted yet (legacy row)". Manager.StartAllActive skips
+// instances whose plugin row has a NULL binary_path and logs a warning directing
+// the operator to re-install the tarball (issue #386).
+type AddPluginBinaryPath struct{}
+
+func (m *AddPluginBinaryPath) Version() int { return 26 }
+func (m *AddPluginBinaryPath) Name() string { return "add_plugin_binary_path" }
+
+func (m *AddPluginBinaryPath) ShouldSkip(ctx context.Context, db *sql.DB) (bool, error) {
+	rows, err := db.QueryContext(ctx, `PRAGMA table_info(plugins)`)
+	if err != nil {
+		return false, fmt.Errorf("pragma table_info(plugins): %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull int
+		var dfltValue *string
+		var pk int
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			return false, fmt.Errorf("scan table_info row: %w", err)
+		}
+		if strings.EqualFold(name, "binary_path") {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func (m *AddPluginBinaryPath) Up(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx,
+		`ALTER TABLE plugins ADD COLUMN binary_path TEXT;`,
+	); err != nil {
+		return fmt.Errorf("add binary_path column: %w", err)
+	}
+	slog.Info("migrated: added plugins.binary_path")
+	return nil
+}

--- a/internal/db/migrations/registry.go
+++ b/internal/db/migrations/registry.go
@@ -29,5 +29,6 @@ func All() []Migration {
 		&AddSubscriptionScope{},
 		&AddPluginOAuthNonces{},
 		&AddPendingReauthorizeHealthState{},
+		&AddPluginBinaryPath{},
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -77,15 +77,16 @@ type OpenaiCompatProvider struct {
 }
 
 type Plugin struct {
-	ID               string `json:"id"`
-	Name             string `json:"name"`
-	PluginVersion    string `json:"plugin_version"`
-	ManifestSnapshot string `json:"manifest_snapshot"`
-	TrustedPubkey    string `json:"trusted_pubkey"`
-	Status           string `json:"status"`
-	Version          int64  `json:"version"`
-	CreatedAt        string `json:"created_at"`
-	UpdatedAt        string `json:"updated_at"`
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	PluginVersion    string  `json:"plugin_version"`
+	ManifestSnapshot string  `json:"manifest_snapshot"`
+	TrustedPubkey    string  `json:"trusted_pubkey"`
+	Status           string  `json:"status"`
+	BinaryPath       *string `json:"binary_path"`
+	Version          int64   `json:"version"`
+	CreatedAt        string  `json:"created_at"`
+	UpdatedAt        string  `json:"updated_at"`
 }
 
 type PluginAudience struct {

--- a/internal/db/plugins.sql.go
+++ b/internal/db/plugins.sql.go
@@ -10,20 +10,21 @@ import (
 )
 
 const createPlugin = `-- name: CreatePlugin :one
-INSERT INTO plugins (id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at)
-VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, ?8)
-RETURNING id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at
+INSERT INTO plugins (id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, ?8, ?9)
+RETURNING id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at
 `
 
 type CreatePluginParams struct {
-	ID               string `json:"id"`
-	Name             string `json:"name"`
-	PluginVersion    string `json:"plugin_version"`
-	ManifestSnapshot string `json:"manifest_snapshot"`
-	TrustedPubkey    string `json:"trusted_pubkey"`
-	Status           string `json:"status"`
-	CreatedAt        string `json:"created_at"`
-	UpdatedAt        string `json:"updated_at"`
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	PluginVersion    string  `json:"plugin_version"`
+	ManifestSnapshot string  `json:"manifest_snapshot"`
+	TrustedPubkey    string  `json:"trusted_pubkey"`
+	Status           string  `json:"status"`
+	BinaryPath       *string `json:"binary_path"`
+	CreatedAt        string  `json:"created_at"`
+	UpdatedAt        string  `json:"updated_at"`
 }
 
 func (q *Queries) CreatePlugin(ctx context.Context, arg CreatePluginParams) (Plugin, error) {
@@ -34,6 +35,7 @@ func (q *Queries) CreatePlugin(ctx context.Context, arg CreatePluginParams) (Plu
 		arg.ManifestSnapshot,
 		arg.TrustedPubkey,
 		arg.Status,
+		arg.BinaryPath,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -45,6 +47,7 @@ func (q *Queries) CreatePlugin(ctx context.Context, arg CreatePluginParams) (Plu
 		&i.ManifestSnapshot,
 		&i.TrustedPubkey,
 		&i.Status,
+		&i.BinaryPath,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -123,7 +126,7 @@ func (q *Queries) DeletePluginInstance(ctx context.Context, id string) (int64, e
 }
 
 const getPluginByID = `-- name: GetPluginByID :one
-SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at FROM plugins WHERE id = ?1
+SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at FROM plugins WHERE id = ?1
 `
 
 func (q *Queries) GetPluginByID(ctx context.Context, id string) (Plugin, error) {
@@ -136,6 +139,7 @@ func (q *Queries) GetPluginByID(ctx context.Context, id string) (Plugin, error) 
 		&i.ManifestSnapshot,
 		&i.TrustedPubkey,
 		&i.Status,
+		&i.BinaryPath,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -144,7 +148,7 @@ func (q *Queries) GetPluginByID(ctx context.Context, id string) (Plugin, error) 
 }
 
 const getPluginByName = `-- name: GetPluginByName :one
-SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at FROM plugins WHERE name = ?1
+SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at FROM plugins WHERE name = ?1
 `
 
 func (q *Queries) GetPluginByName(ctx context.Context, name string) (Plugin, error) {
@@ -157,6 +161,7 @@ func (q *Queries) GetPluginByName(ctx context.Context, name string) (Plugin, err
 		&i.ManifestSnapshot,
 		&i.TrustedPubkey,
 		&i.Status,
+		&i.BinaryPath,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -481,7 +486,7 @@ func (q *Queries) ListPluginInstancesWithExpiringCredentials(ctx context.Context
 }
 
 const listPlugins = `-- name: ListPlugins :many
-SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at FROM plugins ORDER BY name
+SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at FROM plugins ORDER BY name
 `
 
 func (q *Queries) ListPlugins(ctx context.Context) ([]Plugin, error) {
@@ -500,6 +505,7 @@ func (q *Queries) ListPlugins(ctx context.Context) ([]Plugin, error) {
 			&i.ManifestSnapshot,
 			&i.TrustedPubkey,
 			&i.Status,
+			&i.BinaryPath,
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -518,7 +524,7 @@ func (q *Queries) ListPlugins(ctx context.Context) ([]Plugin, error) {
 }
 
 const listPluginsByStatus = `-- name: ListPluginsByStatus :many
-SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at FROM plugins WHERE status = ?1 ORDER BY name
+SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at FROM plugins WHERE status = ?1 ORDER BY name
 `
 
 func (q *Queries) ListPluginsByStatus(ctx context.Context, status string) ([]Plugin, error) {
@@ -537,6 +543,7 @@ func (q *Queries) ListPluginsByStatus(ctx context.Context, status string) ([]Plu
 			&i.ManifestSnapshot,
 			&i.TrustedPubkey,
 			&i.Status,
+			&i.BinaryPath,
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -552,6 +559,34 @@ func (q *Queries) ListPluginsByStatus(ctx context.Context, status string) ([]Plu
 		return nil, err
 	}
 	return items, nil
+}
+
+const updatePluginBinaryPath = `-- name: UpdatePluginBinaryPath :execrows
+UPDATE plugins SET binary_path = ?1, version = version + 1, updated_at = ?2
+WHERE id = ?3 AND version = ?4
+`
+
+type UpdatePluginBinaryPathParams struct {
+	BinaryPath      *string `json:"binary_path"`
+	UpdatedAt       string  `json:"updated_at"`
+	ID              string  `json:"id"`
+	ExpectedVersion int64   `json:"expected_version"`
+}
+
+// UpdatePluginBinaryPath persists the absolute path of the extracted plugin
+// binary after a successful install. Called after UpdatePluginManifest so the
+// CAS version passed here is the post-manifest-update version (#386).
+func (q *Queries) UpdatePluginBinaryPath(ctx context.Context, arg UpdatePluginBinaryPathParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updatePluginBinaryPath,
+		arg.BinaryPath,
+		arg.UpdatedAt,
+		arg.ID,
+		arg.ExpectedVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const updatePluginInstanceConfig = `-- name: UpdatePluginInstanceConfig :execrows

--- a/internal/db/queries/plugins.sql
+++ b/internal/db/queries/plugins.sql
@@ -1,6 +1,6 @@
 -- name: CreatePlugin :one
-INSERT INTO plugins (id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at)
-VALUES (:id, :name, :plugin_version, :manifest_snapshot, :trusted_pubkey, :status, 0, :created_at, :updated_at)
+INSERT INTO plugins (id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at)
+VALUES (:id, :name, :plugin_version, :manifest_snapshot, :trusted_pubkey, :status, :binary_path, 0, :created_at, :updated_at)
 RETURNING *;
 
 -- name: GetPluginByID :one
@@ -31,6 +31,13 @@ WHERE id = :id AND version = :expected_version;
 
 -- name: UpdatePluginStatus :execrows
 UPDATE plugins SET status = :status, version = version + 1, updated_at = :updated_at
+WHERE id = :id AND version = :expected_version;
+
+-- UpdatePluginBinaryPath persists the absolute path of the extracted plugin
+-- binary after a successful install. Called after UpdatePluginManifest so the
+-- CAS version passed here is the post-manifest-update version (#386).
+-- name: UpdatePluginBinaryPath :execrows
+UPDATE plugins SET binary_path = :binary_path, version = version + 1, updated_at = :updated_at
 WHERE id = :id AND version = :expected_version;
 
 -- name: CreatePluginInstance :one

--- a/internal/plugin/dispatch/channel_integration_test.go
+++ b/internal/plugin/dispatch/channel_integration_test.go
@@ -149,6 +149,9 @@ func (q *dispatchIntegFakeQuerier) ListPluginsByStatus(_ context.Context, _ stri
 func (q *dispatchIntegFakeQuerier) ListPluginInstancesByPlugin(_ context.Context, _ string) ([]db.PluginInstance, error) {
 	return nil, nil
 }
+func (q *dispatchIntegFakeQuerier) GetPluginByID(_ context.Context, _ string) (db.Plugin, error) {
+	return db.Plugin{}, nil
+}
 func (q *dispatchIntegFakeQuerier) GetPluginInstanceByID(_ context.Context, _ string) (db.PluginInstance, error) {
 	return db.PluginInstance{}, nil
 }

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -110,7 +110,7 @@ func (l *Loader) StartWatcher(ctx context.Context, q *db.Queries, dir string, pu
 		return nil
 	}
 
-	l.installer = loader.NewInstaller(&verifierAdapter{v: l.verifier}, q, publisher)
+	l.installer = loader.NewInstaller(&verifierAdapter{v: l.verifier}, q, publisher, dir)
 	// The watcher's callback type is func(context.Context, string) error, but
 	// Install now returns (string, error). The adapter discards the plugin ID —
 	// the watcher only needs to know whether install succeeded.

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -90,25 +90,51 @@ const (
 // Watcher; Install is called sequentially (ADR-003 serialization via the
 // watcher's fire channel).
 type Installer struct {
-	verifier  BundleVerifier
-	q         *db.Queries
-	publisher event.Publisher
+	verifier   BundleVerifier
+	q          *db.Queries
+	publisher  event.Publisher
+	pluginsDir string
+	// onInstalled is called after every successful install with the plugin ID.
+	// Nil-safe: if not set, no callback fires. Wire via OnInstalled().
+	onInstalled func(ctx context.Context, pluginID string)
 	// clock is injectable so tests can assert on timestamps without racing real time.
 	clock func() time.Time
 }
 
-// NewInstaller returns an Installer wired to the given verifier, query set, and
-// event publisher. publisher may be nil — state change events are skipped when nil.
-func NewInstaller(v BundleVerifier, q *db.Queries, publisher event.Publisher) *Installer {
-	return &Installer{verifier: v, q: q, publisher: publisher, clock: time.Now}
+// NewInstaller returns an Installer wired to the given verifier, query set,
+// event publisher, and plugins directory. publisher may be nil — state change
+// events are skipped when nil. pluginsDir is the root under which extracted
+// binaries are published to <pluginsDir>/installed/<plugin-name>/; pass an
+// empty string to disable binary publishing (useful for tests that don't need
+// real binaries on disk).
+func NewInstaller(v BundleVerifier, q *db.Queries, publisher event.Publisher, pluginsDir string) *Installer {
+	return &Installer{verifier: v, q: q, publisher: publisher, pluginsDir: pluginsDir, clock: time.Now}
+}
+
+// OnInstalled registers a callback that fires after every successful Install.
+// The callback receives the context and the newly-installed plugin ID.
+// This is how main.go wires the post-install subprocess spawn (issue #386):
+//
+//	installer.OnInstalled(func(ctx context.Context, pluginID string) {
+//	    mgr.StartByPluginID(ctx, pluginID)
+//	})
+//
+// Replaces any previously registered callback. Nil-safe: passing nil disables
+// the callback.
+func (in *Installer) OnInstalled(fn func(ctx context.Context, pluginID string)) {
+	in.onInstalled = fn
 }
 
 // Install runs the full install pipeline for the tarball at tarPath:
-//  1. Extract to a temp directory.
+//  1. Extract to a temp directory inside pluginsDir (same filesystem as the
+//     publish target, so os.Rename stays on-device — avoids EXDEV in Docker
+//     where /tmp and /plugins are on separate filesystems).
 //  2. Parse manifest.yaml.
 //  3. Verify the bundle signature.
-//  4. Snapshot into the plugins table with status=pending_review (new plugin),
-//     or update the manifest (version bump), or skip (same version).
+//  4. Snapshot into the plugins table. Commit branches (createPlugin,
+//     updatePlugin, updatePluginCosmetic) atomically publish the verified
+//     bundle to <pluginsDir>/installed/<name>/ inside the same code path.
+//     Rejection branches (pubkey-mismatch, material-change) never publish.
 //
 // Returns the plugin row ID on success. Returns ("", nil) when verification
 // fails — the audit event (not an error) is the operator-visible signal
@@ -118,7 +144,19 @@ func NewInstaller(v BundleVerifier, q *db.Queries, publisher event.Publisher) *I
 // pending_review|active|removed. A "signature_invalid" status is not stored
 // on the plugin row — #191 owns the per-instance health state machine.
 func (in *Installer) Install(ctx context.Context, tarPath string) (string, error) {
-	tmpDir, err := os.MkdirTemp("", "gleipnir-plugin-*")
+	// Create the extraction temp dir inside pluginsDir so the rename to the
+	// staging path stays on the same filesystem (avoids EXDEV on Docker where
+	// /tmp and /plugins are separate devices). Fall back to os.TempDir() when
+	// pluginsDir is empty (test-only path).
+	extractParent := os.TempDir()
+	if in.pluginsDir != "" {
+		if err := os.MkdirAll(in.pluginsDir, 0o755); err != nil {
+			return "", fmt.Errorf("ensure plugins dir: %w", err)
+		}
+		extractParent = in.pluginsDir
+	}
+
+	tmpDir, err := os.MkdirTemp(extractParent, "incoming-*")
 	if err != nil {
 		return "", fmt.Errorf("create temp dir: %w", err)
 	}
@@ -143,7 +181,88 @@ func (in *Installer) Install(ctx context.Context, tarPath string) (string, error
 		return in.recordSignatureInvalid(ctx, tarPath, m.Name, result.Err)
 	}
 
-	return in.upsertPlugin(ctx, m, manifestBytes, result)
+	// upsertPlugin handles commit vs. rejection branching. Only commit branches
+	// (createPlugin, updatePlugin, updatePluginCosmetic) publish the bundle and
+	// invoke onInstalled. Rejection branches (pubkey-mismatch, material-change)
+	// return committed=false so the disk and hook remain untouched.
+	pluginID, committed, err := in.upsertPlugin(ctx, m, manifestBytes, result, tmpDir)
+	if err != nil {
+		return "", err
+	}
+
+	// Notify the post-install hook (e.g. to spawn the subprocess) only when the
+	// install actually committed a new DB row or manifest update. Rejection paths
+	// (pubkey-mismatch, material-change) must not trigger a spawn.
+	if committed && pluginID != "" && in.onInstalled != nil {
+		in.onInstalled(ctx, pluginID)
+	}
+	return pluginID, nil
+}
+
+// publishBundle moves the extracted and verified bundle from tmpDir to a stable
+// location under <pluginsDir>/installed/<name>/ using a rename swap-aside
+// sequence so the directory is replaced atomically from the perspective of
+// concurrent readers:
+//
+//  1. Rename tmpDir → <dest>.new  (moves the whole tree in one syscall).
+//  2. If <dest> exists: rename <dest> → <dest>.old (displaces the predecessor).
+//  3. Rename <dest>.new → <dest>   (publishes the new bundle).
+//  4. RemoveAll <dest>.old          (best-effort cleanup of the predecessor).
+//
+// Returns the absolute path of the published binary (<dest>/<name>).
+//
+// The existing "defer os.RemoveAll(tmpDir)" in Install is a no-op once
+// tmpDir has been renamed away — os.RemoveAll on a missing path returns nil.
+//
+// On rename failure mid-sequence this function attempts to roll back by
+// renaming <dest>.old back to <dest>, then returns an error.
+func (in *Installer) publishBundle(ctx context.Context, tmpDir, name string) (string, error) {
+	installedRoot := filepath.Join(in.pluginsDir, "installed")
+	if err := os.MkdirAll(installedRoot, 0o755); err != nil {
+		return "", fmt.Errorf("create installed dir: %w", err)
+	}
+
+	dest := filepath.Join(installedRoot, name)
+	staging := dest + ".new"
+	old := dest + ".old"
+
+	// Step 1: move tmpDir → staging. After this, tmpDir no longer exists so
+	// the deferred RemoveAll in Install is a harmless no-op.
+	if err := os.Rename(tmpDir, staging); err != nil {
+		return "", fmt.Errorf("move bundle to staging: %w", err)
+	}
+
+	// Step 2: displace existing dest if present.
+	displaced := false
+	if _, err := os.Lstat(dest); err == nil {
+		if renameErr := os.Rename(dest, old); renameErr != nil {
+			// Roll back: restore staging to tmpDir so Install's defer can clean it.
+			_ = os.Rename(staging, tmpDir)
+			return "", fmt.Errorf("displace previous bundle: %w", renameErr)
+		}
+		displaced = true
+	}
+
+	// Step 3: publish staging → dest.
+	if err := os.Rename(staging, dest); err != nil {
+		if displaced {
+			// Roll back: restore the old bundle so the plugin keeps running.
+			_ = os.Rename(old, dest)
+		}
+		_ = os.Rename(staging, tmpDir)
+		return "", fmt.Errorf("publish bundle: %w", err)
+	}
+
+	// Step 4: clean up the displaced predecessor. Best-effort — log on error but
+	// don't fail the install; the old binary is no longer referenced.
+	if displaced {
+		if err := os.RemoveAll(old); err != nil {
+			slog.WarnContext(ctx, "publishBundle: could not remove old bundle dir",
+				"path", old, "err", err)
+		}
+	}
+
+	return filepath.Join(dest, name), nil
 }
 
 // readManifest parses the manifest.yaml inside the extracted bundle directory.
@@ -195,22 +314,40 @@ func (in *Installer) recordSignatureInvalid(ctx context.Context, tarPath, plugin
 }
 
 // upsertPlugin creates or updates the plugin row and emits an audit event.
-// Returns the plugin row ID so the install handler can surface it to the caller.
-func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, manifestBytes []byte, result VerifyResult) (string, error) {
+// tmpDir is the directory where the verified bundle was extracted; commit
+// branches (createPlugin, updatePlugin, updatePluginCosmetic) call publishBundle
+// to move it to its permanent location and record the path in the DB so
+// Manager.StartAllActive can re-spawn the subprocess on server restart.
+// Rejection branches (pubkey-mismatch, material-change) never publish and
+// return committed=false.
+// Returns (pluginID, committed, error).
+func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, manifestBytes []byte, result VerifyResult, tmpDir string) (string, bool, error) {
 	existing, err := in.q.GetPluginByName(ctx, m.Name)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("get plugin %q: %w", m.Name, err)
+		return "", false, fmt.Errorf("get plugin %q: %w", m.Name, err)
 	}
 
 	nowStr := in.nowStr()
 
 	if errors.Is(err, sql.ErrNoRows) {
-		return in.createPlugin(ctx, m, manifestBytes, result, nowStr)
+		id, commitErr := in.createPlugin(ctx, m, manifestBytes, result, tmpDir, nowStr)
+		return id, commitErr == nil && id != "", commitErr
 	}
 
 	if existing.PluginVersion == m.Version {
-		// Same version already recorded — idempotent no-op (debounce safety net).
-		return existing.ID, nil
+		// Same version already recorded — idempotent re-install (debounce safety net).
+		// If the row has no binary_path yet (legacy row from before #386), backfill it
+		// so a re-deploy of the same tarball repairs the gap without a version bump.
+		if in.pluginsDir != "" && (existing.BinaryPath == nil || *existing.BinaryPath == "") {
+			publishedPath, pubErr := in.publishBundle(ctx, tmpDir, m.Name)
+			if pubErr != nil {
+				return "", false, fmt.Errorf("publish bundle for %q (backfill): %w", m.Name, pubErr)
+			}
+			if err := in.updateBinaryPath(ctx, existing.ID, existing.Version, &publishedPath, nowStr); err != nil {
+				return "", false, fmt.Errorf("backfill binary_path for %q: %w", m.Name, err)
+			}
+		}
+		return existing.ID, false, nil
 	}
 
 	// TOFU pubkey trust check: only applies to verified (signed) bundles.
@@ -225,21 +362,22 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 				ExpectedVersion: existing.Version,
 			})
 			if updateErr != nil {
-				return "", fmt.Errorf("capture trusted pubkey for %q (delayed TOFU): %w", m.Name, updateErr)
+				return "", false, fmt.Errorf("capture trusted pubkey for %q (delayed TOFU): %w", m.Name, updateErr)
 			}
 			if rows == 0 {
-				return "", fmt.Errorf("capture trusted pubkey for %q: CAS conflict (version mismatch)", m.Name)
+				return "", false, fmt.Errorf("capture trusted pubkey for %q: CAS conflict (version mismatch)", m.Name)
 			}
 			// Re-read so updatePlugin sees the bumped version.
 			existing, err = in.q.GetPluginByName(ctx, m.Name)
 			if err != nil {
-				return "", fmt.Errorf("re-read plugin %q after TOFU capture: %w", m.Name, err)
+				return "", false, fmt.Errorf("re-read plugin %q after TOFU capture: %w", m.Name, err)
 			}
 		} else if !bytes.Equal(result.Pubkey, []byte(existing.TrustedPubkey)) {
 			// Key mismatch: a different signing key was used for this update.
 			// Block the update and transition all instances to pending_key_approval
-			// so admins are alerted. Do not call updatePlugin.
-			return in.handlePubkeyMismatch(ctx, existing, result, m.Version, nowStr)
+			// so admins are alerted. Do not publish the bundle.
+			id, mismatchErr := in.handlePubkeyMismatch(ctx, existing, result, m.Version, nowStr)
+			return id, false, mismatchErr
 		}
 	}
 
@@ -248,17 +386,22 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 	// Cosmetic-only changes update the snapshot silently.
 	var oldManifest manifest.Manifest
 	if parseErr := manifest.Unmarshal([]byte(existing.ManifestSnapshot), &oldManifest); parseErr != nil {
-		return "", fmt.Errorf("parse stored manifest snapshot for %q: %w", m.Name, parseErr)
+		return "", false, fmt.Errorf("parse stored manifest snapshot for %q: %w", m.Name, parseErr)
 	}
 	changes := pluginmanifest.Diff(&oldManifest, m)
 	if pluginmanifest.HasMaterial(changes) {
-		return in.handleManifestMaterialChange(ctx, existing, &oldManifest, m, manifestBytes, changes, nowStr)
+		// Rejected path: do not publish the bundle or update binary_path.
+		// The running generation continues using the previously-verified binary.
+		id, matErr := in.handleManifestMaterialChange(ctx, existing, &oldManifest, m, manifestBytes, changes, nowStr)
+		return id, false, matErr
 	}
 	if len(changes) > 0 {
-		return in.updatePluginCosmetic(ctx, existing, m, manifestBytes, changes, nowStr)
+		id, cosErr := in.updatePluginCosmetic(ctx, existing, m, manifestBytes, changes, tmpDir, nowStr)
+		return id, cosErr == nil && id != "", cosErr
 	}
 
-	return in.updatePlugin(ctx, existing, m, manifestBytes, nowStr)
+	id, upErr := in.updatePlugin(ctx, existing, m, manifestBytes, tmpDir, nowStr)
+	return id, upErr == nil && id != "", upErr
 }
 
 // handlePubkeyMismatch transitions all instances of the plugin to
@@ -361,8 +504,20 @@ func (in *Installer) recordAuditEvent(ctx context.Context, eventType, severity, 
 
 // updatePluginCosmetic updates the manifest snapshot for a cosmetic-only change,
 // preserving the current plugin status so an already-active plugin is not
-// regressed to pending_review for a description tweak.
-func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, changes []pluginmanifest.Change, nowStr string) (string, error) {
+// regressed to pending_review for a description tweak. Publishes the verified
+// bundle to disk and updates binary_path after the manifest CAS succeeds.
+func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, changes []pluginmanifest.Change, tmpDir string, nowStr string) (string, error) {
+	// Publish the verified bundle before touching the DB so the subprocess can
+	// be re-spawned with the correct binary on the next restart.
+	var binaryPathPtr *string
+	if in.pluginsDir != "" {
+		publishedPath, pubErr := in.publishBundle(ctx, tmpDir, m.Name)
+		if pubErr != nil {
+			return "", fmt.Errorf("publish bundle for %q (cosmetic): %w", m.Name, pubErr)
+		}
+		binaryPathPtr = &publishedPath
+	}
+
 	rows, err := in.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
 		ManifestSnapshot: string(manifestBytes),
 		PluginVersion:    m.Version,
@@ -376,6 +531,18 @@ func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugi
 	}
 	if rows == 0 {
 		return "", fmt.Errorf("update plugin %q manifest (cosmetic): CAS conflict (version mismatch)", m.Name)
+	}
+
+	// The manifest CAS bumped the version; re-read to get the new version for
+	// the binary_path CAS that follows.
+	if binaryPathPtr != nil {
+		updated, rereadErr := in.q.GetPluginByName(ctx, m.Name)
+		if rereadErr != nil {
+			return "", fmt.Errorf("re-read plugin %q after cosmetic update: %w", m.Name, rereadErr)
+		}
+		if err := in.updateBinaryPath(ctx, existing.ID, updated.Version, binaryPathPtr, nowStr); err != nil {
+			return "", fmt.Errorf("update binary_path for %q (cosmetic): %w", m.Name, err)
+		}
 	}
 
 	if err := in.recordAuditEvent(ctx, auditManifestCosmeticChange, severityInfo, nowStr, map[string]any{
@@ -407,11 +574,23 @@ func pubkeyFingerprint(pubkeyBytes []byte) string {
 }
 
 // createPlugin inserts a new plugin row with status=pending_review.
+// Publishes the verified bundle to disk first, then stores the binary_path
+// in the DB so Manager.StartAllActive can re-spawn the subprocess on server
+// restart without re-extracting the tarball.
 //
 // TODO(plugin): wrap createPlugin + audit insert in a single transaction once
 // Installer takes *sql.DB instead of *db.Queries. Today an audit-insert failure
 // leaves an orphan plugins row; same-version idempotency masks the retry.
-func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, manifestBytes []byte, result VerifyResult, nowStr string) (string, error) {
+func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, manifestBytes []byte, result VerifyResult, tmpDir string, nowStr string) (string, error) {
+	var binaryPathPtr *string
+	if in.pluginsDir != "" {
+		publishedPath, pubErr := in.publishBundle(ctx, tmpDir, m.Name)
+		if pubErr != nil {
+			return "", fmt.Errorf("publish bundle for %q: %w", m.Name, pubErr)
+		}
+		binaryPathPtr = &publishedPath
+	}
+
 	pluginID := model.NewULID()
 	_, err := in.q.CreatePlugin(ctx, db.CreatePluginParams{
 		ID:               pluginID,
@@ -420,6 +599,7 @@ func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, man
 		ManifestSnapshot: string(manifestBytes),
 		TrustedPubkey:    string(result.Pubkey),
 		Status:           statusPendingReview,
+		BinaryPath:       binaryPathPtr,
 		CreatedAt:        nowStr,
 		UpdatedAt:        nowStr,
 	})
@@ -438,13 +618,25 @@ func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, man
 }
 
 // updatePlugin updates the manifest snapshot on an existing plugin row when the
-// version has changed. Uses the CAS guard (ADR-038).
+// version has changed. Publishes the verified bundle to disk first, then updates
+// binary_path after the manifest CAS succeeds. Uses the CAS guard (ADR-038).
 //
 // TODO(plugin): wrap updatePlugin + audit insert in a single transaction once
 // Installer takes *sql.DB instead of *db.Queries. Today an audit-insert failure
 // leaves the plugins row updated but the event unrecorded; same-version
 // idempotency masks the retry.
-func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, nowStr string) (string, error) {
+func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, tmpDir string, nowStr string) (string, error) {
+	// Publish the verified bundle before touching the DB so the subprocess can
+	// be re-spawned with the correct binary on the next restart.
+	var binaryPathPtr *string
+	if in.pluginsDir != "" {
+		publishedPath, pubErr := in.publishBundle(ctx, tmpDir, m.Name)
+		if pubErr != nil {
+			return "", fmt.Errorf("publish bundle for %q: %w", m.Name, pubErr)
+		}
+		binaryPathPtr = &publishedPath
+	}
+
 	rows, err := in.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
 		ManifestSnapshot: string(manifestBytes),
 		PluginVersion:    m.Version,
@@ -462,6 +654,18 @@ func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *ma
 		return "", fmt.Errorf("update plugin %q: CAS conflict (version mismatch)", m.Name)
 	}
 
+	// The manifest CAS bumped the version; re-read to get the new version for
+	// the binary_path CAS that follows.
+	if binaryPathPtr != nil {
+		updated, rereadErr := in.q.GetPluginByName(ctx, m.Name)
+		if rereadErr != nil {
+			return "", fmt.Errorf("re-read plugin %q after manifest update: %w", m.Name, rereadErr)
+		}
+		if err := in.updateBinaryPath(ctx, existing.ID, updated.Version, binaryPathPtr, nowStr); err != nil {
+			return "", fmt.Errorf("update binary_path for %q: %w", m.Name, err)
+		}
+	}
+
 	if err := in.recordAuditEvent(ctx, auditUpdatePending, severityInfo, nowStr, map[string]any{
 		"name":        m.Name,
 		"old_version": existing.PluginVersion,
@@ -470,6 +674,27 @@ func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *ma
 		return "", fmt.Errorf("record plugin_update_pending audit: %w", err)
 	}
 	return existing.ID, nil
+}
+
+// updateBinaryPath writes the published binary path to the plugins row using
+// a CAS guard. A rows==0 result is a non-fatal CAS conflict — the manifest was
+// already bumped by another writer and the binary_path will be set on the next
+// install attempt. We log and continue rather than failing the overall install.
+func (in *Installer) updateBinaryPath(ctx context.Context, pluginID string, version int64, binaryPathPtr *string, nowStr string) error {
+	rows, err := in.q.UpdatePluginBinaryPath(ctx, db.UpdatePluginBinaryPathParams{
+		BinaryPath:      binaryPathPtr,
+		UpdatedAt:       nowStr,
+		ID:              pluginID,
+		ExpectedVersion: version,
+	})
+	if err != nil {
+		return fmt.Errorf("db update binary_path: %w", err)
+	}
+	if rows == 0 {
+		slog.WarnContext(ctx, "updateBinaryPath: CAS conflict; binary_path will be set on next install",
+			"plugin_id", pluginID)
+	}
+	return nil
 }
 
 // nowStr returns the current time as an RFC3339Nano string via the injectable clock.

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -234,10 +234,12 @@ func writeTarball(t *testing.T, path string, entries []tarEntry) {
 }
 
 // newTestInstaller builds an Installer with a fixed clock for timestamp assertions.
+// pluginsDir is typically t.TempDir() for tests that assert on binary publishing,
+// or "" for tests that only care about DB state.
 func newTestInstaller(t *testing.T, q *db.Queries, allowUnsigned bool) *Installer {
 	t.Helper()
 	v := &realVerifier{allowUnsigned: allowUnsigned}
-	inst := NewInstaller(v, q, nil)
+	inst := NewInstaller(v, q, nil, t.TempDir())
 	inst.clock = func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
 	return inst
 }
@@ -722,7 +724,7 @@ func TestInstall_RejectedWithNilErr_NoPanic(t *testing.T) {
 	// Build a valid signed tarball so we get past manifest parsing.
 	tarPath, _ := signedPluginTarball(t, "nil-err-plugin", "1.0.0")
 
-	inst := &Installer{verifier: nilErrVerifier{}, q: q, publisher: nil, clock: time.Now}
+	inst := &Installer{verifier: nilErrVerifier{}, q: q, publisher: nil, pluginsDir: t.TempDir(), clock: time.Now}
 
 	// Must not panic; Install should record an audit event and return nil.
 	if _, err := inst.Install(context.Background(), tarPath); err != nil {
@@ -1106,5 +1108,399 @@ func TestInstall_HotReload_NoChange_NoOp(t *testing.T) {
 	}
 	if len(events) > 0 {
 		t.Errorf("got %d material-change events for version-only bump, want 0", len(events))
+	}
+}
+
+// ── Binary-path persistence tests (#386) ─────────────────────────────────────
+
+// TestInstall_PersistsBinaryPath verifies that a fresh install writes
+// binary_path = <pluginsDir>/installed/<name>/<name> to the plugins row and
+// that the file is present on disk.
+func TestInstall_PersistsBinaryPath(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath, _ := signedPluginTarball(t, "path-plugin", "1.0.0")
+
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "path-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+
+	if row.BinaryPath == nil || *row.BinaryPath == "" {
+		t.Fatal("binary_path: want non-empty after first install, got nil/empty")
+	}
+
+	wantSuffix := filepath.Join("installed", "path-plugin", "path-plugin")
+	if !strings.HasSuffix(*row.BinaryPath, wantSuffix) {
+		t.Errorf("binary_path = %q, want suffix %q", *row.BinaryPath, wantSuffix)
+	}
+
+	if _, err := os.Stat(*row.BinaryPath); err != nil {
+		t.Errorf("binary at persisted path not accessible: %v", err)
+	}
+}
+
+// TestInstall_VersionBumpReplacesBinary verifies that installing a version bump
+// over an existing plugin replaces the binary under installed/ and updates
+// binary_path in the DB to the new file.
+func TestInstall_VersionBumpReplacesBinary(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	buildTar := func(t *testing.T, version string, binaryContent []byte) string {
+		t.Helper()
+		manifestBytes := []byte("schema_version: v1\nname: bump2-plugin\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+		payload := signing.PluginPayload(binaryContent, manifestBytes)
+		sig, signErr := signing.Sign(sk.SecretKey, sk.KeyID, payload, "trusted comment")
+		if signErr != nil {
+			t.Fatalf("sign: %v", signErr)
+		}
+		sigBytes := signing.MarshalSignature(sig, "test sig")
+		tarPath := filepath.Join(t.TempDir(), "bump2-plugin-"+version+".tar.gz")
+		writeTarball(t, tarPath, []tarEntry{
+			{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+			{name: "bump2-plugin", content: binaryContent, mode: 0o755},
+			{name: "signing.pub", content: pubkeyBytes, mode: 0o644},
+			{name: "bump2-plugin.minisig", content: sigBytes, mode: 0o644},
+		})
+		return tarPath
+	}
+
+	tarPath1 := buildTar(t, "1.0.0", []byte("binary content v1"))
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	tarPath2 := buildTar(t, "2.0.0", []byte("binary content v2"))
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2: %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "bump2-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v2: %v", err)
+	}
+
+	if row.BinaryPath == nil {
+		t.Fatal("binary_path: nil after version bump")
+	}
+
+	// The binary at the persisted path should contain v2 content.
+	content, readErr := os.ReadFile(*row.BinaryPath)
+	if readErr != nil {
+		t.Fatalf("read binary at persisted path: %v", readErr)
+	}
+	if string(content) != "binary content v2" {
+		t.Errorf("binary content = %q, want v2", string(content))
+	}
+
+	// The .old directory must be cleaned up.
+	oldDir := filepath.Join(inst.pluginsDir, "installed", "bump2-plugin.old")
+	if _, err := os.Stat(oldDir); err == nil {
+		t.Error("expected .old dir to be removed after version bump, but it exists")
+	}
+}
+
+// TestInstall_RejectedBundleDoesNotPersist verifies that a bad-signature install
+// does not create any directory under <pluginsDir>/installed/.
+func TestInstall_RejectedBundleDoesNotPersist(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath := badSignatureTarball(t, "reject-plugin", "1.0.0")
+
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install (bad sig): %v", err)
+	}
+
+	installedDir := filepath.Join(inst.pluginsDir, "installed", "reject-plugin")
+	if _, err := os.Stat(installedDir); err == nil {
+		t.Error("expected no installed dir for rejected bundle, but it exists")
+	}
+}
+
+// TestInstall_LegacyRowBackfill verifies that installing the same version over a
+// row that has binary_path=NULL backfills the column without a version bump.
+func TestInstall_LegacyRowBackfill(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath, _ := signedPluginTarball(t, "backfill-plugin", "1.0.0")
+
+	// First install to create the row.
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	// Manually clear binary_path to simulate a legacy row from before #386.
+	row, err := q.GetPluginByName(context.Background(), "backfill-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if _, err := q.UpdatePluginBinaryPath(context.Background(), db.UpdatePluginBinaryPathParams{
+		BinaryPath:      nil,
+		UpdatedAt:       row.UpdatedAt,
+		ID:              row.ID,
+		ExpectedVersion: row.Version,
+	}); err != nil {
+		t.Fatalf("clear binary_path: %v", err)
+	}
+
+	// Re-install the same version — should backfill binary_path.
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install (same version, backfill): %v", err)
+	}
+
+	row2, err := q.GetPluginByName(context.Background(), "backfill-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after backfill: %v", err)
+	}
+
+	if row2.BinaryPath == nil || *row2.BinaryPath == "" {
+		t.Error("binary_path: still nil after backfill re-install, expected non-empty")
+	}
+}
+
+// TestInstall_OnInstalled_CalledAfterSuccessfulInstall verifies that the
+// OnInstalled callback fires with the correct plugin ID after a successful install
+// and does not fire for rejected bundles.
+func TestInstall_OnInstalled_CalledAfterSuccessfulInstall(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	var calledWith []string
+	inst.OnInstalled(func(_ context.Context, pluginID string) {
+		calledWith = append(calledWith, pluginID)
+	})
+
+	tarPath, _ := signedPluginTarball(t, "hook-plugin", "1.0.0")
+
+	pluginID, err := inst.Install(context.Background(), tarPath)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if len(calledWith) != 1 {
+		t.Fatalf("OnInstalled called %d times, want 1", len(calledWith))
+	}
+	if calledWith[0] != pluginID {
+		t.Errorf("OnInstalled plugin ID = %q, want %q", calledWith[0], pluginID)
+	}
+
+	// Rejected install must not fire the callback.
+	badTarPath := badSignatureTarball(t, "hook-plugin", "2.0.0")
+	if _, err := inst.Install(context.Background(), badTarPath); err != nil {
+		t.Fatalf("Install (bad sig): %v", err)
+	}
+	if len(calledWith) != 1 {
+		t.Errorf("OnInstalled called %d times after rejected install, want 1 (no new call)", len(calledWith))
+	}
+}
+
+// TestInstall_PubkeyMismatch_DoesNotOverwriteBinary is a regression test for the
+// TOFU bypass described in cycle-1 review feedback: a pubkey-mismatch install must
+// NOT overwrite the on-disk binary or update binary_path in the DB. Before the fix,
+// publishBundle ran unconditionally before upsertPlugin, so the file at the
+// previously-verified binary_path was silently replaced by the untrusted binary.
+// After a server restart, StartAllActive would spawn the unaccepted binary.
+func TestInstall_PubkeyMismatch_DoesNotOverwriteBinary(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	// Install v1 with key A.
+	tarPath1, _ := signedPluginTarball(t, "tofu-guard-plugin", "1.0.0")
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	row1, err := q.GetPluginByName(context.Background(), "tofu-guard-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v1: %v", err)
+	}
+	if row1.BinaryPath == nil {
+		t.Fatal("binary_path nil after v1 install")
+	}
+	v1Path := *row1.BinaryPath
+	v1Content, err := os.ReadFile(v1Path)
+	if err != nil {
+		t.Fatalf("read v1 binary: %v", err)
+	}
+
+	// Attempt v2 signed by a different key (signedPluginTarball generates a fresh keypair each call).
+	tarPath2, _ := signedPluginTarball(t, "tofu-guard-plugin", "2.0.0")
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (different key): %v", err)
+	}
+
+	row2, err := q.GetPluginByName(context.Background(), "tofu-guard-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v2 mismatch: %v", err)
+	}
+
+	// binary_path must be unchanged.
+	if row2.BinaryPath == nil || *row2.BinaryPath != v1Path {
+		got := "<nil>"
+		if row2.BinaryPath != nil {
+			got = *row2.BinaryPath
+		}
+		t.Errorf("binary_path = %q after pubkey-mismatch install, want %q (unchanged)", got, v1Path)
+	}
+
+	// The file at the persisted path must still contain v1 content.
+	afterContent, err := os.ReadFile(v1Path)
+	if err != nil {
+		t.Fatalf("read binary after mismatch install: %v", err)
+	}
+	if string(afterContent) != string(v1Content) {
+		t.Error("binary content changed after pubkey-mismatch install; TOFU bypass regression")
+	}
+
+	// The installed dir must not contain a .new or .old artefact (no partial publish).
+	installedDir := filepath.Join(inst.pluginsDir, "installed", "tofu-guard-plugin")
+	for _, suffix := range []string{".new", ".old"} {
+		if _, statErr := os.Stat(installedDir + suffix); statErr == nil {
+			t.Errorf("unexpected artefact %s after pubkey-mismatch install", installedDir+suffix)
+		}
+	}
+}
+
+// TestInstall_MaterialChange_DoesNotOverwriteBinary verifies that a material-change
+// install does not overwrite the on-disk binary or update binary_path in the DB.
+// Mirrors TestInstall_PubkeyMismatch_DoesNotOverwriteBinary for the material-change path.
+func TestInstall_MaterialChange_DoesNotOverwriteBinary(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	buildTar := func(t *testing.T, version string, manifestContent, binaryContent []byte) string {
+		t.Helper()
+		return buildSignedTarWithContent(t, "matguard-plugin", manifestContent, binaryContent, pubkeyBytes, sk.SecretKey, sk.KeyID)
+	}
+
+	v1Manifest := []byte("schema_version: v1\nname: matguard-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildTar(t, "1.0.0", v1Manifest, []byte("binary content v1"))
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	row1, err := q.GetPluginByName(context.Background(), "matguard-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v1: %v", err)
+	}
+	if row1.BinaryPath == nil {
+		t.Fatal("binary_path nil after v1 install")
+	}
+	v1Path := *row1.BinaryPath
+
+	// v2 adds a new tool — material change that must be blocked.
+	v2Manifest := []byte("schema_version: v1\nname: matguard-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\ntools:\n- name: my_tool\n  description: new tool\n")
+	tarPath2 := buildTar(t, "2.0.0", v2Manifest, []byte("binary content v2"))
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (material change): %v", err)
+	}
+
+	row2, err := q.GetPluginByName(context.Background(), "matguard-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v2: %v", err)
+	}
+
+	// binary_path must be unchanged.
+	if row2.BinaryPath == nil || *row2.BinaryPath != v1Path {
+		got := "<nil>"
+		if row2.BinaryPath != nil {
+			got = *row2.BinaryPath
+		}
+		t.Errorf("binary_path = %q after material-change install, want %q (unchanged)", got, v1Path)
+	}
+
+	// The file at the persisted path must still contain v1 content.
+	afterContent, err := os.ReadFile(v1Path)
+	if err != nil {
+		t.Fatalf("read binary after material-change install: %v", err)
+	}
+	if string(afterContent) != "binary content v1" {
+		t.Errorf("binary content = %q after material-change install, want v1 content", string(afterContent))
+	}
+}
+
+// TestInstall_OnInstalled_NotCalledForPubkeyMismatch verifies that the OnInstalled
+// callback does not fire when an install is blocked by a pubkey mismatch.
+// This is the hook counterpart of TestInstall_PubkeyMismatch_DoesNotOverwriteBinary.
+func TestInstall_OnInstalled_NotCalledForPubkeyMismatch(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	callCount := 0
+	inst.OnInstalled(func(_ context.Context, _ string) { callCount++ })
+
+	// Install v1 — callback fires once.
+	tarPath1, _ := signedPluginTarball(t, "hook-mismatch-plugin", "1.0.0")
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("after v1 install: callback count = %d, want 1", callCount)
+	}
+
+	// Install v2 with a different key — pubkey mismatch, callback must NOT fire.
+	tarPath2, _ := signedPluginTarball(t, "hook-mismatch-plugin", "2.0.0")
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (different key): %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("after pubkey-mismatch install: callback count = %d, want 1 (no new call)", callCount)
+	}
+}
+
+// TestInstall_TmpDirUnderPluginsDir verifies that the extraction temp directory is
+// created inside pluginsDir (not os.TempDir()), ensuring the rename to the staging
+// path stays on the same filesystem and avoids EXDEV on Docker where /tmp and
+// /plugins are separate devices.
+func TestInstall_TmpDirUnderPluginsDir(t *testing.T) {
+	q := openTestDB(t)
+	pluginsDir := t.TempDir()
+	v := &realVerifier{allowUnsigned: false}
+	inst := NewInstaller(v, q, nil, pluginsDir)
+	inst.clock = func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
+
+	tarPath, _ := signedPluginTarball(t, "fsdev-plugin", "1.0.0")
+
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// The staging path used by publishBundle is <pluginsDir>/installed/<name>.new —
+	// verify it was cleaned up (renamed to dest), confirming the rename stayed on-device.
+	stagingPath := filepath.Join(pluginsDir, "installed", "fsdev-plugin.new")
+	if _, err := os.Stat(stagingPath); err == nil {
+		t.Error("staging path still exists after successful install; rename may have failed")
+	}
+
+	// The final published binary must be under pluginsDir, not under os.TempDir().
+	row, err := q.GetPluginByName(context.Background(), "fsdev-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if row.BinaryPath == nil {
+		t.Fatal("binary_path: nil after install")
+	}
+	if !strings.HasPrefix(*row.BinaryPath, pluginsDir) {
+		t.Errorf("binary_path = %q; want prefix %q (must be under pluginsDir, not /tmp)", *row.BinaryPath, pluginsDir)
 	}
 }

--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -42,6 +42,7 @@ var blockedHealthStates = map[model.PluginHealthState]bool{
 type querier interface {
 	ListPluginsByStatus(ctx context.Context, status string) ([]db.Plugin, error)
 	ListPluginInstancesByPlugin(ctx context.Context, pluginID string) ([]db.PluginInstance, error)
+	GetPluginByID(ctx context.Context, id string) (db.Plugin, error)
 	GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error)
 	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
 }
@@ -342,23 +343,78 @@ func (m *Manager) StartAllActive(ctx context.Context) error {
 			continue
 		}
 
+		if p.BinaryPath == nil || *p.BinaryPath == "" {
+			m.logger().Warn("plugin row has no binary_path; skipping spawn (likely a legacy row — redeploy the tarball to repair)",
+				"plugin_id", p.ID)
+			continue
+		}
+
 		for _, inst := range instances {
-			// BinaryPath is not stored in the DB; the loader writes the extracted
-			// binary to a well-known path under PluginsDir. Manager expects that
-			// path to be resolved by the caller. For StartAllActive the binary path
-			// is not yet available (#291 scope: the watcher and installer resolve
-			// it; we log and skip for now).
-			//
-			// TODO #291 follow-up: pass binaryPath through Start when the installer
-			// exposes a DB-persisted binary path column.
-			_ = inst
-			m.logger().Warn("StartAllActive: subprocess spawn not yet wired for persisted instances",
-				"plugin_id", p.ID, "instance_id", inst.ID,
-				"note", "binary path column pending installer work")
+			if err := m.Start(ctx, p, inst, *p.BinaryPath); err != nil {
+				m.logger().Warn("StartAllActive: failed to start instance",
+					"plugin_id", p.ID, "instance_id", inst.ID, "err", err)
+			}
 		}
 	}
 
 	return nil
+}
+
+// StartByPluginID reads the plugin row for pluginID, lists its instances, and
+// calls Start for each instance that is not already running and not in a blocked
+// health state. Per-instance failures are logged at Warn and do not abort the
+// loop — one bad instance must not block others.
+//
+// Returns an error only when the DB lookup fails. Per-instance start errors are
+// considered transient and are not surfaced to the caller.
+func (m *Manager) StartByPluginID(ctx context.Context, pluginID string) error {
+	p, err := m.cfg.Querier.GetPluginByID(ctx, pluginID)
+	if err != nil {
+		return fmt.Errorf("manager: get plugin %s: %w", pluginID, err)
+	}
+
+	if p.BinaryPath == nil || *p.BinaryPath == "" {
+		m.logger().Warn("StartByPluginID: plugin row has no binary_path; cannot spawn",
+			"plugin_id", pluginID)
+		return nil
+	}
+
+	instances, err := m.cfg.Querier.ListPluginInstancesByPlugin(ctx, pluginID)
+	if err != nil {
+		return fmt.Errorf("manager: list instances for plugin %s: %w", pluginID, err)
+	}
+
+	for _, inst := range instances {
+		if err := m.Start(ctx, p, inst, *p.BinaryPath); err != nil {
+			m.logger().Warn("StartByPluginID: failed to start instance",
+				"plugin_id", pluginID, "instance_id", inst.ID, "err", err)
+		}
+	}
+	return nil
+}
+
+// StopByPluginID stops all running instances that belong to pluginID. It takes
+// a snapshot of the running instances under the mutex so the loop does not hold
+// the lock while calling Stop (which blocks on subprocess teardown). Per-instance
+// stop errors are logged and joined; a partial failure does not prevent remaining
+// instances from being stopped.
+func (m *Manager) StopByPluginID(ctx context.Context, pluginID string) error {
+	m.mu.Lock()
+	var toStop []*Instance
+	for _, inst := range m.instances {
+		if inst.PluginID() == pluginID {
+			toStop = append(toStop, inst)
+		}
+	}
+	m.mu.Unlock()
+
+	var errs []error
+	for _, inst := range toStop {
+		if err := m.Stop(ctx, inst.InstanceID()); err != nil {
+			errs = append(errs, fmt.Errorf("instance %s: %w", inst.InstanceID(), err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // Lookup returns the running Instance for instanceID, or nil if no subprocess

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -42,6 +42,15 @@ func (q *fakeQuerier) ListPluginInstancesByPlugin(_ context.Context, pluginID st
 	return q.instances[pluginID], nil
 }
 
+func (q *fakeQuerier) GetPluginByID(_ context.Context, id string) (db.Plugin, error) {
+	for _, p := range q.plugins {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return db.Plugin{}, errors.New("not found")
+}
+
 func (q *fakeQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
 	for _, instances := range q.instances {
 		for _, inst := range instances {
@@ -207,28 +216,171 @@ func TestManager_StopMissingID(t *testing.T) {
 	}
 }
 
-// TestManager_StartAllActive_ContinuesPastErrors verifies that StartAllActive
-// returns nil even when all instances have no binary path available (which is
-// the current state for #291 — binary path is not yet DB-persisted).
-func TestManager_StartAllActive_ContinuesPastErrors(t *testing.T) {
+// TestManager_StartAllActive verifies two cases:
+//  1. BinaryPath == nil → log-and-skip; processStarter is never called.
+//  2. BinaryPath is set → processStarter is invoked once with the correct path.
+func TestManager_StartAllActive(t *testing.T) {
+	binaryPath := "/x/y/binary"
+
+	cases := []struct {
+		name          string
+		binaryPath    *string
+		wantStarted   bool
+		wantStartPath string
+	}{
+		{
+			name:        "nil binary_path skips spawn",
+			binaryPath:  nil,
+			wantStarted: false,
+		},
+		{
+			name:          "populated binary_path spawns instance",
+			binaryPath:    &binaryPath,
+			wantStarted:   true,
+			wantStartPath: binaryPath,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &fakeQuerier{
+				plugins: []db.Plugin{
+					{ID: "p1", Status: "active", BinaryPath: tc.binaryPath},
+				},
+				instances: map[string][]db.PluginInstance{
+					"p1": {{ID: "i1", PluginID: "p1", InstanceName: "i1", HealthState: "healthy"}},
+				},
+			}
+			reg := identity.New()
+
+			var startedPath string
+			var startCalled bool
+			mgr := process.NewManager(process.ManagerConfig{
+				Querier:        q,
+				IdentityIssuer: reg,
+				TestProcessStarter: func(_ context.Context, cfg process.Config) (*process.Instance, error) {
+					startCalled = true
+					startedPath = cfg.BinaryPath
+					// Return an error so we don't need a real subprocess.
+					return nil, errors.New("stub: no subprocess needed")
+				},
+			})
+
+			if err := mgr.StartAllActive(context.Background()); err != nil {
+				t.Fatalf("StartAllActive: %v", err)
+			}
+
+			if startCalled != tc.wantStarted {
+				t.Errorf("processStarter called = %v, want %v", startCalled, tc.wantStarted)
+			}
+			if tc.wantStarted && startedPath != tc.wantStartPath {
+				t.Errorf("BinaryPath passed to starter = %q, want %q", startedPath, tc.wantStartPath)
+			}
+		})
+	}
+}
+
+// TestManager_StartByPluginID_SpawnsOnlyTargetPlugin verifies that StartByPluginID
+// spawns only the instances belonging to the given plugin, not instances of other
+// plugins.
+func TestManager_StartByPluginID_SpawnsOnlyTargetPlugin(t *testing.T) {
+	binaryPath := "/x/y/binary"
 	q := &fakeQuerier{
 		plugins: []db.Plugin{
-			{ID: "p1", Status: "active"},
+			{ID: "p1", Status: "active", BinaryPath: &binaryPath},
+			{ID: "p2", Status: "active", BinaryPath: &binaryPath},
 		},
 		instances: map[string][]db.PluginInstance{
-			"p1": {{ID: "i1", PluginID: "p1", InstanceName: "i1", HealthState: "healthy"}},
+			"p1": {{ID: "i1", PluginID: "p1", InstanceName: "inst-1", HealthState: "healthy"}},
+			"p2": {{ID: "i2", PluginID: "p2", InstanceName: "inst-2", HealthState: "healthy"}},
 		},
 	}
 	reg := identity.New()
+
+	var startedIDs []string
 	mgr := process.NewManager(process.ManagerConfig{
 		Querier:        q,
 		IdentityIssuer: reg,
+		TestProcessStarter: func(_ context.Context, cfg process.Config) (*process.Instance, error) {
+			startedIDs = append(startedIDs, cfg.InstanceID)
+			return nil, errors.New("stub: no subprocess needed")
+		},
 	})
 
-	// StartAllActive should return nil even though it cannot spawn the instance
-	// (binary path not available in DB for #291).
-	if err := mgr.StartAllActive(context.Background()); err != nil {
-		t.Fatalf("StartAllActive: %v", err)
+	if err := mgr.StartByPluginID(context.Background(), "p1"); err != nil {
+		t.Fatalf("StartByPluginID: %v", err)
+	}
+
+	if len(startedIDs) != 1 || startedIDs[0] != "i1" {
+		t.Errorf("started instance IDs = %v, want [i1]", startedIDs)
+	}
+}
+
+// TestManager_StartByPluginID_HonorsBlockedHealthStates verifies that
+// StartByPluginID does not invoke the starter for instances in blocked states.
+func TestManager_StartByPluginID_HonorsBlockedHealthStates(t *testing.T) {
+	binaryPath := "/x/y/binary"
+	q := &fakeQuerier{
+		plugins: []db.Plugin{
+			{ID: "p1", Status: "active", BinaryPath: &binaryPath},
+		},
+		instances: map[string][]db.PluginInstance{
+			"p1": {
+				{ID: "i-healthy", PluginID: "p1", InstanceName: "healthy-inst", HealthState: "healthy"},
+				{ID: "i-crashed", PluginID: "p1", InstanceName: "crashed-inst", HealthState: "crashed"},
+			},
+		},
+	}
+	reg := identity.New()
+
+	var startedIDs []string
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        q,
+		IdentityIssuer: reg,
+		TestProcessStarter: func(_ context.Context, cfg process.Config) (*process.Instance, error) {
+			startedIDs = append(startedIDs, cfg.InstanceID)
+			return nil, errors.New("stub: no subprocess needed")
+		},
+	})
+
+	if err := mgr.StartByPluginID(context.Background(), "p1"); err != nil {
+		t.Fatalf("StartByPluginID: %v", err)
+	}
+
+	// Only the healthy instance should have triggered a start attempt.
+	if len(startedIDs) != 1 || startedIDs[0] != "i-healthy" {
+		t.Errorf("started instance IDs = %v, want [i-healthy]", startedIDs)
+	}
+}
+
+// TestManager_StartByPluginID_NilBinaryPath verifies that StartByPluginID logs
+// and returns nil (not an error) when the plugin row has no binary_path set.
+func TestManager_StartByPluginID_NilBinaryPath(t *testing.T) {
+	q := &fakeQuerier{
+		plugins: []db.Plugin{
+			{ID: "p1", Status: "active", BinaryPath: nil},
+		},
+		instances: map[string][]db.PluginInstance{
+			"p1": {{ID: "i1", PluginID: "p1", InstanceName: "inst-1", HealthState: "healthy"}},
+		},
+	}
+	reg := identity.New()
+
+	var startCalled bool
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        q,
+		IdentityIssuer: reg,
+		TestProcessStarter: func(_ context.Context, _ process.Config) (*process.Instance, error) {
+			startCalled = true
+			return nil, errors.New("should not be called")
+		},
+	})
+
+	if err := mgr.StartByPluginID(context.Background(), "p1"); err != nil {
+		t.Fatalf("StartByPluginID: unexpected error: %v", err)
+	}
+	if startCalled {
+		t.Error("processStarter was called for nil binary_path")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -513,6 +513,18 @@ func run(cfg config.Config) error {
 		handlers.PluginAdminHandler.SetInstaller(loader.Installer())
 	}
 
+	// Register the post-install spawn hook so that a fresh install (via the
+	// admin endpoint or the fsnotify watcher) immediately spawns the plugin
+	// subprocess — no server restart required (#386). The same Installer instance
+	// is used by both paths so this registration covers both.
+	if mgr := loader.Manager(); mgr != nil && loader.Installer() != nil {
+		loader.Installer().OnInstalled(func(ctx context.Context, pluginID string) {
+			if err := mgr.StartByPluginID(ctx, pluginID); err != nil {
+				slog.Warn("post-install spawn failed", "plugin_id", pluginID, "err", err)
+			}
+		})
+	}
+
 	// Phase 3: build the router.
 	r := api.BuildRouter(api.RouterConfig{
 		Handlers: handlers,

--- a/schemas/sql_schemas.sql
+++ b/schemas/sql_schemas.sql
@@ -399,6 +399,7 @@ CREATE TABLE plugins (
     manifest_snapshot  TEXT    NOT NULL,                                                 -- canonical manifest JSON (signed payload component)
     trusted_pubkey     TEXT    NOT NULL,                                                 -- Minisign Ed25519 pubkey, TOFU-captured (ADR-045)
     status             TEXT    NOT NULL CHECK(status IN ('pending_review','active','removed')),
+    binary_path        TEXT,                                                             -- absolute path to extracted plugin executable (#386); NULL on legacy rows
     version            INTEGER NOT NULL DEFAULT 0,                                       -- ADR-038 CAS counter
     created_at         TEXT    NOT NULL,                                                 -- ISO 8601 UTC
     updated_at         TEXT    NOT NULL                                                  -- ISO 8601 UTC


### PR DESCRIPTION
Closes #386

## Summary

- Adds a `binary_path TEXT` column on `plugins` so the host can re-spawn plugin subprocesses on restart and immediately after a successful install (the last gap blocking the Slack kitchen-sink walkthrough #237).
- Restricts the disk-side publish + DB write to commit branches in the installer — pubkey-mismatch and material-change rejection paths can no longer overwrite the on-disk binary (closes a TOFU bypass found in code review).
- Wires the spawn hook on `*loader.Installer` so both the fsnotify watcher and the admin install endpoint trigger a fresh `Manager.StartByPluginID` automatically.
- Moves extraction tmpdir under `pluginsDir/incoming-*` so the publish `os.Rename` stays on the same filesystem (avoids `EXDEV` in production Docker where `/tmp` and `/plugins` are different mounts).

## What changed

- **Schema:** `binary_path` added to `schemas/sql_schemas.sql` and `internal/db/migrations/0001_initial.sql`; new migration `0036_add_plugin_binary_path.go` (version 26).
- **Queries:** `CreatePlugin` extended; new `UpdatePluginBinaryPath :execrows`.
- **Installer:** `pluginsDir` field + constructor param; new `OnInstalled(fn)` hook; `publishBundle` atomic swap-aside (`rename to .new`, displace existing to `.old`, swap, RemoveAll `.old`); `upsertPlugin` returns `(id, committed, err)` so disk/DB stay in lockstep.
- **Manager:** `GetPluginByID` added to the local `querier` interface; `StartAllActive` replaces the no-op TODO with a real nil-check + `Start(ctx, p, inst, *p.BinaryPath)`; new `StartByPluginID` / `StopByPluginID`.
- **Wiring:** `main.go` registers `loader.Installer().OnInstalled(...)` after `loader.Manager()` is ready.

## Test coverage

13 tests added across `internal/plugin/loader/install_test.go` and `internal/plugin/process/manager_test.go`:
- Fresh install persists `binary_path` and the file exists + is executable
- Version bump replaces binary on disk and cleans up `.old`
- Rejected bundle (bad signature) creates no `installed/` artefacts
- Legacy NULL `binary_path` is backfilled on same-version re-install
- `OnInstalled` callback fires on commit and is skipped for rejections
- Pubkey-mismatch and material-change paths do not modify on-disk binary or DB `binary_path` (TOFU regression tests)
- Staging path is under `pluginsDir`, not `os.TempDir()` (EXDEV regression test)
- `Manager.StartAllActive` (table-driven): nil `BinaryPath` is skipped; populated invokes the starter with the right path
- `Manager.StartByPluginID`: scopes spawn to the target plugin and honors `blockedHealthStates`

## Review cycles

2 cycles. Cycle 1 surfaced two production blockers: (a) the disk publish ran for pubkey-mismatch and overwrote the binary at the path the DB still pointed at — a TOFU bypass on restart; (b) `os.Rename` between `/tmp` and `/plugins` would fail with `EXDEV` in Docker. Both fixed in cycle 2 with regression tests.

## CLAUDE.md

No updates needed — no new packages, env vars, API routes, domain types, or ADRs were introduced.

## Out of scope (follow-ups)

- `AcceptManifest`: after a material-change approval the subprocess keeps running the old binary until a re-install. The candidate binary is not preserved by the install pipeline today. Worth filing a follow-up.
- No HTTP uninstall endpoint exists; `Manager.StopByPluginID` was added as cheap symmetry for when that lands.

## Plan

<details>
<summary>Architecture plan (revised after plan review)</summary>

See `.dev-loop/plan.md` (not committed). Key decisions: single dir-rename swap-aside; `OnInstalled` hook on `*loader.Installer` so both watcher and admin install paths trigger spawn; `*string` for the nullable column matching the codebase pattern; `GetPluginByID` added to the `manager.go` local `querier` interface.

</details>

## Test plan

- [ ] Drop a Slack plugin tarball into the watched plugins dir; confirm `ps -ef` in the api container shows a child process
- [ ] Restart the api container; confirm subprocesses re-spawn from persisted paths
- [ ] Install via the admin UI; confirm tools show up on the Tools page within seconds
- [ ] Smoke test #1 from the Slack kitchen-sink walkthrough (manual agent with `<instance>.post_message` capability sends a message)

🤖 Generated with the agentic dev loop