### PR TITLE
fix: subprocess env allowlist prevents secret leakage (#342)

### DIFF
--- a/conn_factory_test.go
+++ b/conn_factory_test.go
@@ -111,10 +111,8 @@ func TestManagerConnFactory(t *testing.T) {
 			TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
 				cfg.BinaryPath = os.Args[0]
 				cfg.Launch = func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
-					os.Setenv("GLEIPNIR_TEST_FIXTURE", "serve-via-sdk")
-					client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
-					os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
-					return client, teardown, err
+					opts.Env = append(opts.Env, "GLEIPNIR_TEST_FIXTURE=serve-via-sdk")
+					return hostwire.Launch(ctx, binaryPath, host, opts)
 				}
 				return process.Start(ctx, cfg)
 			},

--- a/go.work.sum
+++ b/go.work.sum
@@ -84,6 +84,7 @@ golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
 golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=

--- a/internal/plugin/dispatch/channel_integration_test.go
+++ b/internal/plugin/dispatch/channel_integration_test.go
@@ -67,10 +67,8 @@ func TestDispatcher_Notify_ProductionWiring(t *testing.T) {
 		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
 			cfg.BinaryPath = os.Args[0]
 			cfg.Launch = func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
-				os.Setenv("GLEIPNIR_TEST_FIXTURE", "dispatch-serve-via-sdk")
-				client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
-				os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
-				return client, teardown, err
+				opts.Env = append(opts.Env, "GLEIPNIR_TEST_FIXTURE=dispatch-serve-via-sdk")
+				return hostwire.Launch(ctx, binaryPath, host, opts)
 			}
 			return process.Start(ctx, cfg)
 		},

--- a/internal/plugin/hostsvc/end_to_end_integration_test.go
+++ b/internal/plugin/hostsvc/end_to_end_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -355,21 +354,12 @@ func startWriteAuditStepFixture(
 		HostServer:         hostSvc,
 		ServerInterceptors: interceptors,
 		Launch: func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
-			// Inject fixture mode and test-specific env vars before launching.
-			os.Setenv("GLEIPNIR_TEST_FIXTURE", "serve-and-writeauditstep")
-			for _, kv := range env {
-				if k, v, ok := strings.Cut(kv, "="); ok {
-					os.Setenv(k, v)
-				}
-			}
-			client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
-			os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
-			for _, kv := range env {
-				if k, _, ok := strings.Cut(kv, "="); ok {
-					os.Unsetenv(k)
-				}
-			}
-			return client, teardown, err
+			// Inject fixture mode and test-specific env vars via opts.Env so the
+			// subprocess receives them through the hostwire env allowlist mechanism
+			// rather than via os.Setenv on the host process.
+			opts.Env = append(opts.Env, "GLEIPNIR_TEST_FIXTURE=serve-and-writeauditstep")
+			opts.Env = append(opts.Env, env...)
+			return hostwire.Launch(ctx, binaryPath, host, opts)
 		},
 	}
 

--- a/internal/plugin/hostsvc/process_token_integration_test.go
+++ b/internal/plugin/hostsvc/process_token_integration_test.go
@@ -133,12 +133,11 @@ func startIntegrationFixture(t *testing.T, reg *identity.Registry, instanceID st
 		StartupTimeout: 30 * time.Second,
 		StopGrace:      10 * time.Second,
 		IdentityIssuer: reg,
-		// Inject GLEIPNIR_TEST_FIXTURE so the test binary acts as a plugin subprocess.
+		// Inject GLEIPNIR_TEST_FIXTURE via opts.Env (not os.Setenv) so the
+		// subprocess receives it through the hostwire env allowlist mechanism.
 		Launch: func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
-			os.Setenv("GLEIPNIR_TEST_FIXTURE", "serve-and-block")
-			client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
-			os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
-			return client, teardown, err
+			opts.Env = append(opts.Env, "GLEIPNIR_TEST_FIXTURE=serve-and-block")
+			return hostwire.Launch(ctx, binaryPath, host, opts)
 		},
 	}
 
@@ -259,10 +258,8 @@ func TestProcessTokenIntegration_OldTokenRejectedAfterReissue(t *testing.T) {
 		IdentityIssuer: reg,
 		HealthSetter:   func(_ context.Context, _ string, _ model.PluginHealthState, _ string) {},
 		Launch: func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
-			os.Setenv("GLEIPNIR_TEST_FIXTURE", "serve-and-block")
-			client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
-			os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
-			return client, teardown, err
+			opts.Env = append(opts.Env, "GLEIPNIR_TEST_FIXTURE=serve-and-block")
+			return hostwire.Launch(ctx, binaryPath, host, opts)
 		},
 	}
 

--- a/internal/plugin/process/process_test.go
+++ b/internal/plugin/process/process_test.go
@@ -68,11 +68,10 @@ type healthCall struct {
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // fixtureConfig builds a Config that re-execs the test binary in the given
-// fixture mode. The Launch function injects GLEIPNIR_TEST_FIXTURE into the
-// subprocess environment via os.Setenv before calling hostwire.Launch.
-//
-// Because each test case runs serially, using os.Setenv + os.Unsetenv is
-// correct. (If parallel test execution is needed, switch to building a per-test
+// fixture mode. The Launch function injects GLEIPNIR_TEST_FIXTURE via
+// opts.Env, which hostwire.Launch forwards to the subprocess regardless of
+// the env allowlist (opts.Env is the intentional channel for per-instance vars).
+// (If parallel test execution is needed, switch to building a per-test
 // fixture binary in TestMain via `go build -o tmpdir`.)
 func fixtureConfig(
 	t *testing.T,
@@ -99,11 +98,12 @@ func fixtureConfig(
 		IdentityIssuer: issuer,
 		HealthSetter:   healthSetter,
 		// Launch wraps hostwire.Launch with environment injection.
+		// GLEIPNIR_TEST_FIXTURE is passed via opts.Env (not os.Setenv) because
+		// hostwire.Launch now uses a strict env allowlist — the subprocess only
+		// receives vars explicitly passed through opts.Env or the system allowlist.
 		Launch: func(ctx context.Context, binaryPath string, host hostwire.HostServer, opts hostwire.Options) (*hostwire.Client, func(), error) {
-			os.Setenv("GLEIPNIR_TEST_FIXTURE", mode)
-			client, teardown, err := hostwire.Launch(ctx, binaryPath, host, opts)
-			os.Unsetenv("GLEIPNIR_TEST_FIXTURE")
-			return client, teardown, err
+			opts.Env = append(opts.Env, "GLEIPNIR_TEST_FIXTURE="+mode)
+			return hostwire.Launch(ctx, binaryPath, host, opts)
 		},
 	}
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/cmd/internal/runfixture/main.go
+++ b/plugin-sdk/cmd/gleipnir-plugin/cmd/internal/runfixture/main.go
@@ -140,7 +140,7 @@ func (f *fixturePlugin) Bind(_ context.Context, req *bootstrapv1.BindRequest) (*
 	return &bootstrapv1.BindResponse{Ok: true}, nil
 }
 
-// ListTools returns one echo tool.
+// ListTools returns an echo tool and an env_dump tool.
 func (f *fixturePlugin) ListTools(_ context.Context, _ *toolv1.ListToolsRequest) (*toolv1.ListToolsResponse, error) {
 	return &toolv1.ListToolsResponse{
 		Tools: []*toolv1.ToolSchema{
@@ -149,15 +149,30 @@ func (f *fixturePlugin) ListTools(_ context.Context, _ *toolv1.ListToolsRequest)
 				Description: "Echoes the input back as output",
 				InputSchema: `{"type":"object","properties":{"text":{"type":"string"}}}`,
 			},
+			{
+				Name:        "env_dump",
+				Description: "Returns the subprocess environment as a JSON array of KEY=VALUE strings",
+				InputSchema: `{"type":"object"}`,
+			},
 		},
 	}, nil
 }
 
-// Call echoes the input_json back as output_json.
+// Call dispatches to the named tool implementation.
 func (f *fixturePlugin) Call(_ context.Context, req *toolv1.CallRequest) (*toolv1.CallResponse, error) {
-	return &toolv1.CallResponse{
-		OutputJson: req.GetInputJson(),
-	}, nil
+	switch req.GetToolName() {
+	case "env_dump":
+		// Return the subprocess's full environment so tests can assert which vars
+		// were passed in. This is a fixture-only tool — never shipped in production.
+		envJSON, err := json.Marshal(os.Environ())
+		if err != nil {
+			return nil, err
+		}
+		return &toolv1.CallResponse{OutputJson: string(envJSON)}, nil
+	default:
+		// Default: echo the input back as output.
+		return &toolv1.CallResponse{OutputJson: req.GetInputJson()}, nil
+	}
 }
 
 // Start emits one synthetic "fixture.event" via HostService.EmitEvent, then

--- a/plugin-sdk/hostwire/env_test.go
+++ b/plugin-sdk/hostwire/env_test.go
@@ -1,0 +1,132 @@
+package hostwire
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestSafeEnv_ExcludesSecrets verifies that safeEnv never passes host secrets
+// to plugin subprocesses. This is a regression test for the vulnerability where
+// os.Environ() was passed directly, leaking GLEIPNIR_ENCRYPTION_KEY.
+func TestSafeEnv_ExcludesSecrets(t *testing.T) {
+	secrets := []string{
+		"GLEIPNIR_ENCRYPTION_KEY",
+		"GLEIPNIR_DB_PATH",
+		"ANTHROPIC_API_KEY",
+		"OPENAI_API_KEY",
+		"GOOGLE_API_KEY",
+	}
+
+	// Set each secret in the process environment, then verify safeEnv omits it.
+	for _, key := range secrets {
+		t.Setenv(key, "should-not-be-passed-to-plugin")
+	}
+
+	env := safeEnv()
+
+	for _, entry := range env {
+		for _, secret := range secrets {
+			if strings.HasPrefix(entry, secret+"=") {
+				t.Errorf("safeEnv included secret var %s; plugin subprocess would receive the host encryption key", secret)
+			}
+		}
+	}
+}
+
+// TestSafeEnv_IncludesAllowlistedVars verifies that safeEnv passes through the
+// system vars a plugin needs to function (PATH, HOME, etc.).
+func TestSafeEnv_IncludesAllowlistedVars(t *testing.T) {
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("TZ", "UTC")
+
+	env := safeEnv()
+
+	check := func(key, want string) {
+		t.Helper()
+		prefix := key + "="
+		for _, entry := range env {
+			if strings.HasPrefix(entry, prefix) {
+				got := strings.TrimPrefix(entry, prefix)
+				if got != want {
+					t.Errorf("safeEnv: %s = %q, want %q", key, got, want)
+				}
+				return
+			}
+		}
+		t.Errorf("safeEnv: %s not present in result; plugin subprocess would not have it", key)
+	}
+
+	check("PATH", "/usr/local/bin:/usr/bin:/bin")
+	check("HOME", "/home/testuser")
+	check("TZ", "UTC")
+}
+
+// TestSafeEnv_SkipsMissingKeys verifies that safeEnv silently omits allowlisted
+// keys that are not set in the host environment rather than adding them as
+// empty-value entries or panicking. A key that does not appear in os.Environ()
+// at all should not appear in the result.
+func TestSafeEnv_SkipsMissingKeys(t *testing.T) {
+	// Verify that LC_ALL — an allowlisted key that is rarely set in CI — is
+	// absent from the result when it is absent from the process environment.
+	// We look at the raw safeEnv result and check no entry has a key that
+	// was not actually set in the process environment.
+	env := safeEnv()
+
+	// Build a set of keys actually present in the process environment.
+	processKeys := make(map[string]bool)
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		processKeys[key] = true
+	}
+
+	// Every key in the safeEnv result must have come from the actual process env.
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		if !processKeys[key] {
+			t.Errorf("safeEnv included key %q that was not in os.Environ()", key)
+		}
+	}
+}
+
+// TestSafeEnv_NoDuplicates verifies that safeEnv doesn't produce duplicate
+// entries even if os.Environ() contains duplicates (which is technically
+// possible on some platforms).
+func TestSafeEnv_NoDuplicates(t *testing.T) {
+	t.Setenv("PATH", "/bin")
+
+	env := safeEnv()
+
+	seen := make(map[string]bool)
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		if seen[key] {
+			t.Errorf("safeEnv produced duplicate entry for key %q", key)
+		}
+		seen[key] = true
+	}
+}
+
+// TestSafeEnvKeys_AllowlistIsComplete verifies that the allowlist contains
+// only well-known system vars and has no accidental GLEIPNIR_ entries.
+func TestSafeEnvKeys_AllowlistIsComplete(t *testing.T) {
+	for _, key := range safeEnvKeys {
+		if strings.HasPrefix(key, "GLEIPNIR_") {
+			t.Errorf("safeEnvKeys contains %q — Gleipnir vars must be injected via opts.Env, not the allowlist", key)
+		}
+		// Sanity: every entry should be a non-empty identifier.
+		if key == "" {
+			t.Error("safeEnvKeys contains an empty string")
+		}
+		if strings.Contains(key, "=") {
+			t.Errorf("safeEnvKeys entry %q contains '=' — should be just the key name", key)
+		}
+	}
+
+	// PATH must always be present (fundamental for subprocess execution).
+	if !slices.Contains(safeEnvKeys, "PATH") {
+		t.Error("safeEnvKeys does not contain PATH; plugin subprocesses could not resolve tool binaries")
+	}
+}

--- a/plugin-sdk/hostwire/hostwire.go
+++ b/plugin-sdk/hostwire/hostwire.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -114,8 +115,10 @@ type Options struct {
 	OnProcessExited func()
 
 	// Env is a list of extra environment variables to set in the subprocess, in
-	// "KEY=VALUE" form. These are appended to the subprocess's inherited
-	// environment. If nil, no extra variables are added.
+	// "KEY=VALUE" form. These are appended to the subprocess's allowlisted base
+	// environment (see safeEnvKeys). Use this to pass per-instance variables
+	// such as GLEIPNIR_INSTANCE_ID and GLEIPNIR_INSTANCE_TOKEN.
+	// If nil, no extra variables are added.
 	Env []string
 
 	// ServerInterceptors are chained (in slice order) onto the host-side gRPC
@@ -221,6 +224,46 @@ var PluginMap = plugin.PluginSet{
 	"gleipnir": &gleipnirPlugin{},
 }
 
+// safeEnvKeys is the allowlist of environment variable names that are safe to
+// pass from the host process into a plugin subprocess. Only system-level vars
+// needed for basic process operation are included. Gleipnir secrets
+// (GLEIPNIR_ENCRYPTION_KEY, GLEIPNIR_DB_PATH, provider API keys, etc.) are
+// never in this list. The three Gleipnir instance vars
+// (GLEIPNIR_INSTANCE_ID, GLEIPNIR_PLUGIN_ID, GLEIPNIR_INSTANCE_TOKEN) are
+// injected separately via opts.Env by the caller (internal/plugin/process).
+var safeEnvKeys = []string{
+	"PATH",    // required for subprocess tool resolution
+	"HOME",    // expected by most Unix programs
+	"USER",    // expected by some runtimes
+	"TZ",      // timezone — affects log timestamps inside the plugin
+	"TMPDIR",  // standard override for temp file location
+	"LANG",    // locale — affects string handling in some libraries
+	"LC_ALL",  // locale override — takes precedence over LANG
+}
+
+// safeEnv builds a minimal environment for plugin subprocesses by extracting
+// only the allowlisted system vars from the host's os.Environ(). This prevents
+// host secrets (GLEIPNIR_ENCRYPTION_KEY, provider API keys, etc.) from leaking
+// into untrusted plugin processes. The go-plugin library appends its own
+// protocol vars (PLUGIN_MIN_PORT, PLUGIN_PROTOCOL_VERSIONS, etc.) after this
+// base, so those do not need to be listed here.
+func safeEnv() []string {
+	// Build a lookup map from the current environment for O(1) key access.
+	hostEnv := make(map[string]string, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		key, val, _ := strings.Cut(entry, "=")
+		hostEnv[key] = val
+	}
+
+	result := make([]string, 0, len(safeEnvKeys))
+	for _, key := range safeEnvKeys {
+		if val, ok := hostEnv[key]; ok {
+			result = append(result, key+"="+val)
+		}
+	}
+	return result
+}
+
 // Launch starts a plugin subprocess at binaryPath, performs the go-plugin
 // handshake, registers the host's HostService on the broker, and calls
 // Bootstrap.Bind so the plugin knows which stream ID to Dial.
@@ -246,12 +289,16 @@ func Launch(ctx context.Context, binaryPath string, host HostServer, opts Option
 	p := newGleipnirPlugin(host, opts.ServerInterceptors)
 
 	cmd := exec.CommandContext(ctx, binaryPath)
-	if len(opts.Env) > 0 {
-		// Append extra env vars to the subprocess's full inherited environment.
-		// Cmd.Env wins over clientConfig.Env when both are set; by setting it
-		// here we ensure the subprocess sees all of os.Environ() plus our extras.
-		cmd.Env = append(os.Environ(), opts.Env...)
-	}
+
+	// Build the subprocess environment from a strict allowlist rather than
+	// inheriting os.Environ(). This prevents GLEIPNIR_ENCRYPTION_KEY and other
+	// host secrets from leaking to untrusted plugin processes.
+	//
+	// SkipHostEnv=true tells go-plugin not to append os.Environ() on top of
+	// what we set here. go-plugin still appends its own protocol vars
+	// (PLUGIN_MIN_PORT, PLUGIN_PROTOCOL_VERSIONS, the magic cookie, etc.) which
+	// the subprocess needs to complete the handshake — those are safe to pass.
+	cmd.Env = append(safeEnv(), opts.Env...)
 
 	clientConfig := &plugin.ClientConfig{
 		HandshakeConfig:     HandshakeConfig,
@@ -261,6 +308,7 @@ func Launch(ctx context.Context, binaryPath string, host HostServer, opts Option
 		StartTimeout:        opts.StartupTimeout,
 		Logger:              newHCLogger(logger),
 		GRPCBrokerMultiplex: true,
+		SkipHostEnv:         true,
 	}
 
 	if opts.Stderr != nil {

--- a/plugin-sdk/hostwire/launch_test.go
+++ b/plugin-sdk/hostwire/launch_test.go
@@ -2,6 +2,7 @@ package hostwire_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 
 	handshakev1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/handshake/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/hostwire"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/internal/fakehost"
@@ -192,6 +194,94 @@ func TestLaunch_ServerInterceptorsAreInvokedInOrder(t *testing.T) {
 		if gotOrder[0] != 1 {
 			t.Errorf("first interceptor should be 1, got %d", gotOrder[0])
 		}
+	}
+}
+
+// TestLaunch_SubprocessEnvDoesNotLeakSecrets is a regression test for the
+// vulnerability where os.Environ() was passed wholesale to plugin subprocesses,
+// leaking GLEIPNIR_ENCRYPTION_KEY and other host secrets.
+//
+// The test injects a sentinel encryption key into the test process's environment,
+// launches the runfixture plugin, calls its env_dump tool (which returns
+// os.Environ() from inside the subprocess), and asserts the key is absent.
+//
+// Skipped unless GOOS == linux and `go` is on PATH.
+func TestLaunch_SubprocessEnvDoesNotLeakSecrets(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("launch_test requires linux")
+	}
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go binary not on PATH; skipping launch test")
+	}
+
+	// Inject secrets into the host process environment. safeEnv must filter
+	// these out so the subprocess never sees them.
+	t.Setenv("GLEIPNIR_ENCRYPTION_KEY", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	t.Setenv("GLEIPNIR_DB_PATH", "/data/secret.db")
+
+	dir := t.TempDir()
+	fixtureBin := filepath.Join(dir, "runfixture")
+	fixturePkg := "github.com/felag-engineering/gleipnir/plugin-sdk/cmd/gleipnir-plugin/cmd/internal/runfixture"
+
+	sdkRoot := findSDKRoot(t)
+
+	buildCmd := exec.Command(goPath, "build", "-tags", "runfixture", "-o", fixtureBin, fixturePkg)
+	buildCmd.Dir = sdkRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build runfixture: %v\n%s", err, out)
+	}
+
+	host := fakehost.New(fakehost.Options{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, teardown, err := hostwire.Launch(ctx, fixtureBin, host, hostwire.Options{
+		Stderr: os.Stderr,
+	})
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	defer teardown()
+
+	// Call the env_dump tool, which returns the subprocess's os.Environ() as a
+	// JSON array of KEY=VALUE strings.
+	resp, err := client.Tool.Call(ctx, &toolv1.CallRequest{
+		ToolName:  "env_dump",
+		InputJson: "{}",
+	})
+	if err != nil {
+		t.Fatalf("Tool.Call(env_dump): %v", err)
+	}
+
+	var subEnv []string
+	if err := json.Unmarshal([]byte(resp.GetOutputJson()), &subEnv); err != nil {
+		t.Fatalf("parse env_dump output: %v", err)
+	}
+
+	// Assert that no host secrets leaked into the subprocess environment.
+	leakChecks := []string{
+		"GLEIPNIR_ENCRYPTION_KEY",
+		"GLEIPNIR_DB_PATH",
+	}
+	for _, entry := range subEnv {
+		for _, secret := range leakChecks {
+			if strings.HasPrefix(entry, secret+"=") {
+				t.Errorf("subprocess received secret env var %s — host encryption key leaked to plugin subprocess", secret)
+			}
+		}
+	}
+
+	// Assert that fundamental system vars were passed through (PATH at minimum).
+	hasPath := false
+	for _, entry := range subEnv {
+		if strings.HasPrefix(entry, "PATH=") {
+			hasPath = true
+		}
+	}
+	if !hasPath {
+		t.Error("subprocess did not receive PATH; safeEnv allowlist too restrictive")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace `os.Environ()` with a strict allowlist (`safeEnvKeys`) in `hostwire.Launch` so plugin subprocesses only receive essential system vars (`PATH`, `HOME`, `TZ`, `TMPDIR`, `USER`, `LANG`, `LC_ALL`) plus explicitly injected per-instance vars
- Set `SkipHostEnv: true` on `plugin.ClientConfig` to prevent go-plugin from re-adding `os.Environ()` on top
- Migrate all test fixtures from `os.Setenv`/`os.Unsetenv` to `opts.Env` pattern to match the new allowlist-only model

Closes #342

## Why this matters

Plugin subprocesses were receiving the **entire host environment** including `GLEIPNIR_ENCRYPTION_KEY` (the AES-256 master key for all at-rest encryption). A plugin could call `os.Getenv("GLEIPNIR_ENCRYPTION_KEY")` and decrypt the SQLite DB directly, bypassing all gRPC capability enforcement and identity-token auth.

## Architecture plan

<details>
<summary>Plan (scope-gated — direct implementation from issue)</summary>

The fix is surgical: one function (`safeEnv()`) builds a filtered env from the host's `os.Environ()` using a 7-key allowlist, and the `SkipHostEnv` flag on go-plugin's `ClientConfig` prevents the library from re-adding `os.Environ()` after us. The `opts.Env` vars (per-instance identity token, instance ID, plugin ID) are appended after the allowlist so they always reach the subprocess.

</details>

## Test plan

- [x] `TestSafeEnv_ExcludesSecrets` — unit test: `GLEIPNIR_ENCRYPTION_KEY`, `GLEIPNIR_DB_PATH`, provider API keys filtered out
- [x] `TestSafeEnv_IncludesAllowlistedVars` — unit test: `PATH`, `HOME`, `TZ` pass through
- [x] `TestSafeEnv_SkipsMissingKeys` — unit test: keys absent from host env are omitted
- [x] `TestSafeEnv_NoDuplicates` — unit test: no duplicate entries
- [x] `TestSafeEnvKeys_AllowlistIsComplete` — unit test: allowlist has no `GLEIPNIR_` entries
- [x] `TestLaunch_SubprocessEnvDoesNotLeakSecrets` — integration test: spawns real subprocess, calls `env_dump` tool, asserts secrets absent + `PATH` present

## Review cycles: 1 (comment fix only)

CLAUDE.md: no updates needed

🤖 Generated with [Claude Code](https://claude.com/claude-code) via agentic dev-loop