### PR TITLE
feat: host-side ChannelService.Request row-before-call + pre-ack cleanup

### DIFF
--- a/internal/plugin/dispatch/channel.go
+++ b/internal/plugin/dispatch/channel.go
@@ -236,17 +236,19 @@ func (d *Dispatcher) notifyOne(ctx context.Context, rc RouteContext, instanceNam
 }
 
 // Request dispatches a channel request to the first audience entry with
-// request: true (in position order).  It applies a 5s pre-ack deadline; on
-// pre-ack success it inserts a plugin_pending_requests row and returns the
-// requestID and RouteToPlugin so the caller can block on Wait.
+// request: true (in position order).  It inserts a plugin_pending_requests row
+// BEFORE making the gRPC call so that a fast plugin callback (WriteAuditStep)
+// always finds a row to match against.  It applies a 5s pre-ack deadline; on
+// pre-ack success it returns the requestID and RouteToPlugin so the caller can
+// block on Wait.
 //
 // When the first Request-capable entry is the synthetic gleipnir.in-app entry,
 // it returns ("", RouteToInApp, nil) without making any gRPC call or inserting
 // a DB row — the feedback_requests substrate handles in-app Requests.
 //
-// On pre-ack failure, it calls WriteRunStep with a "feedback_dispatch_error"
-// step and returns ErrPreAckFailed.  The caller should map this to
-// runstate.TransitionRunFailed.
+// On pre-ack failure, it transitions the already-inserted row to timed_out and
+// calls WriteRunStep with a "feedback_dispatch_error" step, then returns
+// ErrPreAckFailed.  The caller should map this to runstate.TransitionRunFailed.
 //
 // ErrNoRequestCapableEntry is returned only when disable_in_app_fallback=true
 // and the audience has no persisted Request-capable entries (a state the
@@ -306,6 +308,34 @@ func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteCon
 	d.waiters[reqID] = waiter
 	d.waitersMu.Unlock()
 
+	// Insert the DB row BEFORE the gRPC call so that a fast plugin callback
+	// (WriteAuditStep with feedback_response) always finds an existing row.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	var expiresAtStr *string
+	if expiresAt != nil {
+		s := expiresAt.UTC().Format(time.RFC3339Nano)
+		expiresAtStr = &s
+	}
+	var entryID *string
+	if firstRequest.EntryID != "" {
+		entryID = &firstRequest.EntryID
+	}
+	if _, dbErr := d.cfg.Queries.CreatePluginPendingRequest(ctx, db.CreatePluginPendingRequestParams{
+		ID:               reqID,
+		PluginInstanceID: targetInstance.ID,
+		RunID:            rc.RunID,
+		AudienceEntryID:  entryID,
+		ToolName:         rc.ToolName,
+		ExpiresAt:        expiresAtStr,
+		CreatedAt:        now,
+	}); dbErr != nil {
+		// Row insert failed; clean up the waiter to avoid leaking the channel.
+		d.waitersMu.Lock()
+		delete(d.waiters, reqID)
+		d.waitersMu.Unlock()
+		return "", 0, fmt.Errorf("persist plugin pending request: %w", dbErr)
+	}
+
 	preCtx, cancelPre := context.WithTimeout(ctx, d.cfg.PreAckTimeout)
 	defer cancelPre()
 
@@ -337,13 +367,24 @@ func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteCon
 	}
 
 	if preAckFailMsg != "" {
-		// Deregister the waiter — no row will be inserted, so no one will ever
-		// send on this channel.
+		// Deregister the waiter — no one will send on this channel now.
 		d.waitersMu.Lock()
 		delete(d.waiters, reqID)
 		d.waitersMu.Unlock()
 
 		incRPCError("Request", targetInstance.PluginID, targetInstance.ID)
+
+		// The row was inserted before the gRPC call; transition it to timed_out
+		// so it does not leak as a dangling pending row.  Swallow
+		// ErrTransitionConflict: the scanner may have beaten us to it.
+		if transErr := TransitionTimedOut(ctx, d.cfg.Queries, reqID); transErr != nil {
+			if !errors.Is(transErr, ErrTransitionConflict) {
+				slog.Warn("pre-ack failure: could not transition row to timed_out",
+					"request_id", reqID,
+					"err", transErr,
+				)
+			}
+		}
 
 		if d.cfg.WriteRunStep != nil {
 			_ = d.cfg.WriteRunStep(ctx, rc.RunID, "feedback_dispatch_error", map[string]interface{}{
@@ -354,33 +395,6 @@ func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteCon
 			})
 		}
 		return "", 0, fmt.Errorf("%w: %s", ErrPreAckFailed, preAckFailMsg)
-	}
-
-	// Pre-ack succeeded: persist the pending request row.
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	var expiresAtStr *string
-	if expiresAt != nil {
-		s := expiresAt.UTC().Format(time.RFC3339Nano)
-		expiresAtStr = &s
-	}
-	var entryID *string
-	if firstRequest.EntryID != "" {
-		entryID = &firstRequest.EntryID
-	}
-	if _, dbErr := d.cfg.Queries.CreatePluginPendingRequest(ctx, db.CreatePluginPendingRequestParams{
-		ID:               reqID,
-		PluginInstanceID: targetInstance.ID,
-		RunID:            rc.RunID,
-		AudienceEntryID:  entryID,
-		ToolName:         rc.ToolName,
-		ExpiresAt:        expiresAtStr,
-		CreatedAt:        now,
-	}); dbErr != nil {
-		// Row insert failed; clean up the waiter to avoid leaking the channel.
-		d.waitersMu.Lock()
-		delete(d.waiters, reqID)
-		d.waitersMu.Unlock()
-		return "", 0, fmt.Errorf("persist plugin pending request: %w", dbErr)
 	}
 
 	return reqID, RouteToPlugin, nil

--- a/internal/plugin/dispatch/channel_test.go
+++ b/internal/plugin/dispatch/channel_test.go
@@ -463,8 +463,8 @@ func TestRequest_PreAckSuccess_RowInserted_ResolveFlipsStatus(t *testing.T) {
 }
 
 // TestRequest_PreAckAckedFalse verifies that acked=false causes a
-// feedback_dispatch_error step, returns ErrPreAckFailed, and does not insert a
-// pending row.
+// feedback_dispatch_error step, returns ErrPreAckFailed, and transitions the
+// already-inserted pending row to timed_out.
 func TestRequest_PreAckAckedFalse(t *testing.T) {
 	ds := newSetup(t)
 
@@ -494,13 +494,14 @@ func TestRequest_PreAckAckedFalse(t *testing.T) {
 		t.Errorf("feedback_dispatch_error steps = %d, want 1", len(steps))
 	}
 
-	// No row should be in plugin_pending_requests.
-	var count int
-	if err := ds.store.DB().QueryRow(`SELECT COUNT(*) FROM plugin_pending_requests WHERE run_id = 'run1'`).Scan(&count); err != nil {
-		t.Fatalf("count pending requests: %v", err)
+	// Row must exist with status='timed_out' (inserted before gRPC call, then
+	// transitioned on pre-ack failure).
+	var status string
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE run_id = 'run1'`).Scan(&status); err != nil {
+		t.Fatalf("query pending request: %v", err)
 	}
-	if count != 0 {
-		t.Errorf("pending requests count = %d, want 0", count)
+	if status != "timed_out" {
+		t.Errorf("status = %q, want timed_out", status)
 	}
 }
 
@@ -535,6 +536,15 @@ func TestRequest_PreAckTimeout(t *testing.T) {
 	if len(steps) != 1 {
 		t.Errorf("feedback_dispatch_error steps = %d, want 1", len(steps))
 	}
+
+	// Row must exist with status='timed_out'.
+	var status string
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE run_id = 'run1'`).Scan(&status); err != nil {
+		t.Fatalf("query pending request: %v", err)
+	}
+	if status != "timed_out" {
+		t.Errorf("status = %q, want timed_out", status)
+	}
 }
 
 // TestRequest_PreAckRespError verifies that resp.Error != nil is treated as a
@@ -563,6 +573,15 @@ func TestRequest_PreAckRespError(t *testing.T) {
 	_, _, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
 	if !errors.Is(err, dispatch.ErrPreAckFailed) {
 		t.Errorf("expected ErrPreAckFailed, got %v", err)
+	}
+
+	// Row must exist with status='timed_out'.
+	var status string
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE run_id = 'run1'`).Scan(&status); err != nil {
+		t.Fatalf("query pending request: %v", err)
+	}
+	if status != "timed_out" {
+		t.Errorf("status = %q, want timed_out", status)
 	}
 }
 
@@ -956,5 +975,88 @@ func TestNotify_SyntheticSkipped(t *testing.T) {
 	// Exactly one invocation — the synthetic entry must be skipped.
 	if invokeCount.Load() != 1 {
 		t.Errorf("notify invocations = %d, want 1 (synthetic should be skipped)", invokeCount.Load())
+	}
+}
+
+// TestRequest_RowInsertedBeforeGRPCCall verifies that the plugin_pending_requests
+// row exists with status='pending' at the moment the plugin's Request RPC is
+// invoked.  This is the ordering guarantee: a fast callback (WriteAuditStep)
+// from the plugin can match against the row even on the same round trip.
+func TestRequest_RowInsertedBeforeGRPCCall(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-order")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	ds.clientMap["inst-order"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, req *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			// At this point the row must already exist in the DB.
+			var status string
+			if err := ds.store.DB().QueryRow(
+				`SELECT status FROM plugin_pending_requests WHERE id = ?`,
+				req.GetRequestId(),
+			).Scan(&status); err != nil {
+				t.Errorf("row not found at gRPC call time: %v", err)
+			} else if status != "pending" {
+				t.Errorf("status at gRPC call time = %q, want pending", status)
+			}
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	_, outcome, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if outcome != dispatch.RouteToPlugin {
+		t.Errorf("outcome = %v, want RouteToPlugin", outcome)
+	}
+}
+
+// TestRequest_PreAckFailure_RowTransitionedToTimedOut verifies the cleanup path:
+// when the plugin returns acked=false, the already-inserted row is transitioned
+// to timed_out rather than left as a dangling pending entry.
+func TestRequest_PreAckFailure_RowTransitionedToTimedOut(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-nack2")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-nack2"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: false}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+	_, _, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if !errors.Is(err, dispatch.ErrPreAckFailed) {
+		t.Fatalf("expected ErrPreAckFailed, got %v", err)
+	}
+
+	// Row must exist and be timed_out — not pending and not absent.
+	var status string
+	if err := ds.store.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE run_id = 'run1'`).Scan(&status); err != nil {
+		t.Fatalf("query pending request: %v", err)
+	}
+	if status != "timed_out" {
+		t.Errorf("status = %q, want timed_out", status)
+	}
+
+	// Exactly one feedback_dispatch_error step must have been recorded.
+	steps := ds.stepsByType("feedback_dispatch_error")
+	if len(steps) != 1 {
+		t.Errorf("feedback_dispatch_error steps = %d, want 1", len(steps))
 	}
 }


### PR DESCRIPTION
Closes #411

## Summary

`dispatch.Dispatcher.Request` already makes the `ChannelService.Request` gRPC call to plugin instances over UDS. Two ordering fixes to make the request path production-ready for approval routing (#412):

1. **Row-before-call:** Moved `CreatePluginPendingRequest` to before the gRPC call so the `plugin_pending_requests` row exists for late-callback detection if the call fails or the plugin responds after the pre-ack deadline.

2. **Pre-ack cleanup:** On failure (acked=false, timeout, or gRPC error), the already-inserted row is transitioned to `timed_out` via `TransitionTimedOut`. Previously these paths assumed no row existed.

No new interfaces, no hostsvc changes, no main.go wiring. The plan-reviewer identified that the original architecture (adding `ChannelRequester` interface + `hostsvc.ForwardChannelRequest` + `ChannelClientFactory`) was redundant — dispatch already has the complete gRPC call path with the 5s `PreAckTimeout`.

<details>
<summary>Architecture plan</summary>

**Option A (minimal) selected per plan-reviewer recommendation.**

The gRPC call stays in `dispatch.Dispatcher.Request()` where it already lives. Changes:
1. Reorder `CreatePluginPendingRequest` to before `client.Request(preCtx, req)`
2. On pre-ack failure after row insert, call `TransitionTimedOut` (guarded by row-insert having succeeded — the insert-failure path returns early, so reaching the pre-ack block guarantees the row exists)
3. `ErrTransitionConflict` is swallowed consistently with `Resolve()` and `Wait()` in this package

The 5s deadline is already enforced by `cfg.PreAckTimeout` via `context.WithTimeout`. No second timeout needed.
</details>

## Tests
- 3 existing tests updated: assert `status='timed_out'` instead of `count=0`
- 2 new tests: `TestRequest_RowInsertedBeforeGRPCCall` (ordering proof via sync hook) + `TestRequest_PreAckFailure_RowTransitionedToTimedOut` (cleanup verification)

## Review cycles: 1 (one stale comment fixed inline)
## CLAUDE.md updated: No
## Brainstorming: Not triggered

🤖 Generated with the agentic dev loop