### PR TITLE
fix(plugin/process): close double-spawn race in Manager.Start

### DIFF
--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -130,7 +130,14 @@ type Manager struct {
 	cfg       ManagerConfig
 	mu        sync.Mutex
 	instances map[string]*Instance
-	starter   processStarter
+	// spawning tracks instance IDs that are currently in the process of being
+	// started (between the guard check and the post-spawn map insert). This is
+	// the sentinel that closes the double-spawn race: a second concurrent Start
+	// for the same instance ID will observe the sentinel under m.mu and return
+	// an error without calling the starter a second time. The entry is removed
+	// whether the spawn succeeds or fails.
+	spawning map[string]struct{}
+	starter  processStarter
 
 	// toolGenMu guards toolGenerations.
 	toolGenMu sync.Mutex
@@ -154,6 +161,7 @@ func NewManager(cfg ManagerConfig) *Manager {
 	return &Manager{
 		cfg:             cfg,
 		instances:       make(map[string]*Instance),
+		spawning:        make(map[string]struct{}),
 		starter:         starter,
 		toolGenerations: make(map[string]int64),
 	}
@@ -184,13 +192,27 @@ func (m *Manager) Start(ctx context.Context, plugin db.Plugin, instance db.Plugi
 		return nil
 	}
 
+	// Insert a spawning sentinel under the lock before calling the starter.
+	// This closes the double-spawn race: a second concurrent Start for the same
+	// instance ID will observe either the sentinel or the live *Instance entry
+	// and return an error without calling the starter a second time.
 	m.mu.Lock()
 	_, alreadyRunning := m.instances[instance.ID]
+	_, alreadySpawning := m.spawning[instance.ID]
+	if !alreadyRunning && !alreadySpawning {
+		m.spawning[instance.ID] = struct{}{}
+	}
 	m.mu.Unlock()
 
-	if alreadyRunning {
+	if alreadyRunning || alreadySpawning {
 		return fmt.Errorf("manager: instance %s is already running", instance.ID)
 	}
+	// Remove the sentinel when Start returns, whether it succeeds or fails.
+	defer func() {
+		m.mu.Lock()
+		delete(m.spawning, instance.ID)
+		m.mu.Unlock()
+	}()
 
 	host := hostwire.HostServer(NoopHostServer{})
 	if m.cfg.HostServerFor != nil {

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -173,6 +173,85 @@ func TestManager_IdempotentStart(t *testing.T) {
 	}
 }
 
+// TestManager_ConcurrentStart_SingleSubprocess verifies that when two goroutines
+// call Start for the same instance ID concurrently, exactly one subprocess is
+// spawned. Before the fix a double-spawn race allowed both callers to pass the
+// guard check before either had written to m.instances, resulting in two
+// subprocesses being started. The sentinel-under-lock approach closes this
+// window: the second caller observes the in-progress spawn and returns an error.
+//
+// This test is designed to be run with -race to catch the data race on the
+// spawn counter. The starter intentionally sleeps to widen the race window
+// so it is reliably reproducible even without -race.
+func TestManager_ConcurrentStart_SingleSubprocess(t *testing.T) {
+	reg := identity.New()
+
+	var spawnCount atomic.Int32
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:        &fakeQuerier{},
+		IdentityIssuer: reg,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			// Sleep long enough to ensure the second goroutine reaches the guard
+			// check before the first goroutine inserts into m.instances. Without
+			// the sentinel fix both goroutines would pass the guard and both would
+			// increment spawnCount.
+			time.Sleep(50 * time.Millisecond)
+			spawnCount.Add(1)
+			fc := fixtureConfig(t, "serve-and-block", reg, nil)
+			fc.InstanceID = cfg.InstanceID
+			return process.Start(ctx, fc)
+		},
+	})
+
+	plugin := db.Plugin{ID: "p-concurrent", Status: "active"}
+	instance := db.PluginInstance{
+		ID:           "i-concurrent",
+		PluginID:     "p-concurrent",
+		InstanceName: "concurrent-inst",
+		HealthState:  "healthy",
+	}
+
+	var (
+		wg      sync.WaitGroup
+		errCh   = make(chan error, 2)
+	)
+
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- mgr.Start(ctx, plugin, instance, os.Args[0])
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	var successes, failures int
+	for err := range errCh {
+		if err == nil {
+			successes++
+		} else {
+			failures++
+		}
+	}
+
+	t.Cleanup(func() { mgr.Stop(ctx, instance.ID) }) //nolint:errcheck
+
+	if successes != 1 {
+		t.Errorf("concurrent Start successes = %d, want exactly 1", successes)
+	}
+	if failures != 1 {
+		t.Errorf("concurrent Start failures = %d, want exactly 1", failures)
+	}
+	if n := spawnCount.Load(); n != 1 {
+		t.Errorf("subprocess spawn count = %d, want 1 (double-spawn race detected)", n)
+	}
+}
+
 // TestManager_StopAll verifies that StopAll terminates all running instances
 // and Lookup returns nil for each afterward.
 func TestManager_StopAll(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes the double-spawn race in `Manager.Start` where two concurrent callers for the same `instanceID` could both pass the `m.instances` guard before either completed the spawn, leaking a subprocess and an unrevoked identity token.
- Introduces a `spawning map[string]struct{}` sentinel inserted under `m.mu` before releasing the lock. A second concurrent `Start` for the same instance observes the sentinel and returns an error without calling the starter.
- Adds `TestManager_ConcurrentStart_SingleSubprocess` which fires two goroutines with a 50ms artificial delay in the starter to reliably expose the race window; asserts exactly one spawn and one failure. Passes `go test -race`.

## Test plan

- [ ] `go test -race ./internal/plugin/process/...` — all tests pass, no race detector findings
- [ ] `go test ./internal/plugin/...` — full plugin package suite passes
- [ ] New test `TestManager_ConcurrentStart_SingleSubprocess` verifies: exactly 1 subprocess spawned, 1 success and 1 failure from the two concurrent callers

Fixes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)