### PR TITLE
feat: route feedback requests through Slack with threaded reply UX

### DIFF
--- a/internal/execution/agent/agent.go
+++ b/internal/execution/agent/agent.go
@@ -75,6 +75,9 @@ type Config struct {
 	// ApprovalDispatcher routes approvals through a plugin channel (e.g. Slack).
 	// Nil when plugins are disabled or the policy has no audience configured.
 	ApprovalDispatcher ApprovalChannelDispatcher
+	// FeedbackDispatcher routes feedback requests through a plugin channel (e.g.
+	// Slack threaded reply).  Nil when plugins are disabled or no audience is configured.
+	FeedbackDispatcher FeedbackChannelDispatcher
 	// AudienceID is the DB row ID of the policy's audience, resolved by the
 	// launcher.  Empty string means no audience — fall back to in-app.
 	AudienceID string
@@ -156,6 +159,13 @@ func New(cfg Config) (*BoundAgent, error) {
 		))
 	}
 
+	var feedbackOpts []FeedbackHandlerOption
+	if cfg.FeedbackDispatcher != nil && cfg.AudienceID != "" {
+		feedbackOpts = append(feedbackOpts, WithFeedbackChannelDispatch(
+			cfg.FeedbackDispatcher, cfg.AudienceID, cfg.PolicyID,
+		))
+	}
+
 	return &BoundAgent{
 		policy:             cfg.Policy,
 		policyID:           cfg.PolicyID,
@@ -168,7 +178,7 @@ func New(cfg Config) (*BoundAgent, error) {
 		audit:              cfg.Audit,
 		sm:                 cfg.StateMachine,
 		approvals:          NewApprovalHandler(cfg.Audit, cfg.StateMachine, cfg.ApprovalCh, approvalOpts...),
-		feedback:           NewFeedbackHandler(cfg.Audit, cfg.StateMachine, cfg.DefaultFeedbackTimeout),
+		feedback:           NewFeedbackHandler(cfg.Audit, cfg.StateMachine, cfg.DefaultFeedbackTimeout, feedbackOpts...),
 	}, nil
 }
 

--- a/internal/execution/agent/approval_dispatch.go
+++ b/internal/execution/agent/approval_dispatch.go
@@ -41,3 +41,32 @@ type ApprovalDispatchRequest struct {
 // to the synthetic gleipnir.in-app entry.  ApprovalHandler.Wait treats this as
 // a signal to fall through to the existing approvalCh path unchanged.
 var ErrApprovalRouteToInApp = errors.New("approval: route to in-app channel")
+
+// FeedbackChannelDispatcher routes a feedback request through a plugin channel
+// entry (e.g. Slack message with threaded reply watching).  Parallel to
+// ApprovalChannelDispatcher; the interface lives here to keep all channel-dispatch
+// interfaces together in the agent package.
+//
+// The concrete adapter lives in internal/execution/run (feedback_adapter.go)
+// where both agent and dispatch are already imported.
+type FeedbackChannelDispatcher interface {
+	DispatchFeedback(ctx context.Context, req FeedbackDispatchRequest) (response string, err error)
+}
+
+// FeedbackDispatchRequest carries everything the dispatcher needs to route a
+// single feedback request through a plugin channel.
+type FeedbackDispatchRequest struct {
+	AudienceID string
+	RunID      string
+	PolicyID   string
+	ToolName   string
+	Prompt     string
+	// ExpiresAt is the absolute time at which the feedback request expires.
+	// Nil means no expiry — the adapter defaults to a 1-hour timeout.
+	ExpiresAt *time.Time
+}
+
+// ErrFeedbackRouteToInApp is returned by the adapter when the audience resolves
+// to the synthetic gleipnir.in-app entry.  FeedbackHandler.Wait treats this as
+// a signal to fall through to the existing inAppChannel path unchanged.
+var ErrFeedbackRouteToInApp = errors.New("feedback: route to in-app channel")

--- a/internal/execution/agent/channel.go
+++ b/internal/execution/agent/channel.go
@@ -212,6 +212,29 @@ func (c *inAppChannel) Request(ctx context.Context, req feedbackRequest) (string
 	}
 }
 
+// RegisterWaiter allocates a buffered channel (cap 1) for feedbackID, stores it
+// in the waiters map, and returns the receive-only end.  The caller must call
+// UnregisterWaiter when done — successful response, timeout, or ctx cancel.
+//
+// The registration-before-transition invariant is preserved by the caller (see
+// inAppChannel.Request for the pattern): register first, transition second, so
+// a fast Resolve cannot miss the channel.
+func (c *inAppChannel) RegisterWaiter(feedbackID string) <-chan inAppResponse {
+	ch := make(chan inAppResponse, 1)
+	c.mu.Lock()
+	c.waiters[feedbackID] = ch
+	c.mu.Unlock()
+	return ch
+}
+
+// UnregisterWaiter removes the waiter entry for feedbackID.  Safe to call when
+// no entry exists (e.g. after a successful Resolve already deleted it).
+func (c *inAppChannel) UnregisterWaiter(feedbackID string) {
+	c.mu.Lock()
+	delete(c.waiters, feedbackID)
+	c.mu.Unlock()
+}
+
 // Resolve delivers a response to the waiter registered for requestID.
 //
 // The ch <- send is intentionally OUTSIDE the lock. ch is buffered (cap 1) and

--- a/internal/execution/agent/feedback.go
+++ b/internal/execution/agent/feedback.go
@@ -6,9 +6,12 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
+	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	"github.com/felag-engineering/gleipnir/internal/model"
@@ -51,33 +54,129 @@ type FeedbackHandler struct {
 	sm             *RunStateMachine
 	defaultTimeout time.Duration
 	inApp          *inAppChannel
-	dispatcher     *channelDispatcher
+
+	// Plugin channel routing — populated by WithFeedbackChannelDispatch.
+	// When non-nil and audienceID is non-empty, Wait routes feedback through the
+	// plugin channel instead of blocking on the inApp waiter.
+	channelDispatcher FeedbackChannelDispatcher
+	policyID          string
+	audienceID        string
+}
+
+// FeedbackHandlerOption is a functional option for NewFeedbackHandler.
+type FeedbackHandlerOption func(*FeedbackHandler)
+
+// WithFeedbackChannelDispatch attaches a plugin channel dispatcher to the
+// handler.  When d is non-nil and audienceID is non-empty, Wait routes the
+// feedback request through the plugin channel instead of waiting on the in-app
+// waiter channel.
+func WithFeedbackChannelDispatch(d FeedbackChannelDispatcher, audienceID, policyID string) FeedbackHandlerOption {
+	return func(h *FeedbackHandler) {
+		h.channelDispatcher = d
+		h.audienceID = audienceID
+		h.policyID = policyID
+	}
 }
 
 // NewFeedbackHandler constructs a FeedbackHandler.
-func NewFeedbackHandler(audit *AuditWriter, sm *RunStateMachine, defaultTimeout time.Duration) *FeedbackHandler {
+// Optional functional opts (e.g. WithFeedbackChannelDispatch) are applied
+// after initialization; existing callers that pass zero opts are unaffected.
+func NewFeedbackHandler(audit *AuditWriter, sm *RunStateMachine, defaultTimeout time.Duration, opts ...FeedbackHandlerOption) *FeedbackHandler {
 	inApp := newInAppChannel(audit, sm)
-	return &FeedbackHandler{
+	h := &FeedbackHandler{
 		audit:          audit,
 		sm:             sm,
 		defaultTimeout: defaultTimeout,
 		inApp:          inApp,
-		dispatcher:     newChannelDispatcher(inApp),
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
 }
 
 // Resolve delivers an operator response to the in-app waiter for requestID.
 // Returns agent.ErrUnknownRequestID if no waiter is currently registered
 // (timed out, already answered, or the run was cancelled). Callers should treat
 // that as a benign late-callback signal, not an error.
+//
+// When the plugin dispatch path is active, Resolve returns ErrUnknownRequestID
+// because no in-app waiter is registered — the plugin path uses
+// dispatch.Dispatcher.Resolve (via hostsvc WriteAuditStep) instead.
 func (h *FeedbackHandler) Resolve(requestID, body string) error {
 	return h.inApp.Resolve(requestID, body)
 }
 
+// resolveFeedbackRecord marks the feedback_requests DB row as resolved and
+// emits the feedback.resolved SSE event.  Both operations are best-effort:
+// the agent goroutine must resume regardless of DB or marshal errors.  SSE is
+// gated on the CAS winning (rows > 0) — if the scanner already timed out the
+// row, the SSE must not be emitted for a stale decision.
+func (h *FeedbackHandler) resolveFeedbackRecord(ctx context.Context, runID, feedbackID, responseText string) {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	rows, err := h.sm.Queries().UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
+		Status:     "resolved",
+		Response:   &responseText,
+		ResolvedAt: &now,
+		ID:         feedbackID,
+	})
+	if err != nil {
+		logctx.Logger(ctx).WarnContext(ctx, "plugin feedback: UpdateFeedbackRequestStatus failed",
+			"feedback_id", feedbackID, "run_id", runID, "err", err)
+		return
+	}
+	if rows == 0 {
+		// Scanner already resolved this row (e.g. timeout beat the callback).
+		logctx.Logger(ctx).DebugContext(ctx, "feedback already resolved by scanner",
+			"feedback_id", feedbackID, "run_id", runID)
+		return
+	}
+
+	if pub := h.sm.Publisher(); pub != nil {
+		payload := map[string]string{
+			"feedback_id": feedbackID,
+			"run_id":      runID,
+			"status":      "resolved",
+		}
+		if data, marshalErr := json.Marshal(payload); marshalErr == nil {
+			pub.Publish("feedback.resolved", data)
+		}
+	}
+}
+
+// parseFeedbackResponse extracts the "text" field from a JSON response string.
+// The plugin encodes the reply as {"text":"...", "user":"...", "request_id":"..."}.
+// On parse failure or missing "text", logs a warning and returns responseJSON
+// as-is so the agent always resumes with something meaningful.
+func parseFeedbackResponse(responseJSON string) string {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(responseJSON), &m); err != nil {
+		slog.Warn("feedback response JSON parse failed, using raw response", "err", err)
+		return responseJSON
+	}
+	text, ok := m["text"].(string)
+	if !ok {
+		slog.Warn("feedback response JSON missing 'text' field, using raw response")
+		return responseJSON
+	}
+	return text
+}
+
 // Wait suspends the run waiting for a freeform operator response.
-// It transitions to waiting_for_feedback (which creates the DB record and
-// publishes feedback.created), then blocks on the feedback channel, the timeout
-// channel, or context cancellation. Returns the operator's response text on success.
+//
+// Phase 1 (always runs): write the feedback_request audit step, transition to
+// waiting_for_feedback (which creates the DB record and publishes feedback.created).
+//
+// Phase 2 branches on whether a plugin channel dispatcher is configured:
+//
+//   - Plugin path: delegates to channelDispatcher.DispatchFeedback and blocks
+//     until the Slack plugin calls WriteAuditStep(feedback_response) which triggers
+//     dispatch.Dispatcher.Resolve → Wait unblocks.  The feedback_response audit
+//     step is written by hostsvc, NOT here (hostsvc already writes it, see
+//     BLOCKING #4 in the implementation plan).
+//
+//   - In-app path (fallback): blocks on the inApp waiter channel, writes the
+//     feedback_response audit step here (preserving existing behavior).
 func (h *FeedbackHandler) Wait(ctx context.Context, runID, toolName, inputJSON, mcpOutput string, feedbackTimeout time.Duration) (string, error) {
 	feedbackID := model.NewULID()
 
@@ -88,15 +187,137 @@ func (h *FeedbackHandler) Wait(ctx context.Context, runID, toolName, inputJSON, 
 		expiresAt = time.Now().UTC().Add(feedbackTimeout).Format(time.RFC3339Nano)
 	}
 
-	return h.dispatcher.Request(ctx, feedbackRequest{
-		RunID:         runID,
+	// Pre-register the in-app waiter BEFORE the state transition.  This preserves
+	// the invariant from the original inAppChannel.Request: a Resolve call arriving
+	// immediately after the SSE event (which fires on transition) is never lost.
+	// On the plugin path the waiter is unused; UnregisterWaiter is deferred so it
+	// is cleaned up regardless of which branch executes.
+	ch := h.inApp.RegisterWaiter(feedbackID)
+	defer h.inApp.UnregisterWaiter(feedbackID)
+
+	// Phase 1: write audit step and transition — always runs regardless of dispatch path.
+	if err := h.audit.Write(ctx, Step{
+		RunID: runID,
+		Type:  model.StepTypeFeedbackRequest,
+		Content: map[string]any{
+			"feedback_id": feedbackID,
+			"tool":        toolName,
+			"message":     mcpOutput,
+			"expires_at":  expiresAt,
+		},
+	}); err != nil {
+		return "", fmt.Errorf("writing feedback_request step: %w", err)
+	}
+
+	if err := h.sm.Transition(ctx, model.RunStatusWaitingForFeedback, "", WithFeedbackPayload(FeedbackPayload{
 		FeedbackID:    feedbackID,
 		ToolName:      toolName,
 		ProposedInput: inputJSON,
 		Message:       mcpOutput,
-		Timeout:       feedbackTimeout,
 		ExpiresAt:     expiresAt,
-	})
+	})); err != nil {
+		return "", fmt.Errorf("transitioning run to waiting_for_feedback: %w", err)
+	}
+
+	// Phase 2a: plugin channel path.
+	if h.channelDispatcher != nil && h.audienceID != "" {
+		var expiresAtTime *time.Time
+		if feedbackTimeout > 0 {
+			t := time.Now().UTC().Add(feedbackTimeout)
+			expiresAtTime = &t
+		}
+
+		response, dispatchErr := h.channelDispatcher.DispatchFeedback(ctx, FeedbackDispatchRequest{
+			AudienceID: h.audienceID,
+			RunID:      runID,
+			PolicyID:   h.policyID,
+			ToolName:   toolName,
+			Prompt:     mcpOutput,
+			ExpiresAt:  expiresAtTime,
+		})
+		if errors.Is(dispatchErr, ErrFeedbackRouteToInApp) {
+			// Audience resolved to in-app; fall through to the waiter select below.
+		} else if dispatchErr != nil {
+			return "", fmt.Errorf("plugin feedback dispatch: %w", dispatchErr)
+		} else {
+			// Plugin resolved the request.
+			// NOTE: Do NOT write a feedback_response audit step here.
+			// hostsvc.WriteAuditStep (called by the Slack plugin) has already written
+			// it — writing another would create a duplicate (BLOCKING #4).
+			parsedText := parseFeedbackResponse(response)
+			h.resolveFeedbackRecord(ctx, runID, feedbackID, parsedText)
+			if err := h.sm.Transition(ctx, model.RunStatusRunning, ""); err != nil {
+				return "", fmt.Errorf("transitioning run back to running after plugin feedback: %w", err)
+			}
+			return parsedText, nil
+		}
+	}
+
+	// Phase 2b: in-app waiter path (no dispatcher or fallback from plugin path).
+	// ch was registered before Phase 1; deferred UnregisterWaiter handles cleanup.
+
+	// nil timeoutCh (when feedbackTimeout == 0) blocks forever in the select,
+	// meaning no in-process timeout is applied. Use NewTimer so we can Stop it
+	// on early response — time.After leaks until the duration fires.
+	var timeoutCh <-chan time.Time
+	if feedbackTimeout > 0 {
+		timer := time.NewTimer(feedbackTimeout)
+		defer timer.Stop()
+		timeoutCh = timer.C
+	}
+
+	select {
+	case resp := <-ch:
+		if err := h.audit.Write(ctx, Step{
+			RunID:   runID,
+			Type:    model.StepTypeFeedbackResponse,
+			Content: map[string]any{"feedback_id": feedbackID, "response": resp.text},
+		}); err != nil {
+			return "", fmt.Errorf("writing feedback_response step: %w", err)
+		}
+		if err := h.sm.Transition(ctx, model.RunStatusRunning, ""); err != nil {
+			return "", fmt.Errorf("transitioning run back to running after feedback: %w", err)
+		}
+		h.resolveFeedbackRecord(ctx, runID, feedbackID, resp.text)
+		return resp.text, nil
+
+	case <-timeoutCh:
+		logctx.Logger(ctx).WarnContext(ctx, "feedback timeout reached",
+			"tool", toolName,
+			"timeout", feedbackTimeout.String())
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		// Race the scanner: only the first writer (rows==1) owns the error step.
+		// If the scanner already resolved it (rows==0), return a sentinel error so
+		// Run() still terminates, but skip logAuditError to avoid a duplicate step.
+		rows, dbErr := h.sm.Queries().UpdateFeedbackRequestStatus(
+			context.Background(),
+			db.UpdateFeedbackRequestStatusParams{
+				Status:     "timed_out",
+				Response:   nil,
+				ResolvedAt: &now,
+				ID:         feedbackID,
+			},
+		)
+		if dbErr != nil {
+			logctx.Logger(ctx).WarnContext(ctx, "failed to update feedback status on timeout", "feedback_id", feedbackID, "err", dbErr)
+		}
+		if rows == 1 {
+			err := fmt.Errorf("feedback timeout: operator did not respond within %s", feedbackTimeout)
+			logAuditError(ctx, h.audit, Step{
+				RunID:   runID,
+				Type:    model.StepTypeError,
+				Content: model.ErrorStepContent{Message: err.Error(), Code: model.ErrorCodeFeedbackTimeout},
+			})
+			return "", err
+		}
+		// Scanner won the race: it already wrote the error step and transitioned
+		// the run. Return a sentinel so Run() knows to stop, but avoid a duplicate step.
+		logctx.Logger(ctx).DebugContext(ctx, "feedback already resolved by scanner", "feedback_id", feedbackID)
+		return "", fmt.Errorf("feedback timeout: already resolved by scanner for tool %s", toolName)
+
+	case <-ctx.Done():
+		return "", fmt.Errorf("context cancelled waiting for feedback: %w", ctx.Err())
+	}
 }
 
 // HandleAskOperator dispatches a gleipnir.ask_operator tool call. It validates

--- a/internal/execution/agent/feedback_test.go
+++ b/internal/execution/agent/feedback_test.go
@@ -7,6 +7,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,16 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/testutil"
 	"github.com/felag-engineering/gleipnir/internal/timeout"
 )
+
+// mockFeedbackDispatcher is a simple mock for FeedbackChannelDispatcher.
+type mockFeedbackDispatcher struct {
+	response string
+	err      error
+}
+
+func (m *mockFeedbackDispatcher) DispatchFeedback(_ context.Context, _ FeedbackDispatchRequest) (string, error) {
+	return m.response, m.err
+}
 
 // TestFeedbackHandler_Wait_ResponseReceived verifies the happy path: operator
 // responds via h.Resolve before timeout; feedback_request and feedback_response
@@ -433,5 +444,175 @@ func TestFeedbackHandler_HandleAskOperator_TimeoutResolution(t *testing.T) {
 				t.Errorf("elapsed %v >= %v, timeout should have fired sooner", elapsed, tc.wantFasterThan)
 			}
 		})
+	}
+}
+
+// TestFeedbackHandler_Wait_PluginResponse verifies the plugin dispatch path:
+// mock returns a JSON-encoded response; Wait extracts the text, does NOT write a
+// feedback_response audit step (hostsvc writes it), resolves the DB row, and
+// transitions back to running.
+func TestFeedbackHandler_Wait_PluginResponse(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	pub := &capturePublisher{}
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	mock := &mockFeedbackDispatcher{
+		response: `{"text":"operator reply","user":"U123","request_id":"req-1"}`,
+	}
+	h := NewFeedbackHandler(w, sm, time.Minute, WithFeedbackChannelDispatch(mock, "aud-1", "pol-1"))
+
+	responseText, err := h.Wait(context.Background(), "run1", AskOperatorToolName, "{}", "please answer", time.Minute)
+	if err != nil {
+		t.Fatalf("Wait: unexpected error: %v", err)
+	}
+	if responseText != "operator reply" {
+		t.Errorf("response = %q, want %q", responseText, "operator reply")
+	}
+
+	// Run must be back to running.
+	if sm.Current() != model.RunStatusRunning {
+		t.Errorf("run status = %s, want running", sm.Current())
+	}
+
+	// Flush writer and check audit steps.
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	var hasFeedbackRequest, hasFeedbackResponse bool
+	for _, step := range steps {
+		switch step.Type {
+		case string(model.StepTypeFeedbackRequest):
+			hasFeedbackRequest = true
+		case string(model.StepTypeFeedbackResponse):
+			hasFeedbackResponse = true
+		}
+	}
+	if !hasFeedbackRequest {
+		t.Error("expected feedback_request step in audit trail")
+	}
+	// Plugin path: feedback_response is written by hostsvc, NOT by FeedbackHandler.
+	if hasFeedbackResponse {
+		t.Error("feedback_response step must NOT be written by FeedbackHandler on plugin path (hostsvc writes it)")
+	}
+
+	// The feedback_requests DB row must be resolved.
+	rows, dbErr := s.GetPendingFeedbackRequestsByRun(context.Background(), "run1")
+	if dbErr != nil {
+		t.Fatalf("GetPendingFeedbackRequestsByRun: %v", dbErr)
+	}
+	if len(rows) > 0 {
+		t.Error("feedback_requests row should be resolved (no pending rows)")
+	}
+}
+
+// TestFeedbackHandler_Wait_PluginFallbackToInApp verifies that when the plugin
+// dispatcher returns ErrFeedbackRouteToInApp, Wait falls through to the in-app
+// path and writes a feedback_response audit step.
+func TestFeedbackHandler_Wait_PluginFallbackToInApp(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	pub := &capturePublisher{}
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	mock := &mockFeedbackDispatcher{err: ErrFeedbackRouteToInApp}
+	h := NewFeedbackHandler(w, sm, time.Minute, WithFeedbackChannelDispatch(mock, "aud-1", "pol-1"))
+
+	done := make(chan struct{ body string; err error }, 1)
+	go func() {
+		body, err := h.Wait(context.Background(), "run1", AskOperatorToolName, "{}", "please answer", 500*time.Millisecond)
+		done <- struct{ body string; err error }{body, err}
+	}()
+
+	// Poll until the feedback row appears in the DB.
+	deadline := time.Now().Add(300 * time.Millisecond)
+	var feedbackID string
+	for time.Now().Before(deadline) {
+		rows, err := s.GetPendingFeedbackRequestsByRun(context.Background(), "run1")
+		if err != nil {
+			t.Fatalf("GetPendingFeedbackRequestsByRun: %v", err)
+		}
+		if len(rows) > 0 {
+			feedbackID = rows[0].ID
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if feedbackID == "" {
+		t.Fatal("timed out waiting for feedback row to appear in DB")
+	}
+
+	// Deliver the response via the in-app Resolve path.
+	if err := h.Resolve(feedbackID, "in-app reply"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("Wait: unexpected error: %v", res.err)
+		}
+		if res.body != "in-app reply" {
+			t.Errorf("response = %q, want %q", res.body, "in-app reply")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return within deadline")
+	}
+
+	// In-app path: feedback_response step MUST be written.
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "run1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	var hasFeedbackResponse bool
+	for _, step := range steps {
+		if step.Type == string(model.StepTypeFeedbackResponse) {
+			hasFeedbackResponse = true
+		}
+	}
+	if !hasFeedbackResponse {
+		t.Error("in-app fallback path: expected feedback_response step in audit trail")
+	}
+}
+
+// TestFeedbackHandler_Wait_PluginDispatchError verifies that a non-sentinel error
+// from the plugin dispatcher is propagated wrapped with "plugin feedback dispatch".
+func TestFeedbackHandler_Wait_PluginDispatchError(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "run1", "p1", model.RunStatusRunning)
+
+	sm := NewRunStateMachine("run1", model.RunStatusRunning, s.DB(), s.Queries())
+	w := NewAuditWriter(s.Queries())
+	defer w.Close() //nolint:errcheck
+
+	dispatchErr := errors.New("gRPC unavailable")
+	mock := &mockFeedbackDispatcher{err: dispatchErr}
+	h := NewFeedbackHandler(w, sm, time.Minute, WithFeedbackChannelDispatch(mock, "aud-1", "pol-1"))
+
+	_, err := h.Wait(context.Background(), "run1", AskOperatorToolName, "{}", "please answer", time.Minute)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "plugin feedback dispatch") {
+		t.Errorf("error = %q, want to contain 'plugin feedback dispatch'", err.Error())
+	}
+	if !errors.Is(err, dispatchErr) {
+		t.Errorf("error chain should contain original dispatchErr")
 	}
 }

--- a/internal/execution/run/feedback_adapter.go
+++ b/internal/execution/run/feedback_adapter.go
@@ -1,0 +1,80 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+)
+
+// feedbackChannelRequester is the narrow interface the adapter uses for
+// testability — only the two Dispatcher methods it calls are required.
+// *dispatch.Dispatcher satisfies this structurally.
+type feedbackChannelRequester interface {
+	Request(ctx context.Context, audienceID string, rc dispatch.RouteContext, prompt string, expiresAt *time.Time) (string, dispatch.RoutingOutcome, error)
+	Wait(ctx context.Context, requestID string, timeout time.Duration) (string, error)
+}
+
+// FeedbackChannelAdapter implements agent.FeedbackChannelDispatcher by
+// delegating to a Dispatcher.Request + Wait pair.  It lives in the run package
+// because that package already imports both agent and dispatch — placing it here
+// avoids a new import cycle while keeping it independently testable.
+type FeedbackChannelAdapter struct {
+	d feedbackChannelRequester
+}
+
+// NewFeedbackChannelAdapter constructs a FeedbackChannelAdapter.
+// d is typically a *dispatch.Dispatcher; tests inject a stub via the interface.
+func NewFeedbackChannelAdapter(d feedbackChannelRequester) *FeedbackChannelAdapter {
+	return &FeedbackChannelAdapter{d: d}
+}
+
+// DispatchFeedback routes a feedback request through the plugin channel and
+// blocks until the operator replies, the timeout fires, or ctx is cancelled.
+//
+//   - Returns (responseJSON, nil) when the operator replied; the caller must call
+//     parseFeedbackResponse to extract the text from the JSON envelope.
+//   - Returns ("", agent.ErrFeedbackRouteToInApp) when the audience resolves to
+//     the synthetic in-app entry — the caller falls through to the waiter path.
+//   - Returns ("", err) on any other dispatch or wait failure.
+func (a *FeedbackChannelAdapter) DispatchFeedback(ctx context.Context, req agent.FeedbackDispatchRequest) (string, error) {
+	// Derive the Wait timeout from ExpiresAt.  The caller computes ExpiresAt
+	// once; the adapter owns the derivation so the API surface stays minimal.
+	var waitTimeout time.Duration
+	if req.ExpiresAt != nil {
+		waitTimeout = time.Until(*req.ExpiresAt)
+	}
+	if waitTimeout <= 0 {
+		waitTimeout = time.Hour // sensible default when no expiry is set
+	}
+
+	rc := dispatch.RouteContext{
+		RunID:    req.RunID,
+		PolicyID: req.PolicyID,
+		ToolName: req.ToolName,
+		// "mode":"feedback" tells the Slack plugin to use the threaded-reply UX
+		// instead of button blocks.  Injected transiently — not persisted in the
+		// audience entry's config_json and not declared in the manifest ConfigSchema.
+		Metadata: map[string]string{"mode": "feedback"},
+	}
+
+	reqID, outcome, err := a.d.Request(ctx, req.AudienceID, rc, req.Prompt, req.ExpiresAt)
+	if err != nil {
+		if errors.Is(err, dispatch.ErrNoRequestCapableEntry) {
+			return "", agent.ErrFeedbackRouteToInApp
+		}
+		return "", fmt.Errorf("channel request: %w", err)
+	}
+	if outcome == dispatch.RouteToInApp {
+		return "", agent.ErrFeedbackRouteToInApp
+	}
+
+	responseJSON, err := a.d.Wait(ctx, reqID, waitTimeout)
+	if err != nil {
+		return "", fmt.Errorf("waiting for feedback response: %w", err)
+	}
+	return responseJSON, nil
+}

--- a/internal/execution/run/feedback_adapter_test.go
+++ b/internal/execution/run/feedback_adapter_test.go
@@ -1,0 +1,176 @@
+package run_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/execution/run"
+	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
+)
+
+// feedbackStubRequester extends stubRequester with a capturedRC field so tests
+// can verify the RouteContext (including Metadata) that was passed to Request.
+type feedbackStubRequester struct {
+	requestID      string
+	requestOutcome dispatch.RoutingOutcome
+	requestErr     error
+
+	waitResponse string
+	waitErr      error
+
+	capturedRC dispatch.RouteContext
+}
+
+func (s *feedbackStubRequester) Request(_ context.Context, _ string, rc dispatch.RouteContext, _ string, _ *time.Time) (string, dispatch.RoutingOutcome, error) {
+	s.capturedRC = rc
+	return s.requestID, s.requestOutcome, s.requestErr
+}
+
+func (s *feedbackStubRequester) Wait(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return s.waitResponse, s.waitErr
+}
+
+func TestFeedbackChannelAdapter_DispatchFeedback(t *testing.T) {
+	ctx := context.Background()
+	dummyReq := agent.FeedbackDispatchRequest{
+		AudienceID: "aud-1",
+		RunID:      "run-1",
+		PolicyID:   "pol-1",
+		ToolName:   "gleipnir.ask_operator",
+		Prompt:     "What should I do next?",
+	}
+
+	t.Run("RouteToInApp from Request", func(t *testing.T) {
+		stub := &feedbackStubRequester{
+			requestID:      "",
+			requestOutcome: dispatch.RouteToInApp,
+		}
+		adapter := run.NewFeedbackChannelAdapter(stub)
+		_, err := adapter.DispatchFeedback(ctx, dummyReq)
+		if !errors.Is(err, agent.ErrFeedbackRouteToInApp) {
+			t.Errorf("err = %v, want ErrFeedbackRouteToInApp", err)
+		}
+	})
+
+	t.Run("ErrNoRequestCapableEntry maps to ErrFeedbackRouteToInApp", func(t *testing.T) {
+		stub := &feedbackStubRequester{
+			requestErr: dispatch.ErrNoRequestCapableEntry,
+		}
+		adapter := run.NewFeedbackChannelAdapter(stub)
+		_, err := adapter.DispatchFeedback(ctx, dummyReq)
+		if !errors.Is(err, agent.ErrFeedbackRouteToInApp) {
+			t.Errorf("err = %v, want ErrFeedbackRouteToInApp", err)
+		}
+	})
+
+	t.Run("RouteToPlugin with text response returns raw JSON", func(t *testing.T) {
+		stub := &feedbackStubRequester{
+			requestID:      "req-1",
+			requestOutcome: dispatch.RouteToPlugin,
+			waitResponse:   `{"text":"operator reply","user":"U123","request_id":"req-1"}`,
+		}
+		adapter := run.NewFeedbackChannelAdapter(stub)
+		resp, err := adapter.DispatchFeedback(ctx, dummyReq)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The adapter returns raw JSON; parseFeedbackResponse extracts the text
+		// in FeedbackHandler.Wait, not here.
+		if resp != stub.waitResponse {
+			t.Errorf("response = %q, want %q", resp, stub.waitResponse)
+		}
+	})
+
+	t.Run("Request returns non-sentinel error propagated", func(t *testing.T) {
+		stub := &feedbackStubRequester{
+			requestErr: fmt.Errorf("gRPC unavailable"),
+		}
+		adapter := run.NewFeedbackChannelAdapter(stub)
+		_, err := adapter.DispatchFeedback(ctx, dummyReq)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if errors.Is(err, agent.ErrFeedbackRouteToInApp) {
+			t.Error("non-sentinel request error must not map to ErrFeedbackRouteToInApp")
+		}
+	})
+
+	t.Run("Wait returns error propagated", func(t *testing.T) {
+		stub := &feedbackStubRequester{
+			requestID:      "req-2",
+			requestOutcome: dispatch.RouteToPlugin,
+			waitErr:        fmt.Errorf("context deadline exceeded"),
+		}
+		adapter := run.NewFeedbackChannelAdapter(stub)
+		_, err := adapter.DispatchFeedback(ctx, dummyReq)
+		if err == nil {
+			t.Fatal("expected error from Wait, got nil")
+		}
+	})
+
+	t.Run("Metadata contains mode=feedback in captured RouteContext", func(t *testing.T) {
+		stub := &feedbackStubRequester{
+			requestID:      "req-3",
+			requestOutcome: dispatch.RouteToPlugin,
+			waitResponse:   `{"text":"ok"}`,
+		}
+		adapter := run.NewFeedbackChannelAdapter(stub)
+		_, _ = adapter.DispatchFeedback(ctx, dummyReq)
+
+		if stub.capturedRC.Metadata == nil {
+			t.Fatal("RouteContext.Metadata is nil, want non-nil")
+		}
+		if stub.capturedRC.Metadata["mode"] != "feedback" {
+			t.Errorf("Metadata[mode] = %q, want %q", stub.capturedRC.Metadata["mode"], "feedback")
+		}
+	})
+
+	t.Run("ExpiresAt sets wait timeout", func(t *testing.T) {
+		future := time.Now().Add(2 * time.Hour)
+		req := dummyReq
+		req.ExpiresAt = &future
+
+		stub := &feedbackStubRequester{
+			requestID:      "req-4",
+			requestOutcome: dispatch.RouteToPlugin,
+			waitResponse:   `{"text":"replied"}`,
+		}
+		adapter := run.NewFeedbackChannelAdapter(stub)
+		_, err := adapter.DispatchFeedback(ctx, req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// TestParseFeedbackResponse verifies the standalone parse helper behaviour.
+// parseFeedbackResponse is not exported, so we test it indirectly via
+// FeedbackHandler.Wait in feedback_test.go.  This file focuses on adapter-level
+// behaviour only; parsing edge cases are covered there.
+func TestFeedbackChannelAdapter_NilExpiresAtDefaultsToOneHour(t *testing.T) {
+	// When ExpiresAt is nil the adapter defaults to 1h.  We cannot observe the
+	// actual timeout passed to Wait directly, but we can verify no error is
+	// returned from a stub that always succeeds.
+	stub := &feedbackStubRequester{
+		requestID:      "req-nil-exp",
+		requestOutcome: dispatch.RouteToPlugin,
+		waitResponse:   `{"text":"ok"}`,
+	}
+	adapter := run.NewFeedbackChannelAdapter(stub)
+	req := agent.FeedbackDispatchRequest{
+		AudienceID: "aud-1",
+		RunID:      "run-1",
+		PolicyID:   "pol-1",
+		ToolName:   "gleipnir.ask_operator",
+		Prompt:     "test",
+		ExpiresAt:  nil,
+	}
+	_, err := adapter.DispatchFeedback(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error with nil ExpiresAt: %v", err)
+	}
+}

--- a/internal/execution/run/launcher.go
+++ b/internal/execution/run/launcher.go
@@ -87,6 +87,7 @@ type RunLauncher struct {
 	pluginRegistrar        agent.PluginGenerationLookup
 	pluginDispatcher       agent.PluginToolDispatcher
 	approvalDispatcher     agent.ApprovalChannelDispatcher
+	feedbackDispatcher     agent.FeedbackChannelDispatcher
 }
 
 // registryResolver is the subset of mcp.Registry used by RunLauncher, defined
@@ -125,6 +126,9 @@ type RunLauncherConfig struct {
 	// ApprovalDispatcher routes approvals through a plugin channel when the
 	// policy has an audience configured.  Nil when plugins are disabled.
 	ApprovalDispatcher agent.ApprovalChannelDispatcher
+	// FeedbackDispatcher routes feedback requests through a plugin channel when
+	// the policy has an audience configured.  Nil when plugins are disabled.
+	FeedbackDispatcher agent.FeedbackChannelDispatcher
 }
 
 // NewRunLauncher returns a RunLauncher ready to use.
@@ -147,6 +151,7 @@ func NewRunLauncher(cfg RunLauncherConfig) *RunLauncher {
 		pluginRegistrar:        cfg.PluginRegistrar,
 		pluginDispatcher:       cfg.PluginDispatcher,
 		approvalDispatcher:     cfg.ApprovalDispatcher,
+		feedbackDispatcher:     cfg.FeedbackDispatcher,
 	}
 }
 
@@ -350,6 +355,7 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 		PluginRegistrar:        l.pluginRegistrar,
 		PluginDispatcher:       l.pluginDispatcher,
 		ApprovalDispatcher:     l.approvalDispatcher,
+		FeedbackDispatcher:     l.feedbackDispatcher,
 		AudienceID:             audienceID,
 	})
 	if err != nil {

--- a/internal/plugin/dispatch/channel.go
+++ b/internal/plugin/dispatch/channel.go
@@ -24,6 +24,13 @@ type RouteContext struct {
 	RunID    string
 	PolicyID string
 	ToolName string
+	// Metadata is an optional bag of key-value pairs merged into
+	// channel_config_json before the gRPC Request call. nil means no extra data.
+	// Used to inject transient dispatch-time fields (e.g. "mode":"feedback")
+	// without modifying the manifest ConfigSchema — the schema does not set
+	// additionalProperties: false so the plugin tolerates extra fields via
+	// json.Unmarshal into its typed config struct.
+	Metadata map[string]string
 }
 
 // DispatcherConfig holds all tunable parameters for a Dispatcher.
@@ -339,6 +346,31 @@ func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteCon
 	preCtx, cancelPre := context.WithTimeout(ctx, d.cfg.PreAckTimeout)
 	defer cancelPre()
 
+	// Merge rc.Metadata into the channel config JSON so the plugin receives
+	// transient dispatch-time fields (e.g. "mode":"feedback") without those
+	// fields being persisted in the audience entry or declared in the manifest
+	// ConfigSchema.  Extra fields are tolerated by the plugin's json.Unmarshal
+	// because the schema does not set additionalProperties: false.
+	configJSON := firstRequest.ConfigJSON
+	if len(rc.Metadata) > 0 {
+		var cfgMap map[string]any
+		if configJSON == "" || configJSON == "{}" {
+			cfgMap = make(map[string]any)
+		} else if parseErr := json.Unmarshal([]byte(configJSON), &cfgMap); parseErr != nil {
+			slog.Warn("dispatch: could not parse channel config for metadata merge",
+				"err", parseErr, "request_id", reqID)
+			// cfgMap remains nil — skip the merge and use the original configJSON.
+		}
+		if cfgMap != nil {
+			for k, v := range rc.Metadata {
+				cfgMap[k] = v
+			}
+			if merged, mergeErr := json.Marshal(cfgMap); mergeErr == nil {
+				configJSON = string(merged)
+			}
+		}
+	}
+
 	start := time.Now()
 	resp, rpcErr := client.Request(preCtx, &channelv1.RequestRequest{
 		Context: &commonv1.RequestContext{
@@ -348,7 +380,7 @@ func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteCon
 		},
 		RequestId:         reqID,
 		Prompt:            prompt,
-		ChannelConfigJson: firstRequest.ConfigJSON,
+		ChannelConfigJson: configJSON,
 	})
 	observeRPC("Request", targetInstance.PluginID, targetInstance.ID, start)
 

--- a/main.go
+++ b/main.go
@@ -218,6 +218,7 @@ func run(cfg config.Config) error {
 	// line ~155 so setManager can be called at line 237.
 	var hostSvc *hostsvc.Server
 	var approvalAdapter agent.ApprovalChannelDispatcher
+	var feedbackAdapter agent.FeedbackChannelDispatcher
 	if cfg.PluginsEnabled {
 		identityReg := identity.New()
 		genCtrl := generation.New()
@@ -230,10 +231,12 @@ func run(cfg config.Config) error {
 			// which is deferred to a follow-up issue.
 		})
 
-		// approvalAdapter is constructed here where pluginDispatcher is in scope.
-		// The outer-scoped variable is assigned so RunLauncherConfig below can
-		// reference it without the dispatcher escaping the if block.
+		// approvalAdapter and feedbackAdapter are constructed here where
+		// pluginDispatcher is in scope.  The outer-scoped variables are assigned so
+		// RunLauncherConfig below can reference them without the dispatcher escaping
+		// the if block.
 		approvalAdapter = runpkg.NewApprovalChannelAdapter(pluginDispatcher)
+		feedbackAdapter = runpkg.NewFeedbackChannelAdapter(pluginDispatcher)
 
 		hostSvc = hostsvc.NewServer(
 			store.Queries(),
@@ -369,6 +372,7 @@ func run(cfg config.Config) error {
 		PluginRegistrar:        pluginToolRegistrar,
 		PluginDispatcher:       pluginDispatchAdapter,
 		ApprovalDispatcher:     approvalAdapter,
+		FeedbackDispatcher:     feedbackAdapter,
 	})
 
 	// Wire the trigger dispatch pipeline now that RunLauncher is available.

--- a/plugins/slack/channel_state.go
+++ b/plugins/slack/channel_state.go
@@ -17,6 +17,9 @@ type correlation struct {
 	buttons []responseButton
 	runID   string
 	addedAt time.Time
+	// mode distinguishes the request UX.  "feedback" means the operator replies
+	// in a thread; "" (or any other value) means the button-click path.
+	mode string
 }
 
 // correlationMap stores in-flight Request correlations. Safe for concurrent use.
@@ -55,6 +58,24 @@ func (m *correlationMap) take(requestID string) (correlation, bool) {
 	}
 	m.mu.Unlock()
 	return c, ok
+}
+
+// takeByThreadTS scans the map for an entry whose channel and ts fields match
+// the given channel and threadTS, atomically deletes it, and returns it.
+// Returns ("", zero, false) when no match is found.
+//
+// O(n) on map size — acceptable since the map is bounded by concurrent
+// in-flight requests (typically < 10).
+func (m *correlationMap) takeByThreadTS(channel, threadTS string) (requestID string, c correlation, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, corr := range m.data {
+		if corr.channel == channel && corr.ts == threadTS {
+			delete(m.data, id)
+			return id, corr, true
+		}
+	}
+	return "", correlation{}, false
 }
 
 // sweep evicts all entries older than ttl as of now.

--- a/plugins/slack/channel_state_test.go
+++ b/plugins/slack/channel_state_test.go
@@ -78,6 +78,71 @@ func TestCorrelationMap_Sweep(t *testing.T) {
 	}
 }
 
+// TestCorrelationMap_TakeByThreadTS verifies that takeByThreadTS finds a
+// correlation by channel+ts, atomically deletes it, and returns ok=false on the
+// second call or when channel/ts do not match.
+func TestCorrelationMap_TakeByThreadTS(t *testing.T) {
+	m := &correlationMap{
+		data:   make(map[string]correlation),
+		stopCh: make(chan struct{}),
+	}
+
+	// Put two entries with different channels/ts/modes.
+	m.put("req-feedback", correlation{
+		channel: "C01CHAN",
+		ts:      "1700000001.000001",
+		mode:    "feedback",
+		runID:   "run-feedback",
+		addedAt: time.Now(),
+	})
+	m.put("req-approval", correlation{
+		channel: "C01CHAN",
+		ts:      "1700000002.000001",
+		mode:    "",
+		runID:   "run-approval",
+		addedAt: time.Now(),
+	})
+
+	// Should find the feedback entry by channel+ts.
+	reqID, corr, ok := m.takeByThreadTS("C01CHAN", "1700000001.000001")
+	if !ok {
+		t.Fatal("takeByThreadTS: expected ok=true, got false")
+	}
+	if reqID != "req-feedback" {
+		t.Errorf("requestID: want %q, got %q", "req-feedback", reqID)
+	}
+	if corr.mode != "feedback" {
+		t.Errorf("mode: want %q, got %q", "feedback", corr.mode)
+	}
+
+	// Second call with same args must return ok=false (atomically deleted).
+	_, _, ok = m.takeByThreadTS("C01CHAN", "1700000001.000001")
+	if ok {
+		t.Error("second takeByThreadTS: expected ok=false (already deleted), got true")
+	}
+
+	// Non-matching channel returns false.
+	_, _, ok = m.takeByThreadTS("C99OTHER", "1700000002.000001")
+	if ok {
+		t.Error("non-matching channel: expected ok=false, got true")
+	}
+
+	// Non-matching ts returns false.
+	_, _, ok = m.takeByThreadTS("C01CHAN", "9999999999.999999")
+	if ok {
+		t.Error("non-matching ts: expected ok=false, got true")
+	}
+
+	// The approval entry is still present.
+	_, corr2, ok := m.takeByThreadTS("C01CHAN", "1700000002.000001")
+	if !ok {
+		t.Fatal("approval entry: expected ok=true, got false")
+	}
+	if corr2.runID != "run-approval" {
+		t.Errorf("runID: want %q, got %q", "run-approval", corr2.runID)
+	}
+}
+
 // TestCorrelationMap_Concurrent exercises put/take from 1000 goroutines to
 // detect data races under -race.
 func TestCorrelationMap_Concurrent(t *testing.T) {

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -240,10 +240,16 @@ type SlackChannelMessagePayload struct {
 // SlackChannelEntryConfig documents the Go-side shape of the per-audience-entry
 // config validated against the ConfigSchema above. The actual schema is parsed
 // from the YAML literal; this struct exists for code readability only.
+//
+// Mode is NOT declared in the manifest's channel ConfigSchema — it is injected
+// transiently at dispatch time by the host (via dispatch.RouteContext.Metadata →
+// channel_config_json merge).  json.Unmarshal tolerates extra fields because the
+// schema does not set additionalProperties: false.
 type SlackChannelEntryConfig struct {
 	Channel         string           `json:"channel"`                    // required
 	Mention         string           `json:"mention,omitempty"`          // optional
 	ResponseButtons []responseButton `json:"response_buttons,omitempty"` // optional; defaults applied in Go
+	Mode            string           `json:"mode,omitempty"`             // transient; injected by host at dispatch time
 }
 
 func init() {

--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -655,6 +655,7 @@ func (s *ChannelService) maintainInteractiveHandler(ctx context.Context) {
 		}
 
 		hub.RegisterInteractiveHandler(s.handleInteractive)
+		hub.RegisterMessageHandler(s.handleThreadReply)
 
 		select {
 		case <-ctx.Done():
@@ -836,19 +837,53 @@ func (s *ChannelService) Request(ctx context.Context, req *channelv1.RequestRequ
 		}, nil
 	}
 
+	sc := s.webAPIFactory(creds.Token.AccessToken)
+
+	runID := req.GetContext().GetRunId()
+	type postResult struct{ channel, ts string }
+
+	if cfg.Mode == "feedback" {
+		// Feedback mode: post a plain text message (no buttons) and watch for
+		// threaded replies.  The operator responds by replying in the thread;
+		// handleThreadReply picks up the reply and calls WriteAuditStep.
+		prompt := req.GetPrompt()
+		if cfg.Mention != "" {
+			prompt = cfg.Mention + " " + prompt
+		}
+		res, postErr := callWithRetry(ctx, func(ctx context.Context) (postResult, error) {
+			ch, ts, err := sc.PostMessageContext(ctx, cfg.Channel, slack.MsgOptionText(prompt, false))
+			return postResult{ch, ts}, err
+		})
+		if postErr != nil {
+			code, hint := mapErr(postErr)
+			if hint != healthNone {
+				s.setChannelHealth(hostCtx, hint)
+			}
+			return &channelv1.RequestResponse{
+				Error: channelErrorResponse(code, humanizeSlackErr(postErr)),
+			}, nil
+		}
+		s.correlations.put(req.GetRequestId(), correlation{
+			channel: res.channel,
+			ts:      res.ts,
+			runID:   runID,
+			addedAt: time.Now(),
+			mode:    "feedback",
+		})
+		return &channelv1.RequestResponse{Acked: true}, nil
+	}
+
+	// Default (approval / button) mode: post a Block Kit message with response buttons.
 	buttons := cfg.ResponseButtons
 	if len(buttons) == 0 {
 		buttons = defaultResponseButtons()
 	}
-
-	sc := s.webAPIFactory(creds.Token.AccessToken)
 
 	// Synchronously post the Block Kit message within the host-enforced 5s
 	// pre-ack deadline carried in ctx. callWithRetry honors the deadline; if
 	// Slack's RetryAfter exceeds remaining budget it returns RateLimitedError
 	// which mapErr converts to RATE_LIMITED — the host then writes
 	// feedback_dispatch_error (dispatch/channel.go:347-355).
-	type postResult struct{ channel, ts string }
 	res, postErr := callWithRetry(ctx, func(ctx context.Context) (postResult, error) {
 		blocks := buildRequestBlocks(req.GetRequestId(), req.GetPrompt(), buttons, cfg.Mention)
 		ch, ts, err := sc.PostMessageContext(ctx, cfg.Channel, slack.MsgOptionBlocks(blocks...))
@@ -864,7 +899,6 @@ func (s *ChannelService) Request(ctx context.Context, req *channelv1.RequestRequ
 		}, nil
 	}
 
-	runID := req.GetContext().GetRunId()
 	s.correlations.put(req.GetRequestId(), correlation{
 		channel: res.channel,
 		ts:      res.ts,
@@ -937,6 +971,71 @@ func (s *ChannelService) handleInteractive(evt socketmode.Event, cb slack.Intera
 		}
 		log.Printf("slack: handleInteractive: WriteAuditStep returned ok=false: %s", errMsg)
 	}
+}
+
+// handleThreadReply is called by the socketHub for every EventsAPI event so
+// that ChannelService can watch for threaded replies to feedback messages.
+// Only plain human messages that are threaded replies (SubType == "" and
+// ThreadTimeStamp != "") and whose parent ts matches a known correlation are
+// processed; everything else is ignored silently.
+func (s *ChannelService) handleThreadReply(evt socketmode.Event) {
+	if evt.Type != socketmode.EventTypeEventsAPI {
+		return
+	}
+	eventsAPIEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
+	if !ok {
+		return
+	}
+	msg, ok := eventsAPIEvent.InnerEvent.Data.(*slackevents.MessageEvent)
+	if !ok {
+		return
+	}
+
+	// Only plain human messages that are replies in a thread.
+	// SubType != "" covers bot_message, message_changed, etc.
+	if msg.SubType != "" || msg.ThreadTimeStamp == "" {
+		return
+	}
+	// The parent message itself has ts == thread_ts; skip it so posting the
+	// feedback prompt message does not accidentally resolve itself.
+	if msg.ThreadTimeStamp == msg.TimeStamp {
+		return
+	}
+
+	requestID, corr, ok := s.correlations.takeByThreadTS(msg.Channel, msg.ThreadTimeStamp)
+	if !ok {
+		// Not a thread we are tracking — ignore.
+		return
+	}
+	if corr.mode != "feedback" {
+		// Thread on an approval (button) message — put the correlation back and
+		// ignore the reply so the button-click path continues to work.
+		s.correlations.put(requestID, corr)
+		return
+	}
+
+	payloadJSON, err := json.Marshal(map[string]string{
+		"text":       msg.Text,
+		"user":       msg.User,
+		"request_id": requestID,
+	})
+	if err != nil {
+		log.Printf("slack: handleThreadReply: marshal payload: %v", err)
+		return
+	}
+
+	// No call_id needed: spec §8.5 request_id exemption — the host authorizes
+	// via plugin_pending_requests ownership (same pattern as handleInteractive).
+	_, err = s.host.WriteAuditStep(context.Background(), &hostv1.WriteAuditStepRequest{
+		StepType:    "feedback_response",
+		RequestId:   requestID,
+		PayloadJson: string(payloadJSON),
+	})
+	if err != nil {
+		log.Printf("slack: handleThreadReply: WriteAuditStep: %v", err)
+	}
+	// No response_url to update — the feedback message is a plain text message,
+	// not a Block Kit message with buttons.
 }
 
 // postResponseURL sends a POST to Slack's response_url with replace_original:true,

--- a/plugins/slack/service_test.go
+++ b/plugins/slack/service_test.go
@@ -1376,6 +1376,288 @@ func TestChannelInteractiveAckedSynchronously(t *testing.T) {
 	}
 }
 
+// threadedMessageSocketEvent builds a socketmode.Event of type EventTypeEventsAPI
+// with a MessageEvent whose ThreadTimeStamp is set (a threaded reply).
+func threadedMessageSocketEvent(channelID, user, text, ts, threadTS, teamID string) socketmode.Event {
+	inner := slackevents.EventsAPIInnerEvent{
+		Type: "message",
+		Data: &slackevents.MessageEvent{
+			Channel:         channelID,
+			ChannelType:     "channel",
+			User:            user,
+			Text:            text,
+			TimeStamp:       ts,
+			ThreadTimeStamp: threadTS,
+			EventTimeStamp:  ts,
+		},
+	}
+	outerEvt := slackevents.EventsAPIEvent{
+		TeamID:     teamID,
+		InnerEvent: inner,
+	}
+	return socketmode.Event{
+		Type:    socketmode.EventTypeEventsAPI,
+		Data:    outerEvt,
+		Request: &socketmode.Request{EnvelopeID: "env-thread-" + ts},
+	}
+}
+
+// feedbackCfgJSON builds a channel_config_json string for feedback mode.
+func feedbackCfgJSON(channel string) string {
+	return fmt.Sprintf(`{"channel":%q,"mode":"feedback"}`, channel)
+}
+
+// ── Feedback mode channel tests ───────────────────────────────────────────────
+
+// TestChannelRequestFeedbackMode asserts that Request in feedback mode posts a
+// plain text message (no buttons), stores a correlation with mode="feedback", and
+// returns acked=true.
+func TestChannelRequestFeedbackMode(t *testing.T) {
+	const (
+		channel   = "C01FEEDBACK"
+		ts        = "1700090000.000900"
+		requestID = "req-feedback-mode"
+		token     = "xoxb-feedback-mode"
+	)
+
+	var postBody atomic.Value
+	slackMux := newSlackMux(true)
+	slackMux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		postBody.Store(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": channel,
+			"ts":      ts,
+		})
+	})
+
+	runner := newChannelFakeRunner()
+	client, chanSvc, _, cleanup := setupChannelServiceWithRunner(t,
+		credJSON(token),
+		cfgWithToken("xapp-test-token"),
+		runner,
+		slackMux,
+	)
+	defer cleanup()
+
+	resp, err := client.Request(context.Background(), &channelv1.RequestRequest{
+		RequestId:         requestID,
+		Prompt:            "What should I do next?",
+		ChannelConfigJson: feedbackCfgJSON(channel),
+		Context: &commonv1.RequestContext{
+			RunId:    "run-feedback-1",
+			PolicyId: "pol-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Request RPC: %v", err)
+	}
+	if !resp.GetAcked() {
+		t.Fatalf("Request: want acked=true, got false: %v", resp.GetError().GetMessage())
+	}
+
+	// Verify that the POST body does not contain Block Kit blocks (no buttons).
+	rawBody := postBody.Load()
+	if rawBody == nil {
+		t.Fatal("Slack API was not called")
+	}
+	bodyStr := rawBody.(string)
+	if strings.Contains(bodyStr, "blocks") {
+		t.Error("feedback mode must post plain text, not Block Kit blocks")
+	}
+
+	// Verify correlation is stored with mode="feedback".
+	corr, ok := chanSvc.correlations.take(requestID)
+	if !ok {
+		t.Fatal("correlation not stored for requestID")
+	}
+	if corr.mode != "feedback" {
+		t.Errorf("correlation.mode: want %q, got %q", "feedback", corr.mode)
+	}
+	if corr.ts != ts {
+		t.Errorf("correlation.ts: want %q, got %q", ts, corr.ts)
+	}
+}
+
+// TestChannelRequestFeedbackThreadReply tests the full feedback round-trip:
+// Request (feedback mode) → operator sends threaded reply → handleThreadReply
+// calls WriteAuditStep(feedback_response).
+func TestChannelRequestFeedbackThreadReply(t *testing.T) {
+	const (
+		channel   = "C01FBTHREAD"
+		ts        = "1700091000.000100" // parent message ts = thread_ts we watch
+		replyTS   = "1700091000.000200"
+		requestID = "req-fb-thread"
+		token     = "xoxb-fb-thread"
+		replyText = "Please proceed with caution."
+	)
+
+	runner := newChannelFakeRunner()
+	_, chanSvc, host, cleanup := setupChannelServiceWithRunner(t,
+		credJSON(token),
+		cfgWithToken("xapp-test-token"),
+		runner,
+		slackPostMessageOK(channel, ts),
+	)
+	defer cleanup()
+
+	// Register the thread-reply handler on the hub.
+	hub, _, err := chanSvc.hubRegistry.Acquire("xapp-test-token")
+	if err != nil {
+		t.Fatalf("Acquire hub: %v", err)
+	}
+	hub.RegisterMessageHandler(chanSvc.handleThreadReply)
+
+	// Step 1: Request in feedback mode — posts plain text, stores correlation.
+	reqResp, err := chanSvc.Request(context.Background(), &channelv1.RequestRequest{
+		RequestId:         requestID,
+		Prompt:            "Which deployment strategy should I use?",
+		ChannelConfigJson: feedbackCfgJSON(channel),
+		Context: &commonv1.RequestContext{RunId: "run-thread-1", PolicyId: "pol-1"},
+	})
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if !reqResp.GetAcked() {
+		t.Fatalf("Request: want acked=true, got false: %v", reqResp.GetError())
+	}
+
+	// Step 2: Inject a threaded reply from an operator.
+	// The thread_ts of the reply must match the parent message ts stored in the correlation.
+	runner.Send(threadedMessageSocketEvent(channel, "U01OPERATOR", replyText, replyTS, ts, "T01TEAM"))
+
+	// Step 3: Wait for WriteAuditStep.
+	if !pollUntil(t, 3*time.Second, func() bool { return len(host.AuditSteps()) > 0 }) {
+		t.Fatal("timed out waiting for WriteAuditStep from thread reply")
+	}
+
+	steps := host.AuditSteps()
+	if len(steps) != 1 {
+		t.Fatalf("want 1 audit step, got %d", len(steps))
+	}
+	step := steps[0]
+	if step.StepType != "feedback_response" {
+		t.Errorf("step_type: want feedback_response, got %q", step.StepType)
+	}
+	if step.RequestID != requestID {
+		t.Errorf("request_id: want %q, got %q", requestID, step.RequestID)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(step.PayloadJSON), &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if payload["text"] != replyText {
+		t.Errorf("text: want %q, got %q", replyText, payload["text"])
+	}
+}
+
+// TestChannelRequestFeedbackThreadReply_IgnoresNonThread asserts that a plain
+// (non-threaded) message event does not trigger WriteAuditStep.
+func TestChannelRequestFeedbackThreadReply_IgnoresNonThread(t *testing.T) {
+	const (
+		channel   = "C01FBNOTHREAD"
+		ts        = "1700092000.000100"
+		requestID = "req-fb-nothread"
+		token     = "xoxb-fb-nothread"
+	)
+
+	runner := newChannelFakeRunner()
+	_, chanSvc, host, cleanup := setupChannelServiceWithRunner(t,
+		credJSON(token),
+		cfgWithToken("xapp-test-token"),
+		runner,
+		slackPostMessageOK(channel, ts),
+	)
+	defer cleanup()
+
+	hub, _, err := chanSvc.hubRegistry.Acquire("xapp-test-token")
+	if err != nil {
+		t.Fatalf("Acquire hub: %v", err)
+	}
+	hub.RegisterMessageHandler(chanSvc.handleThreadReply)
+
+	// Request in feedback mode.
+	reqResp, err := chanSvc.Request(context.Background(), &channelv1.RequestRequest{
+		RequestId:         requestID,
+		Prompt:            "Please advise.",
+		ChannelConfigJson: feedbackCfgJSON(channel),
+		Context:           &commonv1.RequestContext{RunId: "run-nothread-1"},
+	})
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if !reqResp.GetAcked() {
+		t.Fatalf("Request: want acked=true, got false")
+	}
+
+	// Send a plain (non-threaded) message — no ThreadTimeStamp.
+	runner.Send(eventsAPISocketEvent(channel, "channel", "U01USER", "just a comment", "1700092000.000200", "T01TEAM"))
+
+	// Give a short window; no audit step should appear.
+	time.Sleep(100 * time.Millisecond)
+	if n := len(host.AuditSteps()); n != 0 {
+		t.Errorf("want 0 audit steps for non-threaded message, got %d", n)
+	}
+}
+
+// TestChannelRequestFeedbackThreadReply_IgnoresApprovalThread asserts that a
+// threaded reply on an approval (button mode) message does not trigger
+// WriteAuditStep and does not consume the correlation.
+func TestChannelRequestFeedbackThreadReply_IgnoresApprovalThread(t *testing.T) {
+	const (
+		channel   = "C01APPROVAL"
+		ts        = "1700093000.000100"
+		replyTS   = "1700093000.000200"
+		requestID = "req-approval-thread"
+		token     = "xoxb-approval-thread"
+	)
+
+	runner := newChannelFakeRunner()
+	_, chanSvc, host, cleanup := setupChannelServiceWithRunner(t,
+		credJSON(token),
+		cfgWithToken("xapp-test-token"),
+		runner,
+		slackPostMessageOK(channel, ts),
+	)
+	defer cleanup()
+
+	hub, _, err := chanSvc.hubRegistry.Acquire("xapp-test-token")
+	if err != nil {
+		t.Fatalf("Acquire hub: %v", err)
+	}
+	hub.RegisterMessageHandler(chanSvc.handleThreadReply)
+
+	// Request in approval (button) mode — no "mode":"feedback" in config.
+	reqResp, err := chanSvc.Request(context.Background(), &channelv1.RequestRequest{
+		RequestId:         requestID,
+		Prompt:            "Approve?",
+		ChannelConfigJson: channelCfgJSON(channel, ""),
+		Context:           &commonv1.RequestContext{RunId: "run-approval-1"},
+	})
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if !reqResp.GetAcked() {
+		t.Fatalf("Request: want acked=true, got false")
+	}
+
+	// Send a threaded reply to the approval message.
+	runner.Send(threadedMessageSocketEvent(channel, "U01OPERATOR", "FYI, I'm approving via buttons", replyTS, ts, "T01TEAM"))
+
+	// Short window — no audit step should appear (approval replies come via buttons).
+	time.Sleep(100 * time.Millisecond)
+	if n := len(host.AuditSteps()); n != 0 {
+		t.Errorf("want 0 audit steps for thread reply on approval message, got %d", n)
+	}
+
+	// The correlation must still be present (not consumed by handleThreadReply).
+	if _, ok := chanSvc.correlations.take(requestID); !ok {
+		t.Error("approval correlation was incorrectly consumed by handleThreadReply")
+	}
+}
+
 // ── lateAuditHost ─────────────────────────────────────────────────────────────
 
 // lateAuditHost is an inline hostv1.HostServiceServer that returns

--- a/plugins/slack/sockethub.go
+++ b/plugins/slack/sockethub.go
@@ -20,6 +20,13 @@ type interactiveHandlerSlot struct {
 	fn func(socketmode.Event, slack.InteractionCallback)
 }
 
+// messageHandlerSlot wraps the message handler function for atomic.Pointer storage.
+// Used by ChannelService to observe EventsAPI events for thread-reply watching without
+// interferring with TriggerService's eventsHandler (which owns Ack).
+type messageHandlerSlot struct {
+	fn func(socketmode.Event)
+}
+
 // socketHub multiplexes a single socketModeRunner between an EventsAPI handler
 // (used by TriggerService) and an interactive handler (used by ChannelService).
 // One hub per xapp-token; created and managed by hubRegistry.
@@ -34,6 +41,7 @@ type socketHub struct {
 	xappToken          string
 	eventsHandler      atomic.Pointer[eventsHandlerSlot]
 	interactiveHandler atomic.Pointer[interactiveHandlerSlot]
+	messageHandler     atomic.Pointer[messageHandlerSlot]
 
 	// done is closed (and doneErr written) when the hub's Run goroutine exits.
 	// Multiple goroutines may read from Done(); the channel is never sent to
@@ -78,6 +86,15 @@ func (h *socketHub) RegisterInteractiveHandler(fn func(socketmode.Event, slack.I
 	h.interactiveHandler.Store(&interactiveHandlerSlot{fn: fn})
 }
 
+// RegisterMessageHandler registers a secondary handler that receives EventsAPI
+// events.  Unlike eventsHandler, this handler must NOT call Ack — Ack is owned
+// by TriggerService's eventsHandler.  Used by ChannelService to watch for
+// threaded replies without creating a second Socket Mode connection.
+// Replaces any previously registered handler atomically.
+func (h *socketHub) RegisterMessageHandler(fn func(socketmode.Event)) {
+	h.messageHandler.Store(&messageHandlerSlot{fn: fn})
+}
+
 // Ack acknowledges a Slack Socket Mode request.
 func (h *socketHub) Ack(req socketmode.Request) {
 	h.runner.Ack(req)
@@ -97,6 +114,12 @@ func (h *socketHub) Run(ctx context.Context) error {
 		case socketmode.EventTypeEventsAPI:
 			if slot := h.eventsHandler.Load(); slot != nil {
 				slot.fn(evt)
+			}
+			// Dispatch to the secondary message handler AFTER eventsHandler so Ack
+			// (owned by eventsHandler/TriggerService) fires first.  messageHandler
+			// must not call Ack.
+			if mslot := h.messageHandler.Load(); mslot != nil {
+				mslot.fn(evt)
 			}
 
 		case socketmode.EventTypeInteractive:

--- a/plugins/slack/translator.go
+++ b/plugins/slack/translator.go
@@ -62,6 +62,15 @@ func translate(inner slackevents.EventsAPIInnerEvent, teamID string) (kind, even
 		if ev.SubType != "" {
 			return "", "", nil, false, nil
 		}
+		// Skip threaded replies — they must not fire trigger events.
+		// Feedback thread replies are handled by ChannelService's handleThreadReply,
+		// not the trigger pipeline.
+		// Known limitation: all threaded replies are suppressed here.  If threaded
+		// trigger events are needed in the future, a separate event kind (e.g.
+		// "thread_reply") should be added rather than removing this filter.
+		if ev.ThreadTimeStamp != "" {
+			return "", "", nil, false, nil
+		}
 		p := SlackChannelMessagePayload{
 			Channel:     ev.Channel,
 			ChannelID:   ev.Channel, // MessageEvent has no separate channel_id field
@@ -81,6 +90,11 @@ func translate(inner slackevents.EventsAPIInnerEvent, teamID string) (kind, even
 		return "channel_message", deriveEventID(ev.Channel, ev.TimeStamp), b, true, nil
 
 	case *slackevents.AppMentionEvent:
+		// Skip threaded mentions for the same reason as MessageEvent above.
+		// If thread-scoped mention triggers are needed later, add a separate event kind.
+		if ev.ThreadTimeStamp != "" {
+			return "", "", nil, false, nil
+		}
 		p := SlackChannelMessagePayload{
 			Channel:     ev.Channel,
 			ChannelID:   ev.Channel, // AppMentionEvent has no separate channel_id field

--- a/plugins/slack/translator_test.go
+++ b/plugins/slack/translator_test.go
@@ -92,7 +92,10 @@ func TestTranslate(t *testing.T) {
 			},
 		},
 		{
-			name: "threaded reply includes thread_ts",
+			// Threaded replies are suppressed to prevent feedback replies from
+			// firing trigger events (BLOCKING #2).  The filter is intentionally broad;
+			// a future "thread_reply" event kind could re-enable threaded triggers.
+			name: "threaded reply is dropped (feedback reply filter)",
 			inner: slackevents.EventsAPIInnerEvent{
 				Type: "message",
 				Data: &slackevents.MessageEvent{
@@ -106,18 +109,7 @@ func TestTranslate(t *testing.T) {
 				},
 			},
 			teamID:   "T01TEAM",
-			wantEmit: true,
-			wantKind: "channel_message",
-			checkPayload: func(t *testing.T, payload []byte) {
-				t.Helper()
-				var p SlackChannelMessagePayload
-				if err := json.Unmarshal(payload, &p); err != nil {
-					t.Fatalf("unmarshal payload: %v", err)
-				}
-				if p.ThreadTs != "1700002000.000100" {
-					t.Errorf("thread_ts: want 1700002000.000100, got %q", p.ThreadTs)
-				}
-			},
+			wantEmit: false,
 		},
 		{
 			name: "SubType bot_message is dropped",
@@ -315,6 +307,53 @@ func TestTranslateEventIDMatchesDeriveEventID(t *testing.T) {
 	want := deriveEventID(channelID, ts)
 	if eventID != want {
 		t.Errorf("event_id mismatch: translate produced %q, deriveEventID produced %q", eventID, want)
+	}
+}
+
+// TestTranslate_SkipsThreadedReplies pins BLOCKING #2: a MessageEvent with a
+// non-empty ThreadTimeStamp must not produce a trigger event regardless of SubType.
+func TestTranslate_SkipsThreadedReplies(t *testing.T) {
+	inner := slackevents.EventsAPIInnerEvent{
+		Type: "message",
+		Data: &slackevents.MessageEvent{
+			Channel:         "C01CHAN",
+			ChannelType:     "channel",
+			User:            "U01USER",
+			Text:            "I confirm the rollback",
+			TimeStamp:       "1700010000.000200",
+			ThreadTimeStamp: "1700010000.000100", // non-empty → threaded reply
+			EventTimeStamp:  "1700010000.000200",
+		},
+	}
+	_, _, _, emit, err := translate(inner, "T01TEAM")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if emit {
+		t.Error("threaded MessageEvent must not emit a trigger event (feedback reply filter)")
+	}
+}
+
+// TestTranslate_SkipsThreadedMentions pins BLOCKING #2 for AppMentionEvent:
+// a threaded @-mention must not produce a trigger event.
+func TestTranslate_SkipsThreadedMentions(t *testing.T) {
+	inner := slackevents.EventsAPIInnerEvent{
+		Type: "app_mention",
+		Data: &slackevents.AppMentionEvent{
+			Channel:         "C01CHAN",
+			User:            "U01USER",
+			Text:            "<@UBOT> help in thread",
+			TimeStamp:       "1700011000.000200",
+			ThreadTimeStamp: "1700011000.000100", // non-empty → threaded mention
+			EventTimeStamp:  "1700011000.000200",
+		},
+	}
+	_, _, _, emit, err := translate(inner, "T01TEAM")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if emit {
+		t.Error("threaded AppMentionEvent must not emit a trigger event (feedback reply filter)")
 	}
 }
 


### PR DESCRIPTION
Closes #417

## Summary

When a policy has an audience pointing at a Request-capable plugin instance, `gleipnir.ask_operator` feedback requests now route through the plugin's ChannelService instead of the in-app UI. The Slack plugin posts the feedback prompt as a channel message and watches for **threaded replies** — the operator responds by replying in the thread, and the agent resumes with their text.

### Host side (mirrors #412 approval routing)
- `FeedbackChannelDispatcher` interface + `FeedbackChannelAdapter` in run/
- `FeedbackHandler.Wait` restructured: plugin path → `dispatch.Dispatcher.Request/Wait` → `resolveFeedbackRecord` (DB update + SSE). Does NOT write `feedback_response` audit step (hostsvc already writes it via WriteAuditStep).
- `RouteContext.Metadata` injects `{"mode":"feedback"}` transiently into `channel_config_json`
- Fallback to in-app when no audience or no Request-capable entry

### Plugin side (Slack threaded replies)
- `Request` branches on `cfg.Mode == "feedback"`: posts plain text (no buttons), stores `requestID → thread_ts` correlation
- `handleThreadReply` watches Socket Mode message events for threaded replies, calls `WriteAuditStep(feedback_response)` with the reply text
- `translate` function skips threaded replies (`ThreadTimeStamp != ""`) to prevent spurious trigger events
- New `messageHandler` slot on `socketHub` for message event dispatch

<details>
<summary>Architecture plan</summary>

The plan mirrors #412's approval pattern: interface-in-agent / adapter-in-run split. The key correctness constraints from plan review:
1. Plugin path does NOT write feedback_response audit step (hostsvc does it)
2. resolveFeedbackRecord uses feedbackID (feedback_requests table), not reqID (plugin_pending_requests)
3. Thread filter in translate prevents feedback threads from firing triggers
4. Mode injection is transient (RouteContext.Metadata), not persisted in audience config
</details>

## Tests
- 3 feedback_test.go tests (plugin response, fallback to in-app, dispatch error)
- 7+1 feedback_adapter_test.go cases (DispatchFeedback + nil ExpiresAt default)
- 1 channel_state_test.go test (takeByThreadTS)
- 4 service_test.go tests (feedback mode, thread reply, non-thread ignore, approval thread ignore)
- 2 translator_test.go tests (skip threaded replies + mentions)

## Review cycles: 1
## CLAUDE.md updated: No
## Brainstorming: Not triggered

🤖 Generated with the agentic dev loop