### PR TITLE
fix(plugin): gRPC message-size limits and per-RPC payload caps on Host service

### DIFF
--- a/internal/plugin/hostsvc/handlers.go
+++ b/internal/plugin/hostsvc/handlers.go
@@ -168,6 +168,25 @@ func (s *Server) GetRunContext(ctx context.Context, _ *hostv1.GetRunContextReque
 	}, nil
 }
 
+// maxPayloadJSONBytes is the per-RPC hard cap on payload_json fields in
+// WriteAuditStep and EmitEvent. 64 KiB is generous for a feedback_response or
+// event payload; anything larger is a sign of misuse or a bug in the plugin.
+const maxPayloadJSONBytes = 64 * 1024
+
+// maxLogMsgBytes is the per-RPC hard cap on the Log msg field. 4 KiB covers
+// any reasonable structured log line including context and stack excerpts.
+const maxLogMsgBytes = 4 * 1024
+
+// maxLogAttrs is the maximum number of key/value pairs a single Log RPC may
+// carry. Unbounded attrs let a plugin override correlation keys such as run_id
+// by appending many attrs; 32 is well above any legitimate use.
+const maxLogAttrs = 32
+
+// maxLogAttrBytes is the per-key and per-value byte cap inside a Log attrs
+// map. 256 bytes accommodates ULIDs, UUIDs, short messages, and most
+// structured metadata. Values that exceed this are signs of misuse.
+const maxLogAttrBytes = 256
+
 // WriteAuditStep accepts only `feedback_response`. It MUST carry a request_id.
 // Authorization is by request-ownership (spec §8.5 exemption): the request_id
 // row's plugin_instance_id (plugin substrate path) or the policy's tool grants
@@ -181,6 +200,11 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 	}
 
 	const rpcMethod = "/gleipnir.plugin.host.v1.HostService/WriteAuditStep"
+
+	if len(req.GetPayloadJson()) > maxPayloadJSONBytes {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"payload_json exceeds maximum size of %d bytes", maxPayloadJSONBytes)
+	}
 
 	if req.GetStepType() != "feedback_response" {
 		s.writeAuditEvent(ctx, inst.ID, "unauthorized_step_type", "high", map[string]string{
@@ -413,6 +437,10 @@ func (s *Server) EmitEvent(ctx context.Context, req *hostv1.EmitEventRequest) (*
 	if req.GetEventKind() == "" {
 		return nil, status.Error(codes.InvalidArgument, "event_kind must not be empty")
 	}
+	if len(req.GetPayloadJson()) > maxPayloadJSONBytes {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"payload_json exceeds maximum size of %d bytes", maxPayloadJSONBytes)
+	}
 
 	// Rate-limit gate: drop excess events before running any per-policy match
 	// scan so a runaway plugin cannot exhaust host resources. Returns Ok=false
@@ -498,6 +526,25 @@ func (s *Server) Log(ctx context.Context, req *hostv1.LogRequest) (*hostv1.LogRe
 	inst, err := s.resolveInstance(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(req.GetMsg()) > maxLogMsgBytes {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"msg exceeds maximum size of %d bytes", maxLogMsgBytes)
+	}
+	if len(req.GetAttrs()) > maxLogAttrs {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"attrs map exceeds maximum of %d entries", maxLogAttrs)
+	}
+	for k, v := range req.GetAttrs() {
+		if len(k) > maxLogAttrBytes {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"attr key exceeds maximum size of %d bytes", maxLogAttrBytes)
+		}
+		if len(v) > maxLogAttrBytes {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"attr value exceeds maximum size of %d bytes", maxLogAttrBytes)
+		}
 	}
 
 	level := protoLevelToSlog(req.GetLevel())

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -2467,3 +2467,342 @@ func readDroppedCounter(t *testing.T, plugin, instance string) float64 {
 	}
 	return 0
 }
+
+// ── tests: per-RPC payload size caps ─────────────────────────────────────────
+
+// oversized returns a string of n bytes filled with 'x'.
+func oversized(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = 'x'
+	}
+	return string(b)
+}
+
+func TestWriteAuditStep_PayloadJSONTooLarge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		payloadSize int
+		wantCode    codes.Code
+	}{
+		{
+			name:        "exactly at cap: accepted",
+			payloadSize: 64 * 1024,
+			wantCode:    codes.OK,
+		},
+		{
+			name:        "one byte over cap: rejected",
+			payloadSize: 64*1024 + 1,
+			wantCode:    codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance:                 db.PluginInstance{ID: "iid-size", PluginID: "plug-size", InstanceName: "myplugin"},
+				pluginPendingRequestErr:  sql.ErrNoRows,
+				feedbackRequest:          db.FeedbackRequest{ID: "fr-size", RunID: "run-size", Status: "pending"},
+				latestStep:               db.RunStep{StepNumber: 0},
+				updateFeedbackStatusRows: 1,
+				run:                      db.Run{ID: "run-size", PolicyID: "pol-size"},
+				policy:                   db.Policy{ID: "pol-size", Yaml: policyYAMLWithTool("myplugin.act")},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.WriteAuditStep(context.Background(), &hostv1.WriteAuditStepRequest{
+				StepType:    "feedback_response",
+				RequestId:   "fr-size",
+				PayloadJson: oversized(tt.payloadSize),
+			})
+
+			if tt.wantCode == codes.OK {
+				if err != nil {
+					t.Errorf("expected no error for payload at cap, got: %v", err)
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != tt.wantCode {
+					t.Errorf("expected %v, got %v", tt.wantCode, err)
+				}
+				if !strings.Contains(st.Message(), "payload_json exceeds") {
+					t.Errorf("message = %q, want to contain \"payload_json exceeds\"", st.Message())
+				}
+			}
+		})
+	}
+}
+
+func TestEmitEvent_PayloadJSONTooLarge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		payloadSize int
+		wantCode    codes.Code
+	}{
+		{
+			name:        "exactly at cap: accepted",
+			payloadSize: 64 * 1024,
+			wantCode:    codes.OK,
+		},
+		{
+			name:        "one byte over cap: rejected",
+			payloadSize: 64*1024 + 1,
+			wantCode:    codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance: db.PluginInstance{ID: "iid-evsize", PluginID: "plug-evsize"},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.EmitEvent(context.Background(), &hostv1.EmitEventRequest{
+				EventId:     "evt-size",
+				EventKind:   "test.event",
+				PayloadJson: oversized(tt.payloadSize),
+			})
+
+			if tt.wantCode == codes.OK {
+				if err != nil {
+					t.Errorf("expected no error for payload at cap, got: %v", err)
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != tt.wantCode {
+					t.Errorf("expected %v, got %v", tt.wantCode, err)
+				}
+				if !strings.Contains(st.Message(), "payload_json exceeds") {
+					t.Errorf("message = %q, want to contain \"payload_json exceeds\"", st.Message())
+				}
+			}
+		})
+	}
+}
+
+func TestLog_MsgTooLarge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		msgSize  int
+		wantCode codes.Code
+	}{
+		{
+			name:     "exactly at cap: accepted",
+			msgSize:  4 * 1024,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "one byte over cap: rejected",
+			msgSize:  4*1024 + 1,
+			wantCode: codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance: db.PluginInstance{ID: "iid-logsize", PluginID: "plug-logsize"},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.Log(context.Background(), &hostv1.LogRequest{
+				Level: hostv1.LogLevel_LOG_LEVEL_INFO,
+				Msg:   oversized(tt.msgSize),
+			})
+
+			if tt.wantCode == codes.OK {
+				if err != nil {
+					t.Errorf("expected no error for msg at cap, got: %v", err)
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != tt.wantCode {
+					t.Errorf("expected %v, got %v", tt.wantCode, err)
+				}
+				if !strings.Contains(st.Message(), "msg exceeds") {
+					t.Errorf("message = %q, want to contain \"msg exceeds\"", st.Message())
+				}
+			}
+		})
+	}
+}
+
+func TestLog_TooManyAttrs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		attrCount int
+		wantCode  codes.Code
+	}{
+		{
+			name:      "exactly at cap: accepted",
+			attrCount: 32,
+			wantCode:  codes.OK,
+		},
+		{
+			name:      "one over cap: rejected",
+			attrCount: 33,
+			wantCode:  codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance: db.PluginInstance{ID: "iid-logattrs", PluginID: "plug-logattrs"},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			attrs := make(map[string]string, tt.attrCount)
+			for i := 0; i < tt.attrCount; i++ {
+				attrs[fmt.Sprintf("key%d", i)] = "val"
+			}
+
+			_, err := srv.Log(context.Background(), &hostv1.LogRequest{
+				Level: hostv1.LogLevel_LOG_LEVEL_INFO,
+				Msg:   "attrs test",
+				Attrs: attrs,
+			})
+
+			if tt.wantCode == codes.OK {
+				if err != nil {
+					t.Errorf("expected no error for %d attrs, got: %v", tt.attrCount, err)
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != tt.wantCode {
+					t.Errorf("expected %v, got %v", tt.wantCode, err)
+				}
+				if !strings.Contains(st.Message(), "attrs map exceeds") {
+					t.Errorf("message = %q, want to contain \"attrs map exceeds\"", st.Message())
+				}
+			}
+		})
+	}
+}
+
+func TestLog_AttrKeyTooLarge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		keySize  int
+		wantCode codes.Code
+	}{
+		{
+			name:     "exactly at cap: accepted",
+			keySize:  256,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "one byte over cap: rejected",
+			keySize:  257,
+			wantCode: codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance: db.PluginInstance{ID: "iid-logkey", PluginID: "plug-logkey"},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.Log(context.Background(), &hostv1.LogRequest{
+				Level: hostv1.LogLevel_LOG_LEVEL_INFO,
+				Msg:   "key size test",
+				Attrs: map[string]string{oversized(tt.keySize): "value"},
+			})
+
+			if tt.wantCode == codes.OK {
+				if err != nil {
+					t.Errorf("expected no error for key at cap, got: %v", err)
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != tt.wantCode {
+					t.Errorf("expected %v, got %v", tt.wantCode, err)
+				}
+				if !strings.Contains(st.Message(), "attr key exceeds") {
+					t.Errorf("message = %q, want to contain \"attr key exceeds\"", st.Message())
+				}
+			}
+		})
+	}
+}
+
+func TestLog_AttrValueTooLarge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		valueSize int
+		wantCode  codes.Code
+	}{
+		{
+			name:      "exactly at cap: accepted",
+			valueSize: 256,
+			wantCode:  codes.OK,
+		},
+		{
+			name:      "one byte over cap: rejected",
+			valueSize: 257,
+			wantCode:  codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance: db.PluginInstance{ID: "iid-logval", PluginID: "plug-logval"},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.Log(context.Background(), &hostv1.LogRequest{
+				Level: hostv1.LogLevel_LOG_LEVEL_INFO,
+				Msg:   "value size test",
+				Attrs: map[string]string{"key": oversized(tt.valueSize)},
+			})
+
+			if tt.wantCode == codes.OK {
+				if err != nil {
+					t.Errorf("expected no error for value at cap, got: %v", err)
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != tt.wantCode {
+					t.Errorf("expected %v, got %v", tt.wantCode, err)
+				}
+				if !strings.Contains(st.Message(), "attr value exceeds") {
+					t.Errorf("message = %q, want to contain \"attr value exceeds\"", st.Message())
+				}
+			}
+		})
+	}
+}

--- a/plugin-sdk/hostwire/hostwire.go
+++ b/plugin-sdk/hostwire/hostwire.go
@@ -191,6 +191,17 @@ func (p *gleipnirPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBrok
 	// Start the host-side gRPC server that the plugin will Dial. This must run
 	// in a goroutine because AcceptAndServe blocks until the listener is closed.
 	go broker.AcceptAndServe(id, func(opts []grpc.ServerOption) *grpc.Server {
+		// Bound incoming message size to 1 MiB (1 << 20). A single Host RPC
+		// payload (WriteAuditStep JSON, EmitEvent payload, Log message) should
+		// never legitimately exceed this; the per-RPC handler caps below are the
+		// first line of defence, but a network-level limit prevents a misbehaving
+		// plugin from exhausting host memory before any handler logic runs.
+		// Send size is capped at the same value to keep the contract symmetric.
+		sizeLimits := []grpc.ServerOption{
+			grpc.MaxRecvMsgSize(1 << 20),
+			grpc.MaxSendMsgSize(1 << 20),
+		}
+		opts = append(sizeLimits, opts...)
 		if len(p.serverInterceptors) > 0 {
 			// Prepend the chain interceptor before the broker-provided server
 			// options. Slice order determines invocation order; the caller is


### PR DESCRIPTION
## Summary

- Prepend `grpc.MaxRecvMsgSize(1 MiB)` + `grpc.MaxSendMsgSize(1 MiB)` to the broker `AcceptAndServe` server-option slice in `hostwire.GRPCClient` — network-level DoS guard before any handler code runs.
- Add handler-level payload caps in three Host RPCs (all return `codes.InvalidArgument` on violation):
  - `WriteAuditStep`: `payload_json` ≤ 64 KiB
  - `EmitEvent`: `payload_json` ≤ 64 KiB
  - `Log`: `msg` ≤ 4 KiB; `attrs` map ≤ 32 entries; each key and value ≤ 256 B

## Size limit rationale

| Limit | Value | Why |
|---|---|---|
| gRPC recv/send | 1 MiB | Hard bound on any single serialized proto message on the Host service |
| `payload_json` | 64 KiB | Generous for a `feedback_response` body or plugin event payload; bloating beyond this is misuse |
| `msg` | 4 KiB | Covers any reasonable structured log line including stack excerpts |
| `attrs` count | 32 | Well above any legitimate use; unbounded count enables run_id/policy_id override attacks |
| `attrs` key/value | 256 B | ULIDs, UUIDs, short metadata all fit; larger values indicate abuse |

## Test plan

- Table-driven tests for every new cap: boundary case (exactly at cap → accepted) and one-byte-over (rejected with `codes.InvalidArgument` and a message containing the cap field name).
- All existing `hostsvc` and `plugin-sdk/hostwire` tests continue to pass.

Fixes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)