### PR TITLE
fix(slack): drop search_messages tool; search:read is user-token-only

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -10,7 +10,7 @@ Parent tracking issue: [#162](https://github.com/felag-engineering/gleipnir/issu
 
 ## What this plugin declares
 
-- **ToolService v1** — `post_message`, `list_channels`, `search_messages`, `react`, `set_topic` (implemented by #233)
+- **ToolService v1** — `post_message`, `list_channels`, `react`, `set_topic` (implemented by #233)
 - **TriggerService v1** — `channel_message` event kind via Slack Socket Mode (#234). Note: subscription-scope channel filtering matches by **channel ID** only (e.g. `C012ABCDEF`); name-based filtering (e.g. `#incidents`) silently does not match because Socket Mode events carry only IDs. Resolving names is future work.
 - **ChannelService v1** — `Notify` and `Request` via Slack DMs and posts (#235)
 - **Auth strategy** — `oauth2_authcode` with Slack's authorization and token endpoints
@@ -123,7 +123,6 @@ oauth_config:
       - im:history
       - im:write
       - mpim:history
-      - search:read
       - users:read
 settings:
   event_subscriptions:
@@ -277,7 +276,7 @@ replace github.com/felag-engineering/gleipnir/plugin-sdk => ../path/to/plugin-sd
 
 ## Tools
 
-The Slack plugin exposes five tools through the `ToolService`. At runtime the host
+The Slack plugin exposes four tools through the `ToolService`. At runtime the host
 prefixes each name with the instance name, so they appear as
 `<instance>.post_message`, `<instance>.list_channels`, etc. (e.g.
 `slack-prod.post_message`).
@@ -325,34 +324,6 @@ to `public_channel`.
     {"id": "C001", "name": "general", "is_private": false, "is_archived": false, "num_members": 42}
   ],
   "next_cursor": ""
-}
-```
-
-### `search_messages`
-
-Search messages across the workspace using Slack's full-text search
-(`search.messages` API).
-
-**Input:**
-```json
-{"query": "deployment failed", "count": 20}
-```
-
-`count` is optional (1–100, defaults to 20).
-
-**Output:**
-```json
-{
-  "matches": [
-    {
-      "channel": "C001",
-      "user": "U001",
-      "text": "deployment failed at 03:00 UTC",
-      "ts": "1700000001.000000",
-      "permalink": "https://myworkspace.slack.com/archives/C001/p1700000001000000"
-    }
-  ],
-  "total": 1
 }
 ```
 
@@ -405,7 +376,6 @@ and shown in the admin UI during install.
 | `im:history`      | **Reserved; no current tool uses it** |
 | `im:write`        | `post_message` to DMs |
 | `mpim:history`    | **Reserved; no current tool uses it** |
-| `search:read`     | `search_messages` |
 | `users:read`      | user lookup in various responses |
 
 > **Note on `*:history` scopes:** The four `*:history` scopes (`channels:history`,
@@ -416,17 +386,9 @@ and shown in the admin UI during install.
 > app-level `xapp-` token and does **not** require these bot-token scopes.
 > Operators who decline these scopes at OAuth time will still get a working
 > installation for the currently-implemented tools (`post_message`,
-> `list_channels`, `search_messages`, `react`, `set_topic`) and the
+> `list_channels`, `react`, `set_topic`) and the
 > `channel_message` trigger; they are requested up-front per the issue AC so the
 > same OAuth grant covers planned tools without a re-authorize round trip.
-
-**Note on `search:read`:** This scope is available for bot tokens but may not
-be granted during OAuth if the Slack app was configured before `search:read`
-was added. Bot-only installs that are missing this scope will see a runtime
-`PERMISSION` error (`missing_scope`) for `search_messages` calls, and the
-plugin will be set to `UNHEALTHY` with detail `auth_expired` in the operator
-UI. To resolve: grant `search:read` in the Slack app settings and re-authorize
-the plugin instance.
 
 ## Token refresh
 

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -12,7 +12,7 @@ import (
 var pluginManifest = manifest.Manifest{
 	SchemaVersion: "v1",
 	Name:          "slack",
-	Version:       "0.1.0",
+	Version:       "0.1.1",
 	Description:   "Slack integration: tools (send/list channels), triggers (channel messages), and channels (notify/request via Slack DMs and posts).",
 	Services: manifest.Services{
 		Tool:    "v1",
@@ -47,7 +47,6 @@ var pluginManifest = manifest.Manifest{
 				"im:history",
 				"im:write",
 				"mpim:history",
-				"search:read",
 				"users:read",
 			},
 			// HasClientID and HasClientSecret describe whether the manifest carries
@@ -127,7 +126,7 @@ properties:
 	},
 }
 
-// buildToolDecls returns the five Slack tool declarations for the manifest.
+// buildToolDecls returns the four Slack tool declarations for the manifest.
 // InputSchema is a *yaml.Node (manifest.ToolDecl.InputSchema, manifest.go:237)
 // produced by manifest.MustReflectSchema — distinct from the JSON-string form
 // used by ToolService.ListTools on the wire (see tools.go:reflectInputSchemaJSON).
@@ -144,11 +143,6 @@ func buildToolDecls() []manifest.ToolDecl {
 			Name:        "list_channels",
 			Description: "List Slack channels visible to the bot user.",
 			InputSchema: manifest.MustReflectSchema(ListChannelsParams{}),
-		},
-		{
-			Name:        "search_messages",
-			Description: "Search messages across the workspace using Slack's search.",
-			InputSchema: manifest.MustReflectSchema(SearchMessagesParams{}),
 		},
 		{
 			Name:        "react",

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -10,7 +10,6 @@ auth:
       - im:history
       - im:write
       - mpim:history
-      - search:read
       - users:read
     token_url: https://slack.com/api/oauth.v2.access
   strategy: oauth2_authcode
@@ -238,24 +237,6 @@ tools:
           type: string
       type: object
     name: list_channels
-  - description: Search messages across the workspace using Slack's search.
-    input_schema:
-      additionalProperties: false
-      properties:
-        count:
-          description: Results per page (1-100)
-          maximum: 100
-          minimum: 1
-          title: Count
-          type: integer
-        query:
-          description: Slack search query (search.messages syntax)
-          title: Query
-          type: string
-      required:
-        - query
-      type: object
-    name: search_messages
   - description: Add an emoji reaction to a Slack message.
     input_schema:
       additionalProperties: false
@@ -295,4 +276,4 @@ tools:
         - topic
       type: object
     name: set_topic
-version: 0.1.0
+version: 0.1.1

--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -29,8 +29,8 @@ import (
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
-// ToolService implements toolv1.ToolServiceServer with five Slack Web API tools:
-// post_message, list_channels, search_messages, react, and set_topic.
+// ToolService implements toolv1.ToolServiceServer with four Slack Web API tools:
+// post_message, list_channels, react, and set_topic.
 // It fetches credentials on every Call (no in-process caching, per spec §9.4).
 type ToolService struct {
 	toolv1.UnimplementedToolServiceServer
@@ -60,7 +60,7 @@ func NewToolService(host hostv1.HostServiceClient, httpClient *http.Client, apiU
 	return &ToolService{host: host, httpClient: httpClient, apiURL: apiURL}
 }
 
-// ListTools advertises the five Slack tools. InputSchema is a JSON string
+// ListTools advertises the four Slack tools. InputSchema is a JSON string
 // because toolv1.ToolSchema.InputSchema is a string on the wire
 // (plugin-sdk/gen/.../tool.pb.go:39); reflectInputSchemaJSON produces it.
 func (s *ToolService) ListTools(_ context.Context, _ *toolv1.ListToolsRequest) (*toolv1.ListToolsResponse, error) {
@@ -75,11 +75,6 @@ func (s *ToolService) ListTools(_ context.Context, _ *toolv1.ListToolsRequest) (
 				Name:        "list_channels",
 				Description: "List Slack channels visible to the bot user.",
 				InputSchema: reflectInputSchemaJSON(ListChannelsParams{}),
-			},
-			{
-				Name:        "search_messages",
-				Description: "Search messages across the workspace using Slack's search. Requires the search:read scope; bot-only installs that were not granted this scope will receive a PERMISSION error at runtime.",
-				InputSchema: reflectInputSchemaJSON(SearchMessagesParams{}),
 			},
 			{
 				Name:        "react",
@@ -102,7 +97,7 @@ func (s *ToolService) Cancel(_ context.Context, _ *toolv1.CancelRequest) (*toolv
 	return &toolv1.CancelResponse{}, nil
 }
 
-// Call dispatches to one of the five Slack tool handlers. It fetches
+// Call dispatches to one of the four Slack tool handlers. It fetches
 // credentials on every invocation (no caching), builds a per-call slack.Client,
 // dispatches by tool name, emits one metric sample, and updates plugin health
 // on persistent auth failures.
@@ -147,7 +142,7 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 	// auth.test, matching the minimal-tool dispatch pattern
 	// (plugin-sdk/examples/minimal-tool/service.go:62-69).
 	switch toolName {
-	case "post_message", "list_channels", "search_messages", "react", "set_topic":
+	case "post_message", "list_channels", "react", "set_topic":
 		// valid — continue
 	default:
 		return errorResponse(commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
@@ -210,8 +205,6 @@ func (s *ToolService) dispatch(ctx context.Context, sc *slack.Client, toolName, 
 		return handlePostMessage(ctx, sc, inputJSON)
 	case "list_channels":
 		return handleListChannels(ctx, sc, inputJSON)
-	case "search_messages":
-		return handleSearchMessages(ctx, sc, inputJSON)
 	case "react":
 		return handleReact(ctx, sc, inputJSON)
 	case "set_topic":

--- a/plugins/slack/service_test.go
+++ b/plugins/slack/service_test.go
@@ -726,7 +726,7 @@ func TestTriggerStartHealthUnhealthyOnInvalidAuth(t *testing.T) {
 
 // ── Tool tests ────────────────────────────────────────────────────────────────
 
-// TestToolListToolsAdvertisesAll asserts that ListTools returns exactly the five
+// TestToolListToolsAdvertisesAll asserts that ListTools returns exactly the four
 // Slack tools by name and that each InputSchema parses as a JSON object.
 func TestToolListToolsAdvertisesAll(t *testing.T) {
 	svcs, cleanup := setupAll(t, nil)
@@ -737,7 +737,7 @@ func TestToolListToolsAdvertisesAll(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 
-	wantNames := []string{"post_message", "list_channels", "search_messages", "react", "set_topic"}
+	wantNames := []string{"post_message", "list_channels", "react", "set_topic"}
 	tools := resp.GetTools()
 	if len(tools) != len(wantNames) {
 		t.Fatalf("want %d tools, got %d", len(wantNames), len(tools))

--- a/plugins/slack/tools.go
+++ b/plugins/slack/tools.go
@@ -32,11 +32,6 @@ type ListChannelsParams struct {
 	Types           string `json:"types,omitempty"            jsonschema:"title=Types,description=Comma-separated channel types (public_channel\\,private_channel\\,mpim\\,im). Defaults to public_channel."`
 }
 
-type SearchMessagesParams struct {
-	Query string `json:"query"         jsonschema:"required,title=Query,description=Slack search query (search.messages syntax)"`
-	Count int    `json:"count,omitempty" jsonschema:"title=Count,description=Results per page (1-100),minimum=1,maximum=100"`
-}
-
 type ReactParams struct {
 	Channel   string `json:"channel"   jsonschema:"required,title=Channel,description=Channel ID containing the message"`
 	Timestamp string `json:"timestamp" jsonschema:"required,title=Timestamp,description=Message ts (e.g. 1700000000.123456)"`
@@ -154,8 +149,6 @@ func classifySlackErrCode(code string) (commonv1.ErrorCode, healthHint) {
 	case "invalid_auth", "account_inactive", "token_revoked", "missing_scope", "not_authed":
 		// Persistent auth failures. The operator UI shows UNHEALTHY + "auth_expired"
 		// so operators know they need to reauthorize or grant missing scopes.
-		// Note: missing_scope is especially likely for search_messages on bot-only
-		// installs that were not granted the search:read scope.
 		return commonv1.ErrorCode_ERROR_CODE_PERMISSION, healthAuthExpired
 
 	case "ratelimited":
@@ -283,48 +276,6 @@ func handleListChannels(ctx context.Context, sc *slack.Client, inputJSON string)
 	return json.Marshal(map[string]any{
 		"channels":    items,
 		"next_cursor": nextCursor,
-	})
-}
-
-func handleSearchMessages(ctx context.Context, sc *slack.Client, inputJSON string) ([]byte, error) {
-	var p SearchMessagesParams
-	if err := json.Unmarshal([]byte(inputJSON), &p); err != nil {
-		return nil, slack.SlackErrorResponse{Err: "invalid_arguments"}
-	}
-
-	params := slack.NewSearchParameters()
-	if p.Count > 0 {
-		params.Count = p.Count
-	}
-
-	result, err := callWithRetry(ctx, func(ctx context.Context) (*slack.SearchMessages, error) {
-		return sc.SearchMessagesContext(ctx, p.Query, params)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	type matchItem struct {
-		Channel   string `json:"channel"`
-		User      string `json:"user"`
-		Text      string `json:"text"`
-		TS        string `json:"ts"`
-		Permalink string `json:"permalink"`
-	}
-	matches := make([]matchItem, len(result.Matches))
-	for i, m := range result.Matches {
-		matches[i] = matchItem{
-			Channel:   m.Channel.ID,
-			User:      m.User,
-			Text:      m.Text,
-			TS:        m.Timestamp,
-			Permalink: m.Permalink,
-		}
-	}
-
-	return json.Marshal(map[string]any{
-		"matches": matches,
-		"total":   result.Total,
 	})
 }
 

--- a/plugins/slack/tools_test.go
+++ b/plugins/slack/tools_test.go
@@ -136,47 +136,6 @@ func toolCases(t *testing.T) []toolCallCase {
 			wantOutputKey: "channels",
 			wantMetric:    true,
 		},
-		// ── search_messages happy path ───────────────────────────────────────
-		{
-			name: "search_messages_happy",
-			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				t.Helper()
-				if !strings.HasSuffix(r.URL.Path, "search.messages") {
-					t.Errorf("unexpected path: %s", r.URL.Path)
-				}
-				form := readForm(r)
-				if form.Get("query") != "foo bar" {
-					t.Errorf("query: want %q, got %q", "foo bar", form.Get("query"))
-				}
-				w.Header().Set("Content-Type", "application/json")
-				w.Write(slackOKResponse(map[string]any{
-					"messages": map[string]any{
-						"matches": []map[string]any{
-							{
-								"channel":   map[string]any{"id": "C001"},
-								"user":      "U001",
-								"text":      "foo bar baz",
-								"ts":        "1700000001.000000",
-								"permalink": "https://example.slack.com/archives/C001/p1700000001",
-							},
-						},
-						"total": 1,
-						"paging": map[string]any{
-							"count": 20,
-							"total": 1,
-							"page":  1,
-							"pages": 1,
-						},
-						"pagination": map[string]any{},
-					},
-				}))
-			},
-			hostOpts:      []plugintest.Option{plugintest.WithCredentialsJSON(credsJSON)},
-			toolName:      "search_messages",
-			inputJSON:     `{"query":"foo bar"}`,
-			wantOutputKey: "matches",
-			wantMetric:    true,
-		},
 		// ── react happy path ─────────────────────────────────────────────────
 		{
 			name: "react_happy",


### PR DESCRIPTION
Closes #388

## Summary

`search:read` is a **User Token Scope only** on Slack — bot tokens cannot request it. Leaving it in the Slack plugin's `oauth_defaults.scopes` returned `Invalid permissions requested` to the operator at OAuth authorize time, blocking the kitchen-sink walkthrough at Step 4.

Per the brainstorming decision (issue refined in Stage 1.5), the `search_messages` tool is **dropped entirely from v1**. Gleipnir doesn't yet support per-instance user-scoped credentials, so shipping a tool that always fails at runtime is worse than not shipping it. We can reintroduce `search_messages` in a later release once user-token plumbing exists.

## Changes

- `plugins/slack/manifest.go`: version `0.1.0` → `0.1.1`; `search:read` removed from `OAuthDefaults.Scopes`; `search_messages` `ToolDecl` removed from `buildToolDecls()`.
- `plugins/slack/manifest.yaml`: regenerated via `make manifest`.
- `plugins/slack/service.go`: `search_messages` `ToolDecl` removed from `ListTools`; dispatch case removed; doc comments updated.
- `plugins/slack/tools.go`: `SearchMessagesParams` and `handleSearchMessages` removed.
- `plugins/slack/tools_test.go`: `search_messages_happy` table case removed.
- `plugins/slack/service_test.go`: `wantNames` trimmed.
- `plugins/slack/README.md`: feature list, example scopes, `### search_messages` section, scope→tool table row, and the "Note on `search:read`" paragraph all removed.

Net: **+13 / −173** across 7 files.

## Upgrade notes — material manifest change

Both changes (removing a tool and removing an OAuth scope) are classified **material** by `internal/plugin/manifest/diff.go` (`diffTools` and `diffOAuthDefaults`). Reinstalling 0.1.1 over a live 0.1.0 install will route to `handleManifestMaterialChange`: instances transition to `pending_manifest_approval` and the new binary will not be activated until an admin calls `POST /api/v1/admin/plugins/{id}/accept-manifest`. This is intentional host-side behavior — no code change required, but operators should expect this on upgrade.

## Architecture plan

<details>
<summary>Click to expand</summary>

Bug fix: scope-list and tool wiring scrub across one package. Scope gate did not skip (7 files), but the issue's refined spec already enumerated every file/line. Architect skipped; plan-reviewer ran adversarially and caught three issues (material-change upgrade path, the `make manifest` regeneration mechanism, and 5 missed "five" → "four" doc-comment updates). All three corrections folded into the revised plan before implementation.

</details>

## Pipeline notes

- Brainstorming: **triggered** — issue had two unresolved product decisions (drop vs. keep `search_messages`; version bump). User chose: drop + 0.1.1.
- Review cycles: **1** (APPROVE on cycle 1).
- CLAUDE.md: no updates required (plugin-internal change; host architecture unaffected).

🤖 Generated with the agentic dev loop