### PR TITLE
fix(dispatch): guard CancelRun goroutines against conn.Close races

### DIFF
--- a/internal/plugin/dispatch/pool.go
+++ b/internal/plugin/dispatch/pool.go
@@ -52,6 +52,11 @@ type instanceState struct {
 	client    toolv1.ToolServiceClient
 	sem       chan struct{} // capacity = max_concurrent_calls
 	queueGate chan struct{} // capacity = max_queue_depth; controls queue accounting
+
+	// closeOnce ensures conn.Close() is called at most once. Multiple CancelRun
+	// goroutines may each decide to force-disconnect the same connection when their
+	// Cancel RPC fails; without this guard the second close is undefined behavior.
+	closeOnce sync.Once
 }
 
 // inflightCall records the instance backing a single in-flight Call so
@@ -102,6 +107,11 @@ type Pool struct {
 	inflightMu       sync.RWMutex
 	inflight         map[string]map[string]*inflightCall
 	inflightByCallID map[string]callBinding
+
+	// cancelWg tracks goroutines spawned by CancelRun. Pool.Close waits on this
+	// before tearing down connections so cancel goroutines never reference an
+	// already-closed conn.
+	cancelWg sync.WaitGroup
 }
 
 // New returns a Pool ready to use. cfg.Connect must be non-nil.
@@ -326,8 +336,8 @@ func (p *Pool) Call(ctx context.Context, runID, policyID, instanceName, toolName
 // calls conn.Close() if the plugin does not respond in time.
 //
 // CancelRun returns as soon as all cancel goroutines have been started; it does
-// NOT wait for them to finish. The in-flight Call goroutines will return on
-// their own once the plugin aborts or the connection closes.
+// NOT wait for them to finish. Pool.Close waits on the internal WaitGroup so
+// cancel goroutines always complete before connections are torn down.
 func (p *Pool) CancelRun(runID string) {
 	snap := p.snapshotInflightForRun(runID)
 	if len(snap) == 0 {
@@ -338,7 +348,10 @@ func (p *Pool) CancelRun(runID string) {
 		callID := callID
 		ic := ic
 
+		p.cancelWg.Add(1)
 		go func() {
+			defer p.cancelWg.Done()
+
 			st, err := p.getOrCreate(ic.instanceName)
 			if err != nil {
 				// Connection not established; nothing to cancel.
@@ -359,12 +372,16 @@ func (p *Pool) CancelRun(runID string) {
 					"run_id", runID,
 					"err", rpcErr,
 				)
-				if closeErr := st.conn.Close(); closeErr != nil {
-					slog.Warn("plugin conn.Close after cancel timeout",
-						"instance", ic.instanceName,
-						"err", closeErr,
-					)
-				}
+				// closeOnce guards against multiple goroutines (one per call on
+				// the same instance) each trying to close the same connection.
+				st.closeOnce.Do(func() {
+					if closeErr := st.conn.Close(); closeErr != nil {
+						slog.Warn("plugin conn.Close after cancel timeout",
+							"instance", ic.instanceName,
+							"err", closeErr,
+						)
+					}
+				})
 				// Remove the cached (now-closed) connection so the next call
 				// triggers a fresh ConnFactory call.
 				p.instancesMu.Lock()
@@ -391,14 +408,23 @@ func (p *Pool) Close() error {
 		p.CancelRun(runID)
 	}
 
+	// Wait for all cancel goroutines to finish before closing connections.
+	// Without this, a cancel goroutine that races against Close could call
+	// conn.Close() on a connection that Close has already torn down.
+	p.cancelWg.Wait()
+
 	// Close all cached connections.
 	p.instancesMu.Lock()
 	defer p.instancesMu.Unlock()
 	var firstErr error
 	for name, st := range p.instances {
-		if err := st.conn.Close(); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("closing connection to plugin %q: %w", name, err)
-		}
+		// closeOnce ensures we don't double-close a connection that a cancel
+		// goroutine already force-closed before Pool.Close ran.
+		st.closeOnce.Do(func() {
+			if err := st.conn.Close(); err != nil && firstErr == nil {
+				firstErr = fmt.Errorf("closing connection to plugin %q: %w", name, err)
+			}
+		})
 	}
 	p.instances = make(map[string]*instanceState)
 	return firstErr

--- a/internal/plugin/dispatch/pool_test.go
+++ b/internal/plugin/dispatch/pool_test.go
@@ -809,3 +809,161 @@ func TestPool_InflightCountByInstance(t *testing.T) {
 		t.Errorf("InflightCountByInstance(other) = %d after completion, want 0", got)
 	}
 }
+
+// TestPool_CancelRun_MultipleCallsSameInstance_NoRaceOnConnClose verifies that
+// when a run has multiple in-flight calls on the same instance and each Cancel
+// RPC times out (triggering conn.Close), the race detector does not report a
+// concurrent close on the same connection.
+func TestPool_CancelRun_MultipleCallsSameInstance_NoRaceOnConnClose(t *testing.T) {
+	const numCalls = 3
+
+	arrived := make(chan struct{}, numCalls)
+
+	srv := &fakeToolServer{
+		callHook: func(ctx context.Context, _ *toolv1.CallRequest) (*toolv1.CallResponse, error) {
+			arrived <- struct{}{}
+			<-ctx.Done()
+			return nil, status.Error(codes.Canceled, ctx.Err().Error())
+		},
+		// Deliberately slow cancel — exceeds CancelTimeout so every goroutine
+		// attempts conn.Close(). Without sync.Once this races.
+		cancelHook: func(ctx context.Context, _ *toolv1.CancelRequest) (*toolv1.CancelResponse, error) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(500 * time.Millisecond):
+			}
+			return &toolv1.CancelResponse{}, nil
+		},
+	}
+
+	pool, cleanup := newTestPool(t, srv, func(cfg *dispatch.Config) {
+		cfg.DefaultMaxConcurrent = numCalls
+		cfg.CallTimeout = 10 * time.Second
+		cfg.CancelTimeout = 20 * time.Millisecond // short → all goroutines hit conn.Close
+	})
+	defer cleanup()
+
+	var wg sync.WaitGroup
+	for i := 0; i < numCalls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pool.Call(context.Background(), "run-race", "pol-1", "inst", "slow-tool", `{}`) //nolint:errcheck
+		}()
+	}
+
+	// Wait until all calls have reached the server hook.
+	for i := 0; i < numCalls; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("call %d did not arrive at server", i+1)
+		}
+	}
+
+	pool.CancelRun("run-race")
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("in-flight Call goroutines did not return after CancelRun")
+	}
+}
+
+// TestPool_Close_WaitsForCancelGoroutines verifies that Pool.Close blocks until
+// all goroutines spawned by CancelRun have finished, so they never reference a
+// connection that has already been torn down.
+func TestPool_Close_WaitsForCancelGoroutines(t *testing.T) {
+	const numCalls = 2
+
+	arrived := make(chan struct{}, numCalls)
+	// cancelStarted signals when a cancel goroutine has begun its work.
+	cancelStarted := make(chan struct{}, numCalls)
+
+	srv := &fakeToolServer{
+		callHook: func(ctx context.Context, _ *toolv1.CallRequest) (*toolv1.CallResponse, error) {
+			arrived <- struct{}{}
+			<-ctx.Done()
+			return nil, status.Error(codes.Canceled, ctx.Err().Error())
+		},
+		cancelHook: func(ctx context.Context, _ *toolv1.CancelRequest) (*toolv1.CancelResponse, error) {
+			// Signal that this cancel goroutine is running, then hold briefly so
+			// Pool.Close has a chance to return too early if the WaitGroup is absent.
+			cancelStarted <- struct{}{}
+			select {
+			case <-ctx.Done():
+			case <-time.After(200 * time.Millisecond):
+			}
+			return &toolv1.CancelResponse{}, nil
+		},
+	}
+
+	pool, srvCleanup := newTestPool(t, srv, func(cfg *dispatch.Config) {
+		cfg.DefaultMaxConcurrent = numCalls
+		cfg.CallTimeout = 10 * time.Second
+		cfg.CancelTimeout = 50 * time.Millisecond
+	})
+	defer srvCleanup()
+
+	var callWg sync.WaitGroup
+	for i := 0; i < numCalls; i++ {
+		callWg.Add(1)
+		go func() {
+			defer callWg.Done()
+			pool.Call(context.Background(), "run-close", "pol-1", "inst", "slow-tool", `{}`) //nolint:errcheck
+		}()
+	}
+
+	// Wait until all calls are registered inside the server.
+	for i := 0; i < numCalls; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("call %d did not arrive at server", i+1)
+		}
+	}
+
+	// Close races with the cancel goroutines — it must not return until they
+	// have all finished.
+	closeDone := make(chan struct{})
+	go func() {
+		pool.Close() //nolint:errcheck
+		close(closeDone)
+	}()
+
+	// Wait for all cancel goroutines to be started (ensures CancelRun fired them).
+	for i := 0; i < numCalls; i++ {
+		select {
+		case <-cancelStarted:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("cancel goroutine %d did not start", i+1)
+		}
+	}
+
+	// Pool.Close should not have returned yet because cancel goroutines are
+	// still running. Give it a short window — if it fires during this window the
+	// WaitGroup is missing.
+	select {
+	case <-closeDone:
+		t.Error("Pool.Close returned before cancel goroutines finished")
+	case <-time.After(20 * time.Millisecond):
+		// Good: Close is still blocking.
+	}
+
+	// After cancel goroutines eventually finish, Close must unblock.
+	select {
+	case <-closeDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Pool.Close did not return after cancel goroutines finished")
+	}
+
+	done := make(chan struct{})
+	go func() { callWg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Call goroutines did not return after Pool.Close")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `sync.Once` to `instanceState` so `conn.Close()` is called at most once per connection, preventing multiple `CancelRun` goroutines from racing on a double-close when their Cancel RPCs all time out for the same instance.
- Adds `cancelWg sync.WaitGroup` to `Pool`; every goroutine spawned by `CancelRun` calls `cancelWg.Add(1)`/`Done()`. `Pool.Close` waits on this group before tearing down connections, eliminating the window where a cancel goroutine could reference an already-closed conn.
- Uses `closeOnce` inside `Pool.Close` itself to avoid double-closing a connection that a cancel goroutine already force-closed.

## Test plan

- `TestPool_CancelRun_MultipleCallsSameInstance_NoRaceOnConnClose` — numCalls=3 in-flight calls on the same instance, every Cancel RPC times out, all goroutines attempt `conn.Close` concurrently; passes cleanly under `-race`.
- `TestPool_Close_WaitsForCancelGoroutines` — asserts `Pool.Close` blocks until cancel goroutines finish (not just until they are started); uses a short sleep window to catch premature return.
- All existing pool tests continue to pass under `-race`.

```
go test -race ./internal/plugin/dispatch/...
ok  github.com/felag-engineering/gleipnir/internal/plugin/dispatch  20.836s
```

Fixes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)