### PR TITLE
Slack kitchen-sink pre-flight: 3 P0s + 7 P1s + Config tab UI

### DIFF
--- a/conn_factory_test.go
+++ b/conn_factory_test.go
@@ -161,3 +161,6 @@ func (q *connFactoryFakeQuerier) GetPluginInstanceByID(_ context.Context, _ stri
 func (q *connFactoryFakeQuerier) UpdatePluginInstanceHealth(_ context.Context, _ db.UpdatePluginInstanceHealthParams) (int64, error) {
 	return 1, nil
 }
+func (q *connFactoryFakeQuerier) InsertPluginAuditEvent(_ context.Context, _ db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error) {
+	return db.PluginAuditEvent{}, nil
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -524,6 +524,22 @@ export interface ApiPluginInstanceForAudience {
   last_oauth_callback_url?: string
 }
 
+// ApiPluginInstanceDetail matches internal/admin/plugin_handler.go → instanceResponse.
+// Returned by GET /api/v1/admin/plugins/{id}/instances/{iid}.
+// config_json is a JSON-encoded map — the client parses it for display.
+// Secret fields in config_json are redacted to "***" (ADR-049).
+export interface ApiPluginInstanceDetail {
+  id: string
+  plugin_id: string
+  instance_name: string
+  state: string
+  detail: string | null
+  version: number
+  updated_at: string
+  subscription_scope_json: string
+  config_json: string
+}
+
 // ApiInstalledPlugin matches the installResponse struct returned by
 // POST /api/v1/admin/plugins (internal/admin/plugin_handler.go:installResponse).
 export interface ApiInstalledPlugin {

--- a/frontend/src/hooks/mutations/plugins.ts
+++ b/frontend/src/hooks/mutations/plugins.ts
@@ -344,6 +344,37 @@ export function useUninstallPlugin() {
 
 // ── Subscription scope ────────────────────────────────────────────────────────
 
+// SetInstanceConfigParams carries the payload for
+// PUT /api/v1/admin/plugins/{id}/instances/{iid}/config.
+export interface SetInstanceConfigParams {
+  pluginId: string
+  instanceId: string
+  config: Record<string, unknown>
+  expectedVersion: number
+}
+
+// useSetInstanceConfig submits a new instance config blob for a plugin instance.
+// On success it invalidates the plugin-instances list so the Config tab re-fetches
+// the new version number and redacted values on next render.
+export function useSetInstanceConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ pluginId, instanceId, config, expectedVersion }: SetInstanceConfigParams) =>
+      apiFetch<unknown>(
+        `/admin/plugins/${encodeURIComponent(pluginId)}/instances/${encodeURIComponent(instanceId)}/config`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ config, expected_version: expectedVersion }),
+        },
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.admin.pluginInstances,
+      })
+    },
+  })
+}
+
 // useSetInstanceSubscriptionScope submits a new subscription scope for a plugin
 // instance. On success it invalidates the plugin-instances list so the audience
 // editor and trigger picker reflect the updated scope.

--- a/frontend/src/hooks/queries/admin.ts
+++ b/frontend/src/hooks/queries/admin.ts
@@ -10,6 +10,7 @@ import type {
   ApiAudience,
   ApiAudienceReferences,
   ApiPluginInstanceForAudience,
+  ApiPluginInstanceDetail,
 } from '@/api/types'
 import { queryKeys } from '../queryKeys'
 
@@ -80,5 +81,18 @@ export function usePluginInstancesForAudience() {
   return useQuery({
     queryKey: queryKeys.admin.pluginInstances,
     queryFn: () => apiFetch<ApiPluginInstanceForAudience[]>('/admin/plugin-instances'),
+  })
+}
+
+// GET /api/v1/admin/plugins/{id}/instances/{iid} — per-instance health + config.
+// config_json is returned redacted (ADR-049) and parsed by the Config tab.
+export function usePluginInstanceDetail(pluginId: string | undefined, instanceId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.plugins.instance(pluginId ?? '', instanceId ?? ''),
+    queryFn: () =>
+      apiFetch<ApiPluginInstanceDetail>(
+        `/admin/plugins/${encodeURIComponent(pluginId!)}/instances/${encodeURIComponent(instanceId!)}`,
+      ),
+    enabled: !!pluginId && !!instanceId,
   })
 }

--- a/frontend/src/pages/AdminPluginInstancePage.module.css
+++ b/frontend/src/pages/AdminPluginInstancePage.module.css
@@ -173,6 +173,20 @@
   color: var(--color-red);
 }
 
+/* CAS conflict notice — shown when the backend returns 409 on config save */
+
+.casConflict {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(212, 145, 90, 0.10); /* accent-muted tint */
+  border: 1px solid rgba(212, 145, 90, 0.3);
+  border-radius: 4px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
 /* Misc */
 
 .placeholder {

--- a/frontend/src/pages/AdminPluginInstancePage.test.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.test.tsx
@@ -20,8 +20,9 @@ vi.mock('@/components/admin/ReauthorizeButton/ReauthorizeButton', () => ({
   ),
 }))
 
-import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
-import { useSetInstanceSubscriptionScope, useBeginPluginOAuth, useDeletePluginInstance } from '@/hooks/mutations/plugins'
+import { usePluginInstancesForAudience, usePluginInstanceDetail } from '@/hooks/queries/admin'
+import { useSetInstanceSubscriptionScope, useBeginPluginOAuth, useDeletePluginInstance, useSetInstanceConfig } from '@/hooks/mutations/plugins'
+import type { ApiPluginInstanceDetail } from '@/api/types'
 import { useCurrentUser } from '@/hooks/queries/users'
 import { ApiError } from '@/api/fetch'
 
@@ -66,6 +67,33 @@ const INSTANCE_NO_SCHEMA: ApiPluginInstanceForAudience = {
   config_schema: null,
   event_kinds: [],
   version: 0,
+}
+
+const INSTANCE_WITH_CONFIG_SCHEMA: ApiPluginInstanceForAudience = {
+  id: INSTANCE_ID,
+  plugin_id: PLUGIN_ID,
+  plugin_name: 'Slack',
+  instance_name: 'slack-prod',
+  state: 'healthy',
+  auth_strategy: 'oauth2_authcode',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: {
+    type: 'object',
+    properties: {
+      app_level_token: {
+        type: 'string',
+        'x-gleipnir-secret': true,
+        description: 'Slack app-level token (xapp-...)',
+      },
+      workspace_name: {
+        type: 'string',
+        description: 'Display name for this workspace',
+      },
+    },
+  },
+  event_kinds: [],
+  version: 3,
 }
 
 const INSTANCE_OAUTH_REFRESH_FAILED: ApiPluginInstanceForAudience = {
@@ -126,6 +154,30 @@ function mockCurrentUser(roles: string[] = ['admin']) {
   } as unknown as ReturnType<typeof useCurrentUser>)
 }
 
+function mockInstanceDetailLoaded(configJson = '{}') {
+  vi.mocked(usePluginInstanceDetail).mockReturnValue({
+    data: {
+      id: INSTANCE_ID,
+      plugin_id: PLUGIN_ID,
+      instance_name: 'slack-prod',
+      state: 'healthy',
+      detail: null,
+      version: 1,
+      updated_at: '2024-01-01T00:00:00Z',
+      subscription_scope_json: '{}',
+      config_json: configJson,
+    },
+    status: 'success',
+  } as unknown as ReturnType<typeof usePluginInstanceDetail>)
+}
+
+function mockInstanceDetailPending() {
+  vi.mocked(usePluginInstanceDetail).mockReturnValue({
+    data: undefined,
+    status: 'pending',
+  } as unknown as ReturnType<typeof usePluginInstanceDetail>)
+}
+
 function mockMutationNoop() {
   vi.mocked(useSetInstanceSubscriptionScope).mockReturnValue({
     mutate: vi.fn(),
@@ -139,6 +191,10 @@ function mockMutationNoop() {
     mutate: vi.fn(),
     isPending: false,
   } as unknown as ReturnType<typeof useDeletePluginInstance>)
+  vi.mocked(useSetInstanceConfig).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useSetInstanceConfig>)
 }
 
 function mockMutationSuccess(onSuccessCapture?: (fn: () => void) => void) {
@@ -161,6 +217,7 @@ describe('AdminPluginInstancePage — loading state', () => {
   beforeEach(() => {
     mockCurrentUser(['admin'])
     mockInstancesPending()
+    mockInstanceDetailPending()
     mockMutationNoop()
   })
 
@@ -174,6 +231,7 @@ describe('AdminPluginInstancePage — with subscription_schema', () => {
   beforeEach(() => {
     mockCurrentUser(['admin'])
     mockInstancesLoaded([INSTANCE_WITH_SCHEMA])
+    mockInstanceDetailLoaded()
     mockMutationNoop()
   })
 
@@ -217,6 +275,7 @@ describe('AdminPluginInstancePage — without subscription_schema', () => {
   beforeEach(() => {
     mockCurrentUser(['admin'])
     mockInstancesLoaded([INSTANCE_NO_SCHEMA])
+    mockInstanceDetailLoaded()
     mockMutationNoop()
   })
 
@@ -225,16 +284,18 @@ describe('AdminPluginInstancePage — without subscription_schema', () => {
     expect(screen.queryByRole('button', { name: /subscriptions/i })).not.toBeInTheDocument()
   })
 
-  it('renders Config and Credentials tabs as placeholders', () => {
+  it('renders Config and Credentials tabs', () => {
     renderPage()
-    expect(screen.getByRole('button', { name: /config/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /credentials/i })).toBeInTheDocument()
+    // Use exact tab button text to avoid matching "Save config" in the tab content.
+    expect(screen.getByRole('button', { name: 'Config' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Credentials' })).toBeInTheDocument()
   })
 })
 
 describe('AdminPluginInstancePage — Re-authorize banner visibility', () => {
   beforeEach(() => {
     mockCurrentUser(['admin'])
+    mockInstanceDetailLoaded()
     mockMutationNoop()
   })
 
@@ -273,6 +334,7 @@ describe('AdminPluginInstancePage — delete instance', () => {
   beforeEach(() => {
     mockCurrentUser(['admin'])
     mockInstancesLoaded([INSTANCE_WITH_SCHEMA])
+    mockInstanceDetailLoaded()
     mockMutationNoop()
   })
 
@@ -354,6 +416,7 @@ describe('AdminPluginInstancePage — oauth_ok query param', () => {
   it('invalidates plugin-instances query on mount when ?oauth_ok=1 is present', async () => {
     mockCurrentUser(['admin'])
     mockInstancesLoaded([INSTANCE_WITH_SCHEMA])
+    mockInstanceDetailLoaded()
     mockMutationNoop()
 
     const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue()
@@ -372,6 +435,7 @@ describe('AdminPluginInstancePage — oauth_ok query param', () => {
   it('does NOT invalidate when ?oauth_ok is absent', async () => {
     mockCurrentUser(['admin'])
     mockInstancesLoaded([INSTANCE_WITH_SCHEMA])
+    mockInstanceDetailLoaded()
     mockMutationNoop()
 
     const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue()
@@ -385,5 +449,143 @@ describe('AdminPluginInstancePage — oauth_ok query param', () => {
     expect(invalidateSpy).not.toHaveBeenCalled()
 
     invalidateSpy.mockRestore()
+  })
+})
+
+// ── Config tab ────────────────────────────────────────────────────────────────
+
+describe('AdminPluginInstancePage — Config tab', () => {
+  function mockConfigMutation(behavior: 'noop' | 'success' | 'conflict' | 'validation') {
+    let mutateFn: ReturnType<typeof vi.fn>
+
+    if (behavior === 'success') {
+      mutateFn = vi.fn((_params, opts: { onSuccess?: () => void }) => {
+        opts.onSuccess?.()
+      })
+    } else if (behavior === 'conflict') {
+      mutateFn = vi.fn((_params, opts: { onError?: (err: unknown) => void }) => {
+        opts.onError?.(new ApiError(409, 'version conflict'))
+      })
+    } else if (behavior === 'validation') {
+      mutateFn = vi.fn((_params, opts: { onError?: (err: unknown) => void }) => {
+        opts.onError?.(
+          new ApiError(422, 'validation failed', undefined, [
+            { field: 'workspace_name', message: 'must not be empty' },
+          ]),
+        )
+      })
+    } else {
+      mutateFn = vi.fn()
+    }
+
+    vi.mocked(useSetInstanceConfig).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof useSetInstanceConfig>)
+
+    return mutateFn
+  }
+
+  beforeEach(() => {
+    mockCurrentUser(['admin'])
+    mockInstancesLoaded([INSTANCE_WITH_CONFIG_SCHEMA])
+    mockInstanceDetailLoaded(JSON.stringify({ app_level_token: '***', workspace_name: 'Acme' }))
+    mockMutationNoop()
+  })
+
+  it('renders the Config tab with schema fields', () => {
+    renderPage()
+    // Navigate to Config tab (it may not be active by default when subscription_schema is absent).
+    const configTabBtn = screen.getByRole('button', { name: 'Config' })
+    fireEvent.click(configTabBtn)
+    // workspace_name should appear as a text input.
+    expect(screen.getByLabelText(/workspace_name/i)).toBeInTheDocument()
+  })
+
+  it('renders secret fields as password inputs', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Config' }))
+    const secretInput = screen.getByLabelText(/app_level_token/i)
+    expect(secretInput).toHaveAttribute('type', 'password')
+  })
+
+  it('shows sentinel placeholder for secret fields already set on server', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Config' }))
+    const secretInput = screen.getByLabelText(/app_level_token/i)
+    // Sentinel "***" should be rendered as empty value with a placeholder.
+    expect(secretInput).toHaveValue('')
+    expect(secretInput).toHaveAttribute('placeholder', '(already set — leave blank to keep)')
+  })
+
+  it('renders without crashing for an empty config_schema', () => {
+    mockInstancesLoaded([
+      { ...INSTANCE_WITH_CONFIG_SCHEMA, config_schema: {} },
+    ])
+    mockInstanceDetailLoaded('{}')
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Config' }))
+    expect(screen.getByText(/no config fields declared/i)).toBeInTheDocument()
+  })
+
+  it('renders without crashing when config_schema is null', () => {
+    mockInstancesLoaded([INSTANCE_NO_SCHEMA])
+    mockInstanceDetailLoaded('{}')
+    renderPage()
+    // Config tab is the default active tab when no subscription_schema is present.
+    expect(screen.getByText(/no config fields declared/i)).toBeInTheDocument()
+  })
+
+  it('calls save mutation with correct params on Save config click', () => {
+    const mutateFn = mockConfigMutation('success')
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Config' }))
+    fireEvent.click(screen.getByRole('button', { name: /save config/i }))
+    expect(mutateFn).toHaveBeenCalledTimes(1)
+    const call = mutateFn.mock.calls[0][0]
+    expect(call.pluginId).toBe(PLUGIN_ID)
+    expect(call.instanceId).toBe(INSTANCE_ID)
+    // The sentinel field should be stripped from the payload.
+    expect(call.config).not.toHaveProperty('app_level_token')
+    // Non-sentinel fields are kept.
+    expect(call.config).toHaveProperty('workspace_name', 'Acme')
+  })
+
+  it('shows "Saved." after a successful save', async () => {
+    mockConfigMutation('success')
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Config' }))
+    fireEvent.click(screen.getByRole('button', { name: /save config/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Saved.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows CAS conflict message on 409', async () => {
+    mockConfigMutation('conflict')
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Config' }))
+    fireEvent.click(screen.getByRole('button', { name: /save config/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/modified elsewhere/i)).toBeInTheDocument()
+    })
+    // Refresh button should be present.
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument()
+  })
+
+  it('shows field-level validation errors on 422', async () => {
+    mockConfigMutation('validation')
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Config' }))
+    fireEvent.click(screen.getByRole('button', { name: /save config/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/must not be empty/i)).toBeInTheDocument()
+    })
+  })
+
+  it('back-link points to /admin/plugins', () => {
+    renderPage()
+    const backLink = screen.getByRole('link', { name: /plugins/i })
+    expect(backLink).toHaveAttribute('href', '/admin/plugins')
   })
 })

--- a/frontend/src/pages/AdminPluginInstancePage.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.tsx
@@ -8,9 +8,9 @@ import { FieldError } from '@/components/form/FieldError/FieldError'
 import { ReauthorizeButton } from '@/components/admin/ReauthorizeButton/ReauthorizeButton'
 import { CredentialsTab } from '@/components/admin/CredentialsTab/CredentialsTab'
 import { DeletePluginInstanceModal } from '@/components/admin/DeletePluginInstanceModal'
-import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
+import { usePluginInstancesForAudience, usePluginInstanceDetail } from '@/hooks/queries/admin'
 import { useCurrentUser } from '@/hooks/queries/users'
-import { useSetInstanceSubscriptionScope, useDeletePluginInstance } from '@/hooks/mutations/plugins'
+import { useSetInstanceSubscriptionScope, useDeletePluginInstance, useSetInstanceConfig } from '@/hooks/mutations/plugins'
 import { isOAuthRefreshFailure } from '@/utils/pluginHealth'
 import { queryKeys } from '@/hooks/queryKeys'
 import { ApiError } from '@/api/fetch'
@@ -31,6 +31,9 @@ interface SchemaProperty {
   type?: string
   items?: { type?: string }
   description?: string
+  // ADR-049: fields annotated with x-gleipnir-secret: true are redacted on read
+  // and must be submitted via a separate write (never round-tripped as "***").
+  'x-gleipnir-secret'?: boolean
 }
 
 interface SchemaShape {
@@ -41,14 +44,20 @@ function isStringArrayProp(prop: SchemaProperty): boolean {
   return prop.type === 'array' && prop.items?.type === 'string'
 }
 
+// REDACTION_SENTINEL is the value the backend substitutes for secret fields on
+// GET. The bulk PUT rejects it — we strip such fields before sending (ADR-049).
+const REDACTION_SENTINEL = '***'
+
 interface SchemaFormProps {
   schema: SchemaShape
   value: Record<string, unknown>
   onChange: (next: Record<string, unknown>) => void
   fieldErrors: Record<string, string>
+  // idPrefix scopes generated DOM ids so subscription and config forms don't collide.
+  idPrefix?: string
 }
 
-function SchemaForm({ schema, value, onChange, fieldErrors }: SchemaFormProps) {
+function SchemaForm({ schema, value, onChange, fieldErrors, idPrefix = 'field' }: SchemaFormProps) {
   const properties = schema.properties ?? {}
   const fields = Object.keys(properties)
 
@@ -64,9 +73,10 @@ function SchemaForm({ schema, value, onChange, fieldErrors }: SchemaFormProps) {
     <div className={styles.schemaFields}>
       {fields.map((name) => {
         const prop = properties[name]
-        const fieldId = `scope-field-${name}`
-        const fieldErrId = `scope-err-${name}`
+        const fieldId = `${idPrefix}-${name}`
+        const fieldErrId = `${idPrefix}-err-${name}`
         const err = fieldErrors[name]
+        const isSecret = !!prop['x-gleipnir-secret']
 
         if (prop.type === 'boolean') {
           return (
@@ -130,6 +140,36 @@ function SchemaForm({ schema, value, onChange, fieldErrors }: SchemaFormProps) {
                       .filter((s) => s.length > 0),
                   )
                 }
+                aria-describedby={err ? fieldErrId : undefined}
+              />
+              <FieldError id={fieldErrId} messages={err} />
+            </div>
+          )
+        }
+
+        // Secret string: password input. The server returns "***" for existing
+        // values — show as placeholder rather than pre-filling so the operator
+        // must explicitly type to change it (prevents sentinel round-trip).
+        if (isSecret) {
+          const currentVal = typeof value[name] === 'string' ? (value[name] as string) : ''
+          const isSentinel = currentVal === REDACTION_SENTINEL
+          return (
+            <div key={name} className={styles.fieldRow}>
+              <label htmlFor={fieldId} className={styles.fieldLabel}>
+                {name}
+                <span className={styles.fieldHint}> (secret)</span>
+              </label>
+              {prop.description && <p className={styles.fieldDesc}>{prop.description}</p>}
+              <input
+                id={fieldId}
+                type="password"
+                className={styles.input}
+                // Show empty when the sentinel arrives — the placeholder communicates
+                // that a value is already set without echoing "***" into the field.
+                value={isSentinel ? '' : currentVal}
+                placeholder={isSentinel ? '(already set — leave blank to keep)' : ''}
+                autoComplete="new-password"
+                onChange={(e) => handleChange(name, e.target.value)}
                 aria-describedby={err ? fieldErrId : undefined}
               />
               <FieldError id={fieldErrId} messages={err} />
@@ -249,6 +289,200 @@ function SubscriptionsTab({
   )
 }
 
+// ── ConfigTab ─────────────────────────────────────────────────────────────────
+
+interface ConfigTabProps {
+  pluginId: string
+  instanceId: string
+  configSchema: Record<string, unknown> | null
+}
+
+function ConfigTab({ pluginId, instanceId, configSchema }: ConfigTabProps) {
+  const queryClient = useQueryClient()
+
+  // Fetch the per-instance detail to get the current (redacted) config values.
+  // The listing endpoint (usePluginInstancesForAudience) includes config_schema
+  // but omits config_json — we need GetInstance for actual values.
+  const { data: detail, status: detailStatus } = usePluginInstanceDetail(pluginId, instanceId)
+
+  // Parse the config_json string from the backend into a plain object.
+  const serverConfig: Record<string, unknown> = (() => {
+    if (!detail?.config_json) return {}
+    try {
+      return JSON.parse(detail.config_json) as Record<string, unknown>
+    } catch {
+      return {}
+    }
+  })()
+
+  const [config, setConfig] = useState<Record<string, unknown>>(serverConfig)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const [globalError, setGlobalError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const [casConflict, setCasConflict] = useState(false)
+
+  const mutation = useSetInstanceConfig()
+
+  // Sync local config whenever the server data refreshes (e.g. after a save
+  // that invalidates the query, or after navigating between instances).
+  useEffect(() => {
+    if (detail?.config_json) {
+      try {
+        setConfig(JSON.parse(detail.config_json) as Record<string, unknown>)
+      } catch {
+        setConfig({})
+      }
+    } else {
+      setConfig({})
+    }
+    setCasConflict(false)
+    setSaved(false)
+    setFieldErrors({})
+    setGlobalError(null)
+  }, [detail?.config_json, instanceId])
+
+  const schema = (configSchema ?? {}) as SchemaShape
+
+  function buildPayloadConfig(): Record<string, unknown> {
+    // Strip fields that still hold the redaction sentinel — the bulk PUT rejects
+    // them (ADR-049 §5). An empty value on a secret field where the server
+    // returned "***" means the operator left it blank (keep existing), so we
+    // also omit those to avoid sending an empty string as the new secret value.
+    const properties = (schema.properties ?? {}) as Record<string, SchemaProperty>
+    const out: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(config)) {
+      const prop = properties[key]
+      if (prop?.['x-gleipnir-secret']) {
+        // Skip sentinel (backend would reject it anyway).
+        if (val === REDACTION_SENTINEL) continue
+        // Skip empty value when the original was a sentinel (operator left blank
+        // = keep current secret).
+        if (val === '' && serverConfig[key] === REDACTION_SENTINEL) continue
+      }
+      out[key] = val
+    }
+    return out
+  }
+
+  function handleSave() {
+    setSaved(false)
+    setFieldErrors({})
+    setGlobalError(null)
+    setCasConflict(false)
+
+    if (!detail) return
+
+    mutation.mutate(
+      {
+        pluginId,
+        instanceId,
+        config: buildPayloadConfig(),
+        expectedVersion: detail.version,
+      },
+      {
+        onSuccess: () => {
+          setSaved(true)
+          // Refresh to pick up the updated version number and any redacted values.
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.plugins.instance(pluginId, instanceId),
+          })
+        },
+        onError: (err) => {
+          const apiErr = err as ApiError
+          if (apiErr.status === 409) {
+            setCasConflict(true)
+          } else if ((apiErr.status === 422 || apiErr.status === 400) && apiErr.issues) {
+            const errs: Record<string, string> = {}
+            for (const issue of apiErr.issues) {
+              const key = issue.field ?? ''
+              errs[key] = issue.message
+            }
+            setFieldErrors(errs)
+          } else {
+            setGlobalError(apiErr.message ?? 'Save failed')
+          }
+        },
+      },
+    )
+  }
+
+  function handleRefresh() {
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.plugins.instance(pluginId, instanceId),
+    })
+    setCasConflict(false)
+  }
+
+  if (detailStatus === 'pending') {
+    return (
+      <div className={styles.tabContent}>
+        <p className={styles.loading}>Loading…</p>
+      </div>
+    )
+  }
+
+  if (detailStatus === 'error') {
+    return (
+      <div className={styles.tabContent}>
+        <p className={styles.errorMsg}>Could not load instance config.</p>
+      </div>
+    )
+  }
+
+  const hasSchema =
+    configSchema !== null &&
+    typeof configSchema === 'object' &&
+    Object.keys(configSchema).length > 0
+
+  return (
+    <div className={styles.tabContent}>
+      <p className={styles.tabIntro}>
+        Configure this plugin instance. Fields marked as secrets are write-only — a
+        placeholder is shown when a value is already set. Leave a secret field blank to
+        keep the current value.
+      </p>
+
+      {hasSchema ? (
+        <SchemaForm
+          schema={schema}
+          value={config}
+          onChange={setConfig}
+          fieldErrors={fieldErrors}
+          idPrefix="config-field"
+        />
+      ) : (
+        <p className={styles.noFields}>No config fields declared in manifest.</p>
+      )}
+
+      {casConflict && (
+        <div className={styles.casConflict}>
+          <span>Configuration was modified elsewhere — refresh to see latest.</span>
+          <Button type="button" variant="secondary" size="small" onClick={handleRefresh}>
+            Refresh
+          </Button>
+        </div>
+      )}
+
+      {globalError && <p className={styles.globalError}>{globalError}</p>}
+
+      <div className={styles.saveRow}>
+        <Button
+          type="button"
+          variant="primary"
+          size="small"
+          onClick={handleSave}
+          disabled={mutation.isPending || !detail}
+        >
+          {mutation.isPending ? 'Saving…' : 'Save config'}
+        </Button>
+        {saved && !mutation.isPending && (
+          <span className={styles.savedConfirm}>Saved.</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function AdminPluginInstancePage() {
@@ -343,10 +577,11 @@ export default function AdminPluginInstancePage() {
 
     if (activeTab === 'config') {
       return (
-        <div className={styles.tabContent}>
-          {/* TODO #241: render instance config form */}
-          <p className={styles.placeholder}>Instance configuration — coming in #241.</p>
-        </div>
+        <ConfigTab
+          pluginId={pluginId!}
+          instanceId={instanceId!}
+          configSchema={instance.config_schema}
+        />
       )
     }
 
@@ -373,9 +608,9 @@ export default function AdminPluginInstancePage() {
 
   return (
     <div className={styles.page}>
-      <Link to="/admin/audiences" className={styles.backLink}>
+      <Link to="/admin/plugins" className={styles.backLink}>
         <ArrowLeft size={14} strokeWidth={1.5} aria-hidden />
-        Audiences
+        Plugins
       </Link>
 
       <PageHeader title={`${pluginName} / ${instanceName}`}>

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -138,12 +138,12 @@ type PluginHandler struct {
 	q                PluginQuerier
 	publisher        event.Publisher
 	clock            func() time.Time
-	triggerRestarter TriggerRestarter   // may be nil if plugins are disabled
-	installer        PluginInstaller    // may be nil if GLEIPNIR_PLUGINS_ENABLED=false
-	store            *db.Store          // nil disables DeleteInstance and Uninstall (503)
-	pluginsDir       string             // empty disables FS cleanup in Uninstall
+	triggerRestarter TriggerRestarter     // may be nil if plugins are disabled
+	installer        PluginInstaller      // may be nil if GLEIPNIR_PLUGINS_ENABLED=false
+	store            *db.Store            // nil disables DeleteInstance and Uninstall (503)
+	pluginsDir       string               // empty disables FS cleanup in Uninstall
 	processManager   PluginProcessManager // nil means skip subprocess Stop
-	toolUnregistrar  ToolUnregistrar    // nil until #194 wires tools.Registrar
+	toolUnregistrar  ToolUnregistrar      // nil until #194 wires tools.Registrar
 }
 
 // NewPluginHandler returns a PluginHandler backed by the given querier, event
@@ -435,10 +435,13 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 	nowStr := h.clock().UTC().Format(time.RFC3339Nano)
 
 	// CAS-guarded manifest commit (ADR-038). Verify rows-affected before touching instances.
+	// Status returns to "active" because the admin has explicitly accepted the candidate
+	// manifest — leaving it pending_review would re-orphan the plugin (subprocess manager
+	// and trigger supervisor both filter to status='active').
 	rows, err := h.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
 		ManifestSnapshot: string(candidateBytes),
 		PluginVersion:    newManifest.Version,
-		Status:           "pending_review",
+		Status:           "active",
 		UpdatedAt:        nowStr,
 		ID:               pluginID,
 		ExpectedVersion:  plugin.Version,
@@ -872,6 +875,15 @@ func (h *PluginHandler) PutInstanceConfig(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Advance the readiness detail (config_missing → credentials_missing → "")
+	// so the admin UI tells the operator what's still missing. Best-effort —
+	// the config write has already committed; advanceInstanceReadiness logs
+	// failures internally.
+	h.advanceInstanceReadiness(ctx, updated, &m)
+	if refreshed, refetchErr := h.q.GetPluginInstanceByID(ctx, instanceID); refetchErr == nil {
+		updated = refreshed
+	}
+
 	// Redact the re-fetched config before returning.
 	redactedFetchedConfig, err := configvalidate.RedactSecrets(updated.ConfigJson, secretNames)
 	if err != nil {
@@ -1138,6 +1150,60 @@ func (h *PluginHandler) unblockInstances(
 	return count
 }
 
+// computeInstanceReadinessDetail returns the appropriate health_detail string
+// for an instance that is sitting in PluginHealthStateUnhealthy, based on what
+// the operator still needs to configure. This is used after the operator saves
+// instance config or credentials so the admin UI tells them what's still
+// missing — without it, the detail stayed at "config_missing" forever even
+// after config was set, giving operators no signal what to do next.
+//
+// The returned string is empty when the instance has everything it needs and
+// is just waiting for the subprocess to come up healthy.
+func computeInstanceReadinessDetail(m *sdkmanifest.Manifest, configJSON string, credentialsPresent bool) string {
+	if configJSON == "" || configJSON == "{}" {
+		return "config_missing"
+	}
+	// Credentials are only required for auth strategies that consume them.
+	// "none" plugins (and unset strategy, which defaults to "none" in the parser)
+	// are config-only.
+	switch m.Auth.Strategy {
+	case "", sdkmanifest.AuthStrategyNone:
+		return "" // ready — subprocess will mark healthy on handshake
+	default:
+		if !credentialsPresent {
+			return "credentials_missing"
+		}
+		return "" // ready
+	}
+}
+
+// advanceInstanceReadiness re-evaluates the instance's readiness detail and
+// writes it back through SetHealthState if it has changed. Best-effort — any
+// failure is logged but not returned to the caller because the underlying
+// config/credentials write has already succeeded. Bypasses the update entirely
+// when the instance is not currently in unhealthy (e.g. already healthy, or
+// pending some other admin action).
+func (h *PluginHandler) advanceInstanceReadiness(ctx context.Context, inst db.PluginInstance, m *sdkmanifest.Manifest) {
+	if model.PluginHealthState(inst.HealthState) != model.PluginHealthStateUnhealthy {
+		return
+	}
+	credentialsPresent := inst.CredentialsEncrypted != nil && *inst.CredentialsEncrypted != ""
+	wanted := computeInstanceReadinessDetail(m, inst.ConfigJson, credentialsPresent)
+	var currentDetail string
+	if inst.HealthDetail != nil {
+		currentDetail = *inst.HealthDetail
+	}
+	if wanted == currentDetail {
+		return
+	}
+	err := pluginstate.SetHealthState(ctx, h.q, h.publisher, inst.ID, pluginstate.OriginHost,
+		model.PluginHealthStateUnhealthy, wanted)
+	if err != nil && !errors.Is(err, pluginstate.ErrTransitionConflict) {
+		slog.WarnContext(ctx, "advanceInstanceReadiness: set health detail failed",
+			"instance_id", inst.ID, "from", currentDetail, "to", wanted, "err", err)
+	}
+}
+
 // writeAuditEvent inserts a plugin-level audit row (PluginInstanceID = nil) with
 // the calling user as actor when one is on the request context. Failures are
 // logged but not surfaced — the upstream DB change has already committed.
@@ -1226,11 +1292,25 @@ func (h *PluginHandler) Install(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := err.Error()
 		switch {
-		case strings.Contains(msg, "extract tarball"),
-			strings.Contains(msg, "read manifest"),
-			strings.Contains(msg, "parse manifest"),
-			strings.Contains(msg, "manifest.name"):
-			httputil.WriteError(w, http.StatusBadRequest, "malformed tarball", msg)
+		case strings.Contains(msg, "extract tarball"):
+			// Tarball-format failures: bad gzip header, file-count limit,
+			// disallowed symlinks, unsupported entry types, uncompressed size cap.
+			httputil.WriteError(w, http.StatusBadRequest, "tarball extraction failed", msg)
+		case strings.Contains(msg, "resolve bundle root"):
+			// Layout failure: manifest.yaml missing both at the tarball root
+			// and under a single top-level directory.
+			httputil.WriteError(w, http.StatusBadRequest, "invalid bundle layout", msg)
+		case strings.Contains(msg, "parse manifest"):
+			// Order matters: "parse manifest" is wrapped inside "read manifest
+			// from %q: %w" so this case must come first.
+			httputil.WriteError(w, http.StatusBadRequest, "manifest.yaml is not valid YAML", msg)
+		case strings.Contains(msg, "read manifest"):
+			httputil.WriteError(w, http.StatusBadRequest, "manifest.yaml missing or unreadable", msg)
+		case strings.Contains(msg, "manifest.name"):
+			// manifest.name missing, empty, or carries path separators (security guard).
+			httputil.WriteError(w, http.StatusBadRequest, "invalid manifest.name", msg)
+		case strings.Contains(msg, "manifest.version"):
+			httputil.WriteError(w, http.StatusBadRequest, "invalid manifest.version", msg)
 		case strings.Contains(msg, "CAS conflict"):
 			httputil.WriteError(w, http.StatusConflict, "concurrent plugin update; retry", "")
 		default:
@@ -1696,10 +1776,10 @@ func (h *PluginHandler) Uninstall(w http.ResponseWriter, r *http.Request) {
 
 	nowStr := h.clock().UTC().Format(time.RFC3339Nano)
 	h.writeAuditEvent(ctx, auditPluginUninstalled, "info", nowStr, map[string]any{
-		"plugin_id":            pluginID,
-		"plugin_name":          plugin.Name,
-		"plugin_version":       plugin.PluginVersion,
-		"instance_count":       len(instances),
+		"plugin_id":           pluginID,
+		"plugin_name":         plugin.Name,
+		"plugin_version":      plugin.PluginVersion,
+		"instance_count":      len(instances),
 		"binary_path_removed": binaryPathRemoved,
 	})
 

--- a/internal/admin/plugin_handler_install_test.go
+++ b/internal/admin/plugin_handler_install_test.go
@@ -59,17 +59,17 @@ func TestPluginHandler_Install(t *testing.T) {
 	tinyTar := []byte("not a real tarball")
 
 	tests := []struct {
-		name           string
-		body           []byte
-		installer      *fakeInstaller
-		seedPlugin     *db.Plugin
-		wantStatus     int
-		wantErrSubstr  string
-		wantDataID     string
+		name          string
+		body          []byte
+		installer     *fakeInstaller
+		seedPlugin    *db.Plugin
+		wantStatus    int
+		wantErrSubstr string
+		wantDataID    string
 	}{
 		{
-			name:  "happy_path: 201 with plugin ID in body",
-			body:  tinyTar,
+			name:      "happy_path: 201 with plugin ID in body",
+			body:      tinyTar,
 			installer: &fakeInstaller{returnID: "plg_123"},
 			seedPlugin: &db.Plugin{
 				ID:            "plg_123",
@@ -88,13 +88,13 @@ func TestPluginHandler_Install(t *testing.T) {
 			wantErrSubstr: "empty tarball body",
 		},
 		{
-			name: "installer_malformed: 400",
+			name: "installer_tarball_extract_failed: 400",
 			body: tinyTar,
 			installer: &fakeInstaller{
 				returnErr: errors.New(`extract tarball "/tmp/x": unexpected EOF`),
 			},
 			wantStatus:    http.StatusBadRequest,
-			wantErrSubstr: "malformed tarball",
+			wantErrSubstr: "tarball extraction failed",
 		},
 		{
 			name: "installer_cas_conflict: 409",
@@ -143,7 +143,7 @@ func TestPluginHandler_Install(t *testing.T) {
 				returnErr: errors.New("read manifest from \"/tmp/x\": stat manifest.yaml: no such file"),
 			},
 			wantStatus:    http.StatusBadRequest,
-			wantErrSubstr: "malformed tarball",
+			wantErrSubstr: "manifest.yaml missing",
 		},
 		{
 			name: "manifest_name_path_traversal: 400",
@@ -152,7 +152,25 @@ func TestPluginHandler_Install(t *testing.T) {
 				returnErr: errors.New(`manifest.name "../escape" escapes bundle directory`),
 			},
 			wantStatus:    http.StatusBadRequest,
-			wantErrSubstr: "malformed tarball",
+			wantErrSubstr: "invalid manifest.name",
+		},
+		{
+			name: "invalid_bundle_layout: 400",
+			body: tinyTar,
+			installer: &fakeInstaller{
+				returnErr: errors.New(`resolve bundle root in "/tmp/x": manifest.yaml not found at bundle root or under a single top-level directory`),
+			},
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "invalid bundle layout",
+		},
+		{
+			name: "parse_manifest_error: 400",
+			body: tinyTar,
+			installer: &fakeInstaller{
+				returnErr: errors.New(`read manifest from "/tmp/x": parse manifest.yaml: yaml: line 3: did not find expected key`),
+			},
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "not valid YAML",
 		},
 	}
 

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -36,8 +36,8 @@ type fakePluginQuerier struct {
 	audienceEntries map[string][]db.ListAudienceEntriesByInstanceRow
 	// casFailOn is the plugin ID that should return 0 rows for UpdatePluginTrustedPubkey
 	// or UpdatePluginManifest to simulate a CAS conflict.
-	casFailOn        string
-	updatePubkey     string // last value written by UpdatePluginTrustedPubkey
+	casFailOn         string
+	updatePubkey      string // last value written by UpdatePluginTrustedPubkey
 	scopeCASFailOnID  string // instance ID that should return 0 rows for UpdatePluginInstanceSubscriptionScope
 	configCASFailOnID string // instance ID that should return 0 rows for UpdatePluginInstanceConfig
 	createInstanceErr error  // if non-nil, CreatePluginInstance returns this error
@@ -565,7 +565,7 @@ func TestPutInstanceConfig_ResponseRedactsWrittenSecret(t *testing.T) {
 // synthesized-response branch.
 type failOnSecondGetInstance struct {
 	*fakePluginQuerier
-	targetID string
+	targetID  string
 	callCount int
 }
 
@@ -1470,13 +1470,13 @@ func TestPluginHandler_PutInstanceConfig_HappyPath(t *testing.T) {
 		Version:          0,
 	})
 	q.seed(db.PluginInstance{
-		ID:          "inst-1",
-		PluginID:    "plugin-1",
+		ID:           "inst-1",
+		PluginID:     "plugin-1",
 		InstanceName: "prod",
-		ConfigJson:  "{}",
-		HealthState: "healthy",
-		Version:     0,
-		UpdatedAt:   "2026-01-01T00:00:00Z",
+		ConfigJson:   "{}",
+		HealthState:  "healthy",
+		Version:      0,
+		UpdatedAt:    "2026-01-01T00:00:00Z",
 	})
 
 	h := NewPluginHandler(q, nil, fixedClock)
@@ -1682,9 +1682,9 @@ func TestPluginHandler_PutInstanceConfig_MalformedManifest_500(t *testing.T) {
 
 // fakeProcessManager is a PluginProcessManager stub that records Stop calls.
 type fakeProcessManager struct {
-	mu            sync.Mutex
-	stoppedIDs    []string
-	stopErr       error
+	mu              sync.Mutex
+	stoppedIDs      []string
+	stopErr         error
 	stoppedByPlugin []string
 }
 

--- a/internal/admin/plugin_oauth_handler.go
+++ b/internal/admin/plugin_oauth_handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -30,13 +31,16 @@ type OAuthPluginQuerier interface {
 //	POST /api/v1/admin/plugins/{id}/instances/{iid}/oauth/begin
 //	GET  /api/v1/admin/plugins/oauth/callback  (unprotected)
 type PluginOAuthHandler struct {
-	mgr *oauth.Manager
-	q   OAuthPluginQuerier
+	mgr          *oauth.Manager
+	q            OAuthPluginQuerier
+	getPublicURL func() string
 }
 
-// NewPluginOAuthHandler constructs a PluginOAuthHandler.
-func NewPluginOAuthHandler(q OAuthPluginQuerier, mgr *oauth.Manager) *PluginOAuthHandler {
-	return &PluginOAuthHandler{mgr: mgr, q: q}
+// NewPluginOAuthHandler constructs a PluginOAuthHandler. getPublicURL is called
+// at request time to validate return_url against the host's configured origin;
+// it mirrors the same closure passed to oauth.NewManager in main.go.
+func NewPluginOAuthHandler(q OAuthPluginQuerier, mgr *oauth.Manager, getPublicURL func() string) *PluginOAuthHandler {
+	return &PluginOAuthHandler{mgr: mgr, q: q, getPublicURL: getPublicURL}
 }
 
 // beginRequest is the JSON body for POST .../oauth/begin.
@@ -105,6 +109,15 @@ func (h *PluginOAuthHandler) Begin(w http.ResponseWriter, r *http.Request) {
 	case sdkmanifest.AuthStrategyOAuth2Authcode:
 		if req.ReturnURL == "" {
 			httputil.WriteError(w, http.StatusBadRequest, "return_url is required for oauth2_authcode", "")
+			return
+		}
+		// Validate return_url before embedding it in the signed HMAC envelope.
+		// The callback endpoint is unauthenticated (browser arrives from the OAuth
+		// provider), so an unvalidated return_url would be an open redirect that
+		// any attacker could weaponise via a CSRF-crafted /oauth/begin POST.
+		if err := validateReturnURL(req.ReturnURL, h.getPublicURL()); err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid return_url",
+				"must be same-origin as public_url or a relative path")
 			return
 		}
 		authorizeURL, err := h.mgr.BeginAuthcode(ctx, instanceID, req.ReturnURL)
@@ -178,14 +191,29 @@ func (h *PluginOAuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	returnURL, err := h.mgr.HandleCallback(ctx, rawState, code)
 	if err != nil {
-		slog.ErrorContext(ctx, "oauth callback: handle failed", "err", err)
+		// Build a user-facing error message. For ProviderExchangeError we surface
+		// Code (and Description when present) so operators see "invalid_code" rather
+		// than the opaque golang.org/x/oauth2 blob. The raw error is always logged.
+		var pee *oauth.ProviderExchangeError
+		userMsg := err.Error()
+		if errors.As(err, &pee) {
+			slog.ErrorContext(ctx, "oauth callback: provider exchange error",
+				"code", pee.Code, "description", pee.Description, "raw", pee.Raw)
+			if pee.Description != "" {
+				userMsg = pee.Code + ": " + pee.Description
+			} else {
+				userMsg = pee.Code
+			}
+		} else {
+			slog.ErrorContext(ctx, "oauth callback: handle failed", "err", err)
+		}
 		// Try to extract ReturnURL from state for best-effort redirect.
 		env, decodeErr := h.mgr.DecodeStateForRedirect(rawState)
 		if decodeErr != nil || env.ReturnURL == "" {
-			httputil.WriteError(w, http.StatusBadRequest, "oauth callback failed", err.Error())
+			httputil.WriteError(w, http.StatusBadRequest, "oauth callback failed", userMsg)
 			return
 		}
-		redirectWithError(w, r, env.ReturnURL, err.Error())
+		redirectWithError(w, r, env.ReturnURL, userMsg)
 		return
 	}
 
@@ -202,6 +230,53 @@ func (h *PluginOAuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	params.Set("oauth_ok", "1")
 	u.RawQuery = params.Encode()
 	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// validateReturnURL checks that returnURL is safe to redirect to after OAuth.
+// We accept:
+//   - A relative path (starts with "/" but not "//", which would be protocol-relative).
+//   - An absolute URL whose origin matches the host's configured publicURL.
+//
+// Anything else (different origin, protocol-relative, unparseable) is rejected
+// to prevent an open-redirect vulnerability: the callback endpoint is
+// intentionally unauthenticated, so an attacker who can craft a /oauth/begin
+// POST (e.g. via CSRF against a logged-in admin) would otherwise control the
+// final redirect destination.
+//
+// Returns ("", nil) when the input is valid. Returns an error when it is not.
+func validateReturnURL(returnURL, publicURL string) error {
+	// Relative paths are safe — the browser resolves them against the current
+	// host, so there is no risk of redirecting to an attacker-controlled origin.
+	// However "//evil.com" (protocol-relative) must be rejected because browsers
+	// treat it as an absolute URL with the current protocol.
+	if strings.HasPrefix(returnURL, "/") && !strings.HasPrefix(returnURL, "//") {
+		return nil
+	}
+
+	// For absolute URLs we require same-origin as publicURL.
+	// Parse both and compare scheme + host (port is included in host when
+	// non-standard, so net/url handles it correctly).
+	parsed, err := url.Parse(returnURL)
+	if err != nil || parsed.Host == "" {
+		// Unparseable or not an absolute URL — reject.
+		return fmt.Errorf("not a valid absolute URL or relative path")
+	}
+
+	if publicURL == "" {
+		// No public URL configured: we cannot verify same-origin, so we must
+		// reject any absolute URL to stay fail-closed.
+		return fmt.Errorf("public_url is not configured; only relative paths are accepted")
+	}
+
+	pub, err := url.Parse(publicURL)
+	if err != nil || pub.Host == "" {
+		return fmt.Errorf("configured public_url is not a valid URL")
+	}
+
+	if parsed.Scheme != pub.Scheme || parsed.Host != pub.Host {
+		return fmt.Errorf("must be same-origin as public_url (%s)", pub.Scheme+"://"+pub.Host)
+	}
+	return nil
 }
 
 // redirectWithError redirects the browser to returnURL with an oauth_error

--- a/internal/admin/plugin_oauth_handler_test.go
+++ b/internal/admin/plugin_oauth_handler_test.go
@@ -136,7 +136,7 @@ func buildOAuthHandler(t *testing.T, q OAuthPluginQuerier, publicURL string) *Pl
 	nonces := oauth.NewMemoryNonceStore(clock)
 	hmacKey := oauth.DeriveHMACKey(make([]byte, 32))
 	mgr := oauth.NewManager(store, nonces, clock, hmacKey, func() string { return publicURL })
-	return NewPluginOAuthHandler(q, mgr)
+	return NewPluginOAuthHandler(q, mgr, func() string { return publicURL })
 }
 
 func TestPluginOAuthHandler_Begin_NonOAuthStrategy_400(t *testing.T) {
@@ -179,7 +179,8 @@ func TestPluginOAuthHandler_Begin_AuthcodeReturnsAuthorizeURL(t *testing.T) {
 
 	h := buildOAuthHandler(t, q, "https://gleipnir.example.com")
 
-	body, _ := json.Marshal(map[string]string{"return_url": "https://app.example.com/settings"})
+	// Use a same-origin return_url so the new open-redirect validation passes.
+	body, _ := json.Marshal(map[string]string{"return_url": "https://gleipnir.example.com/admin/plugins/inst-1"})
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/instances/inst-1/oauth/begin", bytes.NewReader(body))
 	r = withChiParams(r, map[string]string{"id": "plugin-1", "iid": "inst-1"})
 	w := httptest.NewRecorder()
@@ -296,3 +297,113 @@ func TestPluginOAuthHandler_Callback_ProviderError_RedirectsWithError(t *testing
 	}
 }
 
+// --- validateReturnURL tests (Fix 2: open-redirect hardening) ---
+
+// TestValidateReturnURL covers the full acceptance/rejection matrix for
+// return_url validation. Rows with wantErr=false must be accepted; those with
+// wantErr=true must be rejected with a non-nil error.
+func TestValidateReturnURL(t *testing.T) {
+	const publicURL = "https://gleipnir.example.com"
+
+	cases := []struct {
+		name      string
+		returnURL string
+		publicURL string
+		wantErr   bool
+	}{
+		// Relative paths are always accepted.
+		{name: "relative path", returnURL: "/admin/plugins/inst-1", wantErr: false, publicURL: publicURL},
+		{name: "relative path with query", returnURL: "/admin?tab=oauth", wantErr: false, publicURL: publicURL},
+		// Same-origin absolute URLs are accepted.
+		{name: "same-origin absolute", returnURL: "https://gleipnir.example.com/admin/plugins", wantErr: false, publicURL: publicURL},
+		{name: "same-origin root", returnURL: "https://gleipnir.example.com/", wantErr: false, publicURL: publicURL},
+		// Different-origin absolute URLs are rejected.
+		{name: "different-origin absolute", returnURL: "https://evil.com/steal", wantErr: true, publicURL: publicURL},
+		{name: "different-scheme", returnURL: "http://gleipnir.example.com/admin", wantErr: true, publicURL: publicURL},
+		{name: "different host port", returnURL: "https://gleipnir.example.com:9999/admin", wantErr: true, publicURL: publicURL},
+		// Protocol-relative URLs must be rejected (browsers treat // as absolute).
+		{name: "protocol-relative", returnURL: "//evil.com/steal", wantErr: true, publicURL: publicURL},
+		// Malformed / non-URL strings are rejected.
+		{name: "bare word", returnURL: "evil.com", wantErr: true, publicURL: publicURL},
+		{name: "javascript scheme", returnURL: "javascript:alert(1)", wantErr: true, publicURL: publicURL},
+		// When publicURL is empty, only relative paths are accepted.
+		{name: "relative path no publicURL", returnURL: "/admin", wantErr: false, publicURL: ""},
+		{name: "absolute no publicURL", returnURL: "https://gleipnir.example.com/admin", wantErr: true, publicURL: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateReturnURL(tc.returnURL, tc.publicURL)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateReturnURL(%q, %q): expected error, got nil", tc.returnURL, tc.publicURL)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateReturnURL(%q, %q): unexpected error: %v", tc.returnURL, tc.publicURL, err)
+			}
+		})
+	}
+}
+
+// TestPluginOAuthHandler_Begin_InvalidReturnURL_400 exercises the HTTP handler's
+// open-redirect guard. Sends a return_url pointing at a different origin and
+// expects a 400 response.
+func TestPluginOAuthHandler_Begin_InvalidReturnURL_400(t *testing.T) {
+	q := newFakeOAuthPluginQuerier()
+	q.instances["inst-1"] = db.PluginInstance{
+		ID:          "inst-1",
+		PluginID:    "plugin-1",
+		HealthState: "healthy",
+	}
+	q.plugins["plugin-1"] = db.Plugin{
+		ID:               "plugin-1",
+		ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyOAuth2Authcode),
+	}
+	h := buildOAuthHandler(t, q, "https://gleipnir.example.com")
+
+	for _, returnURL := range []string{
+		"https://evil.com/steal",
+		"//evil.com",
+		"javascript:alert(1)",
+	} {
+		body, _ := json.Marshal(map[string]string{"return_url": returnURL})
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/instances/inst-1/oauth/begin", bytes.NewReader(body))
+		r = withChiParams(r, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+		w := httptest.NewRecorder()
+
+		h.Begin(w, r)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("return_url=%q: expected 400, got %d: %s", returnURL, w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "invalid return_url") {
+			t.Errorf("return_url=%q: expected body to mention 'invalid return_url', got: %s", returnURL, w.Body.String())
+		}
+	}
+}
+
+// TestPluginOAuthHandler_Begin_RelativeReturnURL_Accepted verifies that a
+// relative path return_url passes validation and the flow proceeds normally.
+func TestPluginOAuthHandler_Begin_RelativeReturnURL_Accepted(t *testing.T) {
+	q := newFakeOAuthPluginQuerier()
+	q.instances["inst-1"] = db.PluginInstance{
+		ID:          "inst-1",
+		PluginID:    "plugin-1",
+		HealthState: "healthy",
+	}
+	q.plugins["plugin-1"] = db.Plugin{
+		ID:               "plugin-1",
+		ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyOAuth2Authcode),
+	}
+	h := buildOAuthHandler(t, q, "https://gleipnir.example.com")
+
+	body, _ := json.Marshal(map[string]string{"return_url": "/admin/plugins/inst-1"})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/instances/inst-1/oauth/begin", bytes.NewReader(body))
+	r = withChiParams(r, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+	w := httptest.NewRecorder()
+
+	h.Begin(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for relative return_url, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/admin/plugin_readiness_test.go
+++ b/internal/admin/plugin_readiness_test.go
@@ -1,0 +1,81 @@
+package admin
+
+import (
+	"testing"
+
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+)
+
+func TestComputeInstanceReadinessDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		strategy   string
+		configJSON string
+		credsSet   bool
+		want       string
+	}{
+		{
+			name:       "empty_config_returns_config_missing",
+			strategy:   sdkmanifest.AuthStrategyStaticAPIKey,
+			configJSON: "{}",
+			credsSet:   true,
+			want:       "config_missing",
+		},
+		{
+			name:       "empty_config_string_returns_config_missing",
+			strategy:   sdkmanifest.AuthStrategyNone,
+			configJSON: "",
+			credsSet:   false,
+			want:       "config_missing",
+		},
+		{
+			name:       "config_set_with_strategy_none_returns_empty",
+			strategy:   sdkmanifest.AuthStrategyNone,
+			configJSON: `{"key":"v"}`,
+			credsSet:   false,
+			want:       "",
+		},
+		{
+			name:       "config_set_unset_strategy_treated_as_none",
+			strategy:   "",
+			configJSON: `{"key":"v"}`,
+			credsSet:   false,
+			want:       "",
+		},
+		{
+			name:       "config_set_creds_missing_for_auth_strategy_returns_credentials_missing",
+			strategy:   sdkmanifest.AuthStrategyStaticAPIKey,
+			configJSON: `{"key":"v"}`,
+			credsSet:   false,
+			want:       "credentials_missing",
+		},
+		{
+			name:       "config_set_creds_set_for_oauth_returns_empty",
+			strategy:   sdkmanifest.AuthStrategyOAuth2Authcode,
+			configJSON: `{"app_level_token":"xapp-1"}`,
+			credsSet:   true,
+			want:       "",
+		},
+		{
+			name:       "config_set_creds_missing_for_oauth_returns_credentials_missing",
+			strategy:   sdkmanifest.AuthStrategyOAuth2Authcode,
+			configJSON: `{"app_level_token":"xapp-1"}`,
+			credsSet:   false,
+			want:       "credentials_missing",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := &sdkmanifest.Manifest{Auth: sdkmanifest.AuthDecl{Strategy: tc.strategy}}
+			got := computeInstanceReadinessDetail(m, tc.configJSON, tc.credsSet)
+			if got != tc.want {
+				t.Errorf("computeInstanceReadinessDetail = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/plugin/dispatch/channel_integration_test.go
+++ b/internal/plugin/dispatch/channel_integration_test.go
@@ -158,3 +158,6 @@ func (q *dispatchIntegFakeQuerier) GetPluginInstanceByID(_ context.Context, _ st
 func (q *dispatchIntegFakeQuerier) UpdatePluginInstanceHealth(_ context.Context, _ db.UpdatePluginInstanceHealthParams) (int64, error) {
 	return 1, nil
 }
+func (q *dispatchIntegFakeQuerier) InsertPluginAuditEvent(_ context.Context, _ db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error) {
+	return db.PluginAuditEvent{}, nil
+}

--- a/internal/plugin/e2e/composition_test.go
+++ b/internal/plugin/e2e/composition_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/plugin/dedup"
 	plugintrigger "github.com/felag-engineering/gleipnir/internal/plugin/trigger"
-	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 )
 
 // stubInstanceID is used as both the plugin_instances.id column value in
@@ -155,11 +155,14 @@ func seedSubstrateData(t *testing.T) (matchPolicyID, noMatchPolicyID string, q *
 	}
 
 	if _, err := q.CreatePluginInstance(ctx, db.CreatePluginInstanceParams{
-		ID:                    stubInstanceID,
-		PluginID:              pluginID,
-		InstanceName:          "stub-instance",
-		ConfigJson:            "{}",
-		SubscriptionScopeJson: "{}",
+		ID:           stubInstanceID,
+		PluginID:     pluginID,
+		InstanceName: "stub-instance",
+		ConfigJson:   "{}",
+		// Non-empty scope satisfies the supervisor's scope gate (skips streams
+		// for unconfigured instances). The composition test's point is to drive
+		// a stream end-to-end, so we explicitly opt in.
+		SubscriptionScopeJson: `{"watch":"all"}`,
 		HandshakeVersions:     "{}",
 		HealthState:           "healthy",
 		CreatedAt:             now,

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -71,6 +71,7 @@ const (
 
 	// Plugin status values that mirror the DB CHECK constraint.
 	statusPendingReview = "pending_review"
+	statusActive        = "active"
 
 	// Audit event types (ADR-046).
 	auditSignatureInvalid       = "plugin_signature_invalid"
@@ -443,7 +444,7 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 		return id, cosErr == nil && id != "", cosErr
 	}
 
-	id, upErr := in.updatePlugin(ctx, existing, m, manifestBytes, tmpDir, nowStr)
+	id, upErr := in.updatePlugin(ctx, existing, m, manifestBytes, result, tmpDir, nowStr)
 	return id, upErr == nil && id != "", upErr
 }
 
@@ -616,7 +617,24 @@ func pubkeyFingerprint(pubkeyBytes []byte) string {
 	return fmt.Sprintf("%x", pk.KeyID)
 }
 
-// createPlugin inserts a new plugin row with status=pending_review.
+// installStatusFor returns the status value to write for a newly-installed or
+// version-bumped plugin row. Verified bundles (and unsigned bundles when the
+// operator has explicitly opted in via GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true)
+// are promoted to "active" so the subprocess manager and trigger supervisor
+// will pick them up. The "pending_review" status is reserved for paths that
+// require explicit operator approval — currently none in this codepath, but
+// future review-gated flows can reuse the constant.
+func installStatusFor(outcome VerifyOutcome) string {
+	switch outcome {
+	case OutcomeVerified, OutcomeUnsignedPermissive:
+		return statusActive
+	default:
+		return statusPendingReview
+	}
+}
+
+// createPlugin inserts a new plugin row with the status returned by
+// installStatusFor (typically "active" for verified or unsigned-permissive bundles).
 // Publishes the verified bundle to disk first, then stores the binary_path
 // in the DB so Manager.StartAllActive can re-spawn the subprocess on server
 // restart without re-extracting the tarball.
@@ -641,7 +659,7 @@ func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, man
 		PluginVersion:    m.Version,
 		ManifestSnapshot: string(manifestBytes),
 		TrustedPubkey:    string(result.Pubkey),
-		Status:           statusPendingReview,
+		Status:           installStatusFor(result.Outcome),
 		BinaryPath:       binaryPathPtr,
 		CreatedAt:        nowStr,
 		UpdatedAt:        nowStr,
@@ -668,7 +686,7 @@ func (in *Installer) createPlugin(ctx context.Context, m *manifest.Manifest, man
 // Installer takes *sql.DB instead of *db.Queries. Today an audit-insert failure
 // leaves the plugins row updated but the event unrecorded; same-version
 // idempotency masks the retry.
-func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, tmpDir string, nowStr string) (string, error) {
+func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, result VerifyResult, tmpDir string, nowStr string) (string, error) {
 	// Publish the verified bundle before touching the DB so the subprocess can
 	// be re-spawned with the correct binary on the next restart.
 	var binaryPathPtr *string
@@ -683,7 +701,7 @@ func (in *Installer) updatePlugin(ctx context.Context, existing db.Plugin, m *ma
 	rows, err := in.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
 		ManifestSnapshot: string(manifestBytes),
 		PluginVersion:    m.Version,
-		Status:           statusPendingReview,
+		Status:           installStatusFor(result.Outcome),
 		UpdatedAt:        nowStr,
 		ID:               existing.ID,
 		ExpectedVersion:  existing.Version,

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -244,7 +244,12 @@ func newTestInstaller(t *testing.T, q *db.Queries, allowUnsigned bool) *Installe
 	return inst
 }
 
-func TestInstall_NewSignedPlugin_PendingReview(t *testing.T) {
+// TestInstall_NewSignedPlugin_Active verifies that a verified install promotes
+// the plugin row to status=active so the subprocess manager and trigger
+// supervisor (both of which filter by status='active') will pick it up. Before
+// this change a fresh install sat in pending_review forever with no automated
+// path to advance it (no UpdatePluginStatus caller existed).
+func TestInstall_NewSignedPlugin_Active(t *testing.T) {
 	q := openTestDB(t)
 	inst := newTestInstaller(t, q, false)
 
@@ -259,8 +264,8 @@ func TestInstall_NewSignedPlugin_PendingReview(t *testing.T) {
 		t.Fatalf("GetPluginByName: %v", err)
 	}
 
-	if row.Status != "pending_review" {
-		t.Errorf("status = %q, want %q", row.Status, "pending_review")
+	if row.Status != "active" {
+		t.Errorf("status = %q, want %q", row.Status, "active")
 	}
 	if row.PluginVersion != "1.0.0" {
 		t.Errorf("plugin_version = %q, want %q", row.PluginVersion, "1.0.0")
@@ -313,7 +318,7 @@ func TestInstall_BadSignature_AuditOnly(t *testing.T) {
 	}
 }
 
-func TestInstall_VersionBump_PendingReview(t *testing.T) {
+func TestInstall_VersionBump_Active(t *testing.T) {
 	q := openTestDB(t)
 	inst := newTestInstaller(t, q, false)
 
@@ -364,8 +369,8 @@ func TestInstall_VersionBump_PendingReview(t *testing.T) {
 	if row.PluginVersion != "1.1.0" {
 		t.Errorf("plugin_version = %q, want %q", row.PluginVersion, "1.1.0")
 	}
-	if row.Status != "pending_review" {
-		t.Errorf("status = %q, want %q", row.Status, "pending_review")
+	if row.Status != "active" {
+		t.Errorf("status = %q, want %q", row.Status, "active")
 	}
 
 	// A version-string-only bump produces a cosmetic diff (version is a cosmetic field),
@@ -419,7 +424,11 @@ func TestInstall_TarballTooLarge(t *testing.T) {
 	}
 }
 
-func TestInstall_UnsignedPermissive_PendingReview(t *testing.T) {
+// TestInstall_UnsignedPermissive_Active verifies that an unsigned-permissive
+// install also promotes to status=active. The operator's explicit opt-in via
+// GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true is the trust signal — staying in
+// pending_review would defeat the opt-in (instances would never spawn).
+func TestInstall_UnsignedPermissive_Active(t *testing.T) {
 	q := openTestDB(t)
 	// AllowUnsigned=true so unsigned bundles are accepted.
 	inst := newTestInstaller(t, q, true)
@@ -434,8 +443,8 @@ func TestInstall_UnsignedPermissive_PendingReview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPluginByName: %v", err)
 	}
-	if row.Status != "pending_review" {
-		t.Errorf("status = %q, want pending_review", row.Status)
+	if row.Status != "active" {
+		t.Errorf("status = %q, want active", row.Status)
 	}
 }
 
@@ -1519,8 +1528,8 @@ func TestInstall_NestedLayout_Installs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPluginByName: %v", err)
 	}
-	if row.Status != "pending_review" {
-		t.Errorf("status = %q, want pending_review", row.Status)
+	if row.Status != "active" {
+		t.Errorf("status = %q, want active", row.Status)
 	}
 	if row.PluginVersion != "1.0.0" {
 		t.Errorf("plugin_version = %q, want 1.0.0", row.PluginVersion)
@@ -1552,8 +1561,8 @@ func TestInstall_FlatLayout_BackwardCompat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPluginByName: %v", err)
 	}
-	if row.Status != "pending_review" {
-		t.Errorf("status = %q, want pending_review", row.Status)
+	if row.Status != "active" {
+		t.Errorf("status = %q, want active", row.Status)
 	}
 	if row.BinaryPath == nil || *row.BinaryPath == "" {
 		t.Error("binary_path: want non-empty after flat-layout install")

--- a/internal/plugin/oauth/credentials.go
+++ b/internal/plugin/oauth/credentials.go
@@ -64,7 +64,7 @@ type StoredCredentials struct {
 // The plugin receives one header whose value is Scheme + " " + APIKey (or
 // just APIKey when Scheme is empty).
 type StaticAPIKeyCreds struct {
-	HeaderName string `json:"header_name"` // e.g. "X-API-Key"
+	HeaderName string `json:"header_name"`      // e.g. "X-API-Key"
 	Scheme     string `json:"scheme,omitempty"` // optional prefix, e.g. "Bearer"
 	APIKey     string `json:"api_key"`
 }

--- a/internal/plugin/oauth/manager.go
+++ b/internal/plugin/oauth/manager.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"time"
 
+	"golang.org/x/oauth2"
+
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
@@ -18,6 +20,33 @@ import (
 // admin handler maps this sentinel to HTTP 400 so the UI can surface the
 // message directly without the operator needing to tail server logs.
 var ErrConfigInvalid = errors.New("oauth: operator configuration invalid")
+
+// ProviderExchangeError is returned by HandleCallback when the OAuth2 provider
+// rejects the token exchange with a structured error response. It carries the
+// provider's machine-readable error code (e.g. "invalid_code",
+// "redirect_uri_mismatch", "invalid_client") separately from the human-readable
+// description so callers can surface actionable messages without parsing blobs.
+//
+// The Raw field contains the full error string from golang.org/x/oauth2 for
+// logging; it is not shown in UI redirects to avoid leaking internal details.
+type ProviderExchangeError struct {
+	// Code is the OAuth2 error code from the provider's JSON response
+	// (e.g. "invalid_code", "redirect_uri_mismatch", "invalid_client").
+	Code string
+	// Description is the human-readable error_description from the provider.
+	// May be empty when the provider omits the field.
+	Description string
+	// Raw is the full error string from golang.org/x/oauth2.RetrieveError.
+	// Logged at error level; never included in redirect URLs.
+	Raw string
+}
+
+func (e *ProviderExchangeError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("oauth provider error: %s: %s", e.Code, e.Description)
+	}
+	return fmt.Sprintf("oauth provider error: %s", e.Code)
+}
 
 // Manager orchestrates the host-side OAuth2 flows. It handles:
 //   - BeginAuthcode: builds the authorization URL and encodes a signed state
@@ -151,6 +180,19 @@ func (m *Manager) HandleCallback(ctx context.Context, rawState, code string) (st
 
 	tok, err := cfg.Exchange(ctx, code)
 	if err != nil {
+		// Type-assert *oauth2.RetrieveError so we can surface the structured
+		// error_code and error_description fields from the provider's JSON response
+		// separately from the opaque blob produced by err.Error(). This lets the
+		// HTTP handler redirect operators with a readable "invalid_code" rather than
+		// a long "oauth2: cannot fetch token: 200 OK / Response: {...}" blob.
+		var re *oauth2.RetrieveError
+		if errors.As(err, &re) {
+			return "", &ProviderExchangeError{
+				Code:        re.ErrorCode,
+				Description: re.ErrorDescription,
+				Raw:         err.Error(),
+			}
+		}
 		return "", fmt.Errorf("oauth callback: exchange code: %w", err)
 	}
 

--- a/internal/plugin/oauth/manager_test.go
+++ b/internal/plugin/oauth/manager_test.go
@@ -485,6 +485,167 @@ func TestBeginClientcred_SkipsCallbackURL_WhenPublicURLEmpty(t *testing.T) {
 	// The important invariant is: no panic and no error returned.
 }
 
+// providerErrorBody builds a minimal Slack-shaped OAuth error JSON body.
+// code is the machine-readable error code (e.g. "invalid_code");
+// description is the human-readable error_description (may be empty).
+func providerErrorBody(code, description string) string {
+	if description == "" {
+		return `{"error":"` + code + `"}`
+	}
+	return `{"error":"` + code + `","error_description":"` + description + `"}`
+}
+
+// buildCallbackState builds a valid signed state envelope seeded with inst-1
+// and records its nonce in the given store. Returns the base64-encoded state string.
+func buildCallbackState(t *testing.T, nonces NonceStore, hmacKey []byte, clock func() time.Time) string {
+	t.Helper()
+	env, nonce, err := NewStateEnvelope("inst-1", "/admin/plugins/inst-1", clock)
+	if err != nil {
+		t.Fatalf("NewStateEnvelope: %v", err)
+	}
+	if err := nonces.Record(context.Background(), nonce, "inst-1"); err != nil {
+		t.Fatalf("Record nonce: %v", err)
+	}
+	encoded, err := EncodeState(env, hmacKey)
+	if err != nil {
+		t.Fatalf("EncodeState: %v", err)
+	}
+	return encoded
+}
+
+// buildTokenServerWithError returns an httptest.Server that responds to the
+// token endpoint with the given HTTP status code and JSON body.
+func buildTokenServerWithError(t *testing.T, statusCode int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestHandleCallback_ProviderError_InvalidCode checks that a Slack-shaped
+// "invalid_code" response from the token endpoint surfaces as a
+// *ProviderExchangeError with Code="invalid_code".
+func TestHandleCallback_ProviderError_InvalidCode(t *testing.T) {
+	srv := buildTokenServerWithError(t, http.StatusBadRequest,
+		providerErrorBody("invalid_code", "The code has already been redeemed."))
+
+	creds := testCreds("oauth2_authcode")
+	creds.TokenURL = srv.URL + "/token"
+	q := buildInstanceWithCreds(t, creds)
+
+	baseTime := time.Unix(1000000, 0)
+	clock := func() time.Time { return baseTime }
+	store := NewDBStore(q, noopEncrypt, noopDecrypt, q, clock)
+	nonces := &MemoryNonceStore{entries: make(map[string]time.Time), clock: clock}
+	hmacKey := fixedKey()
+	mgr := NewManager(store, nonces, clock, hmacKey, func() string { return "https://gleipnir.example.com" })
+
+	encoded := buildCallbackState(t, nonces, hmacKey, clock)
+
+	_, err := mgr.HandleCallback(context.Background(), encoded, "used-code")
+	if err == nil {
+		t.Fatal("expected error from HandleCallback, got nil")
+	}
+
+	var pee *ProviderExchangeError
+	if !errors.As(err, &pee) {
+		t.Fatalf("expected *ProviderExchangeError, got %T: %v", err, err)
+	}
+	if pee.Code != "invalid_code" {
+		t.Errorf("Code = %q, want %q", pee.Code, "invalid_code")
+	}
+	if pee.Description == "" {
+		t.Error("expected non-empty Description for invalid_code")
+	}
+	if pee.Raw == "" {
+		t.Error("expected non-empty Raw error string")
+	}
+}
+
+// TestHandleCallback_ProviderError_RedirectURIMismatch checks that
+// "redirect_uri_mismatch" surfaces as a *ProviderExchangeError.
+func TestHandleCallback_ProviderError_RedirectURIMismatch(t *testing.T) {
+	srv := buildTokenServerWithError(t, http.StatusBadRequest,
+		providerErrorBody("redirect_uri_mismatch", "redirect_uri did not match"))
+
+	creds := testCreds("oauth2_authcode")
+	creds.TokenURL = srv.URL + "/token"
+	q := buildInstanceWithCreds(t, creds)
+
+	baseTime := time.Unix(1000000, 0)
+	clock := func() time.Time { return baseTime }
+	store := NewDBStore(q, noopEncrypt, noopDecrypt, q, clock)
+	nonces := &MemoryNonceStore{entries: make(map[string]time.Time), clock: clock}
+	hmacKey := fixedKey()
+	mgr := NewManager(store, nonces, clock, hmacKey, func() string { return "https://gleipnir.example.com" })
+
+	encoded := buildCallbackState(t, nonces, hmacKey, clock)
+
+	_, err := mgr.HandleCallback(context.Background(), encoded, "code-xyz")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var pee *ProviderExchangeError
+	if !errors.As(err, &pee) {
+		t.Fatalf("expected *ProviderExchangeError, got %T: %v", err, err)
+	}
+	if pee.Code != "redirect_uri_mismatch" {
+		t.Errorf("Code = %q, want %q", pee.Code, "redirect_uri_mismatch")
+	}
+}
+
+// TestHandleCallback_ProviderError_InvalidClient checks that "invalid_client"
+// (missing/wrong client credentials) surfaces as a *ProviderExchangeError.
+func TestHandleCallback_ProviderError_InvalidClient(t *testing.T) {
+	srv := buildTokenServerWithError(t, http.StatusUnauthorized,
+		providerErrorBody("invalid_client", ""))
+
+	creds := testCreds("oauth2_authcode")
+	creds.TokenURL = srv.URL + "/token"
+	q := buildInstanceWithCreds(t, creds)
+
+	baseTime := time.Unix(1000000, 0)
+	clock := func() time.Time { return baseTime }
+	store := NewDBStore(q, noopEncrypt, noopDecrypt, q, clock)
+	nonces := &MemoryNonceStore{entries: make(map[string]time.Time), clock: clock}
+	hmacKey := fixedKey()
+	mgr := NewManager(store, nonces, clock, hmacKey, func() string { return "https://gleipnir.example.com" })
+
+	encoded := buildCallbackState(t, nonces, hmacKey, clock)
+
+	_, err := mgr.HandleCallback(context.Background(), encoded, "code-abc")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var pee *ProviderExchangeError
+	if !errors.As(err, &pee) {
+		t.Fatalf("expected *ProviderExchangeError, got %T: %v", err, err)
+	}
+	if pee.Code != "invalid_client" {
+		t.Errorf("Code = %q, want %q", pee.Code, "invalid_client")
+	}
+	// Description may be empty when the provider omits the field — that is fine.
+}
+
+// TestProviderExchangeError_ErrorMethod checks the Error() string formatting.
+func TestProviderExchangeError_ErrorMethod(t *testing.T) {
+	withDesc := &ProviderExchangeError{Code: "invalid_code", Description: "already used", Raw: "raw blob"}
+	if withDesc.Error() != "oauth provider error: invalid_code: already used" {
+		t.Errorf("unexpected Error(): %q", withDesc.Error())
+	}
+
+	noDesc := &ProviderExchangeError{Code: "invalid_client", Raw: "raw blob"}
+	if noDesc.Error() != "oauth provider error: invalid_client" {
+		t.Errorf("unexpected Error() with no description: %q", noDesc.Error())
+	}
+}
+
 func TestHandleCallback_NonceSingleUse_WithDBStore(t *testing.T) {
 	baseTime := time.Unix(1000000, 0)
 	clock := func() time.Time { return baseTime }

--- a/internal/plugin/oauth/state.go
+++ b/internal/plugin/oauth/state.go
@@ -293,4 +293,3 @@ func NewStateEnvelope(instanceID, returnURL string, clock func() time.Time) (Sta
 	}
 	return env, nonce, nil
 }
-

--- a/internal/plugin/oauth/store_test.go
+++ b/internal/plugin/oauth/store_test.go
@@ -562,7 +562,7 @@ func TestDBStore_ClearCredentials_WipesSecretsPreservesStrategy(t *testing.T) {
 	store := NewDBStore(q, noopEncrypt, noopDecrypt, q, func() time.Time { return baseTime })
 
 	seed := StoredCredentials{
-		Strategy:  sdkmanifest.AuthStrategyStaticAPIKey,
+		Strategy:     sdkmanifest.AuthStrategyStaticAPIKey,
 		StaticAPIKey: &StaticAPIKeyCreds{HeaderName: "X-Key", APIKey: "secret"},
 	}
 	if err := store.SaveCredentials(context.Background(), "inst-1", seed, 0); err != nil {
@@ -751,7 +751,7 @@ func TestDBStore_MutexSerialisation_SetAPIKeyAndSaveTokenConcurrent(t *testing.T
 
 	baseTime := time.Unix(1000000, 0)
 	seed := StoredCredentials{
-		Strategy: sdkmanifest.AuthStrategyStaticAPIKey,
+		Strategy:     sdkmanifest.AuthStrategyStaticAPIKey,
 		StaticAPIKey: &StaticAPIKeyCreds{HeaderName: "X-Key", APIKey: "old"},
 	}
 	plain, _ := seed.Marshal()

--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -45,6 +46,7 @@ type querier interface {
 	GetPluginByID(ctx context.Context, id string) (db.Plugin, error)
 	GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error)
 	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
+	InsertPluginAuditEvent(ctx context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error)
 }
 
 // processStarter is the function signature for starting a subprocess. The
@@ -183,6 +185,7 @@ func (m *Manager) Start(ctx context.Context, plugin db.Plugin, instance db.Plugi
 
 	inst, err := m.starter(ctx, cfg)
 	if err != nil {
+		m.handleLaunchFailure(ctx, plugin, instance, err)
 		return fmt.Errorf("manager: start instance %s: %w", instance.ID, err)
 	}
 
@@ -491,6 +494,65 @@ func (m *Manager) buildHealthSetter() func(ctx context.Context, instanceID strin
 			"target", string(target),
 			"err", err,
 		)
+	}
+}
+
+// handleLaunchFailure is called when process.Start (or the TestProcessStarter)
+// returns an error. It:
+//  1. Emits a plugin_crashed audit event with the error and stderr excerpt.
+//  2. Calls HealthSetter with a human-readable handshake-failure detail so the
+//     admin UI shows something more actionable than a raw gRPC error string.
+//
+// Both steps are best-effort: failures are logged but do not propagate.
+func (m *Manager) handleLaunchFailure(ctx context.Context, plugin db.Plugin, instance db.PluginInstance, launchErr error) {
+	// Extract stderr from LaunchError when available.
+	var stderrExcerpt string
+	var le *LaunchError
+	if errors.As(launchErr, &le) && len(le.Stderr) > 0 {
+		stderrExcerpt = string(le.Stderr)
+	}
+
+	// Build a concise reason for the health detail. Use the first 120 chars of
+	// the cause so the admin UI card is readable without wrapping.
+	reason := launchErr.Error()
+	if le != nil {
+		reason = le.Cause.Error()
+	}
+	const maxReasonLen = 120
+	if len(reason) > maxReasonLen {
+		reason = reason[:maxReasonLen] + "..."
+	}
+	healthDetail := "subprocess_handshake_failed: " + reason
+
+	// Update health state to unhealthy with the actionable detail. We call the
+	// HealthSetter directly (same path the crash watchdog uses) so the state
+	// machine is the single source of truth.
+	if healthSetter := m.buildHealthSetter(); healthSetter != nil {
+		healthSetter(ctx, instance.ID, model.PluginHealthStateUnhealthy, healthDetail)
+	}
+
+	// Write the audit event. Best-effort: log and continue on DB failure.
+	instanceID := instance.ID
+	payload := map[string]any{
+		"plugin_id":   plugin.ID,
+		"instance_id": instanceID,
+		"error":       launchErr.Error(),
+	}
+	if stderrExcerpt != "" {
+		payload["stderr_excerpt"] = stderrExcerpt
+	}
+	body, _ := json.Marshal(payload)
+	_, auditErr := m.cfg.Querier.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: &instanceID,
+		EventType:        "plugin_crashed",
+		Severity:         "high",
+		ActorUserID:      nil,
+		PayloadJson:      string(body),
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+	})
+	if auditErr != nil {
+		m.logger().Warn("handleLaunchFailure: could not write plugin_crashed audit event",
+			"instance_id", instanceID, "err", auditErr)
 	}
 }
 

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -64,6 +66,10 @@ func (q *fakeQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.Pl
 
 func (q *fakeQuerier) UpdatePluginInstanceHealth(_ context.Context, _ db.UpdatePluginInstanceHealthParams) (int64, error) {
 	return 1, nil
+}
+
+func (q *fakeQuerier) InsertPluginAuditEvent(_ context.Context, _ db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error) {
+	return db.PluginAuditEvent{}, nil
 }
 
 // ── Manager unit tests (blocked states, skip logic, StopAll) ─────────────────
@@ -601,5 +607,143 @@ func TestReloadInstance_WithoutControllerReturnsError(t *testing.T) {
 	err := mgr.ReloadInstance(context.Background(), plugin, instance, "/bin/true", time.Second)
 	if err == nil {
 		t.Fatal("expected error when GenerationController is nil, got nil")
+	}
+}
+
+// ── auditCapturingQuerier ─────────────────────────────────────────────────────
+
+// auditCapturingQuerier extends fakeQuerier with audit-event capture so tests
+// can assert on the plugin_crashed event written by handleLaunchFailure.
+type auditCapturingQuerier struct {
+	fakeQuerier
+	mu     sync.Mutex
+	events []db.InsertPluginAuditEventParams
+	// healthDetails captures the detail string from UpdatePluginInstanceHealth.
+	// The DB column is *string; we store the dereferenced value (empty string
+	// when nil) for simpler test assertions.
+	healthDetails []string
+}
+
+func (q *auditCapturingQuerier) InsertPluginAuditEvent(_ context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error) {
+	q.mu.Lock()
+	q.events = append(q.events, arg)
+	q.mu.Unlock()
+	return db.PluginAuditEvent{}, nil
+}
+
+func (q *auditCapturingQuerier) UpdatePluginInstanceHealth(_ context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error) {
+	detail := ""
+	if arg.HealthDetail != nil {
+		detail = *arg.HealthDetail
+	}
+	q.mu.Lock()
+	q.healthDetails = append(q.healthDetails, detail)
+	q.mu.Unlock()
+	return 1, nil
+}
+
+func (q *auditCapturingQuerier) auditEvents() []db.InsertPluginAuditEventParams {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	out := make([]db.InsertPluginAuditEventParams, len(q.events))
+	copy(out, q.events)
+	return out
+}
+
+// ── Launch-failure tests ──────────────────────────────────────────────────────
+
+// TestManager_LaunchFailure_EmitsAuditEventAndHealthDetail verifies the three
+// assertions from the task spec when a subprocess fails during launch:
+//  1. The error returned from Manager.Start wraps a process.LaunchError.
+//  2. A plugin_crashed audit event is written with plugin_id/instance_id/error
+//     in the payload and severity "high".
+//  3. The instance health detail set on the DB row starts with
+//     "subprocess_handshake_failed:" — not a raw gRPC error string.
+//
+// We use the real "exit-no-handshake" fixture which exits before the go-plugin
+// handshake completes.
+func TestManager_LaunchFailure_EmitsAuditEventAndHealthDetail(t *testing.T) {
+	reg := identity.New()
+	q := &auditCapturingQuerier{
+		fakeQuerier: fakeQuerier{
+			plugins: []db.Plugin{{ID: "p-launch-fail", Status: "active"}},
+			instances: map[string][]db.PluginInstance{
+				"p-launch-fail": {{
+					ID:           "i-launch-fail",
+					PluginID:     "p-launch-fail",
+					InstanceName: "launch-fail-inst",
+					HealthState:  "healthy",
+					Version:      1,
+				}},
+			},
+		},
+	}
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        q,
+		IdentityIssuer: reg,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			fc := fixtureConfig(t, "exit-no-handshake", reg, nil)
+			fc.InstanceID = cfg.InstanceID
+			fc.PluginID = cfg.PluginID
+			return process.Start(ctx, fc)
+		},
+	})
+
+	plugin := db.Plugin{ID: "p-launch-fail", Status: "active"}
+	instance := db.PluginInstance{ID: "i-launch-fail", PluginID: "p-launch-fail", InstanceName: "launch-fail-inst", HealthState: "healthy"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := mgr.Start(ctx, plugin, instance, os.Args[0])
+	if err == nil {
+		t.Fatal("expected error from Manager.Start when handshake fails, got nil")
+	}
+
+	// 1. Error chain must include *process.LaunchError.
+	var le *process.LaunchError
+	if !errors.As(err, &le) {
+		t.Errorf("error chain does not contain *process.LaunchError; got: %v", err)
+	}
+
+	// 2. plugin_crashed audit event must be written with required fields.
+	events := q.auditEvents()
+	var crashed *db.InsertPluginAuditEventParams
+	for i := range events {
+		if events[i].EventType == "plugin_crashed" {
+			crashed = &events[i]
+			break
+		}
+	}
+	if crashed == nil {
+		t.Fatalf("no plugin_crashed audit event found; events: %+v", events)
+	}
+	if crashed.Severity != "high" {
+		t.Errorf("plugin_crashed severity = %q, want %q", crashed.Severity, "high")
+	}
+	if crashed.PluginInstanceID == nil || *crashed.PluginInstanceID != instance.ID {
+		t.Errorf("plugin_crashed PluginInstanceID = %v, want %q", crashed.PluginInstanceID, instance.ID)
+	}
+	if !strings.Contains(crashed.PayloadJson, `"plugin_id"`) {
+		t.Errorf("plugin_crashed payload missing plugin_id field: %s", crashed.PayloadJson)
+	}
+	if !strings.Contains(crashed.PayloadJson, `"instance_id"`) {
+		t.Errorf("plugin_crashed payload missing instance_id field: %s", crashed.PayloadJson)
+	}
+	if !strings.Contains(crashed.PayloadJson, `"error"`) {
+		t.Errorf("plugin_crashed payload missing error field: %s", crashed.PayloadJson)
+	}
+
+	// 3. Health detail recorded in the DB must be actionable (not a raw gRPC string).
+	var sawHandshakeFailed bool
+	for _, detail := range q.healthDetails {
+		if strings.HasPrefix(detail, "subprocess_handshake_failed:") {
+			sawHandshakeFailed = true
+			break
+		}
+	}
+	if !sawHandshakeFailed {
+		t.Errorf("health detail did not start with 'subprocess_handshake_failed:'; recorded details: %v", q.healthDetails)
 	}
 }

--- a/internal/plugin/process/process.go
+++ b/internal/plugin/process/process.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -17,6 +18,34 @@ import (
 	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
+
+// launchStderrCapSize caps how many bytes of stderr output we retain for
+// error reporting when a subprocess fails during the launch/handshake phase.
+// Enough for a meaningful panic traceback without unbounded memory growth.
+const launchStderrCapSize = 4 * 1024 // 4 KiB
+
+// LaunchError is returned by Start when the subprocess fails during the
+// hostwire launch/handshake phase. It carries the underlying error and a
+// (size-capped) excerpt of the subprocess's stderr output so callers can
+// surface both in audit events and health details without grepping logs.
+type LaunchError struct {
+	// InstanceID is the plugin instance the launch was attempted for.
+	InstanceID string
+	// Cause is the underlying error from hostwire/go-plugin.
+	Cause error
+	// Stderr holds up to launchStderrCapSize bytes of stderr output captured
+	// during the launch attempt. May be empty if the subprocess wrote nothing.
+	Stderr []byte
+}
+
+func (e *LaunchError) Error() string {
+	if len(e.Stderr) > 0 {
+		return fmt.Sprintf("plugin %s: launch subprocess: %v; stderr: %s", e.InstanceID, e.Cause, e.Stderr)
+	}
+	return fmt.Sprintf("plugin %s: launch subprocess: %v", e.InstanceID, e.Cause)
+}
+
+func (e *LaunchError) Unwrap() error { return e.Cause }
 
 // defaultStartupTimeout is how long we wait for the go-plugin handshake to
 // complete before giving up. Operators can override this via Config.StartupTimeout.
@@ -145,7 +174,19 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	// go-plugin reserves stdout for the handshake magic-cookie line; piping or
 	// reading stdout here would corrupt the protocol. We only pipe stderr, which
 	// is the agreed log channel per spec §13.
-	stderrW, stderrDone := PipeLines(logger, slog.LevelWarn, "stderr")
+	//
+	// We also tee stderr bytes into a capped capture buffer so that, if the
+	// subprocess fails during launch/handshake, we can include the excerpt in
+	// the returned LaunchError and in the audit event. The buffer is discarded
+	// after a successful launch.
+	var stderrCapMu sync.Mutex
+	var stderrCap bytes.Buffer
+	stderrCapWriter := &cappedWriter{mu: &stderrCapMu, buf: &stderrCap, cap: launchStderrCapSize}
+	logPipeW, stderrDone := PipeLines(logger, slog.LevelWarn, "stderr")
+	stderrW := &multiWriteCloser{
+		writers: []io.Writer{logPipeW, stderrCapWriter},
+		closer:  logPipeW,
+	}
 
 	host := cfg.HostServer
 	if host == nil {
@@ -184,7 +225,16 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		// Revoke the token because no subprocess is running to use it.
 		cfg.IdentityIssuer.Revoke(token)
 		closeWriterSilently(stderrW)
-		return nil, fmt.Errorf("plugin %s: launch subprocess: %w", cfg.InstanceID, err)
+		// Wait briefly for the log pipe drain goroutine to flush any stderr bytes
+		// the subprocess wrote before exiting. PipeLines closes the done channel
+		// when the reader goroutine finishes. We bound the wait so a hung pipe
+		// does not stall the error path indefinitely.
+		waitForDone(stderrDone, 500*time.Millisecond)
+		stderrCapMu.Lock()
+		captured := make([]byte, stderrCap.Len())
+		copy(captured, stderrCap.Bytes())
+		stderrCapMu.Unlock()
+		return nil, &LaunchError{InstanceID: cfg.InstanceID, Cause: err, Stderr: captured}
 	}
 
 	inst := &Instance{
@@ -319,3 +369,54 @@ func validateBinary(binaryPath string) error {
 func closeWriterSilently(w io.WriteCloser) {
 	_ = w.Close()
 }
+
+// waitForDone blocks until ch is closed or the deadline elapses.
+func waitForDone(ch <-chan struct{}, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ch:
+	case <-timer.C:
+	}
+}
+
+// cappedWriter writes bytes into buf up to cap bytes total, discarding any
+// overflow. Concurrent writes are serialised via mu.
+type cappedWriter struct {
+	mu  *sync.Mutex
+	buf *bytes.Buffer
+	cap int
+}
+
+func (c *cappedWriter) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	remaining := c.cap - c.buf.Len()
+	if remaining <= 0 {
+		return len(p), nil // discard overflow; pretend success to unblock writers
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	_, _ = c.buf.Write(p)
+	return len(p), nil // always report full write to callers
+}
+
+// multiWriteCloser fans writes out to all writers and delegates Close to
+// the single closer (the log pipe). This avoids closing the capture buffer
+// (which has no Close method) while still closing the pipe on shutdown.
+type multiWriteCloser struct {
+	writers []io.Writer
+	closer  io.WriteCloser
+}
+
+func (m *multiWriteCloser) Write(p []byte) (int, error) {
+	for _, w := range m.writers {
+		if _, err := w.Write(p); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+func (m *multiWriteCloser) Close() error { return m.closer.Close() }

--- a/internal/plugin/state/pluginstate.go
+++ b/internal/plugin/state/pluginstate.go
@@ -134,8 +134,8 @@ var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
 		model.PluginHealthStateCrashed,
 		model.PluginHealthStateCircuitBroken,
 		model.PluginHealthStatePendingManifestApproval,
-		model.PluginHealthStatePendingKeyApproval,  // signed update arrives for previously-unsigned plugin (#188)
-		model.PluginHealthStatePendingReauthorize,  // public_url changed (#230)
+		model.PluginHealthStatePendingKeyApproval, // signed update arrives for previously-unsigned plugin (#188)
+		model.PluginHealthStatePendingReauthorize, // public_url changed (#230)
 	},
 	// #194 rationale: real availability problems must be visible regardless of
 	// pending_reauthorize. Exit edges include unhealthy/crashed/circuit_broken
@@ -148,6 +148,7 @@ var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
 	},
 	model.PluginHealthStateUnhealthy: {
 		model.PluginHealthStateHealthy,
+		model.PluginHealthStateUnhealthy, // self-loop: host may advance the detail string (config_missing → credentials_missing → …) without leaving unhealthy
 		model.PluginHealthStateCrashed,
 		model.PluginHealthStateCircuitBroken,
 		model.PluginHealthStatePendingKeyApproval, // key mismatch detected during unhealthy state (#188)
@@ -156,8 +157,8 @@ var legalTransitions = map[model.PluginHealthState][]model.PluginHealthState{
 		model.PluginHealthStateHealthy,
 		model.PluginHealthStateUnhealthy,
 		model.PluginHealthStateCrashed,
-		model.PluginHealthStatePendingKeyApproval,  // key mismatch detected during circuit-broken state (#188)
-		model.PluginHealthStatePendingReauthorize,  // public_url changed (#230)
+		model.PluginHealthStatePendingKeyApproval, // key mismatch detected during circuit-broken state (#188)
+		model.PluginHealthStatePendingReauthorize, // public_url changed (#230)
 	},
 	model.PluginHealthStateCrashed: {
 		model.PluginHealthStateHealthy,

--- a/internal/plugin/trigger/supervisor.go
+++ b/internal/plugin/trigger/supervisor.go
@@ -309,6 +309,12 @@ func (s *Supervisor) StopAll() {
 	}
 }
 
+// isEmptyScope returns true when scope is empty or the zero-object "{}",
+// meaning the operator has not yet configured what the instance should watch.
+func isEmptyScope(scope string) bool {
+	return scope == "" || scope == "{}"
+}
+
 // streamLoop is the goroutine body for a single instance trigger stream. It
 // opens TriggerService.Start on the plugin, drains events synchronously into
 // Dispatcher.Handle to preserve per-stream ordering, and reconnects on failure.
@@ -317,6 +323,13 @@ func (s *Supervisor) StopAll() {
 // After UnhealthyAfter consecutive failures, HealthSetter is called with
 // Unhealthy. On the first successful Recv post-recovery the instance is reset
 // to Healthy.
+//
+// Scope gate: if the instance's subscription_scope_json is empty or "{}" the
+// stream is not opened. The goroutine sleeps for BackoffMax and re-checks.
+// It is NOT counted as a failure — this is a normal "not yet configured"
+// state, not a connectivity problem. When the operator saves a non-empty scope
+// and the admin handler calls Restart, this goroutine is cancelled and a fresh
+// one starts with the new scope.
 func (s *Supervisor) streamLoop(ctx context.Context, instanceID string, doneCh chan struct{}) {
 	defer close(doneCh)
 
@@ -324,6 +337,7 @@ func (s *Supervisor) streamLoop(ctx context.Context, instanceID string, doneCh c
 
 	consecutive := 0 // consecutive reconnect failures without a successful Recv
 	markedUnhealthy := false
+	loggedEmptyScope := false // rate-limit the "scope not configured" log line
 
 	for {
 		if ctx.Err() != nil {
@@ -359,6 +373,29 @@ func (s *Supervisor) streamLoop(ctx context.Context, instanceID string, doneCh c
 			s.maybeMarkUnhealthy(ctx, instanceID, consecutive, &markedUnhealthy)
 			continue
 		}
+
+		// Scope gate: skip opening a stream when the operator hasn't configured
+		// what the instance should watch yet. This is not a failure — do not
+		// increment consecutive or mark Unhealthy. Log once at INFO (not on
+		// every retry tick) and sleep for BackoffMax before re-checking.
+		//
+		// When the operator saves a non-empty scope via
+		// PUT .../subscription-scope, the admin handler calls Restart which
+		// cancels this goroutine and starts a fresh one that will pass the gate.
+		if isEmptyScope(dbInst.SubscriptionScopeJson) {
+			if !loggedEmptyScope {
+				log.InfoContext(ctx, "trigger supervisor: subscription scope not configured; skipping stream until scope is set",
+					"instance_id", instanceID)
+				loggedEmptyScope = true
+			}
+			if !s.sleep(ctx, s.cfg.BackoffMax) {
+				return
+			}
+			continue
+		}
+		// Scope is now non-empty — reset the log-once gate so a future empty →
+		// non-empty → empty cycle (edge case) logs again.
+		loggedEmptyScope = false
 
 		// Use a long-lived stream — no deadline. Health pings cover liveness
 		// (spec §13.6). The parent ctx cancellation propagates on shutdown.

--- a/internal/plugin/trigger/supervisor_test.go
+++ b/internal/plugin/trigger/supervisor_test.go
@@ -178,7 +178,9 @@ func (q *supQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.Plu
 	if inst, ok := q.instByID[id]; ok {
 		return inst, nil
 	}
-	return db.PluginInstance{ID: id}, nil
+	// Return a non-empty scope by default so existing tests that do not care
+	// about scope gating continue to reach the stream-open path.
+	return db.PluginInstance{ID: id, SubscriptionScopeJson: `{"_default":true}`}, nil
 }
 func (q *supQuerier) ListPluginsByStatus(_ context.Context, _ string) ([]db.Plugin, error) {
 	return nil, nil
@@ -704,5 +706,184 @@ func TestSupervisor_StopAll(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("StopAll did not complete within 5s")
+	}
+}
+
+// ── Scope gate tests ──────────────────────────────────────────────────────────
+
+// scopeQuerier returns instances whose SubscriptionScopeJson can be changed
+// between calls via the mu-protected scope field, simulating an operator saving
+// a new scope between the first and second stream attempts.
+type scopeQuerier struct {
+	mu    sync.Mutex
+	scope string
+}
+
+func (q *scopeQuerier) setScope(s string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.scope = s
+}
+
+func (q *scopeQuerier) GetSubscribedActivePolicies(_ context.Context) ([]db.Policy, error) {
+	return nil, nil
+}
+func (q *scopeQuerier) GetPluginByID(_ context.Context, _ string) (db.Plugin, error) {
+	return db.Plugin{}, nil
+}
+func (q *scopeQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return db.PluginInstance{ID: id, SubscriptionScopeJson: q.scope}, nil
+}
+func (q *scopeQuerier) ListPluginsByStatus(_ context.Context, _ string) ([]db.Plugin, error) {
+	return nil, nil
+}
+func (q *scopeQuerier) ListPluginInstancesByPlugin(_ context.Context, _ string) ([]db.PluginInstance, error) {
+	return nil, nil
+}
+
+// TestSupervisor_EmptyScope_SkipsStart verifies that when subscription_scope_json
+// is empty ("") or the zero-object "{}", the supervisor does NOT call
+// TriggerService.Start — it silently waits and retries.
+func TestSupervisor_EmptyScope_SkipsStart(t *testing.T) {
+	t.Parallel()
+
+	srv := &alwaysEOFServer{} // would count calls if Start were ever reached
+	client, stop := startFakeTriggerServer(t, srv)
+	defer stop()
+
+	lookup := &fakeInstanceLookup{client: client, pluginID: "test-plugin"}
+	dispatcher := &fakeEventDispatcher{}
+
+	for _, emptyScope := range []string{"", "{}"} {
+		emptyScope := emptyScope
+		t.Run("scope="+emptyScope, func(t *testing.T) {
+			t.Parallel()
+
+			q := &scopeQuerier{scope: emptyScope}
+			sup := plugintrigger.NewSupervisor(plugintrigger.Config{
+				Querier:             q,
+				BackoffInitial:      time.Microsecond,
+				BackoffMax:          5 * time.Millisecond, // short so the gate ticks quickly in tests
+				UnhealthyAfter:      3,
+				TestInstanceLookup:  lookup,
+				TestEventDispatcher: dispatcher,
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+
+			sup.Start(ctx, "inst-empty-scope")
+
+			// Wait for the context to expire — the scope gate should have prevented
+			// any Start call reaching the plugin.
+			<-ctx.Done()
+			sup.StopAll()
+
+			if n := srv.startCount(); n > 0 {
+				t.Errorf("TriggerService.Start called %d time(s) with empty scope %q; expected 0", n, emptyScope)
+			}
+		})
+	}
+}
+
+// TestSupervisor_NonEmptyScope_OpensStream verifies that a non-empty scope
+// results in TriggerService.Start being called.
+func TestSupervisor_NonEmptyScope_OpensStream(t *testing.T) {
+	t.Parallel()
+
+	evCh := make(chan *triggerv1.StartResponse, 1)
+	evCh <- &triggerv1.StartResponse{EventId: "e1", EventKind: "msg", PayloadJson: "{}"}
+	close(evCh)
+
+	srv := &sequentialTriggerServer{eventsCh: evCh}
+	client, stop := startFakeTriggerServer(t, srv)
+	defer stop()
+
+	lookup := &fakeInstanceLookup{client: client, pluginID: "test-plugin"}
+	dispatcher := &fakeEventDispatcher{}
+
+	q := &scopeQuerier{scope: `{"channels":["#general"]}`}
+	sup := plugintrigger.NewSupervisor(plugintrigger.Config{
+		Querier:             q,
+		BackoffInitial:      time.Microsecond,
+		BackoffMax:          5 * time.Millisecond,
+		UnhealthyAfter:      3,
+		TestInstanceLookup:  lookup,
+		TestEventDispatcher: dispatcher,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sup.Start(ctx, "inst-with-scope")
+
+	// The event should arrive at the dispatcher because the scope gate passes.
+	waitFor(t, 3*time.Second, func() bool {
+		return len(dispatcher.received()) >= 1
+	})
+
+	if len(dispatcher.received()) == 0 {
+		t.Error("no events dispatched; expected at least 1 (scope gate should have passed)")
+	}
+}
+
+// TestSupervisor_Restart_EmptyToNonEmpty_TriggersStream verifies the
+// Restart path: when scope transitions from empty → non-empty via Restart,
+// the new goroutine picks up the updated scope and opens a stream.
+//
+// This is the correct handling of the subscription-scope PUT → Restart flow:
+// the admin handler calls Restart after persisting the new scope, and the
+// supervisor's Restart cancels the waiting goroutine and starts a fresh one
+// that re-fetches the DB row.
+func TestSupervisor_Restart_EmptyToNonEmpty_TriggersStream(t *testing.T) {
+	// Not parallel: uses a shared alwaysEOFServer call count that Restart races.
+	evCh := make(chan *triggerv1.StartResponse, 1)
+	evCh <- &triggerv1.StartResponse{EventId: "after-scope-set", EventKind: "msg"}
+	close(evCh)
+
+	srv := &sequentialTriggerServer{eventsCh: evCh}
+	client, stop := startFakeTriggerServer(t, srv)
+	defer stop()
+
+	lookup := &fakeInstanceLookup{client: client, pluginID: "test-plugin"}
+	dispatcher := &fakeEventDispatcher{}
+
+	q := &scopeQuerier{scope: ""} // start with empty scope
+
+	sup := plugintrigger.NewSupervisor(plugintrigger.Config{
+		Querier:             q,
+		BackoffInitial:      time.Microsecond,
+		BackoffMax:          10 * time.Millisecond,
+		UnhealthyAfter:      3,
+		TestInstanceLookup:  lookup,
+		TestEventDispatcher: dispatcher,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sup.Start(ctx, "inst-scope-change")
+
+	// Give the goroutine time to see the empty scope and enter the waiting loop.
+	time.Sleep(30 * time.Millisecond)
+
+	// Now simulate the operator saving a scope: update the querier and Restart.
+	q.setScope(`{"channels":["#general"]}`)
+	sup.Restart(ctx, "inst-scope-change")
+
+	// The new goroutine should see the non-empty scope and open a stream,
+	// delivering the event.
+	waitFor(t, 5*time.Second, func() bool {
+		return len(dispatcher.received()) >= 1
+	})
+
+	got := dispatcher.received()
+	if len(got) == 0 {
+		t.Fatal("no events dispatched after scope update and Restart")
+	}
+	if got[0].EventID != "after-scope-set" {
+		t.Errorf("first event ID = %q, want %q", got[0].EventID, "after-scope-set")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -468,7 +468,7 @@ func run(cfg config.Config) error {
 			cfg.OAuthRefreshLead,
 		)
 		oauthScanner.Start(ctx)
-		pluginOAuthHandler = admin.NewPluginOAuthHandler(store.Queries(), oauthMgr)
+		pluginOAuthHandler = admin.NewPluginOAuthHandler(store.Queries(), oauthMgr, getPublicURL)
 		pluginCredHandler = admin.NewPluginCredentialsHandler(store.Queries(), oauthStore)
 
 		// Wire the callback-URL rescan so it fires whenever an admin changes
@@ -485,18 +485,18 @@ func run(cfg config.Config) error {
 	}
 
 	handlers := api.HandlerBundle{
-		AuthHandler:             authHandler,
-		SettingsHandler:         settingsHandler,
-		AdminHandler:            adminHandler,
-		OpenAICompatHandler:     openaiCompatHandler,
-		PluginAdminHandler:      admin.NewPluginHandler(store.Queries(), broadcaster, nil),
-		PluginOAuthHandler:      pluginOAuthHandler,
+		AuthHandler:              authHandler,
+		SettingsHandler:          settingsHandler,
+		AdminHandler:             adminHandler,
+		OpenAICompatHandler:      openaiCompatHandler,
+		PluginAdminHandler:       admin.NewPluginHandler(store.Queries(), broadcaster, nil),
+		PluginOAuthHandler:       pluginOAuthHandler,
 		PluginCredentialsHandler: pluginCredHandler,
-		AudienceHandler:         audienceH,
-		BindingTestHandler:      bindingTestH,
-		WebhookHandler:          webhookHandler,
-		SSEHandler:              sseHandler,
-		PolicyWebhookHandler:    policyWebhookHandler,
+		AudienceHandler:          audienceH,
+		BindingTestHandler:       bindingTestH,
+		WebhookHandler:           webhookHandler,
+		SSEHandler:               sseHandler,
+		PolicyWebhookHandler:     policyWebhookHandler,
 	}
 
 	// Wire the trigger supervisor into the plugin admin handler so that

--- a/plugins/slack/hub_registry.go
+++ b/plugins/slack/hub_registry.go
@@ -17,20 +17,35 @@ type hubEntry struct {
 	refCount  int // 1 per caller of Acquire
 }
 
+// dead reports whether the underlying hub's Run goroutine has exited. A dead
+// entry must not be returned from Acquire — its Done channel is already
+// closed, so any caller that selects on hub.Done() would receive immediately.
+func (e *hubEntry) dead() bool {
+	select {
+	case <-e.hub.Done():
+		return true
+	default:
+		return false
+	}
+}
+
 // hubRegistry is a process-global registry that creates at most one *socketHub
 // per xapp-token. The same Socket Mode WebSocket is shared by TriggerService
 // (EventsAPI events) and ChannelService (interactive callbacks).
+//
+// Dead hubs are detected on each Acquire and replaced with a fresh entry: when
+// Slack's connection fails (network blip, auth revoked, etc.) the supervisor
+// re-Acquires and gets a working hub rather than a corpse. The release closure
+// only removes its entry from the map if the entry is still the current one,
+// so a late release from a replaced hub does not evict its successor.
 //
 // STALE-HUB ON TOKEN ROTATION (v1 limitation): when an instance config update
 // rotates the xapp-token, TriggerService.Restart Acquires a new hub for the
 // new token while ChannelService continues holding the OLD hub until that
 // token's Socket Mode connection fails. The old connection will fail next time
-// Slack rejects the revoked token; the hub will tear down via ctx cancel from
-// its internal error path, ChannelService's interactive handler will stop
-// receiving callbacks, and any in-flight Request will time out via the host's
-// feedback-timeout path (matching the documented 'in-memory correlation loss on
-// restart' behavior in spec §4.2). Cross-service token-rotation coordination is
-// OUT OF SCOPE — file Phase-8 follow-up if needed.
+// Slack rejects the revoked token; ChannelService's maintainer goroutine
+// observes hub.Done() and re-acquires under the new token. Cross-service
+// token-rotation coordination is OUT OF SCOPE — file Phase-8 follow-up if needed.
 type hubRegistry struct {
 	mu      sync.Mutex
 	factory socketModeFactory
@@ -49,11 +64,24 @@ func newHubRegistry(factory socketModeFactory) *hubRegistry {
 // starting its Run goroutine on first use. Subsequent calls with the same token
 // return the SAME hub. The returned releaseFn must be called when the caller no
 // longer needs the hub; when the ref count reaches zero, the hub is torn down.
+//
+// If a previously-created hub has died (Run goroutine exited), Acquire treats
+// the map entry as absent and creates a fresh hub. Callers that block on
+// hub.Done() will see the new hub's Done channel, not the dead one.
 func (r *hubRegistry) Acquire(xappToken string) (*socketHub, releaseFn, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	entry, ok := r.hubs[xappToken]
+	if ok && entry.dead() {
+		// Replace the dead entry. Outstanding refs from the previous
+		// generation can still call their release closures — those will
+		// observe that the map slot no longer contains their entry and
+		// simply decrement without deleting (the swap below is the
+		// authoritative eviction).
+		delete(r.hubs, xappToken)
+		ok = false
+	}
 	if !ok {
 		hub, err := newSocketHub(r.factory, xappToken)
 		if err != nil {
@@ -82,7 +110,12 @@ func (r *hubRegistry) Acquire(xappToken string) (*socketHub, releaseFn, error) {
 		entry.refCount--
 		if entry.refCount <= 0 {
 			entry.runCancel()
-			delete(r.hubs, xappToken)
+			// Only evict from the map if our entry is still the current one.
+			// A previously-replaced entry (after dead-detection) must not
+			// delete its successor.
+			if current, ok := r.hubs[xappToken]; ok && current == entry {
+				delete(r.hubs, xappToken)
+			}
 		}
 	}
 

--- a/plugins/slack/hub_registry_test.go
+++ b/plugins/slack/hub_registry_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/slack-go/slack/socketmode"
+
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
+)
+
+// runnerWithErr returns a fakeSocketModeRunner whose Run exits immediately
+// with the given error — simulates an auth failure or network blip.
+func runnerWithErr(err error) socketModeFactory {
+	return func(_ string) (socketModeRunner, error) {
+		return &fakeSocketModeRunner{runErr: err}, nil
+	}
+}
+
+// blockingRunner returns a factory producing runners that block until ctx is
+// done (simulates a healthy long-running Socket Mode connection).
+func blockingRunner() socketModeFactory {
+	return func(_ string) (socketModeRunner, error) {
+		return &channelFakeRunner{events: make(chan socketmode.Event)}, nil
+	}
+}
+
+// TestHubRegistry_DeadHubIsReplaced is the regression test for the kitchen-sink
+// pre-flight bug: a transient Slack failure caused the hub's Run goroutine to
+// exit, leaving the dead hubEntry cached in the registry. Every subsequent
+// Acquire returned the corpse — its Done channel was already closed, so
+// TriggerService.Start returned immediately, and the supervisor spin-looped
+// against a dead hub until the plugin was reinstalled.
+//
+// After the fix, Acquire detects the dead entry and creates a fresh hub.
+func TestHubRegistry_DeadHubIsReplaced(t *testing.T) {
+	t.Parallel()
+
+	authErr := errors.New("invalid_auth")
+	r := newHubRegistry(runnerWithErr(authErr))
+
+	hub1, release1, err := r.Acquire("xapp-1")
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+
+	// Wait for the runner's Run goroutine to exit (runErr is returned synchronously).
+	select {
+	case <-hub1.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("hub1 did not exit within 2s")
+	}
+
+	if got := hub1.DoneErr(); got != authErr {
+		t.Errorf("hub1.DoneErr() = %v, want %v", got, authErr)
+	}
+
+	// Second Acquire under the same token must NOT return the dead hub.
+	hub2, release2, err := r.Acquire("xapp-1")
+	if err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	if hub2 == hub1 {
+		t.Fatal("Acquire returned the dead hub instead of a fresh one")
+	}
+
+	// Cleanup — order does not matter; the release closures must both be safe.
+	release1()
+	release2()
+}
+
+// TestChannelService_MaintainerRegistersInteractiveHandler verifies that
+// ChannelService.Start launches a maintainer goroutine that eventually
+// acquires the hub and registers the interactive handler. Before this fix,
+// the constructor's one-shot Acquire silently dropped interactive callbacks
+// forever if config arrived after construction.
+func TestChannelService_MaintainerRegistersInteractiveHandler(t *testing.T) {
+	t.Parallel()
+
+	// Stand up a FakeHost that returns a valid app_level_token.
+	host := plugintest.NewFakeHost(
+		plugintest.WithInstanceConfigJSON(`{"app_level_token":"xapp-test-token"}`),
+	)
+
+	hostLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for host: %v", err)
+	}
+	hostSrv := grpc.NewServer()
+	host.Register(hostSrv)
+	go func() { _ = hostSrv.Serve(hostLis) }()
+	t.Cleanup(hostSrv.Stop)
+
+	hostConn, err := grpc.NewClient(hostLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial host: %v", err)
+	}
+	t.Cleanup(func() { hostConn.Close() })
+	hostClient := hostv1.NewHostServiceClient(hostConn)
+
+	registry := newHubRegistry(blockingRunner())
+
+	cs := NewChannelService(hostClient, registry, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cs.Start(ctx)
+
+	// The maintainer fetches config, acquires hub, registers handler.
+	// Poll because the goroutine runs asynchronously.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		registry.mu.Lock()
+		entry, ok := registry.hubs["xapp-test-token"]
+		registry.mu.Unlock()
+		if ok && entry.hub.interactiveHandler.Load() != nil {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("maintainer did not register interactive handler within 2s")
+}
+
+// TestHubRegistry_LateReleaseDoesNotEvictSuccessor verifies the generation-safe
+// release closure. After Acquire detects a dead hub and swaps in a replacement,
+// a late release call from the original generation must NOT evict the new
+// entry from the map — otherwise a subsequent Acquire would unnecessarily
+// create a third hub.
+func TestHubRegistry_LateReleaseDoesNotEvictSuccessor(t *testing.T) {
+	t.Parallel()
+
+	// First factory call: dead runner. Second factory call: healthy runner.
+	calls := 0
+	factory := func(_ string) (socketModeRunner, error) {
+		calls++
+		if calls == 1 {
+			return &fakeSocketModeRunner{runErr: errors.New("first death")}, nil
+		}
+		return &channelFakeRunner{events: make(chan socketmode.Event)}, nil
+	}
+	r := newHubRegistry(factory)
+
+	hub1, release1, err := r.Acquire("xapp-1")
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+
+	// Wait for hub1 to die.
+	select {
+	case <-hub1.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("hub1 did not exit within 2s")
+	}
+
+	// Acquire again — gets a fresh hub2 (the healthy one).
+	hub2, release2, err := r.Acquire("xapp-1")
+	if err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	if hub2 == hub1 {
+		t.Fatal("Acquire returned the dead hub")
+	}
+
+	// Late release of the dead hub1's ref. Must not evict hub2 from the map.
+	release1()
+
+	// A third Acquire should return hub2 (still the current entry), not create a
+	// third hub. If release1 wrongly evicted hub2, the factory would be called
+	// a third time.
+	hub3, release3, err := r.Acquire("xapp-1")
+	if err != nil {
+		t.Fatalf("third Acquire: %v", err)
+	}
+	if hub3 != hub2 {
+		t.Errorf("late release evicted the live successor: hub3 != hub2 (factory called %d times, want 2)", calls)
+	}
+
+	release2()
+	release3()
+}

--- a/plugins/slack/main.go
+++ b/plugins/slack/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
@@ -25,7 +26,13 @@ func main() {
 			return NewTriggerService(host, registry)
 		}),
 		serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
-			return NewChannelService(host, registry, http.DefaultClient)
+			cs := NewChannelService(host, registry, http.DefaultClient)
+			// Maintainer goroutine keeps the interactive handler registered
+			// across late-config and hub-death. Bound to context.Background
+			// because the plugin process has no explicit shutdown hook —
+			// goroutine ends when the process exits.
+			cs.Start(context.Background())
+			return cs
 		}),
 	)
 }

--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -160,7 +160,7 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 			if hint != healthNone {
 				s.setHealth(hostCtx, hint)
 			}
-			return errorResponse(code, "auth.test failed: "+authErr.Error()), nil
+			return errorResponse(code, "auth.test failed: "+humanizeSlackErr(authErr)), nil
 		}
 		// Store address of a fresh local copy. Storing &creds.Token.AccessToken
 		// would persist a pointer into the just-fetched StoredCredentials
@@ -191,7 +191,7 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 		if hint != healthNone {
 			s.setHealth(hostCtx, hint)
 		}
-		return errorResponse(code, callErr.Error()), nil
+		return errorResponse(code, humanizeSlackErr(callErr)), nil
 	}
 
 	return &toolv1.CallResponse{OutputJson: string(outputJSON)}, nil
@@ -242,6 +242,8 @@ func (s *ToolService) setHealth(ctx context.Context, h healthHint) {
 		detail = "auth_expired"
 	case healthAuthMissing:
 		detail = "auth_missing"
+	case healthMissingScope:
+		detail = "missing_scope"
 	default:
 		return
 	}
@@ -532,6 +534,8 @@ func (s *TriggerService) setTriggerHealth(ctx context.Context, h healthHint) {
 		detail = "auth_expired"
 	case healthConfigMissing:
 		detail = "config_missing"
+	case healthMissingScope:
+		detail = "missing_scope"
 	default:
 		return
 	}
@@ -577,16 +581,29 @@ type ChannelService struct {
 	correlations  *correlationMap
 }
 
-// NewChannelService creates a production ChannelService. It acquires the shared
-// socketHub for the instance's xapp-token and registers the interactive handler.
-// If GetInstanceConfig fails or the token is absent, interactive callbacks are
-// silently dropped until the next restart (Notify/Request still report the error
-// inline via setChannelHealth).
+// channelHubConfigRetry is the delay between attempts when the app-level
+// token has not yet been written to instance config. Held as a package
+// variable so tests can shorten it without exporting an API.
+var channelHubConfigRetry = 10 * time.Second
+
+// channelHubReacquireDelay is the delay before re-acquiring after a hub
+// death. A small non-zero delay avoids a tight spin against a backend that
+// is failing fast.
+var channelHubReacquireDelay = time.Second
+
+// NewChannelService creates a production ChannelService. Call Start to launch
+// the background goroutine that maintains the interactive-handler registration
+// against the shared socketHub.
+//
+// Notify and Request work as soon as credentials and channel config are
+// configured (they do not depend on the maintainer goroutine). Interactive
+// callbacks (button clicks) require the maintainer to have successfully
+// registered the handler at least once.
 func NewChannelService(host hostv1.HostServiceClient, registry *hubRegistry, httpClient *http.Client) *ChannelService {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	s := &ChannelService{
+	return &ChannelService{
 		host:        host,
 		hubRegistry: registry,
 		webAPIFactory: func(token string) slackWebAPI {
@@ -595,33 +612,95 @@ func NewChannelService(host hostv1.HostServiceClient, registry *hubRegistry, htt
 		httpClient:   httpClient,
 		correlations: newCorrelationMap(5*time.Minute, 24*time.Hour),
 	}
+}
 
-	// Register the interactive handler at construction so it is in place before
-	// any Request call arrives. We fetch the token synchronously here; if it
-	// fails we skip registration and interactive callbacks won't fire, but
-	// Notify/Request will surface the error inline.
-	cfgResp, err := host.GetInstanceConfig(context.Background(), &hostv1.GetInstanceConfigRequest{})
+// Start launches the maintainer goroutine that keeps the interactive-handler
+// registered on the shared socketHub. The goroutine runs until ctx is done.
+//
+// The maintainer handles two failure modes that the one-shot constructor used
+// to drop on the floor:
+//
+//   - Late config: if the instance config does not yet contain
+//     app_level_token (the state immediately after install but before the
+//     operator fills the config form), the maintainer waits and retries
+//     instead of silently dropping interactive callbacks forever.
+//
+//   - Dead hub: if the underlying Socket Mode connection fails (network
+//     blip, token revoked), hub.Done() fires; the maintainer re-acquires,
+//     which produces a fresh hub thanks to hubRegistry's dead-entry
+//     detection, and re-registers the handler. Without this, the first
+//     transient failure would permanently silence Approve/Reject buttons.
+func (s *ChannelService) Start(ctx context.Context) {
+	go s.maintainInteractiveHandler(ctx)
+}
+
+func (s *ChannelService) maintainInteractiveHandler(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		token := s.fetchAppLevelToken(ctx)
+		if token == "" {
+			if !sleepCtx(ctx, channelHubConfigRetry) {
+				return
+			}
+			continue
+		}
+
+		hub, release, err := s.hubRegistry.Acquire(token)
+		if err != nil {
+			log.Printf("slack: ChannelService: Acquire hub for interactive handler: %v", err)
+			if !sleepCtx(ctx, channelHubReacquireDelay) {
+				return
+			}
+			continue
+		}
+
+		hub.RegisterInteractiveHandler(s.handleInteractive)
+
+		select {
+		case <-ctx.Done():
+			release()
+			return
+		case <-hub.Done():
+			log.Printf("slack: ChannelService: socket hub died (%v); reacquiring", hub.DoneErr())
+			release()
+			if !sleepCtx(ctx, channelHubReacquireDelay) {
+				return
+			}
+		}
+	}
+}
+
+// fetchAppLevelToken returns the configured app_level_token, or "" if config is
+// missing, malformed, or unreadable. Errors are logged but not propagated so
+// the maintainer loop can keep retrying.
+func (s *ChannelService) fetchAppLevelToken(ctx context.Context) string {
+	cfgResp, err := s.host.GetInstanceConfig(ctx, &hostv1.GetInstanceConfigRequest{})
 	if err != nil {
-		log.Printf("slack: ChannelService: GetInstanceConfig at startup: %v", err)
-		return s
+		log.Printf("slack: ChannelService: GetInstanceConfig: %v", err)
+		return ""
 	}
 	token, err := extractAppLevelToken(cfgResp.GetConfigJson())
-	if err != nil || token == "" {
-		// Token not yet configured — skip registration. Interactive callbacks
-		// won't fire until the plugin restarts with a token in config.
-		return s
-	}
-
-	hub, _, err := registry.Acquire(token)
 	if err != nil {
-		log.Printf("slack: ChannelService: Acquire hub for interactive handler: %v", err)
-		return s
+		log.Printf("slack: ChannelService: extract app_level_token: %v", err)
+		return ""
 	}
-	// We intentionally do not call the releaseFn — this hub reference persists
-	// for the plugin process lifetime so the interactive handler always fires.
-	hub.RegisterInteractiveHandler(s.handleInteractive)
+	return token
+}
 
-	return s
+// sleepCtx returns true if d elapsed, false if ctx was cancelled first.
+// Uses a timer with explicit Stop so a cancelled context does not leak it.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // newChannelServiceForTest creates a ChannelService for testing with an injected
@@ -713,7 +792,7 @@ func (s *ChannelService) Notify(ctx context.Context, req *channelv1.NotifyReques
 		}
 		return &channelv1.NotifyResponse{
 			Ok:    false,
-			Error: channelErrorResponse(code, postErr.Error()),
+			Error: channelErrorResponse(code, humanizeSlackErr(postErr)),
 		}, nil
 	}
 
@@ -784,7 +863,7 @@ func (s *ChannelService) Request(ctx context.Context, req *channelv1.RequestRequ
 			s.setChannelHealth(hostCtx, hint)
 		}
 		return &channelv1.RequestResponse{
-			Error: channelErrorResponse(code, postErr.Error()),
+			Error: channelErrorResponse(code, humanizeSlackErr(postErr)),
 		}, nil
 	}
 
@@ -903,6 +982,8 @@ func (s *ChannelService) setChannelHealth(ctx context.Context, h healthHint) {
 		detail = "auth_expired"
 	case healthAuthMissing:
 		detail = "auth_missing"
+	case healthMissingScope:
+		detail = "missing_scope"
 	default:
 		return
 	}

--- a/plugins/slack/service_test.go
+++ b/plugins/slack/service_test.go
@@ -1777,4 +1777,3 @@ func TestChannelService_Request_HandleInteractiveTakesCorrelation(t *testing.T) 
 		t.Error("correlation entry still present after handleInteractive ran; handleInteractive must call take()")
 	}
 }
-

--- a/plugins/slack/tools.go
+++ b/plugins/slack/tools.go
@@ -92,6 +92,7 @@ const (
 	healthAuthExpired                     // persistent auth failure — set UNHEALTHY
 	healthAuthMissing                     // no credentials configured — set UNHEALTHY
 	healthConfigMissing                   // required instance config field missing — set UNHEALTHY
+	healthMissingScope                    // bot OAuth scope grant insufficient — set UNHEALTHY
 )
 
 // mapErr maps a Slack API error to an ErrorCode and optional health hint.
@@ -136,8 +137,9 @@ func mapErr(err error) (commonv1.ErrorCode, healthHint) {
 }
 
 // classifySlackErrCode maps a Slack API error-code string to an ErrorCode and
-// health hint. All Slack error strings that indicate a persistent auth problem
-// return healthAuthExpired so the host can surface them in the operator UI.
+// health hint. Auth-class errors are split so the operator sees an actionable
+// distinction in the admin UI: "auth_expired" (re-authorize) vs "missing_scope"
+// (fix the Slack app scope grants).
 func classifySlackErrCode(code string) (commonv1.ErrorCode, healthHint) {
 	switch code {
 	case "channel_not_found", "not_in_channel", "user_not_found", "message_not_found":
@@ -146,9 +148,17 @@ func classifySlackErrCode(code string) (commonv1.ErrorCode, healthHint) {
 	case "invalid_arguments", "msg_too_long", "message_text_required", "bad_query", "invalid_name":
 		return commonv1.ErrorCode_ERROR_CODE_INVALID_ARG, healthNone
 
-	case "invalid_auth", "account_inactive", "token_revoked", "missing_scope", "not_authed":
+	case "missing_scope":
+		// Distinct from the auth_expired bucket: re-authorizing with the same
+		// Slack app will NOT help — the operator must add the missing scope in
+		// the Slack app's OAuth & Permissions page, reinstall the app, then
+		// re-authorize. Surfacing this as "auth_expired" misled operators into
+		// clicking Re-authorize forever.
+		return commonv1.ErrorCode_ERROR_CODE_PERMISSION, healthMissingScope
+
+	case "invalid_auth", "account_inactive", "token_revoked", "not_authed":
 		// Persistent auth failures. The operator UI shows UNHEALTHY + "auth_expired"
-		// so operators know they need to reauthorize or grant missing scopes.
+		// so operators know they need to reauthorize.
 		return commonv1.ErrorCode_ERROR_CODE_PERMISSION, healthAuthExpired
 
 	case "ratelimited":
@@ -159,6 +169,27 @@ func classifySlackErrCode(code string) (commonv1.ErrorCode, healthHint) {
 	}
 
 	return commonv1.ErrorCode_ERROR_CODE_INTERNAL, healthNone
+}
+
+// humanizeSlackErr wraps a Slack error with an actionable hint for the most
+// common first-time setup failures. The raw Slack error code is preserved as
+// a prefix so operators can still grep logs for "not_in_channel" etc.
+func humanizeSlackErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	raw := err.Error()
+	switch {
+	case strings.Contains(raw, "not_in_channel"):
+		return raw + " — the Slack bot is not a member of this channel; invite it with /invite @<bot> in the target channel and retry"
+	case strings.Contains(raw, "channel_not_found"):
+		return raw + " — Slack reports this channel does not exist or the bot cannot see it (private channels require the bot to be invited)"
+	case strings.Contains(raw, "missing_scope"):
+		return raw + " — the bot's OAuth scopes do not include a scope required for this call; add the missing scope in the Slack app's OAuth & Permissions page, reinstall the app, and re-authorize"
+	case strings.Contains(raw, "token_revoked"), strings.Contains(raw, "invalid_auth"), strings.Contains(raw, "not_authed"), strings.Contains(raw, "account_inactive"):
+		return raw + " — the Slack token is no longer valid; re-authorize the plugin in the admin UI"
+	}
+	return raw
 }
 
 // ── Rate-limit retry helper ───────────────────────────────────────────────────

--- a/plugins/slack/tools_test.go
+++ b/plugins/slack/tools_test.go
@@ -545,10 +545,14 @@ func TestMapErr(t *testing.T) {
 			wantHealth: healthAuthExpired,
 		},
 		{
+			// missing_scope is split out of the auth-expired bucket because
+			// re-authorizing the plugin with the same Slack app cannot fix it —
+			// the operator must add the missing scope in the Slack app's OAuth
+			// & Permissions page first.
 			name:       "missing_scope",
 			err:        slackAPIError("missing_scope"),
 			wantCode:   commonv1.ErrorCode_ERROR_CODE_PERMISSION,
-			wantHealth: healthAuthExpired,
+			wantHealth: healthMissingScope,
 		},
 		{
 			name:       "token_revoked",


### PR DESCRIPTION
## Summary

Pre-flight hardening before running the end-to-end Slack kitchen-sink test (#162 / #237). Four parallel audits surfaced 12 issues, all addressed here. Each commit is a logical fix area; they can be reviewed independently.

**Three P0s — without these, the kitchen-sink test cannot start:**

1. **Auto-promote installed plugins to status=active** — `UpdatePluginStatus` had zero non-test callers; fresh installs sat in `pending_review` forever; subprocess manager and trigger supervisor both filter strictly to `status='active'`. Verified installs (and unsigned-permissive under operator opt-in) now go straight to `active`.

2. **Hub registry dead-detection** — ChannelService held a permanent hub ref; first transient Socket Mode failure left a dead `hubEntry` cached; supervisor spin-looped against a corpse until plugin reinstall. `Acquire` detects dead entries and replaces them, with a generation-safe release closure (mirrors ADR-038 CAS discipline).

3. **ChannelService maintainer goroutine** — one-shot `Acquire` at construction silently dropped interactive callbacks forever if config arrived late. Replaced with a background loop that retries on missing config and re-acquires on hub death.

**Seven P1s — improve operator experience during setup:**

4. **Precise install HTTP errors** — 7 distinct responses instead of one generic 400 (tarball extract, bundle layout, missing manifest, parse failure, manifest.name validation, manifest.version validation, CAS conflict).

5. **Slack error mapping** — `missing_scope` split out of `auth_expired` bucket (re-authorizing cannot fix it); `humanizeSlackErr` prepends actionable hints to raw Slack codes (`not_in_channel` → "invite the bot"; `missing_scope` → "add the scope in OAuth & Permissions"; etc.).

6. **Health detail advancement** — instance detail moves through `config_missing` → `credentials_missing` → "" as the operator fills the form. Required adding `unhealthy → unhealthy` self-loop to the state graph.

7. **OAuth provider error codes** — `*ProviderExchangeError{Code, Description, Raw}` surfaces structured Slack error fields instead of opaque `oauth2.RetrieveError` wrapped blob. Operators can now distinguish `invalid_code` from `redirect_uri_mismatch` from `invalid_client`.

8. **OAuth ReturnURL same-origin validation** — closes open-redirect via the unauthenticated callback handler.

9. **Subprocess launch failure attribution** — captures up to 4 KiB of stderr, writes `plugin_crashed` audit event, sets actionable health detail (`subprocess_handshake_failed: <reason>`). No more "grep server logs and correlate by instance_id" diagnostic experience.

10. **Trigger supervisor scope gate** — skips opening streams against instances with empty `subscription_scope_json` (operator hasn't configured what to watch). Removes log spam + clobbering of health detail during normal first-time setup.

**One P2 — operator UX:**

11. **Instance Config tab** — was `<p>coming in #241</p>` placeholder; built using existing `SchemaForm` with secret-aware redaction sentinel handling per ADR-049. Back-link fixed (was pointing at `/admin/audiences`, should be `/admin/plugins`).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass, no FAIL lines
- [x] `npm run build` (frontend) clean
- [x] `npx vitest run` — 73 test files, 1060 tests pass
- [x] New regression tests: hub-registry dead-replacement, hub-registry generation-safe release, ChannelService maintainer registration, readiness detail computation (7 cases), 12-case `ValidateReturnURL`, 4 OAuth provider-error cases, subprocess launch-failure audit, 3 supervisor scope-gate cases, 10 ConfigTab UI cases
- [ ] Run the Playwright kitchen-sink spec (`tests/playwright/slack-kitchen-sink.spec.ts`) against a real Slack workspace — this is what the PR enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)