### PR TITLE
feat: route approval requests through policy audience (single-entry, no fan-out)

### DIFF
--- a/internal/execution/agent/agent.go
+++ b/internal/execution/agent/agent.go
@@ -72,6 +72,12 @@ type Config struct {
 	ApprovalCh             <-chan bool
 	StateMachine           *RunStateMachine
 	DefaultFeedbackTimeout time.Duration
+	// ApprovalDispatcher routes approvals through a plugin channel (e.g. Slack).
+	// Nil when plugins are disabled or the policy has no audience configured.
+	ApprovalDispatcher ApprovalChannelDispatcher
+	// AudienceID is the DB row ID of the policy's audience, resolved by the
+	// launcher.  Empty string means no audience — fall back to in-app.
+	AudienceID string
 }
 
 // New returns a BoundAgent ready to run, or an error if schema narrowing fails
@@ -143,6 +149,13 @@ func New(cfg Config) (*BoundAgent, error) {
 		})
 	}
 
+	var approvalOpts []ApprovalHandlerOption
+	if cfg.ApprovalDispatcher != nil && cfg.AudienceID != "" {
+		approvalOpts = append(approvalOpts, WithApprovalChannelDispatch(
+			cfg.ApprovalDispatcher, cfg.AudienceID, cfg.PolicyID,
+		))
+	}
+
 	return &BoundAgent{
 		policy:             cfg.Policy,
 		policyID:           cfg.PolicyID,
@@ -154,7 +167,7 @@ func New(cfg Config) (*BoundAgent, error) {
 		llmClient:          cfg.LLMClient,
 		audit:              cfg.Audit,
 		sm:                 cfg.StateMachine,
-		approvals:          NewApprovalHandler(cfg.Audit, cfg.StateMachine, cfg.ApprovalCh),
+		approvals:          NewApprovalHandler(cfg.Audit, cfg.StateMachine, cfg.ApprovalCh, approvalOpts...),
 		feedback:           NewFeedbackHandler(cfg.Audit, cfg.StateMachine, cfg.DefaultFeedbackTimeout),
 	}, nil
 }

--- a/internal/execution/agent/approval.go
+++ b/internal/execution/agent/approval.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -22,16 +23,54 @@ type ApprovalHandler struct {
 	audit      *AuditWriter
 	sm         *RunStateMachine
 	approvalCh <-chan bool // receive-only: handler never closes the channel
+
+	// Plugin channel routing — populated by WithApprovalChannelDispatch.
+	// When non-nil the handler dispatches through the plugin channel instead
+	// of blocking on approvalCh.  Falls back to in-app on ErrApprovalRouteToInApp.
+	channelDispatcher ApprovalChannelDispatcher
+	policyID          string
+	audienceID        string
+}
+
+// ApprovalHandlerOption is a functional option for NewApprovalHandler.
+type ApprovalHandlerOption func(*ApprovalHandler)
+
+// WithApprovalChannelDispatch attaches a plugin channel dispatcher to the
+// handler.  When d is non-nil and audienceID is non-empty, Wait routes the
+// approval through the plugin channel instead of blocking on approvalCh.
+func WithApprovalChannelDispatch(d ApprovalChannelDispatcher, audienceID, policyID string) ApprovalHandlerOption {
+	return func(h *ApprovalHandler) {
+		h.channelDispatcher = d
+		h.audienceID = audienceID
+		h.policyID = policyID
+	}
 }
 
 // NewApprovalHandler constructs an ApprovalHandler. approvalCh must be
 // receive-only (compile-time guarantee the handler does not close it).
-func NewApprovalHandler(audit *AuditWriter, sm *RunStateMachine, approvalCh <-chan bool) *ApprovalHandler {
-	return &ApprovalHandler{
+// Optional functional opts (e.g. WithApprovalChannelDispatch) are applied
+// after initialization; existing callers that pass zero opts are unaffected.
+func NewApprovalHandler(audit *AuditWriter, sm *RunStateMachine, approvalCh <-chan bool, opts ...ApprovalHandlerOption) *ApprovalHandler {
+	h := &ApprovalHandler{
 		audit:      audit,
 		sm:         sm,
 		approvalCh: approvalCh,
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// formatApprovalPrompt builds a human-readable description of the pending
+// approval gate.  The prompt is sent to the plugin channel (e.g. Slack) so the
+// operator understands what they are approving without needing to open the UI.
+func formatApprovalPrompt(toolName string, input map[string]any) string {
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return fmt.Sprintf("Approval required for tool `%s`", toolName)
+	}
+	return fmt.Sprintf("Approval required for tool `%s` with input: %s", toolName, string(inputJSON))
 }
 
 // Wait suspends the run at an approval gate for the given tool entry.
@@ -71,6 +110,46 @@ func (h *ApprovalHandler) Wait(ctx context.Context, runID string, entry resolved
 		return fmt.Errorf("transitioning run to waiting_for_approval: %w", err)
 	}
 
+	// Plugin channel routing: when a dispatcher and audience are configured,
+	// route the approval through the plugin (e.g. Slack approve/deny buttons).
+	// ErrApprovalRouteToInApp falls through to the existing approvalCh select
+	// below; all other results (approved, denied, error) are terminal.
+	if h.channelDispatcher != nil && h.audienceID != "" {
+		var expiresAtTime *time.Time
+		if entry.tool.Timeout > 0 {
+			t := time.Now().UTC().Add(entry.tool.Timeout)
+			expiresAtTime = &t
+		}
+		prompt := formatApprovalPrompt(internalName, input)
+		approved, dispatchErr := h.channelDispatcher.DispatchApproval(ctx, ApprovalDispatchRequest{
+			AudienceID: h.audienceID,
+			RunID:      runID,
+			PolicyID:   h.policyID,
+			ToolName:   internalName,
+			Prompt:     prompt,
+			ExpiresAt:  expiresAtTime,
+		})
+		if errors.Is(dispatchErr, ErrApprovalRouteToInApp) {
+			// Audience resolved to in-app; fall through to the approvalCh select.
+		} else if dispatchErr != nil {
+			return fmt.Errorf("plugin approval dispatch for tool %s: %w", internalName, dispatchErr)
+		} else if !approved {
+			err := fmt.Errorf("tool call %s rejected by operator", internalName)
+			logAuditError(ctx, h.audit, Step{
+				RunID:   runID,
+				Type:    model.StepTypeError,
+				Content: model.ErrorStepContent{Message: err.Error(), Code: model.ErrorCodeApprovalRejected},
+			})
+			return err
+		} else {
+			if err := h.sm.Transition(ctx, model.RunStatusRunning, ""); err != nil {
+				return fmt.Errorf("transitioning run back to running after approval: %w", err)
+			}
+			return nil
+		}
+	}
+
+	// --- In-app approval path (unchanged) ---
 	// nil timeoutCh (when Timeout == 0) blocks forever in the select,
 	// meaning no timeout is applied. Use NewTimer so we can Stop it
 	// on early approval — time.After leaks until the duration fires.

--- a/internal/execution/agent/approval_dispatch.go
+++ b/internal/execution/agent/approval_dispatch.go
@@ -1,0 +1,43 @@
+// Package agent — this file defines the ApprovalChannelDispatcher interface and
+// the types it operates on.  The interface lives in the agent package so the agent
+// can depend on it without importing internal/plugin/dispatch (which would violate
+// the package-boundary constraint: agent must not import execution-layer packages).
+// The concrete adapter lives in internal/execution/run (approval_adapter.go) where
+// both agent and dispatch are already imported.
+package agent
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ApprovalChannelDispatcher routes an approval request through a plugin channel
+// entry (e.g. Slack DM with approve/deny buttons).  It is narrow — only the
+// types the agent package already knows about are used.
+//
+// The implementation lives in internal/execution/run to avoid the circular
+// import that would result from agent importing internal/plugin/dispatch.
+type ApprovalChannelDispatcher interface {
+	DispatchApproval(ctx context.Context, req ApprovalDispatchRequest) (approved bool, err error)
+}
+
+// ApprovalDispatchRequest carries everything the dispatcher needs to route a
+// single approval gate through a plugin channel.
+type ApprovalDispatchRequest struct {
+	AudienceID string
+	RunID      string
+	PolicyID   string
+	ToolName   string
+	Prompt     string
+	// ExpiresAt is the absolute time at which the approval gate expires.
+	// Nil means no expiry — the adapter defaults to a 1-hour timeout.
+	// The adapter derives the Timeout duration via time.Until(*ExpiresAt) so
+	// callers compute ExpiresAt once; the adapter owns the derivation.
+	ExpiresAt *time.Time
+}
+
+// ErrApprovalRouteToInApp is returned by the adapter when the audience resolves
+// to the synthetic gleipnir.in-app entry.  ApprovalHandler.Wait treats this as
+// a signal to fall through to the existing approvalCh path unchanged.
+var ErrApprovalRouteToInApp = errors.New("approval: route to in-app channel")

--- a/internal/execution/agent/approval_test.go
+++ b/internal/execution/agent/approval_test.go
@@ -6,6 +6,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -254,6 +255,194 @@ func TestApprovalHandler_Wait_Timeout_ScannerWins(t *testing.T) {
 	// Exactly one run.status_changed(failed) event from the scanner.
 	if n := pub.countByStatus("run.status_changed", "failed"); n != 1 {
 		t.Errorf("run.status_changed(failed) events = %d, want 1", n)
+	}
+}
+
+// mockApprovalDispatcher implements ApprovalChannelDispatcher for tests.
+type mockApprovalDispatcher struct {
+	approved bool
+	err      error
+}
+
+func (m *mockApprovalDispatcher) DispatchApproval(_ context.Context, _ ApprovalDispatchRequest) (bool, error) {
+	return m.approved, m.err
+}
+
+// TestApprovalHandler_Wait_PluginApproved verifies the happy path when a plugin
+// channel dispatcher returns (true, nil): Wait returns nil and the run transitions
+// back to running.
+func TestApprovalHandler_Wait_PluginApproved(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	approvalCh := make(chan bool, 1) // not pre-loaded — plugin path must not read it
+
+	pub := &capturePublisher{}
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	mock := &mockApprovalDispatcher{approved: true, err: nil}
+	h := NewApprovalHandler(w, sm, (<-chan bool)(approvalCh),
+		WithApprovalChannelDispatch(mock, "audience-1", "p1"),
+	)
+
+	err := h.Wait(context.Background(), "run1", approvalEntry(0), "my-server.do_thing", map[string]any{})
+	if err != nil {
+		t.Fatalf("Wait: unexpected error: %v", err)
+	}
+
+	if sm.Current() != model.RunStatusRunning {
+		t.Errorf("run status = %s, want running", sm.Current())
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	var hasApprovalRequest bool
+	for _, step := range steps {
+		if step.Type == string(model.StepTypeApprovalRequest) {
+			hasApprovalRequest = true
+		}
+	}
+	if !hasApprovalRequest {
+		t.Error("expected approval_request step in audit trail")
+	}
+}
+
+// TestApprovalHandler_Wait_PluginDenied verifies that when the plugin dispatcher
+// returns (false, nil), Wait returns an error containing "rejected" and writes an
+// error step.
+func TestApprovalHandler_Wait_PluginDenied(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	approvalCh := make(chan bool, 1) // not pre-loaded
+
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries())
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	mock := &mockApprovalDispatcher{approved: false, err: nil}
+	h := NewApprovalHandler(w, sm, (<-chan bool)(approvalCh),
+		WithApprovalChannelDispatch(mock, "audience-1", "p1"),
+	)
+
+	err := h.Wait(context.Background(), "run1", approvalEntry(0), "my-server.do_thing", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error on plugin denial, got nil")
+	}
+	if !strings.Contains(err.Error(), "rejected") {
+		t.Errorf("error = %q, want to contain 'rejected'", err.Error())
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	var hasError bool
+	for _, step := range steps {
+		if step.Type == string(model.StepTypeError) {
+			hasError = true
+		}
+	}
+	if !hasError {
+		t.Error("expected error step written on plugin denial")
+	}
+}
+
+// TestApprovalHandler_Wait_PluginFallbackToInApp verifies that when the dispatcher
+// returns ErrApprovalRouteToInApp, the handler falls through to the in-app approvalCh
+// path and approves when the channel is pre-loaded with true.
+func TestApprovalHandler_Wait_PluginFallbackToInApp(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	// Pre-load the in-app approval channel so the fallback path approves immediately.
+	approvalCh := make(chan bool, 1)
+	approvalCh <- true
+
+	pub := &capturePublisher{}
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	mock := &mockApprovalDispatcher{approved: false, err: ErrApprovalRouteToInApp}
+	h := NewApprovalHandler(w, sm, (<-chan bool)(approvalCh),
+		WithApprovalChannelDispatch(mock, "audience-1", "p1"),
+	)
+
+	err := h.Wait(context.Background(), "run1", approvalEntry(0), "my-server.do_thing", map[string]any{})
+	if err != nil {
+		t.Fatalf("Wait: unexpected error after in-app fallback: %v", err)
+	}
+
+	if sm.Current() != model.RunStatusRunning {
+		t.Errorf("run status = %s, want running after in-app approval", sm.Current())
+	}
+}
+
+// TestApprovalHandler_Wait_PluginDispatchError verifies that a non-sentinel
+// dispatcher error is propagated with context wrapping "plugin approval dispatch".
+func TestApprovalHandler_Wait_PluginDispatchError(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	approvalCh := make(chan bool, 1)
+
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries())
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	mock := &mockApprovalDispatcher{approved: false, err: fmt.Errorf("connection refused")}
+	h := NewApprovalHandler(w, sm, (<-chan bool)(approvalCh),
+		WithApprovalChannelDispatch(mock, "audience-1", "p1"),
+	)
+
+	err := h.Wait(context.Background(), "run1", approvalEntry(0), "my-server.do_thing", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error from dispatcher, got nil")
+	}
+	if !strings.Contains(err.Error(), "plugin approval dispatch") {
+		t.Errorf("error = %q, want to contain 'plugin approval dispatch'", err.Error())
+	}
+}
+
+// TestApprovalHandler_Wait_NoDispatcherConfigured verifies that when no channel
+// dispatcher is configured, the handler falls through to the existing in-app
+// approvalCh path unchanged.
+func TestApprovalHandler_Wait_NoDispatcherConfigured(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	approvalCh := make(chan bool, 1)
+	approvalCh <- true
+
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries())
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	// No options — dispatcher is nil, in-app path is used unchanged.
+	h := NewApprovalHandler(w, sm, (<-chan bool)(approvalCh))
+
+	err := h.Wait(context.Background(), "run1", approvalEntry(0), "my-server.do_thing", map[string]any{})
+	if err != nil {
+		t.Fatalf("Wait: unexpected error: %v", err)
+	}
+	if sm.Current() != model.RunStatusRunning {
+		t.Errorf("run status = %s, want running", sm.Current())
 	}
 }
 

--- a/internal/execution/run/approval_adapter.go
+++ b/internal/execution/run/approval_adapter.go
@@ -1,0 +1,110 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+)
+
+// approvalChannelRequester is the narrow interface the adapter uses for
+// testability — only the two Dispatcher methods it calls are required.
+// *dispatch.Dispatcher satisfies this structurally.
+type approvalChannelRequester interface {
+	Request(ctx context.Context, audienceID string, rc dispatch.RouteContext, prompt string, expiresAt *time.Time) (string, dispatch.RoutingOutcome, error)
+	Wait(ctx context.Context, requestID string, timeout time.Duration) (string, error)
+}
+
+// ApprovalChannelAdapter implements agent.ApprovalChannelDispatcher by
+// delegating to a Dispatcher.Request + Wait pair.  It lives in the run package
+// because that package already imports both agent and dispatch — placing it
+// here avoids a new import cycle while keeping it independently testable.
+type ApprovalChannelAdapter struct {
+	d approvalChannelRequester
+}
+
+// NewApprovalChannelAdapter constructs an ApprovalChannelAdapter.
+// d is typically a *dispatch.Dispatcher; tests inject a stub via the interface.
+func NewApprovalChannelAdapter(d approvalChannelRequester) *ApprovalChannelAdapter {
+	return &ApprovalChannelAdapter{d: d}
+}
+
+// DispatchApproval routes an approval request through the plugin channel and
+// blocks until the operator responds, the timeout fires, or ctx is cancelled.
+//
+//   - Returns (true, nil) when the operator approves.
+//   - Returns (false, nil) when the operator denies.
+//   - Returns (false, agent.ErrApprovalRouteToInApp) when the audience resolves
+//     to the synthetic in-app entry — the caller falls through to the approvalCh
+//     path.
+//   - Returns (false, err) on any other dispatch or wait failure.
+func (a *ApprovalChannelAdapter) DispatchApproval(ctx context.Context, req agent.ApprovalDispatchRequest) (bool, error) {
+	// Derive the Wait timeout from ExpiresAt.  The caller computes ExpiresAt
+	// once; the adapter owns the derivation so the API surface stays minimal.
+	var waitTimeout time.Duration
+	if req.ExpiresAt != nil {
+		waitTimeout = time.Until(*req.ExpiresAt)
+	}
+	if waitTimeout <= 0 {
+		waitTimeout = time.Hour // sensible default when no expiry is set
+	}
+
+	rc := dispatch.RouteContext{
+		RunID:    req.RunID,
+		PolicyID: req.PolicyID,
+		ToolName: req.ToolName,
+	}
+
+	reqID, outcome, err := a.d.Request(ctx, req.AudienceID, rc, req.Prompt, req.ExpiresAt)
+	if err != nil {
+		if errors.Is(err, dispatch.ErrNoRequestCapableEntry) {
+			return false, agent.ErrApprovalRouteToInApp
+		}
+		return false, fmt.Errorf("channel request: %w", err)
+	}
+	if outcome == dispatch.RouteToInApp {
+		return false, agent.ErrApprovalRouteToInApp
+	}
+
+	responseJSON, err := a.d.Wait(ctx, reqID, waitTimeout)
+	if err != nil {
+		return false, fmt.Errorf("waiting for approval response: %w", err)
+	}
+
+	approved, err := ParseApprovalDecision(responseJSON)
+	if err != nil {
+		return false, fmt.Errorf("parsing approval decision: %w", err)
+	}
+	return approved, nil
+}
+
+// approvalDecisionBody is the wire format for plugin-channel approval responses.
+type approvalDecisionBody struct {
+	Decision string `json:"decision"`
+}
+
+// ParseApprovalDecision interprets the JSON response from a plugin channel
+// approval callback.  Expected format: {"decision":"approved"|"denied"}.
+// Exported so the table-driven test in the external test package can target it
+// directly without going through DispatchApproval.
+func ParseApprovalDecision(responseJSON string) (bool, error) {
+	var body approvalDecisionBody
+	if err := json.Unmarshal([]byte(responseJSON), &body); err != nil {
+		return false, fmt.Errorf("invalid approval response JSON: %w", err)
+	}
+	if body.Decision == "" {
+		return false, fmt.Errorf("approval response missing decision field (empty)")
+	}
+	switch body.Decision {
+	case "approved":
+		return true, nil
+	case "denied":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown approval decision %q: want approved or denied", body.Decision)
+	}
+}

--- a/internal/execution/run/approval_adapter_test.go
+++ b/internal/execution/run/approval_adapter_test.go
@@ -1,0 +1,192 @@
+package run_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/execution/run"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+)
+
+// TestParseApprovalDecision is a table-driven test for the exported
+// ParseApprovalDecision helper.  It is in the external test package so the
+// helper must be exported — see plan §6.
+func TestParseApprovalDecision(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        string
+		wantApproved bool
+		wantErrText  string // non-empty means we expect an error containing this string
+	}{
+		{
+			name:         "approved",
+			input:        `{"decision":"approved"}`,
+			wantApproved: true,
+		},
+		{
+			name:         "denied",
+			input:        `{"decision":"denied"}`,
+			wantApproved: false,
+		},
+		{
+			name:        "unknown decision",
+			input:       `{"decision":"unknown"}`,
+			wantErrText: "unknown",
+		},
+		{
+			name:        "empty decision field",
+			input:       `{}`,
+			wantErrText: "empty",
+		},
+		{
+			name:        "invalid json",
+			input:       `invalid json`,
+			wantErrText: "invalid",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			approved, err := run.ParseApprovalDecision(tc.input)
+			if tc.wantErrText != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrText)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrText) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), tc.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if approved != tc.wantApproved {
+				t.Errorf("approved = %v, want %v", approved, tc.wantApproved)
+			}
+		})
+	}
+}
+
+// stubRequester is a mock for the approvalChannelRequester interface used by
+// NewApprovalChannelAdapter.  Tests configure return values per-call.
+type stubRequester struct {
+	requestID      string
+	requestOutcome dispatch.RoutingOutcome
+	requestErr     error
+
+	waitResponse string
+	waitErr      error
+}
+
+func (s *stubRequester) Request(_ context.Context, _ string, _ dispatch.RouteContext, _ string, _ *time.Time) (string, dispatch.RoutingOutcome, error) {
+	return s.requestID, s.requestOutcome, s.requestErr
+}
+
+func (s *stubRequester) Wait(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return s.waitResponse, s.waitErr
+}
+
+func TestApprovalChannelAdapter_DispatchApproval(t *testing.T) {
+	ctx := context.Background()
+	dummyReq := agent.ApprovalDispatchRequest{
+		AudienceID: "aud-1",
+		RunID:      "run-1",
+		PolicyID:   "pol-1",
+		ToolName:   "some.tool",
+		Prompt:     "Approve?",
+	}
+
+	t.Run("RouteToInApp from Request", func(t *testing.T) {
+		stub := &stubRequester{
+			requestID:      "",
+			requestOutcome: dispatch.RouteToInApp,
+		}
+		adapter := run.NewApprovalChannelAdapter(stub)
+		approved, err := adapter.DispatchApproval(ctx, dummyReq)
+		if !errors.Is(err, agent.ErrApprovalRouteToInApp) {
+			t.Errorf("err = %v, want ErrApprovalRouteToInApp", err)
+		}
+		if approved {
+			t.Error("approved must be false on in-app route")
+		}
+	})
+
+	t.Run("ErrNoRequestCapableEntry maps to ErrApprovalRouteToInApp", func(t *testing.T) {
+		stub := &stubRequester{
+			requestErr: dispatch.ErrNoRequestCapableEntry,
+		}
+		adapter := run.NewApprovalChannelAdapter(stub)
+		approved, err := adapter.DispatchApproval(ctx, dummyReq)
+		if !errors.Is(err, agent.ErrApprovalRouteToInApp) {
+			t.Errorf("err = %v, want ErrApprovalRouteToInApp", err)
+		}
+		if approved {
+			t.Error("approved must be false on no-entry route")
+		}
+	})
+
+	t.Run("RouteToPlugin + approved response", func(t *testing.T) {
+		stub := &stubRequester{
+			requestID:      "req-1",
+			requestOutcome: dispatch.RouteToPlugin,
+			waitResponse:   `{"decision":"approved"}`,
+		}
+		adapter := run.NewApprovalChannelAdapter(stub)
+		approved, err := adapter.DispatchApproval(ctx, dummyReq)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !approved {
+			t.Error("expected approved=true")
+		}
+	})
+
+	t.Run("RouteToPlugin + denied response", func(t *testing.T) {
+		stub := &stubRequester{
+			requestID:      "req-2",
+			requestOutcome: dispatch.RouteToPlugin,
+			waitResponse:   `{"decision":"denied"}`,
+		}
+		adapter := run.NewApprovalChannelAdapter(stub)
+		approved, err := adapter.DispatchApproval(ctx, dummyReq)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if approved {
+			t.Error("expected approved=false on denied response")
+		}
+	})
+
+	t.Run("Request returns non-sentinel error", func(t *testing.T) {
+		stub := &stubRequester{
+			requestErr: fmt.Errorf("gRPC unavailable"),
+		}
+		adapter := run.NewApprovalChannelAdapter(stub)
+		_, err := adapter.DispatchApproval(ctx, dummyReq)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if errors.Is(err, agent.ErrApprovalRouteToInApp) {
+			t.Error("non-sentinel request error must not map to ErrApprovalRouteToInApp")
+		}
+	})
+
+	t.Run("Wait returns error", func(t *testing.T) {
+		stub := &stubRequester{
+			requestID:      "req-3",
+			requestOutcome: dispatch.RouteToPlugin,
+			waitErr:        fmt.Errorf("context deadline exceeded"),
+		}
+		adapter := run.NewApprovalChannelAdapter(stub)
+		_, err := adapter.DispatchApproval(ctx, dummyReq)
+		if err == nil {
+			t.Fatal("expected error from Wait, got nil")
+		}
+	})
+}
+

--- a/internal/execution/run/launcher.go
+++ b/internal/execution/run/launcher.go
@@ -86,6 +86,7 @@ type RunLauncher struct {
 	toolClassifier         ToolSourceClassifier
 	pluginRegistrar        agent.PluginGenerationLookup
 	pluginDispatcher       agent.PluginToolDispatcher
+	approvalDispatcher     agent.ApprovalChannelDispatcher
 }
 
 // registryResolver is the subset of mcp.Registry used by RunLauncher, defined
@@ -121,6 +122,9 @@ type RunLauncherConfig struct {
 	ToolClassifier         ToolSourceClassifier         // nil when plugins are disabled; all grants go to MCP path
 	PluginRegistrar        agent.PluginGenerationLookup // nil when plugins are disabled
 	PluginDispatcher       agent.PluginToolDispatcher   // nil when plugins are disabled
+	// ApprovalDispatcher routes approvals through a plugin channel when the
+	// policy has an audience configured.  Nil when plugins are disabled.
+	ApprovalDispatcher agent.ApprovalChannelDispatcher
 }
 
 // NewRunLauncher returns a RunLauncher ready to use.
@@ -142,6 +146,7 @@ func NewRunLauncher(cfg RunLauncherConfig) *RunLauncher {
 		toolClassifier:         cfg.ToolClassifier,
 		pluginRegistrar:        cfg.PluginRegistrar,
 		pluginDispatcher:       cfg.PluginDispatcher,
+		approvalDispatcher:     cfg.ApprovalDispatcher,
 	}
 }
 
@@ -311,6 +316,24 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 
 	audit := agent.NewAuditWriter(l.store.Queries(), agent.WithPublisher(l.publisher))
 
+	// Resolve the audience DB row ID when a plugin channel dispatcher is available
+	// and the policy names an audience.  A misspelled or missing audience name logs
+	// a warning and falls back to in-app rather than failing the run — the warning
+	// makes the misconfiguration visible without hard-blocking the operator.
+	var audienceID string
+	if params.ParsedPolicy.Audience != "" && l.approvalDispatcher != nil {
+		aud, audErr := l.store.Queries().GetPluginAudienceByName(ctx, params.ParsedPolicy.Audience)
+		if audErr != nil {
+			slog.Warn("audience lookup failed, falling back to in-app approval",
+				"audience_name", params.ParsedPolicy.Audience,
+				"policy_id", params.PolicyID,
+				"err", audErr,
+			)
+		} else {
+			audienceID = aud.ID
+		}
+	}
+
 	// Cap 1 so SendApproval (non-blocking select) can deliver a decision that
 	// arrives in the narrow window between the agent unparking and reading the
 	// channel.
@@ -326,6 +349,8 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 		PluginTools:            pluginToolEntries,
 		PluginRegistrar:        l.pluginRegistrar,
 		PluginDispatcher:       l.pluginDispatcher,
+		ApprovalDispatcher:     l.approvalDispatcher,
+		AudienceID:             audienceID,
 	})
 	if err != nil {
 		// context.Background(): the HTTP request context that produced ctx may

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -321,6 +321,12 @@ type ParsedPolicy struct {
 	Trigger      TriggerConfig
 	Capabilities CapabilitiesConfig
 	Agent        AgentConfig
+	// Audience names the plugin audience used for approval routing.
+	// Unlike folder (ADR-020, cosmetic/UI-only), audience is consumed at
+	// runtime — the launcher resolves it to an audience DB row ID and passes
+	// it to the agent so Wait can route approvals through a plugin channel.
+	// Empty string means no audience is configured; fall back to in-app.
+	Audience string
 }
 
 // TriggerConfig holds trigger-type-specific fields. Only fields relevant to

--- a/internal/policy/parser.go
+++ b/internal/policy/parser.go
@@ -55,6 +55,7 @@ func Parse(raw string, defaultProvider, defaultModel string) (*model.ParsedPolic
 	p.Capabilities = convertCapabilities(r.Capabilities)
 	mc := resolveModelConfig(r.Model, defaultProvider, defaultModel)
 	p.Agent = convertAgent(r.Agent, mc)
+	p.Audience = strings.TrimSpace(r.Audience)
 
 	return p, nil
 }
@@ -322,6 +323,7 @@ type rawPolicy struct {
 	Trigger      rawTrigger      `yaml:"trigger"`
 	Capabilities rawCapabilities `yaml:"capabilities"`
 	Agent        rawAgent        `yaml:"agent"`
+	Audience     string          `yaml:"audience"`
 }
 
 // rawModel holds the top-level `model:` section introduced in issue #344.

--- a/main.go
+++ b/main.go
@@ -211,11 +211,13 @@ func run(cfg config.Config) error {
 	// reads the instance ID from the context populated by UnaryInstanceTokenInterceptor.
 	// UnaryCallIDInterceptor is last so it only attaches to authenticated,
 	// generation-tracked calls.
-	// hostSvc is declared outside the if block so the post-launcher wiring
-	// (SetTriggerSink, triggerSupervisor) can reach it without the variable
-	// going out of scope. Analogous to connFactory being declared at line ~155
-	// so setManager can be called at line 237.
+	// hostSvc and approvalAdapter are declared outside the if block so that
+	// post-launcher wiring (SetTriggerSink, triggerSupervisor) can reach hostSvc,
+	// and the RunLauncherConfig can reference approvalAdapter, without either
+	// variable going out of scope.  Analogous to connFactory being declared at
+	// line ~155 so setManager can be called at line 237.
 	var hostSvc *hostsvc.Server
+	var approvalAdapter agent.ApprovalChannelDispatcher
 	if cfg.PluginsEnabled {
 		identityReg := identity.New()
 		genCtrl := generation.New()
@@ -223,7 +225,15 @@ func run(cfg config.Config) error {
 		pluginDispatcher := dispatch.NewDispatcher(dispatch.DispatcherConfig{
 			Queries: store.Queries(),
 			Connect: connFactory.Connect,
+			// TODO(#NNN): Wire WriteRunStep here for audit trail completeness.
+			// Requires constructing an AuditWriter outside the agent package,
+			// which is deferred to a follow-up issue.
 		})
+
+		// approvalAdapter is constructed here where pluginDispatcher is in scope.
+		// The outer-scoped variable is assigned so RunLauncherConfig below can
+		// reference it without the dispatcher escaping the if block.
+		approvalAdapter = runpkg.NewApprovalChannelAdapter(pluginDispatcher)
 
 		hostSvc = hostsvc.NewServer(
 			store.Queries(),
@@ -358,6 +368,7 @@ func run(cfg config.Config) error {
 		ToolClassifier:         toolClassifier,
 		PluginRegistrar:        pluginToolRegistrar,
 		PluginDispatcher:       pluginDispatchAdapter,
+		ApprovalDispatcher:     approvalAdapter,
 	})
 
 	// Wire the trigger dispatch pipeline now that RunLauncher is available.


### PR DESCRIPTION
Closes #412

## Summary

When a policy has an `audience` entry pointing at a plugin instance with Request capability (e.g., Slack), approval requests are now routed through the plugin's `ChannelService.Request` instead of the in-app UI.

**Design constraints (deliberately simple v1):**
- **Single audience entry** — picks the first Request-capable entry
- **One response path** — if routed to plugin, the in-app `approvalCh` select is never reached. No race conditions.
- **Fallback to in-app** — `ErrApprovalRouteToInApp` sentinel causes clean fall-through to existing behavior

## Changes

- **`internal/model/model.go`** — `Audience string` on `ParsedPolicy`
- **`internal/policy/parser.go`** — Parse audience from YAML
- **`internal/execution/agent/approval_dispatch.go`** (new) — `ApprovalChannelDispatcher` interface, `ApprovalDispatchRequest`, `ErrApprovalRouteToInApp`
- **`internal/execution/agent/approval.go`** — `WithApprovalChannelDispatch` option, routing branch in `Wait()`, `formatApprovalPrompt`
- **`internal/execution/agent/agent.go`** — `ApprovalDispatcher`/`AudienceID` on Config, wired in `New()`
- **`internal/execution/run/approval_adapter.go`** (new) — adapter bridging agent → dispatch, `ParseApprovalDecision` exported
- **`internal/execution/run/launcher.go`** — audience ID lookup with warn-and-fallback
- **`main.go`** — outer-scoped `approvalAdapter`, constructed inside `if cfg.PluginsEnabled`

## Tests

11 new tests:
- 5 in `approval_test.go` (plugin approved/denied/fallback/error/no-dispatcher)
- 5+1 in `approval_adapter_test.go` (ParseApprovalDecision table-driven + DispatchApproval mock-based)

<details>
<summary>Architecture plan</summary>

Interface-in-agent / adapter-in-run split preserves the package boundary (`internal/execution/agent` does not import `internal/plugin/dispatch`). `ApprovalChannelDispatcher` is defined in the agent package; `ApprovalChannelAdapter` in the run package satisfies it by wrapping `dispatch.Dispatcher.Request/Wait`. The launcher resolves the audience name to a DB ID via `GetPluginAudienceByName` and passes it through `agent.Config`. `ApprovalHandler.Wait()` tries plugin dispatch first; on `ErrApprovalRouteToInApp` it falls through to the existing in-app `approvalCh` select.

Known gaps documented with TODOs: `WriteRunStep` nil in `DispatcherConfig` (audit trail gap); in-app UI still shows approve/deny buttons for plugin-routed approvals (stale decision silently discarded via cap-1 buffer).
</details>

## Review cycles: 1
## CLAUDE.md updated: No
## Brainstorming: Not triggered

🤖 Generated with the agentic dev loop