### PR TITLE
fix(plugin/identity): constant-time token comparison to prevent timing side-channel

### DIFF
--- a/internal/plugin/identity/registry.go
+++ b/internal/plugin/identity/registry.go
@@ -9,10 +9,21 @@ package identity
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
 	"sync"
 )
+
+// tokenEntry holds the instance ID and raw token bytes stored for a registered
+// token. The map key is SHA-256(raw), a non-secret index used for O(1) lookup;
+// the raw bytes are compared with subtle.ConstantTimeCompare at verification
+// time so the comparison does not leak timing information about the secret.
+type tokenEntry struct {
+	instanceID string
+	raw        [32]byte
+}
 
 // Registry maps 256-bit random tokens to stable plugin instance IDs.
 //
@@ -22,17 +33,21 @@ import (
 //   - Revoke(token) drops the token, e.g. on subprocess exit.
 //   - RevokeInstance(instanceID) drops all state for an instance, e.g. on uninstall.
 //   - Lookup(token) resolves a token to an instance ID.
+//
+// Token comparison in Lookup uses crypto/subtle.ConstantTimeCompare to avoid
+// timing side-channels. The map is keyed by SHA-256(token bytes), a non-secret
+// deterministic index, so lookup remains O(1).
 type Registry struct {
 	mu         sync.RWMutex
-	byToken    map[string]string // token → instanceID
-	byInstance map[string]string // instanceID → current token
+	byHash     map[[32]byte]tokenEntry // SHA-256(token) → entry
+	byInstance map[string][32]byte     // instanceID → SHA-256(token) hash key
 }
 
 // New returns an empty Registry ready for use.
 func New() *Registry {
 	return &Registry{
-		byToken:    make(map[string]string),
-		byInstance: make(map[string]string),
+		byHash:     make(map[[32]byte]tokenEntry),
+		byInstance: make(map[string][32]byte),
 	}
 }
 
@@ -44,23 +59,24 @@ func New() *Registry {
 // Returns an error only when the OS random source fails, which should be treated
 // as fatal by the caller.
 func (r *Registry) Issue(instanceID string) (string, error) {
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
 		return "", fmt.Errorf("identity.Issue: read random bytes: %w", err)
 	}
-	token := base64.RawURLEncoding.EncodeToString(raw)
+	token := base64.RawURLEncoding.EncodeToString(raw[:])
+	hash := sha256.Sum256(raw[:])
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	// Revoke the prior token for this instance, if any, so an old generation
 	// cannot authenticate after a new one is issued.
-	if prior, ok := r.byInstance[instanceID]; ok {
-		delete(r.byToken, prior)
+	if priorHash, ok := r.byInstance[instanceID]; ok {
+		delete(r.byHash, priorHash)
 	}
 
-	r.byToken[token] = instanceID
-	r.byInstance[instanceID] = token
+	r.byHash[hash] = tokenEntry{instanceID: instanceID, raw: raw}
+	r.byInstance[instanceID] = hash
 	return token, nil
 }
 
@@ -68,21 +84,29 @@ func (r *Registry) Issue(instanceID string) (string, error) {
 // for the owning instance if that instance's current token is the one being
 // revoked (so RevokeInstance and Revoke stay consistent).
 //
-// Revoke is a no-op when token is not registered.
+// Revoke is a no-op when token is not registered or cannot be decoded.
 func (r *Registry) Revoke(token string) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(raw) != 32 {
+		return
+	}
+	var rawArr [32]byte
+	copy(rawArr[:], raw)
+	hash := sha256.Sum256(rawArr[:])
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	instanceID, ok := r.byToken[token]
+	entry, ok := r.byHash[hash]
 	if !ok {
 		return
 	}
-	delete(r.byToken, token)
+	delete(r.byHash, hash)
 
-	// Only remove the byInstance entry if it still points at this token; a
-	// concurrent Issue for the same instance would have already replaced it.
-	if r.byInstance[instanceID] == token {
-		delete(r.byInstance, instanceID)
+	// Only remove the byInstance entry if it still points at this token's hash;
+	// a concurrent Issue for the same instance would have already replaced it.
+	if r.byInstance[entry.instanceID] == hash {
+		delete(r.byInstance, entry.instanceID)
 	}
 }
 
@@ -94,19 +118,44 @@ func (r *Registry) RevokeInstance(instanceID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	token, ok := r.byInstance[instanceID]
+	hash, ok := r.byInstance[instanceID]
 	if !ok {
 		return
 	}
-	delete(r.byToken, token)
+	delete(r.byHash, hash)
 	delete(r.byInstance, instanceID)
 }
 
 // Lookup resolves token to the instance ID that owns it. Returns ("", false)
-// when the token is unknown or has been revoked.
+// when the token is unknown, has been revoked, or cannot be decoded.
+//
+// The comparison is performed in constant time using crypto/subtle.ConstantTimeCompare
+// to prevent timing side-channels. The SHA-256 hash of the decoded token bytes
+// is used as a non-secret map key for O(1) lookup; the actual secret bytes are
+// compared only after the map entry is found.
 func (r *Registry) Lookup(token string) (instanceID string, ok bool) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(raw) != 32 {
+		return "", false
+	}
+	var rawArr [32]byte
+	copy(rawArr[:], raw)
+	hash := sha256.Sum256(rawArr[:])
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	id, found := r.byToken[token]
-	return id, found
+
+	entry, found := r.byHash[hash]
+	if !found {
+		return "", false
+	}
+
+	// Constant-time comparison of the decoded token bytes against the stored
+	// raw bytes. This prevents timing attacks even if hash collisions were
+	// somehow forced — the attacker cannot learn anything from comparison timing.
+	if subtle.ConstantTimeCompare(rawArr[:], entry.raw[:]) != 1 {
+		return "", false
+	}
+
+	return entry.instanceID, true
 }

--- a/internal/plugin/identity/registry_test.go
+++ b/internal/plugin/identity/registry_test.go
@@ -117,3 +117,37 @@ func TestRegistry_TokensAreUnpredictable(t *testing.T) {
 		}
 	}
 }
+
+// TestRegistry_LookupRejectsWrongLength verifies that tokens whose decoded byte
+// length differs from the expected 32 bytes are rejected without a successful
+// lookup. This is a functional correctness check for the length guard that
+// prevents wrong-length inputs from reaching the constant-time comparison.
+func TestRegistry_LookupRejectsWrongLength(t *testing.T) {
+	t.Parallel()
+
+	r := identity.New()
+	_, err := r.Issue("instance-len")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"empty", ""},
+		{"too_short_16_bytes", "AAAAAAAAAAAAAAAAAAAAAA"},  // 16 bytes base64url
+		{"too_long_48_bytes", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}, // 48 bytes base64url
+		{"not_base64", "!!!not-valid-base64!!!"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, ok := r.Lookup(tc.token)
+			if ok {
+				t.Errorf("Lookup(%q) returned ok=true, want false for wrong-length/invalid token", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces direct map key lookup (`r.byToken[token]`) with a SHA-256-keyed map plus `crypto/subtle.ConstantTimeCompare` in `Registry.Lookup`
- Tokens are now stored as `[32]byte` raw bytes in `tokenEntry` structs; the map key is `SHA-256(raw)`, a non-secret deterministic index that enables O(1) retrieval without exposing the secret to timing variation
- Incoming tokens are base64-decoded and length-checked (must be exactly 32 bytes) before any comparison reaches `subtle.ConstantTimeCompare`
- `Revoke` updated to base64-decode its argument and look up via the same hash key

## Test plan

- [ ] `TestRegistry_IssueLookupRoundtrip` — valid token resolves correctly
- [ ] `TestRegistry_IssueAutoRevokesPriorToken` — old generation token rejected after re-issue
- [ ] `TestRegistry_RevokeRemoves` — explicit revoke makes token invalid
- [ ] `TestRegistry_RevokeInstanceRemovesAll` — instance revoke clears all state
- [ ] `TestRegistry_LookupUnknownToken` — unknown token returns false
- [ ] `TestRegistry_LookupRejectsWrongLength` — new test: empty, too-short, too-long, and invalid-base64 inputs all rejected without false positives
- [ ] All `internal/plugin/hostsvc` tests pass (interceptor still works correctly)
- [ ] `go build ./...` clean

Fixes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)