### PR TITLE
fix(hostsvc): close TOCTOU race on feedback audit step_number

### DIFF
--- a/internal/plugin/hostsvc/end_to_end_integration_test.go
+++ b/internal/plugin/hostsvc/end_to_end_integration_test.go
@@ -438,7 +438,7 @@ func TestHostsvcE2E_WriteAuditStep_HappyPath(t *testing.T) {
 		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
 	}
 
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
+	hostSvc := hostsvc.NewServer(q, store.DB(), testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{
@@ -548,7 +548,7 @@ func TestHostsvcE2E_WriteAuditStep_WrongStepType(t *testing.T) {
 		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
 	}
 
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
+	hostSvc := hostsvc.NewServer(q, store.DB(), testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{
@@ -641,7 +641,7 @@ func TestHostsvcE2E_WriteAuditStep_MissingToken(t *testing.T) {
 		countingInterceptor(hostsvc.UnaryCallIDInterceptor(), &callIDCount),
 	}
 
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
+	hostSvc := hostsvc.NewServer(q, store.DB(), testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{
@@ -746,7 +746,7 @@ func TestHostsvcE2E_WriteAuditStep_PluginSubstrate_Late(t *testing.T) {
 	// fakeChannelResolver returns (false, nil) simulating a scanner-conflict
 	// (row resolved, waiter gone).
 	ch := &fakeChannelResolver{resolved: false, err: nil}
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, ch)
+	hostSvc := hostsvc.NewServer(q, store.DB(), testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, ch)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{
@@ -842,7 +842,7 @@ func TestHostsvcE2E_WriteAuditStep_PluginSubstrate_Happy(t *testing.T) {
 
 	// Fake resolver simulates CAS win.
 	ch := &fakeChannelResolver{resolved: true, err: nil}
-	hostSvc := hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, ch)
+	hostSvc := hostsvc.NewServer(q, store.DB(), testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, ch)
 
 	resultPath := t.TempDir() + "/result.json"
 	env := []string{

--- a/internal/plugin/hostsvc/feedback_audit_concurrency_test.go
+++ b/internal/plugin/hostsvc/feedback_audit_concurrency_test.go
@@ -1,0 +1,280 @@
+package hostsvc_test
+
+// Concurrent WriteAuditStep test — exercises the TOCTOU fix from #348.
+//
+// The race: two goroutines both call WriteAuditStep(feedback_response) for the
+// same run_id at the same time. Before the fix, both could observe the same
+// MAX(step_number) and attempt to INSERT with the same (run_id, step_number),
+// causing a unique-constraint violation. The fix wraps the
+// latestStepNumber+CreateRunStep+UpdateFeedbackRequestStatus in a single
+// transaction, so only one writer can hold the write lock at a time.
+//
+// The test uses a real SQLite DB (not a fakeQuerier) to reproduce the
+// production execution environment.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/hostsvc"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+)
+
+// openConcurrencyStore opens a temp-file SQLite store for concurrency tests.
+func openConcurrencyStore(t *testing.T) (*db.Store, *db.Queries) {
+	t.Helper()
+	dbPath := t.TempDir() + "/concurrency_test.db"
+	store, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("store.Migrate: %v", err)
+	}
+	return store, store.Queries()
+}
+
+// seedConcurrencyRun inserts the minimal DB rows needed for N concurrent
+// WriteAuditStep calls: one plugin, one instance, one policy, one run, and N
+// distinct feedback_request rows. Returns the run ID and a slice of feedback
+// request IDs.
+func seedConcurrencyRun(t *testing.T, q *db.Queries, n int, instanceID, instanceName string) (runID string, feedbackIDs []string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	pluginID := model.NewULID()
+	_, err := q.CreatePlugin(ctx, db.CreatePluginParams{
+		ID:               pluginID,
+		Name:             "concurrency-test-plugin",
+		PluginVersion:    "0.1.0",
+		ManifestSnapshot: `name: concurrency-test-plugin`,
+		TrustedPubkey:    "test-pubkey",
+		Status:           "active",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	})
+	if err != nil {
+		t.Fatalf("CreatePlugin: %v", err)
+	}
+
+	_, err = q.CreatePluginInstance(ctx, db.CreatePluginInstanceParams{
+		ID:                instanceID,
+		PluginID:          pluginID,
+		InstanceName:      instanceName,
+		ConfigJson:        `{}`,
+		HandshakeVersions: `{}`,
+		HealthState:       "healthy",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	})
+	if err != nil {
+		t.Fatalf("CreatePluginInstance: %v", err)
+	}
+
+	policyID := model.NewULID()
+	policyYAML := fmt.Sprintf(`
+name: concurrency-test-policy
+trigger:
+  type: manual
+capabilities:
+  tools:
+    - tool: %s.echo
+`, instanceName)
+	_, err = q.CreatePolicy(ctx, db.CreatePolicyParams{
+		ID:          policyID,
+		Name:        "concurrency-test-policy",
+		TriggerType: "manual",
+		Yaml:        policyYAML,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	runID = model.NewULID()
+	_, err = q.CreateRun(ctx, db.CreateRunParams{
+		ID:          runID,
+		PolicyID:    policyID,
+		Model:       "claude-opus-4-5",
+		TriggerType: "manual",
+		StartedAt:   now,
+		CreatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	for i := 0; i < n; i++ {
+		frID := model.NewULID()
+		_, err = q.CreateFeedbackRequest(ctx, db.CreateFeedbackRequestParams{
+			ID:        frID,
+			RunID:     runID,
+			ToolName:  "gleipnir.ask_operator",
+			Message:   fmt.Sprintf("concurrent feedback request %d", i),
+			CreatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("CreateFeedbackRequest[%d]: %v", i, err)
+		}
+		feedbackIDs = append(feedbackIDs, frID)
+	}
+	return runID, feedbackIDs
+}
+
+// TestWriteAuditStep_ConcurrentFeedbackStepsHaveUniqueStepNumbers spawns N
+// goroutines each calling WriteAuditStep(feedback_response) for a distinct
+// feedback_request on the same run. It asserts that all resulting step_number
+// values are unique — the pre-fix race would produce duplicates (constraint
+// violation or silent overwrite) under -race.
+func TestWriteAuditStep_ConcurrentFeedbackStepsHaveUniqueStepNumbers(t *testing.T) {
+	const concurrency = 8
+
+	store, q := openConcurrencyStore(t)
+	instanceID := "conc-inst-" + model.NewULID()
+	instanceName := "conc-plugin"
+	runID, feedbackIDs := seedConcurrencyRun(t, q, concurrency, instanceID, instanceName)
+
+	binder := &fakeInstanceBinder{id: instanceID, ok: true}
+	pub := &fakePublisher{}
+	// Pass sql.ErrNoRows for GetPluginPendingRequest so all calls take the
+	// native (feedback_requests) path.
+	fq := &fakeInstanceQuerier{
+		store:        store,
+		q:            q,
+		instanceID:   instanceID,
+		instanceName: instanceName,
+	}
+	srv := hostsvc.NewServer(fq, store.DB(), testEncryptionKey, &fakeResolver{}, binder, pub, nil)
+
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	for i := 0; i < concurrency; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := context.Background()
+			resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
+				StepType:    "feedback_response",
+				RequestId:   feedbackIDs[i],
+				PayloadJson: fmt.Sprintf(`{"index":%d}`, i),
+			})
+			if err != nil {
+				errs[i] = fmt.Errorf("goroutine %d: RPC error: %w", i, err)
+				return
+			}
+			if !resp.GetOk() {
+				errs[i] = fmt.Errorf("goroutine %d: ok=false: %v", i, resp.GetError().GetMessage())
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d failed: %v", i, err)
+		}
+	}
+
+	// Collect all step_numbers for the run and assert they are unique.
+	steps, err := q.ListRunSteps(context.Background(), db.ListRunStepsParams{
+		RunID: runID,
+		After: -1,
+		Limit: int64(concurrency + 10),
+	})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	if len(steps) != concurrency {
+		t.Errorf("step count = %d, want %d", len(steps), concurrency)
+	}
+	seen := make(map[int64]bool, len(steps))
+	for _, s := range steps {
+		if seen[s.StepNumber] {
+			t.Errorf("duplicate step_number %d in run %s", s.StepNumber, runID)
+		}
+		seen[s.StepNumber] = true
+	}
+}
+
+// fakeInstanceQuerier wraps a real *db.Queries so WriteAuditStep can look up
+// the real DB rows, but intercepts GetPluginPendingRequest to return
+// sql.ErrNoRows (forcing the native feedback_requests path) and
+// GetPluginInstanceByID to return the seeded instance row.
+type fakeInstanceQuerier struct {
+	fakeAuditQuerier
+	store        *db.Store
+	q            *db.Queries
+	instanceID   string
+	instanceName string
+}
+
+func (f *fakeInstanceQuerier) GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error) {
+	return f.q.GetPluginInstanceByID(ctx, id)
+}
+
+func (f *fakeInstanceQuerier) UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error) {
+	return f.q.UpdatePluginInstanceHealth(ctx, arg)
+}
+
+func (f *fakeInstanceQuerier) GetLatestRunStep(ctx context.Context, runID string) (db.RunStep, error) {
+	return f.q.GetLatestRunStep(ctx, runID)
+}
+
+func (f *fakeInstanceQuerier) GetFeedbackRequest(ctx context.Context, id string) (db.FeedbackRequest, error) {
+	return f.q.GetFeedbackRequest(ctx, id)
+}
+
+func (f *fakeInstanceQuerier) UpdateFeedbackRequestStatus(ctx context.Context, arg db.UpdateFeedbackRequestStatusParams) (int64, error) {
+	return f.q.UpdateFeedbackRequestStatus(ctx, arg)
+}
+
+func (f *fakeInstanceQuerier) CreateRunStep(ctx context.Context, arg db.CreateRunStepParams) (db.RunStep, error) {
+	return f.q.CreateRunStep(ctx, arg)
+}
+
+func (f *fakeInstanceQuerier) GetRun(ctx context.Context, id string) (db.Run, error) {
+	return f.q.GetRun(ctx, id)
+}
+
+func (f *fakeInstanceQuerier) GetPolicy(ctx context.Context, id string) (db.Policy, error) {
+	return f.q.GetPolicy(ctx, id)
+}
+
+// GetPluginPendingRequest always returns sql.ErrNoRows to force the native
+// feedback_requests path in WriteAuditStep.
+func (f *fakeInstanceQuerier) GetPluginPendingRequest(_ context.Context, _ string) (db.PluginPendingRequest, error) {
+	return db.PluginPendingRequest{}, sql.ErrNoRows
+}
+
+func (f *fakeInstanceQuerier) GetPluginByID(ctx context.Context, id string) (db.Plugin, error) {
+	return f.q.GetPluginByID(ctx, id)
+}
+
+func (f *fakeInstanceQuerier) ListPolicies(ctx context.Context) ([]db.Policy, error) {
+	return f.q.ListPolicies(ctx)
+}
+
+func (f *fakeInstanceQuerier) ListRunsByPolicy(ctx context.Context, arg db.ListRunsByPolicyParams) ([]db.ListRunsByPolicyRow, error) {
+	return f.q.ListRunsByPolicy(ctx, arg)
+}
+
+func (f *fakeInstanceQuerier) ListAllActiveUsersWithRoles(ctx context.Context) ([]db.ListAllActiveUsersWithRolesRow, error) {
+	return f.q.ListAllActiveUsersWithRoles(ctx)
+}
+
+func (f *fakeInstanceQuerier) ListActiveUsersByRole(ctx context.Context, role string) ([]db.ListActiveUsersByRoleRow, error) {
+	return f.q.ListActiveUsersByRole(ctx, role)
+}
+
+// compile-time check that fakeInstanceQuerier satisfies Querier.
+var _ hostsvc.Querier = (*fakeInstanceQuerier)(nil)

--- a/internal/plugin/hostsvc/handlers.go
+++ b/internal/plugin/hostsvc/handlers.go
@@ -343,40 +343,12 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 		return nil, status.Error(codes.PermissionDenied, "unauthorized_request_id")
 	}
 
-	// Determine the next step number.
-	latestStep, err := s.latestStepNumber(ctx, fr.RunID)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "resolve step index: %v", err)
-	}
-	nextStep := latestStep + 1
-
-	// Insert the run step and resolve the feedback request. A race with the
-	// agent loop is acceptable under ADR-003 audit-write serialization — the
-	// feedback resolution path in the main loop also writes a step and resolves
-	// the request; whichever writer lands first wins (UpdateFeedbackRequestStatus
-	// is guarded by AND status='pending').
-	_, err = s.q.CreateRunStep(ctx, db.CreateRunStepParams{
-		ID:         model.NewULID(),
-		RunID:      fr.RunID,
-		StepNumber: nextStep,
-		Type:       "feedback_response",
-		Content:    payloadJSON,
-		TokenCost:  0,
-		CreatedAt:  time.Now().UTC().Format(time.RFC3339Nano),
-	})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "create run step: %v", err)
-	}
-
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	_, err = s.q.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
-		Status:     "resolved",
-		Response:   &payloadJSON,
-		ResolvedAt: &now,
-		ID:         requestID,
-	})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "update feedback request status: %v", err)
+	// Insert the run step and resolve the feedback request atomically.
+	// Without a transaction, two concurrent writers can observe the same
+	// MAX(step_number) and attempt to insert with the same (run_id, step_number),
+	// violating the unique constraint (fixes #348, ADR-038 discipline).
+	if err := s.writeFeedbackResponseStep(ctx, fr.RunID, requestID, payloadJSON); err != nil {
+		return nil, err
 	}
 
 	// Publish so SSE subscribers and tests can observe the step.
@@ -390,6 +362,97 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 	}
 
 	return &hostv1.WriteAuditStepResponse{Ok: true}, nil
+}
+
+// writeFeedbackResponseStep inserts a feedback_response run_step and resolves
+// the feedback_request atomically inside a single transaction. This prevents
+// the TOCTOU race where two concurrent writers observe the same MAX(step_number)
+// and attempt to insert with the same (run_id, step_number) value (fixes #348).
+//
+// When s.sqlDB is nil (unit tests using a fake Querier), the operations run
+// without a transaction — acceptable because fake Queriers are single-threaded
+// and the race only manifests against a real SQLite connection pool.
+func (s *Server) writeFeedbackResponseStep(ctx context.Context, runID, requestID, payloadJSON string) error {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	stepID := model.NewULID()
+
+	if s.sqlDB == nil {
+		// Test path: no real DB, run without transaction.
+		latestStep, err := s.latestStepNumber(ctx, runID)
+		if err != nil {
+			return status.Errorf(codes.Internal, "resolve step index: %v", err)
+		}
+		_, err = s.q.CreateRunStep(ctx, db.CreateRunStepParams{
+			ID:         stepID,
+			RunID:      runID,
+			StepNumber: latestStep + 1,
+			Type:       "feedback_response",
+			Content:    payloadJSON,
+			TokenCost:  0,
+			CreatedAt:  now,
+		})
+		if err != nil {
+			return status.Errorf(codes.Internal, "create run step: %v", err)
+		}
+		_, err = s.q.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
+			Status:     "resolved",
+			Response:   &payloadJSON,
+			ResolvedAt: &now,
+			ID:         requestID,
+		})
+		if err != nil {
+			return status.Errorf(codes.Internal, "update feedback request status: %v", err)
+		}
+		return nil
+	}
+
+	tx, err := s.sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return status.Errorf(codes.Internal, "begin feedback response tx: %v", err)
+	}
+	defer tx.Rollback() //nolint:errcheck — Rollback is a no-op after Commit
+
+	qtx := db.New(tx)
+
+	latestStep, err := qtx.GetLatestRunStep(ctx, runID)
+	var nextStep int64
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return status.Errorf(codes.Internal, "resolve step index in tx: %v", err)
+		}
+		// No steps yet — first step is 0.
+		nextStep = 0
+	} else {
+		nextStep = latestStep.StepNumber + 1
+	}
+
+	_, err = qtx.CreateRunStep(ctx, db.CreateRunStepParams{
+		ID:         stepID,
+		RunID:      runID,
+		StepNumber: nextStep,
+		Type:       "feedback_response",
+		Content:    payloadJSON,
+		TokenCost:  0,
+		CreatedAt:  now,
+	})
+	if err != nil {
+		return status.Errorf(codes.Internal, "create run step in tx: %v", err)
+	}
+
+	_, err = qtx.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
+		Status:     "resolved",
+		Response:   &payloadJSON,
+		ResolvedAt: &now,
+		ID:         requestID,
+	})
+	if err != nil {
+		return status.Errorf(codes.Internal, "update feedback request status in tx: %v", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return status.Errorf(codes.Internal, "commit feedback response tx: %v", err)
+	}
+	return nil
 }
 
 // EmitMetric records a plugin-emitted metric in Prometheus. The host

--- a/internal/plugin/hostsvc/server.go
+++ b/internal/plugin/hostsvc/server.go
@@ -2,6 +2,7 @@ package hostsvc
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 	"time"
 
@@ -100,6 +101,7 @@ type Server struct {
 	hostv1.UnimplementedHostServiceServer
 
 	q             Querier
+	sqlDB         *sql.DB // used to open transactions in WriteAuditStep (native path)
 	encryptionKey []byte
 	resolver      CallContextResolver
 	binder        InstanceBinder
@@ -157,6 +159,11 @@ func (s *Server) getTriggerSink() TriggerSink {
 // caller's plugin instance ID from the request context (production wiring uses
 // NewContextBinder paired with UnaryInstanceTokenInterceptor — see issue #202).
 //
+// sqlDB is the underlying *sql.DB used to open transactions in the native
+// feedback path of WriteAuditStep (fixes #348). Pass nil only in unit tests
+// that use a fake Querier and do not exercise concurrent writes — the
+// transactional path is skipped when sqlDB is nil.
+//
 // channels may be nil (e.g. in tests that only exercise the native
 // feedback_requests path). When nil and a plugin_pending_requests row is found
 // for a WriteAuditStep request_id, the call is treated as a late callback with
@@ -164,6 +171,7 @@ func (s *Server) getTriggerSink() TriggerSink {
 // the *dispatch.Dispatcher.
 func NewServer(
 	q Querier,
+	sqlDB *sql.DB,
 	encryptionKey []byte,
 	resolver CallContextResolver,
 	binder InstanceBinder,
@@ -175,6 +183,7 @@ func NewServer(
 	}
 	return &Server{
 		q:             q,
+		sqlDB:         sqlDB,
 		encryptionKey: encryptionKey,
 		resolver:      resolver,
 		binder:        binder,

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -246,7 +246,7 @@ func (h *testSlogHandler) all() []slog.Record {
 func newTestServer(t *testing.T, q *fakeQuerier, resolver hostsvc.CallContextResolver, pub *fakePublisher) *hostsvc.Server {
 	t.Helper()
 	binder := &fakeInstanceBinder{id: "iid-test", ok: true}
-	return hostsvc.NewServer(q, testEncryptionKey, resolver, binder, pub, nil)
+	return hostsvc.NewServer(q, nil, testEncryptionKey, resolver, binder, pub, nil)
 }
 
 func ctxWithCallID(callID string) context.Context {
@@ -523,7 +523,7 @@ func TestWriteAuditStep_NoCallID_SubstratePath(t *testing.T) {
 	}
 	ch := &fakeChannelResolver{resolved: true}
 	binder := &fakeInstanceBinder{id: "iid-caller", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
 
 	// context.Background() — no call_id. Must succeed via request-ownership.
 	resp, err := srv.WriteAuditStep(context.Background(), &hostv1.WriteAuditStepRequest{
@@ -592,7 +592,7 @@ func TestWriteAuditStep_NoCallID_CrossInstanceEscalation(t *testing.T) {
 		pluginPendingRequest: pendingRequest("iid-other", "pending"),
 	}
 	binder := &fakeInstanceBinder{id: "iid-caller", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	_, err := srv.WriteAuditStep(context.Background(), &hostv1.WriteAuditStepRequest{
 		StepType:  "feedback_response",
@@ -750,7 +750,7 @@ func newTestServerWithContextBinder(
 	pub *fakePublisher,
 ) *hostsvc.Server {
 	t.Helper()
-	return hostsvc.NewServer(q, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
+	return hostsvc.NewServer(q, nil, testEncryptionKey, resolver, hostsvc.NewContextBinder(), pub, nil)
 }
 
 // callWriteAuditStep runs UnaryInstanceTokenInterceptor then calls
@@ -946,7 +946,7 @@ func TestPluginSubstrate_HappyPath(t *testing.T) {
 	ch := &fakeChannelResolver{resolved: true, err: nil}
 	pub := &fakePublisher{}
 	binder := &fakeInstanceBinder{id: "iid-ps", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, pub, ch)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, pub, ch)
 
 	ctx := ctxWithCallID("call-ps-happy")
 	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
@@ -991,7 +991,7 @@ func TestPluginSubstrate_LateAlreadyResolved(t *testing.T) {
 	}
 	ch := &fakeChannelResolver{resolved: false, err: nil}
 	binder := &fakeInstanceBinder{id: "iid-late", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
 
 	ctx := ctxWithCallID("call-ps-late")
 	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
@@ -1040,7 +1040,7 @@ func TestPluginSubstrate_LateAlreadyTimedOut(t *testing.T) {
 	}
 	ch := &fakeChannelResolver{resolved: false, err: nil}
 	binder := &fakeInstanceBinder{id: "iid-to", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
 
 	ctx := ctxWithCallID("call-ps-timedout")
 	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
@@ -1080,7 +1080,7 @@ func TestPluginSubstrate_EvictedWaiter(t *testing.T) {
 	}
 	ch := &fakeChannelResolver{resolved: false, err: dispatch.ErrUnknownRequestID}
 	binder := &fakeInstanceBinder{id: "iid-ev", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, ch)
 
 	ctx := ctxWithCallID("call-ps-evicted")
 	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
@@ -1123,7 +1123,7 @@ func TestPluginSubstrate_NilResolver(t *testing.T) {
 	}
 	// channels=nil
 	binder := &fakeInstanceBinder{id: "iid-nil", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	ctx := ctxWithCallID("call-ps-nil")
 	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
@@ -1166,7 +1166,7 @@ func TestPluginSubstrate_UnauthorizedInstance(t *testing.T) {
 		pluginPendingRequest: pendingRequest("iid-other", "pending"),
 	}
 	binder := &fakeInstanceBinder{id: "iid-caller", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	ctx := ctxWithCallID("call-ps-unauth")
 	_, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
@@ -1213,7 +1213,7 @@ func TestPluginSubstrate_FallThroughToFeedbackRequests(t *testing.T) {
 	}
 	pub := &fakePublisher{}
 	binder := &fakeInstanceBinder{id: "iid-ft", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, pub, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, pub, nil)
 
 	ctx := ctxWithCallID("call-ft")
 	resp, err := srv.WriteAuditStep(ctx, &hostv1.WriteAuditStepRequest{
@@ -1236,7 +1236,7 @@ func TestEmitMetric_ForcePrefix(t *testing.T) {
 	q := &fakeQuerier{
 		instance: db.PluginInstance{ID: "iid-prefix", PluginID: "plug-prefix"},
 	}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-prefix", ok: true}, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-prefix", ok: true}, &fakePublisher{}, nil)
 
 	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
 		Name:  "prefix_test_metric",
@@ -1251,7 +1251,7 @@ func TestEmitMetric_AutoInjectLabels(t *testing.T) {
 	q := &fakeQuerier{
 		instance: db.PluginInstance{ID: "inst-auto-label", PluginID: "plug-auto-label"},
 	}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "inst-auto-label", ok: true}, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "inst-auto-label", ok: true}, &fakePublisher{}, nil)
 
 	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
 		Name:  "auto_label_verify_metric",
@@ -1301,7 +1301,7 @@ func TestEmitMetric_RejectsInconsistentLabelKeys(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-incons", PluginID: "plug-incons"},
 	}
 	binder := &fakeInstanceBinder{id: "iid-incons", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	// First emission: registers the metric with label key "a".
 	_, err := srv.EmitMetric(context.Background(), &hostv1.EmitMetricRequest{
@@ -1356,7 +1356,7 @@ func TestEmitMetric_CardinalityCap(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-cap", PluginID: "plug-cap"},
 	}
 	binder := &fakeInstanceBinder{id: "iid-cap", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	// Emit 100 distinct values for label "env" — all must succeed.
 	for i := 0; i < 100; i++ {
@@ -1390,7 +1390,7 @@ func TestEmitMetric_CardinalityCap_Concurrent(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-conc", PluginID: "plug-conc"},
 	}
 	binder := &fakeInstanceBinder{id: "iid-conc", ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 
 	const total = 200
 	var successes, exhausted atomic.Int64
@@ -1513,7 +1513,7 @@ func TestEmitEvent_ForwardsToTriggerSink(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-sink", PluginID: "plug-sink"},
 	}
 	pub := &fakePublisher{}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-sink", ok: true}, pub, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-sink", ok: true}, pub, nil)
 
 	sink := &fakeTriggerSink{}
 	srv.SetTriggerSink(sink)
@@ -1581,7 +1581,7 @@ func TestServer_SetTriggerSink_LateBinding(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-late", PluginID: "plug-late"},
 	}
 	pub := &fakePublisher{}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-late", ok: true}, pub, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, &fakeInstanceBinder{id: "iid-late", ok: true}, pub, nil)
 
 	// First call before SetTriggerSink: SSE-only.
 	_, err := srv.EmitEvent(context.Background(), &hostv1.EmitEventRequest{
@@ -1870,7 +1870,7 @@ func TestNewServer_NilBinderPanics(t *testing.T) {
 	}()
 
 	q := &fakeQuerier{}
-	hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, nil, &fakePublisher{}, nil)
+	hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, nil, &fakePublisher{}, nil)
 }
 
 // ── test helpers: Tier-2 manifest snapshots ───────────────────────────────────
@@ -2382,7 +2382,7 @@ func TestEmitEvent_RateLimit_Integration(t *testing.T) {
 	sink := &fakeTriggerSink{}
 
 	binder := &fakeInstanceBinder{id: instanceID, ok: true}
-	srv := hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, pub, nil)
+	srv := hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, pub, nil)
 	srv.SetTriggerSink(sink)
 
 	const (

--- a/main.go
+++ b/main.go
@@ -240,6 +240,7 @@ func run(cfg config.Config) error {
 
 		hostSvc = hostsvc.NewServer(
 			store.Queries(),
+			store.DB(),
 			encryptionKey,
 			pluginPool,
 			hostsvc.NewContextBinder(),


### PR DESCRIPTION
## Summary

- Two concurrent `WriteAuditStep(feedback_response)` calls on the same `run_id` could both read the same `MAX(step_number)` and attempt to INSERT with the same `(run_id, step_number)`, causing a unique-constraint violation and corrupting the audit trail.
- Wraps `GetLatestRunStep` + `CreateRunStep` + `UpdateFeedbackRequestStatus` in a single `BEGIN…COMMIT` transaction in the native `feedback_requests` path of `WriteAuditStep`.
- Adds `*sql.DB` as the second parameter to `NewServer`; `nil` is accepted for unit tests using a fake `Querier` (falls back to the pre-fix non-transactional path, safe in single-threaded test contexts).

Fixes #348

## Test plan

- [ ] `go test -race ./internal/plugin/hostsvc/...` passes — includes new `TestWriteAuditStep_ConcurrentFeedbackStepsHaveUniqueStepNumbers` (8 goroutines, real SQLite DB, asserts all `step_number` values are unique)
- [ ] `go test -race ./internal/plugin/...` — all plugin sub-packages pass
- [ ] `go build ./...` — no compilation errors
- [ ] Existing `TestWriteAuditStep_*` and e2e integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)