### PR TITLE
fix: supervisor Start-or-Restart for post-boot instances + healthy-on-stream-open guard

### DIFF
--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -128,11 +128,12 @@ type PluginInstaller interface {
 	Install(ctx context.Context, tarPath string) (string, error)
 }
 
-// TriggerRestarter is the narrow interface used to restart a plugin's trigger
-// stream after its subscription scope changes. Implemented by
+// TriggerRestarter is the narrow interface used to start or restart a plugin's
+// trigger stream after its subscription scope changes. Implemented by
 // *plugintrigger.Supervisor; kept narrow here so the admin package does not
 // import the trigger package directly.
 type TriggerRestarter interface {
+	Start(ctx context.Context, instanceID string)
 	Restart(ctx context.Context, instanceID string)
 }
 
@@ -684,10 +685,12 @@ func (h *PluginHandler) PutSubscriptionScope(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Restart the trigger stream so the plugin picks up the new scope. This is
-	// fire-and-continue — the supervisor's Start call is fast; stream opening
-	// is asynchronous inside the goroutine.
+	// Ensure the trigger stream is running with the latest scope. Start is
+	// a no-op if already supervised; Restart cancels and re-opens so the
+	// plugin picks up the new scope. Both are needed because instances
+	// created after boot were never supervised by StartAll.
 	if h.triggerRestarter != nil {
+		h.triggerRestarter.Start(ctx, instanceID)
 		h.triggerRestarter.Restart(ctx, instanceID)
 	}
 

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -1247,6 +1247,8 @@ type fakeTriggerRestarter struct {
 	restartIDs []string
 }
 
+func (f *fakeTriggerRestarter) Start(_ context.Context, _ string) {}
+
 func (f *fakeTriggerRestarter) Restart(_ context.Context, instanceID string) {
 	f.mu.Lock()
 	f.restartIDs = append(f.restartIDs, instanceID)

--- a/internal/plugin/trigger/supervisor.go
+++ b/internal/plugin/trigger/supervisor.go
@@ -379,6 +379,7 @@ func (s *Supervisor) streamLoop(ctx context.Context, instanceID string, doneCh c
 	consecutive := 0 // consecutive reconnect failures without a successful Recv
 	markedUnhealthy := false
 	loggedEmptyScope := false // rate-limit the "scope not configured" log line
+	initialHealthSet := false // fires once on first successful stream open
 
 	for {
 		if ctx.Err() != nil {
@@ -456,6 +457,17 @@ func (s *Supervisor) streamLoop(ctx context.Context, instanceID string, doneCh c
 			continue
 		}
 
+		// On the very first successful stream open, mark Healthy so the admin
+		// UI can see the instance is connected before any events arrive.
+		// Subsequent reconnects skip this — the recovery path in recvLoop
+		// handles marking Healthy after failures resolve.
+		if !initialHealthSet {
+			initialHealthSet = true
+			if s.cfg.HealthSetter != nil {
+				s.cfg.HealthSetter(ctx, instanceID, model.PluginHealthStateHealthy, "")
+			}
+		}
+
 		// Recv loop — single goroutine to preserve per-stream event ordering.
 		recvErr := s.recvLoop(ctx, instanceID, stream, log, &markedUnhealthy, &consecutive)
 		if recvErr == nil || ctx.Err() != nil {
@@ -474,8 +486,8 @@ func (s *Supervisor) streamLoop(ctx context.Context, instanceID string, doneCh c
 }
 
 // recvLoop drains messages from stream until EOF, an error, or ctx cancellation.
-// It resets the consecutive-failure counter and heals the health state on the
-// first successful Recv. Returns nil on clean context cancellation.
+// On the first successful Recv it resets the consecutive-failure counter and
+// clears the markedUnhealthy flag. Returns nil on clean context cancellation.
 func (s *Supervisor) recvLoop(
 	ctx context.Context,
 	instanceID string,
@@ -498,24 +510,15 @@ func (s *Supervisor) recvLoop(
 			return err
 		}
 
-		// First successful Recv: mark the instance Healthy and reset the failure
-		// counter regardless of whether we were previously marked Unhealthy.
-		// A fresh stream that never failed still needs an explicit Healthy
-		// transition — the DB default is unhealthy/config_missing, and the plugin
-		// itself only emits SetHealthState on failure paths (e.g. auth expired,
-		// missing scope).
-		//
-		// Note: when reconnecting from an already-healthy state, this call
-		// triggers a warn-level ErrIllegalTransition in Manager.HealthSetter
-		// (process/manager.go). That is expected and handled gracefully
-		// (warn-and-continue) — it is not actionable and not a sign of breakage.
 		if firstEvent {
 			firstEvent = false
-			*consecutive = 0
-			if s.cfg.HealthSetter != nil {
-				s.cfg.HealthSetter(ctx, instanceID, model.PluginHealthStateHealthy, "")
+			if *markedUnhealthy {
+				if s.cfg.HealthSetter != nil {
+					s.cfg.HealthSetter(ctx, instanceID, model.PluginHealthStateHealthy, "")
+				}
+				*markedUnhealthy = false
 			}
-			*markedUnhealthy = false
+			*consecutive = 0
 		}
 
 		evt := Event{

--- a/internal/plugin/trigger/supervisor_test.go
+++ b/internal/plugin/trigger/supervisor_test.go
@@ -461,29 +461,41 @@ func TestSupervisor_RecoveryAfterFailures(t *testing.T) {
 	recoveryCh <- &triggerv1.StartResponse{EventId: "recovery", EventKind: "message"}
 	close(recoveryCh)
 
-	// Wait for Healthy to be reported.
+	// Wait for a recovery Healthy (one that comes after an Unhealthy event).
 	waitFor(t, 8*time.Second, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
+		var sawU bool
 		for _, e := range healthEvents {
-			if e.state == model.PluginHealthStateHealthy {
+			if e.state == model.PluginHealthStateUnhealthy {
+				sawU = true
+			}
+			if e.state == model.PluginHealthStateHealthy && sawU {
 				return true
 			}
 		}
 		return false
 	})
 
-	// Verify ordering: Unhealthy must appear before Healthy.
+	// Verify the recovery sequence: there must be an Unhealthy event
+	// followed by a Healthy event. The initial stream-open Healthy (before
+	// any failures) is expected and does not violate the ordering.
 	mu.Lock()
 	defer mu.Unlock()
-	var sawUnhealthy bool
+	var sawUnhealthy, sawRecovery bool
 	for _, e := range healthEvents {
 		if e.state == model.PluginHealthStateUnhealthy {
 			sawUnhealthy = true
 		}
-		if e.state == model.PluginHealthStateHealthy && !sawUnhealthy {
-			t.Error("saw Healthy before Unhealthy — wrong order")
+		if e.state == model.PluginHealthStateHealthy && sawUnhealthy {
+			sawRecovery = true
 		}
+	}
+	if !sawUnhealthy {
+		t.Error("expected at least one Unhealthy event from consecutive failures")
+	}
+	if !sawRecovery {
+		t.Error("expected a Healthy event after the Unhealthy event (recovery)")
 	}
 }
 


### PR DESCRIPTION
Closes #409

## Summary

Two fixes discovered during the live kitchen-sink E2E (Slack message → trigger → agent → `post_message` → reply):

1. **`Restart` is a no-op for unsupervised instances.** Instances created after boot were never supervised by `StartAll`. The scope PUT handler only called `Restart` → no-op → trigger stream never started. **Fix:** widened `TriggerRestarter` interface to include `Start`; handler calls `Start` (no-op if already supervised) then `Restart` (re-opens with new scope).

2. **Healthy-on-stream-open fired on every reconnect.** This prevented consecutive failures from accumulating — the recovery-after-failures test broke. **Fix:** `initialHealthSet` bool in `streamLoop` fires only on the first successful stream open per goroutine lifetime. Recovery uses the existing `recvLoop.firstEvent` path.

## Changes

- `internal/admin/plugin_handler.go` — `TriggerRestarter` interface gains `Start`; scope PUT calls `Start` then `Restart`
- `internal/admin/plugin_handler_test.go` — `fakeTriggerRestarter` gains `Start` stub
- `internal/plugin/trigger/supervisor.go` — `initialHealthSet` in `streamLoop`; `recvLoop` keeps recovery HealthSetter for `markedUnhealthy` path
- `internal/plugin/trigger/supervisor_test.go` — `RecoveryAfterFailures` assertion updated to accept initial Healthy before Unhealthy

## Verified

These fixes were validated in a live E2E: Slack message triggered a `subscribed` run, agent resolved `slack-e2e.post_message` via the plugin dispatcher, and the reply token landed in the Slack channel. Full trace confirmed in conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)