### PR TITLE
fix: trigger.Supervisor.Restart leaks HTTP request ctx into stream goroutine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ node_modules
 *.jpeg
 /gleipnirctl
 /gleipnir-plugin
+
+# Local plugin bundles extracted by the loader at runtime (owned by container root)
+local-plugins/installed/
+local-plugins/*.tar.gz
+local-plugins/*.tgz

--- a/internal/plugin/e2e/composition_test.go
+++ b/internal/plugin/e2e/composition_test.go
@@ -378,6 +378,11 @@ func TestSubstrate_HappyPath_FiresMatchingPolicyOnly(t *testing.T) {
 		UnhealthyAfter:      3,
 		Querier:             q,
 	})
+	// StopAll prevents the stream goroutine from leaking past the test. Pre-patch
+	// these goroutines were terminated by the deadline ctx expiring; post-patch
+	// they are parented off context.Background() (the RootCtx default), so an
+	// explicit cleanup is required (#401).
+	t.Cleanup(sup.StopAll)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -454,6 +459,11 @@ func TestSubstrate_DedupShortCircuits_NoLaunch(t *testing.T) {
 		UnhealthyAfter:      3,
 		Querier:             q,
 	})
+	// StopAll prevents the stream goroutine from leaking past the test. Pre-patch
+	// these goroutines were terminated by the deadline ctx expiring; post-patch
+	// they are parented off context.Background() (the RootCtx default), so an
+	// explicit cleanup is required (#401).
+	t.Cleanup(sup.StopAll)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/plugin/trigger/supervisor.go
+++ b/internal/plugin/trigger/supervisor.go
@@ -86,6 +86,22 @@ type Config struct {
 	// processManager.HealthSetter() in main.go.
 	HealthSetter func(ctx context.Context, instanceID string, target model.PluginHealthState, detail string)
 
+	// RootCtx is the long-lived parent context for all stream goroutines spawned
+	// by Start. It should be the server's lifetime context — the same one passed
+	// to loader.StartManager and triggerSupervisor.StartAll in main.go.
+	//
+	// If nil, context.Background() is used so tests that omit this field
+	// continue to compile and run. Production callers MUST set this to ensure
+	// that goroutine lifetimes are bounded by the server, not by the process.
+	//
+	// The distinction matters because Restart is called from the admin HTTP
+	// handler with r.Context() as its per-call ctx. That ctx is cancelled as
+	// soon as the HTTP response flushes, which would kill the freshly-started
+	// stream goroutine before it can connect (#401). Parenting off RootCtx
+	// instead ensures per-request callers of Restart cannot silently cancel the
+	// new stream.
+	RootCtx context.Context
+
 	// Logger is the base logger. If nil, slog.Default() is used.
 	Logger *slog.Logger
 
@@ -108,6 +124,7 @@ type Config struct {
 // All public methods are safe for concurrent use.
 type Supervisor struct {
 	cfg        Config
+	rootCtx    context.Context // long-lived parent for all stream goroutines; set by NewSupervisor
 	lookup     InstanceLookup  // resolved from cfg.Manager in NewSupervisor
 	dispatcher EventDispatcher // resolved from cfg.Dispatcher in NewSupervisor
 
@@ -135,6 +152,14 @@ func NewSupervisor(cfg Config) *Supervisor {
 		cfg.Logger = slog.Default()
 	}
 
+	// Use the caller-supplied root context when provided; fall back to
+	// Background so existing tests that omit RootCtx continue to compile.
+	// Production callers in main.go MUST supply RootCtx — see Config.RootCtx.
+	rootCtx := cfg.RootCtx
+	if rootCtx == nil {
+		rootCtx = context.Background()
+	}
+
 	var lookup InstanceLookup
 	if cfg.TestInstanceLookup != nil {
 		lookup = cfg.TestInstanceLookup
@@ -151,6 +176,7 @@ func NewSupervisor(cfg Config) *Supervisor {
 
 	return &Supervisor{
 		cfg:        cfg,
+		rootCtx:    rootCtx,
 		lookup:     lookup,
 		dispatcher: dispatcher,
 		instances:  make(map[string]context.CancelFunc),
@@ -216,16 +242,25 @@ func (s *Supervisor) StartAll(ctx context.Context) error {
 // The goroutine calls TriggerService.Start on the plugin, drains events into
 // Dispatcher.Handle, and auto-restarts on failure with exponential backoff.
 //
-// The goroutine exits when ctx is cancelled (host shutdown) or Stop/StopAll is
-// called. Callers may observe goroutine exit via the done channel returned by
-// startedDone; for external callers the done channel is internal.
-func (s *Supervisor) Start(ctx context.Context, instanceID string) {
+// The goroutine exits when the supervisor's rootCtx is cancelled (host
+// shutdown) or Stop/StopAll is called.
+//
+// The ctx parameter is accepted for interface compatibility but is intentionally
+// NOT used to parent the new stream goroutine. Stream goroutines must outlive
+// any individual caller's ctx — for example, the HTTP request ctx that
+// initiated a Restart is cancelled as soon as the response flushes, which
+// would silently kill the freshly-started stream. Parenting off s.rootCtx
+// instead ensures that only host shutdown or an explicit Stop can terminate
+// the goroutine (#401).
+func (s *Supervisor) Start(_ context.Context, instanceID string) {
 	s.mu.Lock()
 	if _, alreadyRunning := s.instances[instanceID]; alreadyRunning {
 		s.mu.Unlock()
 		return
 	}
-	streamCtx, cancel := context.WithCancel(ctx)
+	// Parent off the supervisor's long-lived rootCtx, not the caller's ctx.
+	// See the function doc above for why this matters (#401).
+	streamCtx, cancel := context.WithCancel(s.rootCtx)
 	doneCh := make(chan struct{})
 	s.instances[instanceID] = cancel
 	s.done[instanceID] = doneCh
@@ -258,6 +293,12 @@ func (s *Supervisor) Stop(instanceID string) {
 // the DB, so scope changes take effect immediately.
 //
 // If instanceID is not currently supervised, Restart is a no-op.
+//
+// The ctx parameter is currently unused — the new stream is parented off the
+// supervisor's long-lived rootCtx (#401). The parameter is retained so the
+// TriggerRestarter interface (internal/admin/plugin_handler.go) and existing
+// call sites continue to compile without change. Adding caller-side
+// cancellation of the <-oldDone wait would be a separate piece of work.
 //
 // Lock discipline: the lookup-delete-cancel is done under a single s.mu
 // acquisition so a concurrent Stop arriving mid-Restart sees either the old

--- a/internal/plugin/trigger/supervisor_test.go
+++ b/internal/plugin/trigger/supervisor_test.go
@@ -321,8 +321,11 @@ func TestSupervisor_ReconnectsOnEOF(t *testing.T) {
 	}
 }
 
-// TestSupervisor_ContextCancel verifies that cancelling the outer context
-// causes the stream goroutine to exit, observable via StopAll returning.
+// TestSupervisor_ContextCancel verifies that cancelling the supervisor's root
+// context (not the per-call Start ctx) causes the stream goroutine to exit,
+// observable via StopAll returning. This exercises the real contract post-#401:
+// the goroutine is parented off rootCtx, so only rootCtx cancellation (or an
+// explicit Stop/StopAll) can drive exit (#401).
 func TestSupervisor_ContextCancel(t *testing.T) {
 	t.Parallel()
 
@@ -332,14 +335,31 @@ func TestSupervisor_ContextCancel(t *testing.T) {
 
 	lookup := &fakeInstanceLookup{client: client, pluginID: "test-plugin"}
 	dispatcher := &fakeEventDispatcher{}
+	q := &supQuerier{}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	sup := newSupervisor(lookup, dispatcher, nil)
-	sup.Start(ctx, "inst-1")
+	// Build the supervisor with an explicit, cancellable RootCtx so we can
+	// verify that it is the rootCtx — not the per-call Start arg — that drives
+	// goroutine exit (#401).
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	sup := plugintrigger.NewSupervisor(plugintrigger.Config{
+		Querier:             q,
+		BackoffInitial:      time.Microsecond,
+		BackoffMax:          time.Millisecond,
+		UnhealthyAfter:      3,
+		TestInstanceLookup:  lookup,
+		TestEventDispatcher: dispatcher,
+		RootCtx:             rootCtx,
+	})
+
+	// Pass a separate, independent ctx to Start — it must not affect the
+	// goroutine's lifetime under the new contract.
+	sup.Start(context.Background(), "inst-1")
 
 	// Give the goroutine time to reach stream.Recv before cancelling.
 	time.Sleep(30 * time.Millisecond)
-	cancel()
+
+	// Cancel the root context, which is the actual parent of the stream goroutine.
+	rootCancel()
 
 	done := make(chan struct{})
 	go func() {
@@ -349,9 +369,9 @@ func TestSupervisor_ContextCancel(t *testing.T) {
 
 	select {
 	case <-done:
-		// Clean exit — goroutine exited after ctx cancel.
+		// Clean exit — goroutine exited after rootCtx cancel.
 	case <-time.After(5 * time.Second):
-		t.Fatal("supervisor goroutine did not exit within 5s after ctx cancel")
+		t.Fatal("supervisor goroutine did not exit within 5s after rootCtx cancel")
 	}
 }
 
@@ -616,6 +636,58 @@ func TestSupervisor_Restart_NotSupervised_IsNoOp(t *testing.T) {
 	if srv.startCount() != 0 {
 		t.Errorf("expected 0 Start calls after Restart of unsupervised instance, got %d", srv.startCount())
 	}
+}
+
+// TestSupervisor_Restart_PerCallCtxCancel_DoesNotKillNewStream is the
+// regression test for #401. It verifies that cancelling the per-call ctx
+// passed to Restart does NOT kill the freshly-started stream goroutine.
+//
+// Pre-patch: Start(shortCtx, id) parented streamCtx off the dead shortCtx;
+// the goroutine exited at the first ctx-check in streamLoop and srv.startCount
+// never reached 2. Post-patch: Start ignores shortCtx and parents off rootCtx;
+// the goroutine survives and the second Start call is observed.
+//
+// Not parallel — it observes goroutine survival across a tight time window.
+func TestSupervisor_Restart_PerCallCtxCancel_DoesNotKillNewStream(t *testing.T) {
+	srv := &captureStartServer{}
+	client, stop := startFakeTriggerServer(t, srv)
+	defer stop()
+
+	lookup := &fakeInstanceLookup{client: client, pluginID: "test-plugin"}
+	dispatcher := &fakeEventDispatcher{}
+
+	// Non-empty scope so the scope gate passes and the stream actually opens.
+	q := &scopeQuerier{scope: `{"channel":"#dev"}`}
+
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+
+	sup := plugintrigger.NewSupervisor(plugintrigger.Config{
+		Querier:             q,
+		BackoffInitial:      time.Microsecond,
+		BackoffMax:          time.Millisecond,
+		UnhealthyAfter:      3,
+		TestInstanceLookup:  lookup,
+		TestEventDispatcher: dispatcher,
+		RootCtx:             rootCtx,
+	})
+	t.Cleanup(sup.StopAll)
+
+	// Seed the first stream.
+	sup.Start(context.Background(), "inst-1")
+	waitFor(t, 2*time.Second, func() bool { return srv.startCount() >= 1 })
+
+	// Cancel the per-call ctx BEFORE calling Restart so that the old Start
+	// implementation (which derived streamCtx from the caller's ctx) would
+	// immediately kill the new goroutine at the first ctx.Err() check (#401).
+	shortCtx, shortCancel := context.WithCancel(context.Background())
+	shortCancel() // dead ctx passed to Restart
+
+	sup.Restart(shortCtx, "inst-1")
+
+	// The new stream goroutine must survive despite shortCtx being cancelled.
+	// If it does, srv.startCount() reaches 2.
+	waitFor(t, 5*time.Second, func() bool { return srv.startCount() >= 2 })
 }
 
 // TestSupervisor_StopRacesRestart_NoDeadlockNoDoubleStart verifies the

--- a/main.go
+++ b/main.go
@@ -361,6 +361,9 @@ func run(cfg config.Config) error {
 			Dispatcher:   triggerDispatcher,
 			HealthSetter: loader.Manager().HealthSetter(),
 			Logger:       slog.Default(),
+			// long-lived server ctx; parents stream goroutines so per-request
+			// callers of Restart cannot cancel them (#401).
+			RootCtx: ctx,
 		})
 		go func() {
 			if err := triggerSupervisor.StartAll(ctx); err != nil {


### PR DESCRIPTION
Closes #401

## Summary

`Supervisor.Start` derived `streamCtx` from the caller's ctx. When `Restart` was called from `plugin_handler.go:688` (`PutSubscriptionScope`), it forwarded `r.Context()` — which is cancelled the moment the PUT response flushes. The freshly-restarted stream goroutine died within milliseconds, silently disabling the trigger stream until the next API restart.

**Fix:** Give `Supervisor` a long-lived `RootCtx` at construction time (wired from `main.go`'s server-lifetime ctx). `Start` now parents `streamCtx` off `s.rootCtx`, ignoring the per-call ctx entirely. Nil-safe fallback to `context.Background()` keeps all existing callers compiling unchanged.

## Changes

- **`internal/plugin/trigger/supervisor.go`** — Added `Config.RootCtx` field; `Supervisor` stores resolved `rootCtx` (nil → `context.Background()`); `Start` parents `streamCtx` off `s.rootCtx`; `Restart` godoc updated to document ctx is currently unused (kept for interface stability).
- **`main.go`** — Wired `RootCtx: ctx` at the `NewSupervisor` call site.
- **`internal/plugin/trigger/supervisor_test.go`** — Rewrote `TestSupervisor_ContextCancel` to drive exit via explicit `rootCtx` cancellation (not the `Start`-arg ctx). Added `TestSupervisor_Restart_PerCallCtxCancel_DoesNotKillNewStream`: cancels `shortCtx` *before* calling `Restart`, asserts `srv.startCount() >= 2`.
- **`internal/plugin/e2e/composition_test.go`** — Added `t.Cleanup(sup.StopAll)` at two `NewSupervisor` sites to prevent goroutine leaks.
- **`.gitignore`** — Added `local-plugins/installed/` (container-root-owned bundle dir that trips host-side `gofmt`).

<details>
<summary>Architecture plan</summary>

Root cause: `supervisor.go:228` derives `streamCtx` from the caller's ctx via `context.WithCancel(ctx)`. `Restart(ctx, id)` at line 267–283 calls `s.Start(ctx, id)` with whatever ctx the caller passed. The production caller `plugin_handler.go:688` passes `r.Context()`. Response flush → ctx cancelled → stream goroutine exits at `streamLoop`'s first `ctx.Err()` check.

Fix shape: Add `RootCtx context.Context` to `Config`, store as `rootCtx` on `Supervisor`, parent all stream goroutines off `s.rootCtx`. Keep `Start`/`Restart` signatures unchanged so `TriggerRestarter` interface is stable. Nil-safe default to `context.Background()`.

Plan-reviewer caught two blocking issues in the initial plan: (1) `TestSupervisor_ContextCancel` would pass for the wrong reason after the fix (silent semantic break), (2) the regression test's `shortCancel()` fired after `Restart` returns. Both addressed in the revised plan.
</details>

## Review cycles: 1 (approved on first pass)
## CLAUDE.md updated: No (no new packages, env vars, routes, or ADRs)
## Brainstorming: Not triggered (issue was well-specified)

🤖 Generated with the agentic dev loop