### PR TITLE
fix(plugin/hostsvc): cap metric name cardinality and sort label keys deterministically

### DIFF
--- a/internal/plugin/hostsvc/export_test.go
+++ b/internal/plugin/hostsvc/export_test.go
@@ -13,3 +13,11 @@ func SetTimeNowForTest(fn func() time.Time) (restore func()) {
 	timeNow = fn
 	return func() { timeNow = orig }
 }
+
+// Exported caps for use in external test package assertions.
+const (
+	MetricNameCap      = metricNameCap
+	MaxMetricNameBytes = maxMetricNameBytes
+	MaxLabelKeyBytes   = maxLabelKeyBytes
+	MaxLabelValueBytes = maxLabelValueBytes
+)

--- a/internal/plugin/hostsvc/handlers.go
+++ b/internal/plugin/hostsvc/handlers.go
@@ -405,7 +405,7 @@ func (s *Server) EmitMetric(ctx context.Context, req *hostv1.EmitMetricRequest) 
 	errCode, metricErr := s.metrics.set(req.GetName(), req.GetValue(), req.GetLabels(), inst.PluginID, inst.ID)
 	if metricErr != nil {
 		grpcCode := codes.InvalidArgument
-		if errCode == "cardinality_cap_exceeded" {
+		if errCode == "cardinality_cap_exceeded" || errCode == "metric_name_cap_exceeded" {
 			grpcCode = codes.ResourceExhausted
 		}
 		return nil, status.Errorf(grpcCode, "%s: %v", errCode, metricErr)

--- a/internal/plugin/hostsvc/metrics.go
+++ b/internal/plugin/hostsvc/metrics.go
@@ -2,6 +2,7 @@ package hostsvc
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -14,6 +15,22 @@ import (
 // per metric. Exceeding this limit on any label causes the emission to be
 // rejected with codes.ResourceExhausted (loud failure, per spec §8.1).
 const cardinalityCap = 100
+
+// metricNameCap is the maximum number of distinct metric names a single plugin
+// instance may register. A misbehaving plugin emitting unbounded distinct names
+// would grow the Prometheus registry without bound; this cap prevents that.
+const metricNameCap = 100
+
+// maxMetricNameBytes is the maximum byte length of a user-supplied metric name
+// (before the gleipnir_plugin_ prefix is added). Prometheus itself enforces a
+// similar constraint; we reject early with a clear error.
+const maxMetricNameBytes = 128
+
+// maxLabelKeyBytes is the maximum byte length of a user-supplied label key.
+const maxLabelKeyBytes = 64
+
+// maxLabelValueBytes is the maximum byte length of a user-supplied label value.
+const maxLabelValueBytes = 256
 
 // gaugeEntry pairs a registered GaugeVec with the sorted set of user-supplied
 // label keys it was registered with. This lets us detect inconsistent label
@@ -71,10 +88,19 @@ func (m *pluginMetrics) set(name string, value float64, userLabels map[string]st
 	if name == "" {
 		return "invalid_metric_name", fmt.Errorf("metric name must not be empty")
 	}
+	if len(name) > maxMetricNameBytes {
+		return "invalid_metric_name", fmt.Errorf("metric name exceeds maximum length of %d bytes", maxMetricNameBytes)
+	}
 
-	for k := range userLabels {
+	for k, v := range userLabels {
 		if reservedLabels[k] {
 			return "reserved_label", fmt.Errorf("label key %q is reserved by the host (auto-injected)", k)
+		}
+		if len(k) > maxLabelKeyBytes {
+			return "invalid_label", fmt.Errorf("label key %q exceeds maximum length of %d bytes", k, maxLabelKeyBytes)
+		}
+		if len(v) > maxLabelValueBytes {
+			return "invalid_label", fmt.Errorf("label value for key %q exceeds maximum length of %d bytes", k, maxLabelValueBytes)
 		}
 	}
 
@@ -103,17 +129,33 @@ func (m *pluginMetrics) set(name string, value float64, userLabels map[string]st
 
 	entry, exists := m.gauges[fullName]
 	if !exists {
+		// Enforce the per-plugin metric name cap before registering a new GaugeVec.
+		// This prevents a misbehaving plugin from growing the registry without bound.
+		if len(m.gauges) >= metricNameCap {
+			return "metric_name_cap_exceeded", fmt.Errorf(
+				"plugin has reached the %d distinct metric name cap; metric %q rejected",
+				metricNameCap, fullName,
+			)
+		}
+
 		// Build the user-key set for future consistency checks.
 		userKeySet := make(map[string]struct{}, len(userLabels))
 		for k := range userLabels {
 			userKeySet[k] = struct{}{}
 		}
 
-		// Build the full label key list: user keys + auto-injected plugin + instance.
-		labelKeys := make([]string, 0, len(userLabels)+2)
+		// Build the full label key list: user keys (sorted) + auto-injected plugin + instance.
+		// Sorting is required for deterministic GaugeVec registration: ranging over
+		// a map has non-deterministic order in Go, and two calls with the same metric
+		// name but different map-iteration order would produce AlreadyRegisteredError.
+		userKeys := make([]string, 0, len(userLabels))
 		for k := range userLabels {
-			labelKeys = append(labelKeys, k)
+			userKeys = append(userKeys, k)
 		}
+		sort.Strings(userKeys)
+
+		labelKeys := make([]string, 0, len(userLabels)+2)
+		labelKeys = append(labelKeys, userKeys...)
 		labelKeys = append(labelKeys, metrics.LabelPlugin, metrics.LabelInstance)
 
 		opts := prometheus.GaugeOpts{

--- a/internal/plugin/hostsvc/metrics_test.go
+++ b/internal/plugin/hostsvc/metrics_test.go
@@ -1,0 +1,231 @@
+package hostsvc_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/plugin/hostsvc"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+)
+
+// newMetricsServer is a helper that builds a hostsvc.Server wired for
+// EmitMetric tests. Each test must use a distinct pluginID and instanceID to
+// avoid Prometheus name collisions across tests that run in the same process.
+func newMetricsServer(t *testing.T, pluginID, instanceID string) *hostsvc.Server {
+	t.Helper()
+	q := &fakeQuerier{
+		instance: db.PluginInstance{ID: instanceID, PluginID: pluginID},
+	}
+	binder := &fakeInstanceBinder{id: instanceID, ok: true}
+	return hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+}
+
+// TestEmitMetric_MetricNameCap verifies that a plugin instance may not register
+// more than MetricNameCap distinct metric names. The (MetricNameCap+1)th
+// distinct name must be rejected with codes.ResourceExhausted and error code
+// "metric_name_cap_exceeded" in the status message.
+func TestEmitMetric_MetricNameCap(t *testing.T) {
+	srv := newMetricsServer(t, "plug-namecap", "iid-namecap")
+
+	// Emit MetricNameCap distinct names — all must succeed.
+	for i := 0; i < hostsvc.MetricNameCap; i++ {
+		name := fmt.Sprintf("namecap_metric_%04d", i)
+		_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+			Name:  name,
+			Value: float64(i),
+		})
+		if err != nil {
+			t.Fatalf("emission %d (name=%q): unexpected error: %v", i, name, err)
+		}
+	}
+
+	// The (MetricNameCap+1)th distinct name must be rejected.
+	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+		Name:  "namecap_metric_overflow",
+		Value: 999,
+	})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.ResourceExhausted {
+		t.Fatalf("overflow name: expected codes.ResourceExhausted, got %v", err)
+	}
+	if !strings.Contains(st.Message(), "metric_name_cap_exceeded") {
+		t.Errorf("status message = %q, want it to contain %q", st.Message(), "metric_name_cap_exceeded")
+	}
+}
+
+// TestEmitMetric_MetricNameCap_RepeatedNameNotCounted verifies that repeatedly
+// emitting the same metric name does not consume additional name-cap slots.
+func TestEmitMetric_MetricNameCap_RepeatedNameNotCounted(t *testing.T) {
+	srv := newMetricsServer(t, "plug-namecap-rep", "iid-namecap-rep")
+
+	// Emit one name 10 times.
+	for i := 0; i < 10; i++ {
+		_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+			Name:  "repeated_metric",
+			Value: float64(i),
+		})
+		if err != nil {
+			t.Fatalf("repeated emission %d: unexpected error: %v", i, err)
+		}
+	}
+
+	// (MetricNameCap - 1) additional distinct names must still succeed because
+	// the repeated name only consumed one slot.
+	for i := 0; i < hostsvc.MetricNameCap-1; i++ {
+		name := fmt.Sprintf("namecap_rep_extra_%04d", i)
+		_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+			Name:  name,
+			Value: float64(i),
+		})
+		if err != nil {
+			t.Fatalf("extra emission %d (name=%q): unexpected error: %v", i, name, err)
+		}
+	}
+}
+
+// TestEmitMetric_MetricNameLengthCap verifies that metric names longer than
+// MaxMetricNameBytes are rejected with codes.InvalidArgument.
+func TestEmitMetric_MetricNameLengthCap(t *testing.T) {
+	srv := newMetricsServer(t, "plug-namelen", "iid-namelen")
+
+	// Exactly at the limit must succeed.
+	atLimit := strings.Repeat("a", hostsvc.MaxMetricNameBytes)
+	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+		Name:  atLimit,
+		Value: 1,
+	})
+	if err != nil {
+		t.Fatalf("name at limit (%d bytes): unexpected error: %v", hostsvc.MaxMetricNameBytes, err)
+	}
+
+	// One byte over the limit must be rejected.
+	overLimit := strings.Repeat("b", hostsvc.MaxMetricNameBytes+1)
+	_, err = srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+		Name:  overLimit,
+		Value: 2,
+	})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("name over limit: expected codes.InvalidArgument, got %v", err)
+	}
+	if !strings.Contains(st.Message(), "invalid_metric_name") {
+		t.Errorf("status message = %q, want it to contain %q", st.Message(), "invalid_metric_name")
+	}
+}
+
+// TestEmitMetric_LabelKeyLengthCap verifies that label keys longer than
+// MaxLabelKeyBytes are rejected with codes.InvalidArgument.
+func TestEmitMetric_LabelKeyLengthCap(t *testing.T) {
+	srv := newMetricsServer(t, "plug-labelkey", "iid-labelkey")
+
+	// Key exactly at the limit must succeed.
+	atLimit := strings.Repeat("k", hostsvc.MaxLabelKeyBytes)
+	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+		Name:   "label_key_cap_metric",
+		Value:  1,
+		Labels: map[string]string{atLimit: "v"},
+	})
+	if err != nil {
+		t.Fatalf("label key at limit (%d bytes): unexpected error: %v", hostsvc.MaxLabelKeyBytes, err)
+	}
+
+	// Key one byte over the limit must be rejected.
+	overLimit := strings.Repeat("j", hostsvc.MaxLabelKeyBytes+1)
+	_, err = srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+		Name:   "label_key_cap_metric_2",
+		Value:  2,
+		Labels: map[string]string{overLimit: "v"},
+	})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("label key over limit: expected codes.InvalidArgument, got %v", err)
+	}
+	if !strings.Contains(st.Message(), "invalid_label") {
+		t.Errorf("status message = %q, want it to contain %q", st.Message(), "invalid_label")
+	}
+}
+
+// TestEmitMetric_LabelValueLengthCap verifies that label values longer than
+// MaxLabelValueBytes are rejected with codes.InvalidArgument.
+func TestEmitMetric_LabelValueLengthCap(t *testing.T) {
+	srv := newMetricsServer(t, "plug-labelval", "iid-labelval")
+
+	// Value exactly at the limit must succeed.
+	atLimit := strings.Repeat("v", hostsvc.MaxLabelValueBytes)
+	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+		Name:   "label_val_cap_metric",
+		Value:  1,
+		Labels: map[string]string{"env": atLimit},
+	})
+	if err != nil {
+		t.Fatalf("label value at limit (%d bytes): unexpected error: %v", hostsvc.MaxLabelValueBytes, err)
+	}
+
+	// Value one byte over the limit must be rejected.
+	overLimit := strings.Repeat("w", hostsvc.MaxLabelValueBytes+1)
+	_, err = srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+		Name:   "label_val_cap_metric_2",
+		Value:  2,
+		Labels: map[string]string{"env": overLimit},
+	})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("label value over limit: expected codes.InvalidArgument, got %v", err)
+	}
+	if !strings.Contains(st.Message(), "invalid_label") {
+		t.Errorf("status message = %q, want it to contain %q", st.Message(), "invalid_label")
+	}
+}
+
+// TestEmitMetric_LabelKeySortingDeterminism verifies that two EmitMetric calls
+// for the same metric name with the same set of label keys — but constructed in
+// a way that could produce different map iteration orders — do not produce an
+// AlreadyRegisteredError or inconsistent_label_keys rejection. This is the
+// regression test for the non-deterministic label ordering bug.
+//
+// The test calls EmitMetric several times with a five-key label map. Because Go
+// map iteration order is randomised per run, repeatedly registering with a naive
+// range-over-map would fail. With sort.Strings applied before GaugeVec
+// registration the order is stable and subsequent calls succeed.
+func TestEmitMetric_LabelKeySortingDeterminism(t *testing.T) {
+	srv := newMetricsServer(t, "plug-sort", "iid-sort")
+
+	// Five label keys chosen to exercise different sort orderings.
+	labels := map[string]string{
+		"zebra":   "z",
+		"alpha":   "a",
+		"mango":   "m",
+		"bravo":   "b",
+		"charlie": "c",
+	}
+
+	// Emit the same metric name 20 times. Any non-determinism in label-key
+	// ordering would surface as inconsistent_label_keys or panic on the second
+	// registration attempt.
+	for i := 0; i < 20; i++ {
+		// Rebuild the map on every iteration to encourage different iteration
+		// orders (Go randomises per map allocation).
+		freshLabels := map[string]string{
+			"zebra":   "z",
+			"alpha":   "a",
+			"mango":   "m",
+			"bravo":   "b",
+			"charlie": "c",
+		}
+		_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
+			Name:   "sorted_label_metric",
+			Value:  float64(i),
+			Labels: freshLabels,
+		})
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error (label key ordering bug?): %v", i, err)
+		}
+	}
+	_ = labels // used only for documentation
+}


### PR DESCRIPTION
## Summary

- **Metric name cardinality cap**: A plugin emitting unbounded distinct metric names would grow the Prometheus registry without limit. Added `metricNameCap = 100` checked before `prometheus.NewGaugeVec` registration; the 101st distinct name is rejected with `codes.ResourceExhausted` / `metric_name_cap_exceeded` (mirrors the existing `cardinality_cap_exceeded` pattern).
- **Deterministic label-key sort**: `labelKeys` was built by ranging over `userLabels` map, whose iteration order is randomised per allocation in Go. Two calls with the same metric name but different map-iteration order produced distinct `GaugeVec` registrations, triggering `AlreadyRegisteredError`. Fixed by applying `sort.Strings(userKeys)` before building `labelKeys`.
- **Length caps**: Added `maxMetricNameBytes = 128`, `maxLabelKeyBytes = 64`, `maxLabelValueBytes = 256` with `codes.InvalidArgument` / `"invalid_label"` for clear diagnostics.

Fixes #354

## Test plan

- `TestEmitMetric_MetricNameCap`: emits `MetricNameCap` distinct names (all succeed), then verifies the 101st is rejected with `codes.ResourceExhausted` + `"metric_name_cap_exceeded"`.
- `TestEmitMetric_MetricNameCap_RepeatedNameNotCounted`: repeated emissions of the same name consume only one slot, leaving room for `MetricNameCap - 1` additional distinct names.
- `TestEmitMetric_MetricNameLengthCap`: name exactly at `MaxMetricNameBytes` succeeds; one byte over is rejected.
- `TestEmitMetric_LabelKeyLengthCap`: label key exactly at `MaxLabelKeyBytes` succeeds; one byte over is rejected.
- `TestEmitMetric_LabelValueLengthCap`: label value exactly at `MaxLabelValueBytes` succeeds; one byte over is rejected.
- `TestEmitMetric_LabelKeySortingDeterminism`: emits the same 5-key metric name 20 times, rebuilding the map each iteration to encourage different Go map iteration orders; verifies no `inconsistent_label_keys` error or panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)