### PR TITLE
feat: wire plugin tools.Registrar.RegisterInstanceTools into spawn sequence

### DIFF
--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -148,6 +148,13 @@ type StartManagerConfig struct {
 	IdentityRegistry     *identity.Registry
 	GenerationController *generation.Controller
 	ServerInterceptors   []grpc.UnaryServerInterceptor
+	// ToolRegistrar claims and releases plugin tool dot-names in the shared
+	// namespace arbiter when instances start/stop. Required — a nil registrar
+	// means tools would be silently invisible to agents (StartManager enforces
+	// non-nil). ManagerConfig.ToolRegistrar accepts nil for tests and the
+	// GLEIPNIR_PLUGINS_ENABLED=false path; this field is the stricter production
+	// entry point.
+	ToolRegistrar process.ToolRegistrar
 }
 
 // StartManager constructs a process.Manager wired to the host-side substrate
@@ -179,12 +186,16 @@ func (l *Loader) StartManager(ctx context.Context, cfg StartManagerConfig) error
 	if cfg.ServerInterceptors == nil {
 		return fmt.Errorf("StartManager: ServerInterceptors must not be nil")
 	}
+	if cfg.ToolRegistrar == nil {
+		return fmt.Errorf("StartManager: ToolRegistrar must not be nil")
+	}
 
 	l.manager = process.NewManager(process.ManagerConfig{
 		Querier:              cfg.Querier,
 		Publisher:            cfg.Publisher,
 		IdentityIssuer:       cfg.IdentityRegistry,
 		GenerationController: cfg.GenerationController,
+		ToolRegistrar:        cfg.ToolRegistrar,
 		// One shared server per host; per-instance routing via token interceptor.
 		HostServerFor:      func(_ string) hostwire.HostServer { return cfg.HostServer },
 		ServerInterceptors: cfg.ServerInterceptors,

--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/plugin/generation"
 	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 )
 
 // blockedHealthStates is the set of health states that should not have a
@@ -53,6 +54,14 @@ type querier interface {
 // default is process.Start; tests inject a stub to avoid real subprocess
 // spawning.
 type processStarter func(ctx context.Context, cfg Config) (*Instance, error)
+
+// ToolRegistrar registers and unregisters plugin tool names in the cross-source
+// namespace arbiter. The production implementation is *tools.Registrar from
+// internal/plugin/tools.
+type ToolRegistrar interface {
+	RegisterInstanceTools(ctx context.Context, instanceID, instanceName string, toolNames []string, generation int64) error
+	UnregisterInstance(ctx context.Context, instanceName string)
+}
 
 // ManagerConfig holds all constructor parameters for a Manager.
 type ManagerConfig struct {
@@ -99,6 +108,11 @@ type ManagerConfig struct {
 	// controller and returns an error when one is not configured.
 	GenerationController *generation.Controller
 
+	// ToolRegistrar claims and releases plugin tool dot-names in the shared
+	// namespace arbiter. When nil (tests, GLEIPNIR_PLUGINS_ENABLED=false),
+	// tool registration is skipped. Production callers must set this.
+	ToolRegistrar ToolRegistrar
+
 	// TestProcessStarter overrides process.Start. Intended for unit tests only;
 	// production callers must leave this nil. When set, Manager.Start calls
 	// this function instead of the real process.Start, which avoids spawning
@@ -114,6 +128,16 @@ type Manager struct {
 	mu        sync.Mutex
 	instances map[string]*Instance
 	starter   processStarter
+
+	// toolGenMu guards toolGenerations.
+	toolGenMu sync.Mutex
+	// toolGenerations tracks the tool-registrar generation per instance ID.
+	// This counter is independent of the host-RPC generation in
+	// generation.Controller (see generation/controller.go). The tool generation
+	// is int64 and tracks stale capability snapshots; the host-RPC generation
+	// is uint64 and tracks in-flight RPC refcounts. They live in different
+	// epochs — do not attempt to correlate them.
+	toolGenerations map[string]int64
 }
 
 // NewManager constructs a Manager from cfg. The returned manager has no running
@@ -125,9 +149,10 @@ func NewManager(cfg ManagerConfig) *Manager {
 	}
 
 	return &Manager{
-		cfg:       cfg,
-		instances: make(map[string]*Instance),
-		starter:   starter,
+		cfg:             cfg,
+		instances:       make(map[string]*Instance),
+		starter:         starter,
+		toolGenerations: make(map[string]int64),
 	}
 }
 
@@ -200,18 +225,63 @@ func (m *Manager) Start(ctx context.Context, plugin db.Plugin, instance db.Plugi
 	m.instances[instance.ID] = inst
 	m.mu.Unlock()
 
+	// Register the plugin's manifest-declared tools in the shared namespace
+	// arbiter. Parsing the manifest here (rather than in the caller) keeps
+	// tool registration tightly coupled to the spawn lifecycle. On conflict,
+	// the Registrar already drives the instance to unhealthy and writes an audit
+	// event (#194); we surface the error to the caller so the subsystem can
+	// decide how to handle it.
+	if m.cfg.ToolRegistrar != nil {
+		var mfst sdkmanifest.Manifest
+		if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &mfst); parseErr != nil {
+			m.logger().Warn("could not parse manifest for tool registration",
+				"instance_id", instance.ID,
+				"err", parseErr,
+			)
+		} else if len(mfst.Tools) > 0 {
+			toolNames := make([]string, len(mfst.Tools))
+			for i, td := range mfst.Tools {
+				toolNames[i] = td.Name
+			}
+			gen := m.nextToolGeneration(instance.ID)
+			if regErr := m.cfg.ToolRegistrar.RegisterInstanceTools(
+				ctx, instance.ID, instance.InstanceName, toolNames, gen,
+			); regErr != nil {
+				m.logger().Warn("plugin tool registration failed",
+					"instance_id", instance.ID,
+					"instance_name", instance.InstanceName,
+					"err", regErr,
+				)
+				return fmt.Errorf("manager: register tools for instance %s: %w", instance.ID, regErr)
+			}
+		}
+	}
+
 	return nil
 }
 
 // Stop terminates the subprocess for instanceID and removes it from the
 // running-instances map. Returns nil if instanceID is not found (idempotent).
 func (m *Manager) Stop(ctx context.Context, instanceID string) error {
+	// Capture the instance name before stopWithoutUnregister deletes it from
+	// the map — tool unregistration is keyed by name, not ULID.
+	var instanceName string
+	m.mu.Lock()
+	if inst, ok := m.instances[instanceID]; ok {
+		instanceName = inst.cfg.InstanceName
+	}
+	m.mu.Unlock()
+
 	if err := m.stopWithoutUnregister(ctx, instanceID); err != nil {
 		return err
 	}
 	if m.cfg.GenerationController != nil {
 		m.cfg.GenerationController.UnregisterInstance(instanceID)
 	}
+	if m.cfg.ToolRegistrar != nil && instanceName != "" {
+		m.cfg.ToolRegistrar.UnregisterInstance(ctx, instanceName)
+	}
+	m.removeToolGeneration(instanceID)
 	return nil
 }
 
@@ -283,6 +353,15 @@ func (m *Manager) ReloadInstance(ctx context.Context, plugin db.Plugin, instance
 		return fmt.Errorf("manager: stop instance %s for reload: %w", instance.ID, err)
 	}
 
+	// Release old tool reservations before starting the new generation. If the
+	// manifest changed during hot-reload (different tool set), stale reservations
+	// would block the new generation from registering cleanly. We do NOT call
+	// removeToolGeneration here — nextToolGeneration increments from the previous
+	// value when Start registers the new tool set, preserving monotonicity.
+	if m.cfg.ToolRegistrar != nil {
+		m.cfg.ToolRegistrar.UnregisterInstance(ctx, instance.InstanceName)
+	}
+
 	if err := m.Start(ctx, plugin, instance, binaryPath); err != nil {
 		return fmt.Errorf("manager: restart instance %s after reload: %w", instance.ID, err)
 	}
@@ -317,6 +396,17 @@ func (m *Manager) StopAll(ctx context.Context) error {
 				mu.Lock()
 				errs = append(errs, fmt.Errorf("instance %s: %w", id, err))
 				mu.Unlock()
+			}
+			// Best-effort tool unregistration. Not strictly necessary during
+			// shutdown (the arbiter and toolGenerations are in-memory and die
+			// with the process), but keeps the invariant that Stop always
+			// releases tool names.
+			//
+			// GenerationController.UnregisterInstance is intentionally NOT called
+			// here (pre-existing gap; StopAll deletes the map in bulk). Both
+			// omissions are harmless: the in-memory state dies with the process.
+			if m.cfg.ToolRegistrar != nil {
+				m.cfg.ToolRegistrar.UnregisterInstance(ctx, inst.cfg.InstanceName)
 			}
 		}(id, inst)
 	}
@@ -548,6 +638,28 @@ func (m *Manager) handleLaunchFailure(ctx context.Context, plugin db.Plugin, ins
 		m.logger().Warn("handleLaunchFailure: could not write plugin_crashed audit event",
 			"instance_id", instanceID, "err", auditErr)
 	}
+}
+
+// nextToolGeneration returns the next tool-registrar generation for instanceID.
+// On cold start (no previous entry) it returns 1. On reload it increments the
+// previous value, preserving monotonicity. This counter is independent of the
+// host-RPC generation.Controller (generation/controller.go).
+func (m *Manager) nextToolGeneration(instanceID string) int64 {
+	m.toolGenMu.Lock()
+	defer m.toolGenMu.Unlock()
+	prev := m.toolGenerations[instanceID]
+	next := prev + 1
+	m.toolGenerations[instanceID] = next
+	return next
+}
+
+// removeToolGeneration removes the tool-generation entry for instanceID. Called
+// on Stop (full teardown). Not called on ReloadInstance — the reload path uses
+// nextToolGeneration to increment instead, preserving the monotonic counter.
+func (m *Manager) removeToolGeneration(instanceID string) {
+	m.toolGenMu.Lock()
+	defer m.toolGenMu.Unlock()
+	delete(m.toolGenerations, instanceID)
 }
 
 // logger returns the configured logger, falling back to slog.Default().

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/plugin/generation"
 	"github.com/felag-engineering/gleipnir/internal/plugin/identity"
 	"github.com/felag-engineering/gleipnir/internal/plugin/process"
+	"github.com/felag-engineering/gleipnir/internal/plugin/tools"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 )
 
 // ── fakeQuerier ──────────────────────────────────────────────────────────────
@@ -746,4 +749,332 @@ func TestManager_LaunchFailure_EmitsAuditEventAndHealthDetail(t *testing.T) {
 	if !sawHandshakeFailed {
 		t.Errorf("health detail did not start with 'subprocess_handshake_failed:'; recorded details: %v", q.healthDetails)
 	}
+}
+
+// ── Tool registration tests ───────────────────────────────────────────────────
+
+// fakeToolRegistrar records RegisterInstanceTools and UnregisterInstance calls
+// for assertion in unit tests. Thread-safe.
+type fakeToolRegistrar struct {
+	mu              sync.Mutex
+	registerCalls   []registerCall
+	unregisterCalls []string
+	registerErr     error // if set, RegisterInstanceTools returns this
+}
+
+type registerCall struct {
+	instanceID   string
+	instanceName string
+	toolNames    []string
+	generation   int64
+}
+
+func (f *fakeToolRegistrar) RegisterInstanceTools(_ context.Context, instanceID, instanceName string, toolNames []string, generation int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.registerCalls = append(f.registerCalls, registerCall{instanceID, instanceName, toolNames, generation})
+	return f.registerErr
+}
+
+func (f *fakeToolRegistrar) UnregisterInstance(_ context.Context, instanceName string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.unregisterCalls = append(f.unregisterCalls, instanceName)
+}
+
+// manifestWithTools returns a minimal manifest YAML string declaring the given
+// tool names. Includes schema_version, name, and version so Unmarshal produces
+// a well-formed Manifest.
+func manifestWithTools(toolNames ...string) string {
+	var sb strings.Builder
+	sb.WriteString("schema_version: \"1\"\nname: test-plugin\nversion: \"1.0.0\"\ntools:\n")
+	for _, t := range toolNames {
+		sb.WriteString("  - name: " + t + "\n")
+	}
+	return sb.String()
+}
+
+// TestManager_Start_RegistersTools verifies that Manager.Start calls
+// RegisterInstanceTools with the correct tool names, instance ID, instance
+// name, and generation (1 on cold start) extracted from the manifest snapshot.
+func TestManager_Start_RegistersTools(t *testing.T) {
+	reg := identity.New()
+	registrar := &fakeToolRegistrar{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        &fakeQuerier{},
+		IdentityIssuer: reg,
+		ToolRegistrar:  registrar,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			fc := fixtureConfig(t, "serve-and-block", reg, nil)
+			// Copy InstanceID and InstanceName so the stored instance reflects
+			// the real identifiers; RegisterInstanceTools reads InstanceName via
+			// instance.InstanceName from the db row (not from proc.Config), so
+			// this does not affect what Manager passes to RegisterInstanceTools,
+			// but it ensures Stop's unregistration call uses the right name.
+			fc.InstanceID = cfg.InstanceID
+			fc.InstanceName = cfg.InstanceName
+			return process.Start(ctx, fc)
+		},
+	})
+
+	plugin := db.Plugin{
+		ID:               "p-tools",
+		Status:           "active",
+		ManifestSnapshot: manifestWithTools("send", "read"),
+	}
+	instance := db.PluginInstance{
+		ID:           "i-tools",
+		PluginID:     "p-tools",
+		InstanceName: "my-plugin",
+		HealthState:  "healthy",
+	}
+
+	if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { mgr.Stop(ctx, instance.ID) }) //nolint:errcheck
+
+	registrar.mu.Lock()
+	calls := registrar.registerCalls
+	registrar.mu.Unlock()
+
+	if len(calls) != 1 {
+		t.Fatalf("RegisterInstanceTools called %d times, want 1", len(calls))
+	}
+	call := calls[0]
+	if call.instanceID != instance.ID {
+		t.Errorf("instanceID = %q, want %q", call.instanceID, instance.ID)
+	}
+	if call.instanceName != instance.InstanceName {
+		t.Errorf("instanceName = %q, want %q", call.instanceName, instance.InstanceName)
+	}
+	if len(call.toolNames) != 2 || call.toolNames[0] != "send" || call.toolNames[1] != "read" {
+		t.Errorf("toolNames = %v, want [send read]", call.toolNames)
+	}
+	if call.generation != 1 {
+		t.Errorf("generation = %d, want 1 (cold start)", call.generation)
+	}
+}
+
+// TestManager_Stop_UnregistersTools verifies that Manager.Stop calls
+// UnregisterInstance with the correct instance name.
+func TestManager_Stop_UnregistersTools(t *testing.T) {
+	reg := identity.New()
+	registrar := &fakeToolRegistrar{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        &fakeQuerier{},
+		IdentityIssuer: reg,
+		ToolRegistrar:  registrar,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			fc := fixtureConfig(t, "serve-and-block", reg, nil)
+			// Copy both InstanceID and InstanceName from the manager-supplied cfg
+			// so inst.cfg.InstanceName reflects the real instance name when Stop
+			// reads it for tool unregistration.
+			fc.InstanceID = cfg.InstanceID
+			fc.InstanceName = cfg.InstanceName
+			return process.Start(ctx, fc)
+		},
+	})
+
+	plugin := db.Plugin{
+		ID:               "p-stop",
+		Status:           "active",
+		ManifestSnapshot: manifestWithTools("tool-x"),
+	}
+	instance := db.PluginInstance{
+		ID:           "i-stop",
+		PluginID:     "p-stop",
+		InstanceName: "stop-plugin",
+		HealthState:  "healthy",
+	}
+
+	if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := mgr.Stop(ctx, instance.ID); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	registrar.mu.Lock()
+	unregCalls := registrar.unregisterCalls
+	registrar.mu.Unlock()
+
+	if len(unregCalls) == 0 {
+		t.Fatal("UnregisterInstance was not called after Stop")
+	}
+	// Assert at least one call with the correct instance name.
+	found := false
+	for _, name := range unregCalls {
+		if name == instance.InstanceName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("UnregisterInstance not called with %q; calls: %v", instance.InstanceName, unregCalls)
+	}
+}
+
+// TestManager_Start_ToolConflict_DrivesUnhealthy verifies that when a plugin
+// instance's manifest declares a tool name that conflicts with an existing
+// reservation in the arbiter, the instance is driven to unhealthy and a
+// plugin_tool_namespace_conflict audit event is written.
+//
+// This is the acceptance-criteria integration test from issue #400: it uses a
+// real testutil.NewTestStore + tools.Registrar + pre-populated arbiter.
+func TestManager_Start_ToolConflict_DrivesUnhealthy(t *testing.T) {
+	reg := identity.New()
+	store := testutil.NewTestStore(t)
+
+	// Seed a plugin and instance row in the real DB so the state machine can
+	// update health_state and insert audit events.
+	ctx := context.Background()
+	now := "2024-01-01T00:00:00Z"
+	if _, err := store.Queries().CreatePlugin(ctx, db.CreatePluginParams{
+		ID:               "p-conflict",
+		Name:             "conflict-plugin",
+		PluginVersion:    "1.0.0",
+		ManifestSnapshot: "{}",
+		TrustedPubkey:    "pubkey",
+		Status:           "active",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("CreatePlugin: %v", err)
+	}
+	if _, err := store.Queries().CreatePluginInstance(ctx, db.CreatePluginInstanceParams{
+		ID:                "i-conflict",
+		PluginID:          "p-conflict",
+		InstanceName:      "inst-a",
+		ConfigJson:        "{}",
+		HandshakeVersions: "{}",
+		HealthState:       string(model.PluginHealthStateHealthy),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}); err != nil {
+		t.Fatalf("CreatePluginInstance: %v", err)
+	}
+
+	// Pre-populate the arbiter with a reservation for "inst-a.send" owned by
+	// an MCP source so the plugin's start will conflict.
+	arbiter := toolregistry.New()
+	mcpSrc := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "inst-a"}
+	if err := arbiter.Reserve(toolregistry.DotName("inst-a", "send"), mcpSrc); err != nil {
+		t.Fatalf("pre-reserve: %v", err)
+	}
+
+	toolRegistrar := tools.New(arbiter, store.Queries(), nil)
+
+	// Use the dbQuerierAdapter so Manager reads from the real test store while
+	// the tools.Registrar writes health state and audit events into it.
+	realQ := &dbQuerierAdapter{q: store.Queries()}
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        realQ,
+		IdentityIssuer: reg,
+		ToolRegistrar:  toolRegistrar,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			fc := fixtureConfig(t, "serve-and-block", reg, nil)
+			fc.InstanceID = cfg.InstanceID
+			return process.Start(ctx, fc)
+		},
+	})
+
+	plugin := db.Plugin{
+		ID:               "p-conflict",
+		Status:           "active",
+		ManifestSnapshot: manifestWithTools("send"),
+	}
+	instance := db.PluginInstance{
+		ID:           "i-conflict",
+		PluginID:     "p-conflict",
+		InstanceName: "inst-a",
+		HealthState:  string(model.PluginHealthStateHealthy),
+	}
+
+	startCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Start returns an error because RegisterInstanceTools encounters a conflict.
+	err := mgr.Start(startCtx, plugin, instance, os.Args[0])
+	if err == nil {
+		// Subprocess started — clean up before failing.
+		mgr.Stop(startCtx, instance.ID) //nolint:errcheck
+		t.Fatal("expected error from Manager.Start on tool conflict, got nil")
+	}
+
+	// The subprocess was stored in the map before registration ran, so Stop
+	// is safe to call to clean up the spawned goroutine.
+	mgr.Stop(startCtx, instance.ID) //nolint:errcheck
+
+	// Assert health_state in DB is unhealthy.
+	row, fetchErr := store.Queries().GetPluginInstanceByID(ctx, "i-conflict")
+	if fetchErr != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", fetchErr)
+	}
+	if row.HealthState != string(model.PluginHealthStateUnhealthy) {
+		t.Errorf("health_state = %q after conflict, want %q", row.HealthState, model.PluginHealthStateUnhealthy)
+	}
+
+	// Assert a plugin_tool_namespace_conflict audit event exists.
+	iid := "i-conflict"
+	events, listErr := store.Queries().ListPluginAuditEventsByInstance(ctx, db.ListPluginAuditEventsByInstanceParams{
+		PluginInstanceID: &iid,
+		Offset:           0,
+		Limit:            20,
+	})
+	if listErr != nil {
+		t.Fatalf("ListPluginAuditEventsByInstance: %v", listErr)
+	}
+	found := false
+	for _, e := range events {
+		if e.EventType == "plugin_tool_namespace_conflict" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no plugin_tool_namespace_conflict audit event found; events: %+v", events)
+	}
+}
+
+// dbQuerierAdapter adapts *db.Queries to satisfy the process.Manager's querier
+// interface (a subset of db.Queries). Used in the conflict integration test so
+// the Manager reads from the real test store while the tools.Registrar also
+// writes health state and audit events into the same store.
+type dbQuerierAdapter struct {
+	q *db.Queries
+}
+
+func (a *dbQuerierAdapter) ListPluginsByStatus(ctx context.Context, status string) ([]db.Plugin, error) {
+	return a.q.ListPluginsByStatus(ctx, status)
+}
+
+func (a *dbQuerierAdapter) ListPluginInstancesByPlugin(ctx context.Context, pluginID string) ([]db.PluginInstance, error) {
+	return a.q.ListPluginInstancesByPlugin(ctx, pluginID)
+}
+
+func (a *dbQuerierAdapter) GetPluginByID(ctx context.Context, id string) (db.Plugin, error) {
+	return a.q.GetPluginByID(ctx, id)
+}
+
+func (a *dbQuerierAdapter) GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error) {
+	return a.q.GetPluginInstanceByID(ctx, id)
+}
+
+func (a *dbQuerierAdapter) UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error) {
+	return a.q.UpdatePluginInstanceHealth(ctx, arg)
+}
+
+func (a *dbQuerierAdapter) InsertPluginAuditEvent(ctx context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error) {
+	return a.q.InsertPluginAuditEvent(ctx, arg)
 }

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	pluginoauth "github.com/felag-engineering/gleipnir/internal/plugin/oauth"
 	"github.com/felag-engineering/gleipnir/internal/plugin/process"
 	plugintrigger "github.com/felag-engineering/gleipnir/internal/plugin/trigger"
+	plugintools "github.com/felag-engineering/gleipnir/internal/plugin/tools"
 	"github.com/felag-engineering/gleipnir/internal/policy"
 	"github.com/felag-engineering/gleipnir/internal/settings"
 	"github.com/felag-engineering/gleipnir/internal/timeout"
@@ -186,10 +187,11 @@ func run(cfg config.Config) error {
 	// tool registrar. Constructed once here so both sides see the same state.
 	arbiter := toolregistry.New()
 
-	// TODO #194 follow-up: inject arbiter into plugin tools.Registrar when
-	// plugin start lands. The Registrar constructor is:
-	//   tools.New(arbiter, store.Queries(), broadcaster)
-	// Wire it wherever the plugin instance start sequence calls RegisterInstanceTools.
+	// Plugin tool registrar: claims <instance>.<tool> dot-names in the shared
+	// arbiter when a plugin instance starts, and releases them on stop. Constructed
+	// unconditionally so the reference is available regardless of PluginsEnabled;
+	// it is only injected into StartManagerConfig inside the if-block below.
+	pluginToolRegistrar := plugintools.New(arbiter, store.Queries(), broadcaster)
 
 	// Activate the hostsvc.Server and start the process.Manager when plugins are
 	// enabled. This block runs after pluginPool (needed as CallContextResolver),
@@ -235,6 +237,7 @@ func run(cfg config.Config) error {
 			IdentityRegistry:     identityReg,
 			GenerationController: genCtrl,
 			ServerInterceptors:   interceptors,
+			ToolRegistrar:        pluginToolRegistrar,
 		}); err != nil {
 			return fmt.Errorf("start plugin manager: %w", err)
 		}


### PR DESCRIPTION
Closes #400

## Summary

`RegisterInstanceTools` was implemented and unit-tested (as part of #194) but had **zero production callers**. `main.go:189-192` carried an explicit TODO. This PR wires it into the subprocess lifecycle so plugin tools are visible to agents at run time.

- **`main.go`** — Construct `tools.Registrar` and inject into `StartManagerConfig`; TODO comment removed
- **`internal/plugin/process/manager.go`** — `ToolRegistrar` interface; `toolGenerations` map for independent generation tracking (per `generation/controller.go:26-29` warning — host-RPC and tool-registrar generations are separate epochs); `RegisterInstanceTools` in `Start`, `UnregisterInstance` in `Stop`/`ReloadInstance`/`StopAll`
- **`internal/plugin/loader.go`** — `ToolRegistrar` in `StartManagerConfig` (required, nil = error)
- **3 new tests** — `RegistersTools` (unit), `StopUnregisters` (unit), `ToolConflict_DrivesUnhealthy` (integration with real DB + arbiter asserting `health_state=unhealthy` + `plugin_tool_namespace_conflict` audit event)

This is a prerequisite for #399 (split plugin vs MCP tool resolution in the launcher).

<details>
<summary>Architecture plan</summary>

**Problem:** `tools.Registrar.RegisterInstanceTools` (registrar.go:63) is implemented and tested but never called. The shared `toolregistry.Registry` arbiter has no plugin entries, so any agent-side lookup for `<instance>.<tool>` names comes up empty.

**Fix:** Define a `ToolRegistrar` interface on `process.Manager`, inject it via `ManagerConfig`, and call `RegisterInstanceTools` in `Manager.Start` after the subprocess is stored in the map. Tool names come from parsing the plugin's `ManifestSnapshot` via `manifest.Unmarshal`. The tool-registration generation uses an independent `toolGenerations map[string]int64` counter — NOT the host-RPC generation from `generation.Controller.RegisterInstance` (which has an explicit architectural warning against correlation at `controller.go:26-29`). `UnregisterInstance` is called in `Stop` (before cleanup), `ReloadInstance` (between stop and re-start), and `StopAll` (in each cleanup goroutine).

Plan-reviewer caught two blocking issues: (1) generation counter independence violation, (2) test compile gaps. Both addressed in revised plan.
</details>

## Review cycles: 1 (approved on first pass)
## CLAUDE.md updated: No
## Brainstorming: Not triggered (issue was well-specified)

🤖 Generated with the agentic dev loop