### PR TITLE
fix: healthy transition on first start + spec subscription-scope step

### DIFF
--- a/internal/plugin/trigger/supervisor.go
+++ b/internal/plugin/trigger/supervisor.go
@@ -498,16 +498,24 @@ func (s *Supervisor) recvLoop(
 			return err
 		}
 
-		// First successful Recv after failures: reset health and counter.
+		// First successful Recv: mark the instance Healthy and reset the failure
+		// counter regardless of whether we were previously marked Unhealthy.
+		// A fresh stream that never failed still needs an explicit Healthy
+		// transition — the DB default is unhealthy/config_missing, and the plugin
+		// itself only emits SetHealthState on failure paths (e.g. auth expired,
+		// missing scope).
+		//
+		// Note: when reconnecting from an already-healthy state, this call
+		// triggers a warn-level ErrIllegalTransition in Manager.HealthSetter
+		// (process/manager.go). That is expected and handled gracefully
+		// (warn-and-continue) — it is not actionable and not a sign of breakage.
 		if firstEvent {
 			firstEvent = false
-			if *markedUnhealthy {
-				if s.cfg.HealthSetter != nil {
-					s.cfg.HealthSetter(ctx, instanceID, model.PluginHealthStateHealthy, "")
-				}
-				*markedUnhealthy = false
-			}
 			*consecutive = 0
+			if s.cfg.HealthSetter != nil {
+				s.cfg.HealthSetter(ctx, instanceID, model.PluginHealthStateHealthy, "")
+			}
+			*markedUnhealthy = false
 		}
 
 		evt := Event{

--- a/internal/plugin/trigger/supervisor_test.go
+++ b/internal/plugin/trigger/supervisor_test.go
@@ -901,6 +901,77 @@ func TestSupervisor_NonEmptyScope_OpensStream(t *testing.T) {
 	}
 }
 
+// TestSupervisor_HealthyOnFirstRecv_NoPreFailure verifies that the supervisor
+// calls HealthSetter(Healthy) on the first successful Recv even when the
+// instance was never previously marked Unhealthy (clean first start with valid
+// credentials). This covers the gap where the DB default is
+// unhealthy/config_missing and the plugin itself only emits SetHealthState on
+// failure paths — without this fix the instance would never transition to
+// Healthy.
+func TestSupervisor_HealthyOnFirstRecv_NoPreFailure(t *testing.T) {
+	t.Parallel()
+
+	evCh := make(chan *triggerv1.StartResponse, 1)
+	evCh <- &triggerv1.StartResponse{EventId: "first-event", EventKind: "message", PayloadJson: "{}"}
+	close(evCh)
+
+	client, stop := startFakeTriggerServer(t, &sequentialTriggerServer{eventsCh: evCh})
+	defer stop()
+
+	type healthEvent struct {
+		state  model.PluginHealthState
+		detail string
+	}
+	var mu sync.Mutex
+	var healthEvents []healthEvent
+
+	// Cancel the supervisor as soon as the first Healthy event is seen. This
+	// stops the reconnect loop before it accumulates enough consecutive failures
+	// to trigger an Unhealthy call, keeping the test deterministic.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	healthSetter := func(_ context.Context, _ string, state model.PluginHealthState, detail string) {
+		mu.Lock()
+		healthEvents = append(healthEvents, healthEvent{state, detail})
+		mu.Unlock()
+		if state == model.PluginHealthStateHealthy {
+			cancel() // stop the supervisor immediately on first Healthy
+		}
+	}
+
+	lookup := &fakeInstanceLookup{client: client, pluginID: "test-plugin"}
+	dispatcher := &fakeEventDispatcher{}
+	sup := newSupervisor(lookup, dispatcher, healthSetter)
+
+	sup.Start(ctx, "inst-fresh")
+
+	// Wait until at least one health event is recorded, then let Stop drain the
+	// goroutine. The cancel in the healthSetter above fires on the first Healthy
+	// call, so the goroutine exits shortly after we see the event.
+	waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(healthEvents) > 0
+	})
+
+	// Stop blocks until the goroutine exits (drains doneCh), ensuring no more
+	// health events are appended after we read the slice below.
+	sup.Stop("inst-fresh")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// The Healthy event must have appeared, and it must be the first health event
+	// recorded (no Unhealthy should precede it on a clean first start).
+	if len(healthEvents) == 0 {
+		t.Fatal("HealthSetter never called on clean first start")
+	}
+	if healthEvents[0].state != model.PluginHealthStateHealthy {
+		t.Errorf("first HealthSetter call = %v, want Healthy", healthEvents[0].state)
+	}
+}
+
 // TestSupervisor_Restart_EmptyToNonEmpty_TriggersStream verifies the
 // Restart path: when scope transitions from empty → non-empty via Restart,
 // the new goroutine picks up the updated scope and opens a stream.

--- a/tests/playwright/slack-kitchen-sink.spec.ts
+++ b/tests/playwright/slack-kitchen-sink.spec.ts
@@ -92,16 +92,47 @@ test('kitchen sink: slack → trigger → run → slack reply', async ({ request
   expect(credResp.ok(), `set oauth token failed: ${await credResp.text()}`).toBe(true);
 
   // Gap 6: use the new instance-config endpoint; wrap payload in {config, expected_version}.
+  // expected_version is 1 (not 0) because the oauth-token PUT above already bumped
+  // the row's version from 0 → 1. The oauth-token PUT returns 204 No Content so
+  // we cannot extract the version from its response body — hardcoded 1 is correct
+  // for this controlled E2E setup where no concurrent writers exist.
   const cfgResp = await ctx.put(
     `/api/v1/admin/plugins/${pluginID}/instances/${instanceID}/config`,
     {
       data: {
         config: { app_level_token: process.env.SLACK_TEST_APP_TOKEN },
-        expected_version: 0,
+        expected_version: 1,
       },
     },
   );
   expect(cfgResp.ok(), `set config failed: ${await cfgResp.text()}`).toBe(true);
+
+  // Re-fetch the instance to get the latest version before writing subscription
+  // scope. Between the config PUT response and now, the plugin subprocess may
+  // have called SetHealthState via hostsvc (bumping the version). Using the
+  // config PUT response version directly would risk a 409 on a stale version.
+  const freshInstResp = await ctx.get(
+    `/api/v1/admin/plugins/${pluginID}/instances/${instanceID}`,
+  );
+  expect(freshInstResp.ok(), `re-fetch instance failed: ${await freshInstResp.text()}`).toBe(true);
+  const freshInst = await freshInstResp.json();
+  const scopeVersion: number = freshInst.data?.version;
+
+  // The supervisor gates on isEmptyScope: when subscription_scope_json is "{}"
+  // (the CreatePluginInstance default) it skips opening the TriggerService stream
+  // entirely. Without a non-empty scope, no Socket Mode connection opens and no
+  // Slack events reach the dispatcher.
+  const channelID = process.env.SLACK_TEST_CHANNEL_ID!;
+  const scopeResp = await ctx.put(
+    `/api/v1/admin/plugins/${pluginID}/instances/${instanceID}/subscription-scope`,
+    {
+      data: {
+        scope: { channels: [channelID] },
+        expected_version: scopeVersion,
+      },
+    },
+  );
+  expect(scopeResp.ok(), `set subscription scope failed: ${await scopeResp.text()}`).toBe(true);
 
   // Poll until the instance becomes healthy (deadline: 30s).
   const healthDeadline = Date.now() + 30_000;
@@ -121,7 +152,6 @@ test('kitchen sink: slack → trigger → run → slack reply', async ({ request
   expect(healthy, 'instance never reached state=healthy within 30s').toBe(true);
 
   // ── Step 5: Create the kitchen-sink policy ─────────────────────────────────
-  const channelID = process.env.SLACK_TEST_CHANNEL_ID!;
   const policyYAML = `\
 name: slack-e2e-kitchen-sink
 trigger:


### PR DESCRIPTION
Closes #407

## Summary

Two gaps preventing the kitchen-sink Playwright spec from passing after #399–#405 merge:

1. **Supervisor never marks Healthy on clean first start.** `recvLoop` only called `HealthSetter(Healthy)` when recovering from a prior unhealthy state. A fresh stream goroutine that connected successfully on first try stayed at `unhealthy/config_missing` forever. Fixed by calling `HealthSetter(Healthy)` unconditionally on the first successful `Recv`, using the existing `firstEvent` guard. Reconnect-from-healthy produces a warn-level `ErrIllegalTransition` log (swallowed gracefully by `Manager.HealthSetter`).

2. **Playwright spec missing subscription-scope step.** The spec seeded credentials and config but never called `PUT .../subscription-scope`. Without a scope, the supervisor skips opening the TriggerService stream (no Socket Mode, no events). Added the PUT step between config seeding and the healthy poll, with a fresh GET to read the latest instance version and avoid CAS 409 races from the subprocess calling `SetHealthState` between the config PUT response and the scope write.

Also fixed `expected_version` in the config PUT from `0` to `1` (the oauth-token PUT bumps the version).

<details>
<summary>Architecture plan</summary>

**Fix 1:** In `supervisor.go` `recvLoop`, the `firstEvent` block at line 502 already fires once per stream connection. Changed the `HealthSetter(Healthy)` call from conditional (`if *markedUnhealthy`) to unconditional, with `*markedUnhealthy = false` reset afterwards. The `firstEvent` bool is local to `recvLoop` and resets to `true` on each reconnect (fresh `recvLoop` invocation at line 460).

**Fix 2:** In the Playwright spec, hoisted `channelID` before the scope step, added a re-fetch GET to capture the latest instance version (eliminates race from `advanceInstanceReadiness` + subprocess health callbacks), then the scope PUT with `{ channels: [channelID] }`.

Plan-reviewer caught 2 blocking issues (version race, reconnect log noise) — both addressed.
</details>

## Review cycles: 1 (approved on first pass)
## CLAUDE.md updated: No
## Brainstorming: Not triggered (issue was well-specified)

🤖 Generated with the agentic dev loop