### PR TITLE
refactor(plugin): collapse VerifyOutcome/VerifyResult to loader-canonical types

### DIFF
--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -115,7 +115,7 @@ func (l *Loader) StartWatcher(ctx context.Context, q *db.Queries, sqlDB *sql.DB,
 		return nil
 	}
 
-	l.installer = loader.NewInstaller(&verifierAdapter{v: l.verifier}, q, sqlDB, publisher, dir)
+	l.installer = loader.NewInstaller(l.verifier, q, sqlDB, publisher, dir)
 	// The watcher's callback type is func(context.Context, string) error, but
 	// Install now returns (string, error). The adapter discards the plugin ID —
 	// the watcher only needs to know whether install succeeded.
@@ -204,27 +204,3 @@ func (l *Loader) StartManager(ctx context.Context, cfg StartManagerConfig) error
 	return l.manager.StartAllActive(ctx)
 }
 
-// verifierAdapter bridges *Verifier (returns plugin.VerifyResult) to
-// loader.BundleVerifier (returns loader.VerifyResult). The explicit switch
-// insulates callers from any future iota reordering in either type.
-type verifierAdapter struct{ v *Verifier }
-
-func (a *verifierAdapter) VerifyBundle(bundleDir, binaryPath string) loader.VerifyResult {
-	r := a.v.VerifyBundle(bundleDir, binaryPath)
-
-	var outcome loader.VerifyOutcome
-	switch r.Outcome {
-	case OutcomeVerified:
-		outcome = loader.OutcomeVerified
-	case OutcomeUnsignedPermissive:
-		outcome = loader.OutcomeUnsignedPermissive
-	default: // OutcomeRejected or any future value
-		outcome = loader.OutcomeRejected
-	}
-
-	return loader.VerifyResult{
-		Outcome: outcome,
-		Pubkey:  r.Pubkey,
-		Err:     r.Err,
-	}
-}

--- a/internal/plugin/verify.go
+++ b/internal/plugin/verify.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/felag-engineering/gleipnir/internal/plugin/loader"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
 
@@ -18,50 +19,6 @@ import (
 // admin install and admin run* — a meaningful security property, but a
 // narrower one than a curated registry with an identity layer would
 // provide.
-
-// VerifyOutcome is the high-level result of verifying a plugin bundle.
-type VerifyOutcome int
-
-const (
-	// OutcomeVerified means the bundle was signed and the signature
-	// cryptographically validates against the embedded pubkey.
-	OutcomeVerified VerifyOutcome = iota
-
-	// OutcomeUnsignedPermissive means the bundle is missing a .minisig (or
-	// signing.pub) and the host is running with GLEIPNIR_ALLOW_UNSIGNED_PLUGINS
-	// set. The bundle is allowed to load, but every load emits a high-severity
-	// audit event and the instance health state is set to unsigned_permissive.
-	OutcomeUnsignedPermissive
-
-	// OutcomeRejected means verification failed. The caller MUST NOT load the
-	// bundle. The accompanying error explains why (bad signature, missing
-	// file in non-permissive mode, malformed key, etc.).
-	OutcomeRejected
-)
-
-func (o VerifyOutcome) String() string {
-	switch o {
-	case OutcomeVerified:
-		return "verified"
-	case OutcomeUnsignedPermissive:
-		return "unsigned_permissive"
-	case OutcomeRejected:
-		return "rejected"
-	default:
-		return fmt.Sprintf("unknown(%d)", int(o))
-	}
-}
-
-// VerifyResult is the structured outcome of a verification attempt.
-type VerifyResult struct {
-	Outcome VerifyOutcome
-	// Pubkey is the embedded signing.pub bytes (raw, parseable via
-	// signing.ParsePublicKey). Populated on Verified outcomes; empty on
-	// UnsignedPermissive (no key was supplied) and Rejected.
-	Pubkey []byte
-	// Err is non-nil on Rejected outcomes and explains the failure mode.
-	Err error
-}
 
 // Bundle layout convention (spec §5.1, §14.5):
 //
@@ -87,13 +44,15 @@ const (
 // Verifier verifies plugin bundles against their embedded Minisign signature.
 //
 // AllowUnsigned controls behaviour when a bundle has no .minisig or signing.pub:
-// when true, the verifier returns OutcomeUnsignedPermissive (caller is expected
-// to honour the warning surface in ADR-045 §6); when false, the verifier
-// returns OutcomeRejected.
+// when true, the verifier returns loader.OutcomeUnsignedPermissive (caller is
+// expected to honour the warning surface in ADR-045 §6); when false, the
+// verifier returns loader.OutcomeRejected.
 //
 // Bundles that DO carry a signature are verified strictly regardless of
 // AllowUnsigned — permissive mode never relaxes verification of signed
 // bundles. (ADR-045 §6, last bullet.)
+//
+// Verifier implements loader.BundleVerifier directly — no adapter required.
 type Verifier struct {
 	AllowUnsigned bool
 }
@@ -103,8 +62,8 @@ type Verifier struct {
 // path — both are supported), and returns the verification outcome.
 //
 // VerifyBundle never panics. Filesystem errors and parse errors all surface
-// as OutcomeRejected with a wrapped error.
-func (v *Verifier) VerifyBundle(bundleDir, binaryPath string) VerifyResult {
+// as loader.OutcomeRejected with a wrapped error.
+func (v *Verifier) VerifyBundle(bundleDir, binaryPath string) loader.VerifyResult {
 	manifestPath := filepath.Join(bundleDir, manifestFilename)
 	pubkeyPath := filepath.Join(bundleDir, pubkeyFilename)
 	sigPath, sigErr := findMinisig(bundleDir)
@@ -127,7 +86,7 @@ func (v *Verifier) VerifyBundle(bundleDir, binaryPath string) VerifyResult {
 	case missingPubkey && missingSig:
 		// Unsigned. Decide based on AllowUnsigned.
 		if v.AllowUnsigned {
-			return VerifyResult{Outcome: OutcomeUnsignedPermissive}
+			return loader.VerifyResult{Outcome: loader.OutcomeUnsignedPermissive}
 		}
 		return reject(errors.New("bundle is unsigned (no signing.pub or .minisig); set GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true to allow"))
 
@@ -163,7 +122,7 @@ func (v *Verifier) VerifyBundle(bundleDir, binaryPath string) VerifyResult {
 		return reject(fmt.Errorf("signature verification failed: %w", err))
 	}
 
-	return VerifyResult{Outcome: OutcomeVerified, Pubkey: pubkeyBytes}
+	return loader.VerifyResult{Outcome: loader.OutcomeVerified, Pubkey: pubkeyBytes}
 }
 
 // findMinisig looks for a single *.minisig file inside bundleDir. The plugin
@@ -184,6 +143,6 @@ func findMinisig(bundleDir string) (string, error) {
 	}
 }
 
-func reject(err error) VerifyResult {
-	return VerifyResult{Outcome: OutcomeRejected, Err: err}
+func reject(err error) loader.VerifyResult {
+	return loader.VerifyResult{Outcome: loader.OutcomeRejected, Err: err}
 }

--- a/internal/plugin/verify_test.go
+++ b/internal/plugin/verify_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/felag-engineering/gleipnir/internal/plugin/loader"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
 
@@ -62,8 +63,8 @@ func TestVerifier_Signed_Verifies(t *testing.T) {
 	v := &Verifier{}
 
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeVerified {
-		t.Fatalf("Outcome = %v (err=%v), want %v", got.Outcome, got.Err, OutcomeVerified)
+	if got.Outcome != loader.OutcomeVerified {
+		t.Fatalf("Outcome = %v (err=%v), want %v", got.Outcome, got.Err, loader.OutcomeVerified)
 	}
 	if len(got.Pubkey) == 0 {
 		t.Errorf("Pubkey: got empty, want signing.pub bytes")
@@ -79,8 +80,8 @@ func TestVerifier_MutatedBinary_Rejected(t *testing.T) {
 
 	v := &Verifier{}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 	if got.Err == nil {
 		t.Errorf("Err: got nil, want explanation")
@@ -96,8 +97,8 @@ func TestVerifier_MutatedManifest_Rejected(t *testing.T) {
 
 	v := &Verifier{}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 }
 
@@ -115,8 +116,8 @@ func TestVerifier_Unsigned_RejectedByDefault(t *testing.T) {
 
 	v := &Verifier{}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 }
 
@@ -133,8 +134,8 @@ func TestVerifier_Unsigned_AllowedInPermissiveMode(t *testing.T) {
 
 	v := &Verifier{AllowUnsigned: true}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeUnsignedPermissive {
-		t.Fatalf("Outcome = %v (err=%v), want %v", got.Outcome, got.Err, OutcomeUnsignedPermissive)
+	if got.Outcome != loader.OutcomeUnsignedPermissive {
+		t.Fatalf("Outcome = %v (err=%v), want %v", got.Outcome, got.Err, loader.OutcomeUnsignedPermissive)
 	}
 }
 
@@ -149,8 +150,8 @@ func TestVerifier_Permissive_DoesNotSkipVerificationOfSigned(t *testing.T) {
 
 	v := &Verifier{AllowUnsigned: true}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v (signed bundles must verify even in permissive mode)", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v (signed bundles must verify even in permissive mode)", got.Outcome, loader.OutcomeRejected)
 	}
 }
 
@@ -164,8 +165,8 @@ func TestVerifier_HalfSigned_OnlyPubkey_Rejected(t *testing.T) {
 
 	v := &Verifier{AllowUnsigned: true} // even permissive: half-signed is malformed
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 }
 
@@ -178,8 +179,8 @@ func TestVerifier_HalfSigned_OnlyMinisig_Rejected(t *testing.T) {
 
 	v := &Verifier{AllowUnsigned: true}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 }
 
@@ -192,8 +193,8 @@ func TestVerifier_MissingManifest_Rejected(t *testing.T) {
 
 	v := &Verifier{}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 }
 
@@ -207,8 +208,8 @@ func TestVerifier_TwoMinisigFiles_Rejected(t *testing.T) {
 
 	v := &Verifier{}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 }
 
@@ -225,7 +226,7 @@ func TestVerifier_SmokeAgainstSigningPackage(t *testing.T) {
 
 	v := &Verifier{}
 	got := v.VerifyBundle(bundleDir, binaryPath)
-	if got.Outcome != OutcomeVerified {
+	if got.Outcome != loader.OutcomeVerified {
 		t.Fatalf("verifier rejected fresh bundle: %v", got.Err)
 	}
 
@@ -266,8 +267,8 @@ func TestVerifier_MissingBinary_Rejected(t *testing.T) {
 
 	v := &Verifier{}
 	got := v.VerifyBundle(bundleDir, filepath.Join(bundleDir, "does-not-exist"))
-	if got.Outcome != OutcomeRejected {
-		t.Fatalf("Outcome = %v, want %v", got.Outcome, OutcomeRejected)
+	if got.Outcome != loader.OutcomeRejected {
+		t.Fatalf("Outcome = %v, want %v", got.Outcome, loader.OutcomeRejected)
 	}
 	if !errors.Is(got.Err, os.ErrNotExist) {
 		t.Errorf("Err = %v; want errors.Is(.., os.ErrNotExist) true", got.Err)


### PR DESCRIPTION
## Summary

- Removes the duplicate `VerifyOutcome` enum, `VerifyResult` struct, and their `String()` method from `internal/plugin/verify.go` (~40 LOC)
- Removes the `verifierAdapter` bridge type from `internal/plugin/loader.go` (~24 LOC)
- `Verifier.VerifyBundle` now returns `loader.VerifyResult` directly, satisfying `loader.BundleVerifier` structurally — Go interfaces are structural, so no import change is needed in `internal/plugin/loader`
- `verify_test.go` updated to reference `loader.OutcomeVerified`, `loader.OutcomeRejected`, `loader.OutcomeUnsignedPermissive`

Pure refactor — no functional change. The "mirrors internal/plugin.VerifyOutcome without creating an import cycle" comment in `install.go:26` is now obsolete (the types were always in loader; plugin was the one duplicating them).

Fixes #352

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/plugin/...` passes (all packages except `hostsvc` which has a pre-existing build failure unrelated to this PR — `metrics_test.go:26` wrong arg count for `NewServer`, present on `plugin-architecture` before this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)