### PR TITLE
fix(plugin/loader): wrap updatePluginCosmetic + audit insert in a single tx

### DIFF
--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -559,8 +559,8 @@ func (in *Installer) transitionAllInstances(ctx context.Context, existing db.Plu
 // the InsertPluginAuditEvent error so callers can wrap it with their own context.
 //
 // Used by the non-transactional paths (recordSignatureInvalid, handlePubkeyMismatch,
-// handleManifestMaterialChange, updatePluginCosmetic). Transactional paths
-// (createPlugin, updatePlugin) call insertAuditRow directly with a tx-bound *db.Queries.
+// handleManifestMaterialChange). Transactional paths (createPlugin, updatePlugin,
+// updatePluginCosmetic) call insertAuditRow directly with a tx-bound *db.Queries.
 func (in *Installer) recordAuditEvent(ctx context.Context, eventType, severity, nowStr string, payload map[string]any) error {
 	return insertAuditRow(ctx, in.q, eventType, severity, nowStr, payload)
 }
@@ -629,6 +629,9 @@ func updateBinaryPathTx(ctx context.Context, q *db.Queries, pluginID string, ver
 // preserving the current plugin status so an already-active plugin is not
 // regressed to pending_review for a description tweak. Publishes the verified
 // bundle to disk and updates binary_path after the manifest CAS succeeds.
+//
+// The manifest update and the audit event are committed atomically so a
+// mid-update failure cannot leave the plugins row advanced without an audit row.
 func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, changes []pluginmanifest.Change, tmpDir string, nowStr string) (string, error) {
 	// Publish the verified bundle before touching the DB so the subprocess can
 	// be re-spawned with the correct binary on the next restart.
@@ -641,41 +644,47 @@ func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugi
 		binaryPathPtr = &publishedPath
 	}
 
-	rows, err := in.q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
-		ManifestSnapshot: string(manifestBytes),
-		PluginVersion:    m.Version,
-		Status:           existing.Status, // preserve current status — cosmetic change must not regress an active plugin
-		UpdatedAt:        nowStr,
-		ID:               existing.ID,
-		ExpectedVersion:  existing.Version,
+	err := in.inTx(ctx, func(q *db.Queries) error {
+		rows, mErr := q.UpdatePluginManifest(ctx, db.UpdatePluginManifestParams{
+			ManifestSnapshot: string(manifestBytes),
+			PluginVersion:    m.Version,
+			Status:           existing.Status, // preserve current status — cosmetic change must not regress an active plugin
+			UpdatedAt:        nowStr,
+			ID:               existing.ID,
+			ExpectedVersion:  existing.Version,
+		})
+		if mErr != nil {
+			return fmt.Errorf("update plugin %q manifest (cosmetic): %w", m.Name, mErr)
+		}
+		if rows == 0 {
+			return fmt.Errorf("update plugin %q manifest (cosmetic): CAS conflict (version mismatch)", m.Name)
+		}
+
+		// The manifest CAS bumped the version; re-read inside the same tx to get
+		// the new version for the binary_path CAS that follows.
+		if binaryPathPtr != nil {
+			updated, rereadErr := q.GetPluginByName(ctx, m.Name)
+			if rereadErr != nil {
+				return fmt.Errorf("re-read plugin %q after cosmetic update: %w", m.Name, rereadErr)
+			}
+			if pathErr := updateBinaryPathTx(ctx, q, existing.ID, updated.Version, binaryPathPtr, nowStr); pathErr != nil {
+				return fmt.Errorf("update binary_path for %q (cosmetic): %w", m.Name, pathErr)
+			}
+		}
+
+		if auditErr := insertAuditRow(ctx, q, auditManifestCosmeticChange, severityInfo, nowStr, map[string]any{
+			"plugin_id":       existing.ID,
+			"name":            existing.Name,
+			"old_version":     existing.PluginVersion,
+			"new_version":     m.Version,
+			"cosmetic_fields": pluginmanifest.CosmeticFields(changes),
+		}); auditErr != nil {
+			return fmt.Errorf("record manifest_cosmetic_change audit for %q: %w", existing.Name, auditErr)
+		}
+		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("update plugin %q manifest (cosmetic): %w", m.Name, err)
-	}
-	if rows == 0 {
-		return "", fmt.Errorf("update plugin %q manifest (cosmetic): CAS conflict (version mismatch)", m.Name)
-	}
-
-	// The manifest CAS bumped the version; re-read to get the new version for
-	// the binary_path CAS that follows.
-	if binaryPathPtr != nil {
-		updated, rereadErr := in.q.GetPluginByName(ctx, m.Name)
-		if rereadErr != nil {
-			return "", fmt.Errorf("re-read plugin %q after cosmetic update: %w", m.Name, rereadErr)
-		}
-		if err := in.updateBinaryPath(ctx, existing.ID, updated.Version, binaryPathPtr, nowStr); err != nil {
-			return "", fmt.Errorf("update binary_path for %q (cosmetic): %w", m.Name, err)
-		}
-	}
-
-	if err := in.recordAuditEvent(ctx, auditManifestCosmeticChange, severityInfo, nowStr, map[string]any{
-		"plugin_id":       existing.ID,
-		"name":            existing.Name,
-		"old_version":     existing.PluginVersion,
-		"new_version":     m.Version,
-		"cosmetic_fields": pluginmanifest.CosmeticFields(changes),
-	}); err != nil {
-		return "", fmt.Errorf("record manifest_cosmetic_change audit for %q: %w", existing.Name, err)
+		return "", err
 	}
 	return existing.ID, nil
 }

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -938,6 +938,85 @@ func TestInstall_TransactionalCreate(t *testing.T) {
 	}
 }
 
+// TestInstall_TransactionalUpdateRollback verifies that when the audit insert
+// inside updatePluginCosmetic's transaction fails, the manifest update is also
+// rolled back. The plugin row must remain at the original version so the next
+// retry can succeed (and the CAS guard won't conflict on an already-bumped version).
+//
+// A version-only bump is a cosmetic change and exercises the updatePluginCosmetic
+// path. TestInstall_TransactionalRollback covers the createPlugin path.
+func TestInstall_TransactionalUpdateRollback(t *testing.T) {
+	store := openTestStore(t)
+	q := store.Queries()
+
+	// Generate a keypair and install v1 successfully so an existing row is present.
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	buildTar := func(t *testing.T, version string) string {
+		t.Helper()
+		manifestBytes := []byte("schema_version: v1\nname: update-rollback-plugin\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+		binaryBytes := []byte("binary for " + version)
+		payload := signing.PluginPayload(binaryBytes, manifestBytes)
+		sig, signErr := signing.Sign(sk.SecretKey, sk.KeyID, payload, "trusted comment")
+		if signErr != nil {
+			t.Fatalf("sign: %v", signErr)
+		}
+		sigBytes := signing.MarshalSignature(sig, "test sig")
+		tarPath := filepath.Join(t.TempDir(), "update-rollback-plugin-"+version+".tar.gz")
+		writeTarball(t, tarPath, []tarEntry{
+			{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+			{name: "update-rollback-plugin", content: binaryBytes, mode: 0o755},
+			{name: "signing.pub", content: pubkeyBytes, mode: 0o644},
+			{name: "update-rollback-plugin.minisig", content: sigBytes, mode: 0o644},
+		})
+		return tarPath
+	}
+
+	// Install v1 with a working installer (audit table intact).
+	v := &realVerifier{allowUnsigned: false}
+	inst := NewInstaller(v, q, store.DB(), nil, t.TempDir())
+	inst.clock = func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
+
+	if _, err := inst.Install(context.Background(), buildTar(t, "1.0.0")); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+	rowBefore, err := q.GetPluginByName(context.Background(), "update-rollback-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after v1: %v", err)
+	}
+	if rowBefore.PluginVersion != "1.0.0" {
+		t.Fatalf("unexpected version after v1 install: %s", rowBefore.PluginVersion)
+	}
+
+	// Sabotage the audit table so the audit insert inside updatePlugin's tx fails.
+	if _, err := store.DB().Exec("DROP TABLE plugin_audit_events"); err != nil {
+		t.Fatalf("drop audit table: %v", err)
+	}
+
+	// Attempt v2 install — must fail because the audit insert will error.
+	id, err := inst.Install(context.Background(), buildTar(t, "2.0.0"))
+	if err == nil {
+		t.Fatalf("expected install to fail when audit insert errors during updatePlugin; got id=%q nil err", id)
+	}
+
+	// The plugins row must still be at v1 — the manifest CAS was rolled back.
+	rowAfter, getErr := q.GetPluginByName(context.Background(), "update-rollback-plugin")
+	if getErr != nil {
+		t.Fatalf("GetPluginByName after failed v2 install: %v", getErr)
+	}
+	if rowAfter.PluginVersion != "1.0.0" {
+		t.Errorf("plugin_version = %q after updatePlugin rollback, want 1.0.0 (rolled back)", rowAfter.PluginVersion)
+	}
+	// The DB-level version counter must also be unchanged so the next retry's CAS guard succeeds.
+	if rowAfter.Version != rowBefore.Version {
+		t.Errorf("db version counter = %d after rollback, want %d (unchanged)", rowAfter.Version, rowBefore.Version)
+	}
+}
+
 func TestReadManifest_Validation(t *testing.T) {
 	base := "schema_version: v1\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n"
 


### PR DESCRIPTION
## Summary

- `updatePluginCosmetic` was the only commit path that was not atomic: `UpdatePluginManifest` committed immediately, and if `InsertPluginAuditEvent` failed afterwards, the plugin row advanced to the new version with no audit record — exactly the audit gap described in #349.
- `createPlugin` and `updatePlugin` already used `inTx` (the TODO comment from the issue was already resolved for those two paths). This PR closes the remaining gap on the cosmetic-update path.
- The manifest CAS update, binary_path update, and `plugin_manifest_cosmetic_change` audit row are now all committed in a single transaction via the existing `inTx` helper. A failure in any write rolls back all three.

## Changes

- **`internal/plugin/loader/install.go`**: Refactor `updatePluginCosmetic` to use `inTx`. Move the binary_path update inside the transaction (mirrors `updatePlugin`'s pattern). Update `recordAuditEvent` comment.
- **`internal/plugin/loader/install_test.go`**: Add `TestInstall_TransactionalUpdateRollback` — drops `plugin_audit_events` after a successful v1 install, attempts a cosmetic v2 install, and asserts that the plugin row and DB version counter are unchanged (no CAS conflict on retry).

## Test plan

- [ ] `go test ./internal/plugin/loader/... -timeout 120s` — all tests pass including new `TestInstall_TransactionalUpdateRollback`
- [ ] `go build ./...` — clean build
- [ ] Existing `TestInstall_TransactionalRollback` (createPlugin path) and `TestInstall_TransactionalCreate` still pass

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)