### PR TITLE
fix: loader auto-strips nested tarball layout

### DIFF
--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -166,16 +166,24 @@ func (in *Installer) Install(ctx context.Context, tarPath string) (string, error
 		return "", fmt.Errorf("extract tarball %q: %w", tarPath, err)
 	}
 
-	m, manifestBytes, err := readManifest(tmpDir)
+	// Resolve the bundle root: some packagers (e.g. gleipnir-plugin package) wrap
+	// everything under a single top-level directory (e.g. slack-0.1.1/). Walk
+	// into that directory when present so the rest of the pipeline sees a flat root.
+	bundleDir, err := resolveBundleRoot(tmpDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve bundle root in %q: %w", tarPath, err)
+	}
+
+	m, manifestBytes, err := readManifest(bundleDir)
 	if err != nil {
 		return "", fmt.Errorf("read manifest from %q: %w", tarPath, err)
 	}
 
-	binaryPath := filepath.Join(tmpDir, m.Name)
-	if rel, err := filepath.Rel(tmpDir, binaryPath); err != nil || strings.HasPrefix(rel, "..") {
+	binaryPath := filepath.Join(bundleDir, m.Name)
+	if rel, err := filepath.Rel(bundleDir, binaryPath); err != nil || strings.HasPrefix(rel, "..") {
 		return "", fmt.Errorf("manifest.name %q escapes bundle directory", m.Name)
 	}
-	result := in.verifier.VerifyBundle(tmpDir, binaryPath)
+	result := in.verifier.VerifyBundle(bundleDir, binaryPath)
 
 	if result.Outcome == OutcomeRejected {
 		return in.recordSignatureInvalid(ctx, tarPath, m.Name, result.Err)
@@ -185,7 +193,7 @@ func (in *Installer) Install(ctx context.Context, tarPath string) (string, error
 	// (createPlugin, updatePlugin, updatePluginCosmetic) publish the bundle and
 	// invoke onInstalled. Rejection branches (pubkey-mismatch, material-change)
 	// return committed=false so the disk and hook remain untouched.
-	pluginID, committed, err := in.upsertPlugin(ctx, m, manifestBytes, result, tmpDir)
+	pluginID, committed, err := in.upsertPlugin(ctx, m, manifestBytes, result, bundleDir)
 	if err != nil {
 		return "", err
 	}
@@ -265,6 +273,38 @@ func (in *Installer) publishBundle(ctx context.Context, tmpDir, name string) (st
 	return filepath.Join(dest, name), nil
 }
 
+// resolveBundleRoot determines which directory within the extracted tmpDir
+// contains manifest.yaml. Two layouts are supported:
+//
+//   - Flat: manifest.yaml sits directly in tmpDir (legacy / manually-packaged tarballs).
+//   - Nested: tmpDir contains exactly one subdirectory, and manifest.yaml lives
+//     inside that subdirectory (layout produced by "gleipnir-plugin package").
+//
+// Standard packaging tools (npm, helm, cargo, git-archive) all wrap their
+// payload under a single top-level directory; this mirrors that convention.
+// Any other layout returns an error so operators get a clear message instead
+// of a confusing "no such file" failure.
+func resolveBundleRoot(tmpDir string) (string, error) {
+	// Fast path: flat layout.
+	if _, err := os.Stat(filepath.Join(tmpDir, "manifest.yaml")); err == nil {
+		return tmpDir, nil
+	}
+
+	// Check for the single-directory nested layout.
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return "", fmt.Errorf("read extracted dir: %w", err)
+	}
+	if len(entries) == 1 && entries[0].IsDir() {
+		nested := filepath.Join(tmpDir, entries[0].Name())
+		if _, err := os.Stat(filepath.Join(nested, "manifest.yaml")); err == nil {
+			return nested, nil
+		}
+	}
+
+	return "", fmt.Errorf("manifest.yaml not found at bundle root or under a single top-level directory")
+}
+
 // readManifest parses the manifest.yaml inside the extracted bundle directory.
 // Returns the parsed manifest, the raw YAML bytes, and any error.
 func readManifest(bundleDir string) (*manifest.Manifest, []byte, error) {
@@ -314,10 +354,13 @@ func (in *Installer) recordSignatureInvalid(ctx context.Context, tarPath, plugin
 }
 
 // upsertPlugin creates or updates the plugin row and emits an audit event.
-// tmpDir is the directory where the verified bundle was extracted; commit
-// branches (createPlugin, updatePlugin, updatePluginCosmetic) call publishBundle
-// to move it to its permanent location and record the path in the DB so
-// Manager.StartAllActive can re-spawn the subprocess on server restart.
+// tmpDir is the resolved bundle root containing manifest.yaml — for flat
+// tarballs this is the extraction directory itself, for nested tarballs it
+// is the single top-level subdirectory inside the extraction directory (see
+// resolveBundleRoot). Commit branches (createPlugin, updatePlugin,
+// updatePluginCosmetic) call publishBundle to move it to its permanent
+// location and record the path in the DB so Manager.StartAllActive can
+// re-spawn the subprocess on server restart.
 // Rejection branches (pubkey-mismatch, material-change) never publish and
 // return committed=false.
 // Returns (pluginID, committed, error).

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -1468,6 +1468,124 @@ func TestInstall_OnInstalled_NotCalledForPubkeyMismatch(t *testing.T) {
 	}
 }
 
+// nestedSignedPluginTarball builds a fully signed tarball in the nested layout
+// that "gleipnir-plugin package" produces: every file lives under a single
+// top-level directory named "<name>-<version>/".
+func nestedSignedPluginTarball(t *testing.T, name, version string) string {
+	t.Helper()
+
+	prefix := name + "-" + version + "/"
+	manifestBytes := []byte("schema_version: v1\nname: " + name + "\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	binaryBytes := []byte("fake binary content for " + name)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	payload := signing.PluginPayload(binaryBytes, manifestBytes)
+	sig, err := signing.Sign(sk.SecretKey, sk.KeyID, payload, "trusted comment")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+	sigBytes := signing.MarshalSignature(sig, "test sig")
+
+	tarPath := filepath.Join(t.TempDir(), name+".tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: prefix, typeflag: tar.TypeDir, mode: 0o755},
+		{name: prefix + "manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: prefix + name, content: binaryBytes, mode: 0o755},
+		{name: prefix + "signing.pub", content: pubkeyBytes, mode: 0o644},
+		{name: prefix + name + ".minisig", content: sigBytes, mode: 0o644},
+	})
+	return tarPath
+}
+
+// TestInstall_NestedLayout_Installs verifies that a tarball where every file
+// lives under a single top-level "<name>-<version>/" directory (the layout
+// produced by "gleipnir-plugin package") installs successfully. This is the
+// primary regression test for issue #387.
+func TestInstall_NestedLayout_Installs(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath := nestedSignedPluginTarball(t, "nested-plugin", "1.0.0")
+
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install (nested layout): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "nested-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if row.Status != "pending_review" {
+		t.Errorf("status = %q, want pending_review", row.Status)
+	}
+	if row.PluginVersion != "1.0.0" {
+		t.Errorf("plugin_version = %q, want 1.0.0", row.PluginVersion)
+	}
+	if row.BinaryPath == nil || *row.BinaryPath == "" {
+		t.Error("binary_path: want non-empty after nested-layout install")
+	}
+	// The published binary must be accessible at the persisted path.
+	if _, err := os.Stat(*row.BinaryPath); err != nil {
+		t.Errorf("binary at persisted path not accessible: %v", err)
+	}
+}
+
+// TestInstall_FlatLayout_BackwardCompat verifies that a tarball with a flat
+// layout (manifest.yaml at the tarball root) continues to install successfully.
+// This is an explicit contract test so any future change that breaks flat
+// tarballs is caught immediately.
+func TestInstall_FlatLayout_BackwardCompat(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath, _ := signedPluginTarball(t, "flat-plugin", "1.0.0")
+
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install (flat layout): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "flat-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	if row.Status != "pending_review" {
+		t.Errorf("status = %q, want pending_review", row.Status)
+	}
+	if row.BinaryPath == nil || *row.BinaryPath == "" {
+		t.Error("binary_path: want non-empty after flat-layout install")
+	}
+}
+
+// TestInstall_InvalidLayout_ReturnsError verifies that a tarball with neither a
+// flat nor a single-nested-directory layout returns a clear error mentioning the
+// bundle layout, rather than a confusing "no such file" error.
+func TestInstall_InvalidLayout_ReturnsError(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, true) // allowUnsigned so verifier is not the rejection path
+
+	// Build a tarball with two top-level directories — neither flat nor single-nested.
+	manifestBytes := []byte("schema_version: v1\nname: broken-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath := filepath.Join(t.TempDir(), "broken.tar.gz")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "dir-a/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "dir-a/manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: "dir-b/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "dir-b/other.txt", content: []byte("irrelevant"), mode: 0o644},
+	})
+
+	_, err := inst.Install(context.Background(), tarPath)
+	if err == nil {
+		t.Fatal("Install: expected error for invalid layout, got nil")
+	}
+	if !strings.Contains(err.Error(), "bundle root") {
+		t.Errorf("Install error = %q; want it to mention bundle layout (\"bundle root\")", err.Error())
+	}
+}
+
 // TestInstall_TmpDirUnderPluginsDir verifies that the extraction temp directory is
 // created inside pluginsDir (not os.TempDir()), ensuring the rename to the staging
 // path stays on the same filesystem and avoids EXDEV on Docker where /tmp and


### PR DESCRIPTION
Closes #387

## Summary

`gleipnir-plugin package` produces tarballs where every file lives under a single `<name>-<version>/` top-level directory:

```
slack-0.1.1/manifest.yaml
slack-0.1.1/signing.pub
slack-0.1.1/slack
slack-0.1.1/slack.minisig
```

But `loader.Install()` looked for `manifest.yaml` at the extraction root and failed immediately with `read manifest.yaml: ... no such file or directory`. The kitchen-sink walkthrough worked around it by re-tarring with `--strip-components=1`.

This PR adds `resolveBundleRoot` to the loader:
- **Flat layout** (`manifest.yaml` at the root) → returns the extraction dir unchanged. Backward-compatible.
- **Nested layout** (exactly one top-level subdirectory containing `manifest.yaml`) → returns that subdirectory. Handles the packager's output.
- **Anything else** → clear error mentioning bundle root.

`readManifest`, the binary path, `VerifyBundle`, and `upsertPlugin` are all routed through the resolved root so signed nested tarballs verify correctly (the verifier reads `signing.pub` / `<name>.minisig` from the bundle dir). `defer os.RemoveAll(tmpDir)` is unchanged — it still cleans up the outer extraction parent.

## Tests

- `TestInstall_NestedLayout_Installs` — the primary regression test (signed nested tarball installs successfully).
- `TestInstall_FlatLayout_BackwardCompat` — explicit contract that flat tarballs still install.
- `TestInstall_InvalidLayout_ReturnsError` — a tarball with two top-level dirs fails with an error mentioning "bundle root".

All 37 tests in `internal/plugin/loader/...` pass.

## Architecture plan

<details>
<summary>Click to expand</summary>

```
Summary:
  After ExtractTarball, the loader currently treats `tmpDir` as the bundle root.
  If the tarball has a single top-level directory (the layout `gleipnir-plugin package`
  produces), the manifest is one level deeper and Install() fails. Fix: after
  extraction, resolve the "bundle root" — the directory containing `manifest.yaml`.
  Use that resolved path for readManifest, binaryPath construction, and verifier.VerifyBundle.

Affected files:
  - internal/plugin/loader/install.go: add resolveBundleRoot helper; route Install() through it.
  - internal/plugin/loader/install_test.go: add 3 tests covering nested, flat, invalid layouts.

Scope-gate skip — no architect pass. Localized bug fix with explicit acceptance criteria.
```

</details>

## Pipeline notes

- Review cycles: **1** (APPROVE on cycle 1, with two non-blocking nits applied: stale doc comment fixed, unused unsigned-helper removed).
- Brainstorming: not triggered — issue was well-specified.
- CLAUDE.md: no updates required (internal-package detail, no env vars / routes / ADRs touched).

🤖 Generated with the agentic dev loop