### PR TITLE
refactor(plugin): consolidate nodeToJSON/canonicalSchemaBytes into schemautil

### DIFF
--- a/internal/plugin/configvalidate/configvalidate.go
+++ b/internal/plugin/configvalidate/configvalidate.go
@@ -13,15 +13,14 @@ package configvalidate
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/felag-engineering/gleipnir/internal/plugin/schemautil"
 	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/santhosh-tekuri/jsonschema/v6/kind"
-	"gopkg.in/yaml.v3"
 )
 
 // ErrNotChannelPlugin is returned by ForChannelAudience when the manifest does
@@ -54,7 +53,7 @@ func ForChannelAudience(m *sdkmanifest.Manifest) (*Validator, error) {
 	if m.Services.Channel == "" || len(m.Channels) == 0 {
 		return nil, ErrNotChannelPlugin
 	}
-	jsonBytes, err := nodeToJSON(m.Channels[0].ConfigSchema)
+	jsonBytes, err := schemautil.ToJSON(m.Channels[0].ConfigSchema)
 	if err != nil {
 		return nil, fmt.Errorf("configvalidate: marshal channel config_schema: %w", err)
 	}
@@ -64,7 +63,7 @@ func ForChannelAudience(m *sdkmanifest.Manifest) (*Validator, error) {
 // ForInstanceConfig returns a Validator for the per-instance config schema
 // declared in m.ConfigSchema.
 func ForInstanceConfig(m *sdkmanifest.Manifest) (*Validator, error) {
-	jsonBytes, err := nodeToJSON(m.ConfigSchema)
+	jsonBytes, err := schemautil.ToJSON(m.ConfigSchema)
 	if err != nil {
 		return nil, fmt.Errorf("configvalidate: marshal instance config_schema: %w", err)
 	}
@@ -75,7 +74,7 @@ func ForInstanceConfig(m *sdkmanifest.Manifest) (*Validator, error) {
 // scope schema declared in m.SubscriptionSchema. A nil SubscriptionSchema
 // produces a validator that accepts any object (empty schema).
 func ForSubscriptionScope(m *sdkmanifest.Manifest) (*Validator, error) {
-	jsonBytes, err := nodeToJSON(m.SubscriptionSchema)
+	jsonBytes, err := schemautil.ToJSON(m.SubscriptionSchema)
 	if err != nil {
 		return nil, fmt.Errorf("configvalidate: marshal subscription_schema: %w", err)
 	}
@@ -90,7 +89,7 @@ func ForTriggerBinding(m *sdkmanifest.Manifest, eventKind string) (*Validator, e
 		if decl.Kind != eventKind {
 			continue
 		}
-		jsonBytes, err := nodeToJSON(decl.BindingSchema)
+		jsonBytes, err := schemautil.ToJSON(decl.BindingSchema)
 		if err != nil {
 			return nil, fmt.Errorf("configvalidate: marshal binding_schema for %q: %w", eventKind, err)
 		}
@@ -251,28 +250,3 @@ func rfc6901Unescape(tok string) string {
 	return tok
 }
 
-// nodeToJSON converts a *yaml.Node to canonical JSON bytes suitable for
-// feeding to the jsonschema compiler. Returns an error when the node cannot be
-// marshalled.
-//
-// TODO: this mirrors canonicalSchemaBytes in internal/plugin/manifest/diff.go.
-// Consolidate into a shared helper when a third caller appears.
-func nodeToJSON(node *yaml.Node) ([]byte, error) {
-	if node == nil {
-		// nil schema → empty object schema (validates anything).
-		return []byte(`{}`), nil
-	}
-	raw, err := yaml.Marshal(node)
-	if err != nil {
-		return nil, fmt.Errorf("yaml marshal: %w", err)
-	}
-	var tree any
-	if err := yaml.Unmarshal(raw, &tree); err != nil {
-		return nil, fmt.Errorf("yaml unmarshal: %w", err)
-	}
-	out, err := json.Marshal(tree)
-	if err != nil {
-		return nil, fmt.Errorf("json marshal: %w", err)
-	}
-	return out, nil
-}

--- a/internal/plugin/manifest/diff.go
+++ b/internal/plugin/manifest/diff.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/felag-engineering/gleipnir/internal/plugin/schemautil"
 	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -272,13 +273,13 @@ func diffTools(old, new *sdkmanifest.Manifest) []Change {
 				To:       fmt.Sprintf("%v", newTool.ApprovalRequired),
 			})
 		}
-		oldIn := canonicalSchemaBytes(oldTool.InputSchema)
-		newIn := canonicalSchemaBytes(newTool.InputSchema)
+		oldIn := schemautil.ToJSONStripped(oldTool.InputSchema)
+		newIn := schemautil.ToJSONStripped(newTool.InputSchema)
 		if !bytes.Equal(oldIn, newIn) {
 			changes = append(changes, Change{Field: "tools." + name + ".input_schema", Material: true, From: string(oldIn), To: string(newIn)})
 		}
-		oldOut := canonicalSchemaBytes(oldTool.OutputSchema)
-		newOut := canonicalSchemaBytes(newTool.OutputSchema)
+		oldOut := schemautil.ToJSONStripped(oldTool.OutputSchema)
+		newOut := schemautil.ToJSONStripped(newTool.OutputSchema)
 		if !bytes.Equal(oldOut, newOut) {
 			changes = append(changes, Change{Field: "tools." + name + ".output_schema", Material: true, From: string(oldOut), To: string(newOut)})
 		}
@@ -299,8 +300,8 @@ func toolDeclMap(tools []sdkmanifest.ToolDecl) map[string]sdkmanifest.ToolDecl {
 
 // diffConfigSchema compares the instance config_schema after stripping cosmetic keys.
 func diffConfigSchema(old, new *sdkmanifest.Manifest) []Change {
-	oldBytes := canonicalSchemaBytes(old.ConfigSchema)
-	newBytes := canonicalSchemaBytes(new.ConfigSchema)
+	oldBytes := schemautil.ToJSONStripped(old.ConfigSchema)
+	newBytes := schemautil.ToJSONStripped(new.ConfigSchema)
 	if bytes.Equal(oldBytes, newBytes) {
 		return nil
 	}
@@ -312,8 +313,8 @@ func diffConfigSchema(old, new *sdkmanifest.Manifest) []Change {
 // scope JSON might no longer validate against the new schema (same reasoning as
 // config_schema).
 func diffSubscriptionSchema(old, new *sdkmanifest.Manifest) []Change {
-	oldBytes := canonicalSchemaBytes(old.SubscriptionSchema)
-	newBytes := canonicalSchemaBytes(new.SubscriptionSchema)
+	oldBytes := schemautil.ToJSONStripped(old.SubscriptionSchema)
+	newBytes := schemautil.ToJSONStripped(new.SubscriptionSchema)
 	if bytes.Equal(oldBytes, newBytes) {
 		return nil
 	}
@@ -343,13 +344,13 @@ func diffEventKinds(old, new *sdkmanifest.Manifest) []Change {
 		if !ok {
 			continue
 		}
-		oldBinding := canonicalSchemaBytes(oldEK.BindingSchema)
-		newBinding := canonicalSchemaBytes(newEK.BindingSchema)
+		oldBinding := schemautil.ToJSONStripped(oldEK.BindingSchema)
+		newBinding := schemautil.ToJSONStripped(newEK.BindingSchema)
 		if !bytes.Equal(oldBinding, newBinding) {
 			changes = append(changes, Change{Field: "event_kinds." + kind + ".binding_schema", Material: true, From: string(oldBinding), To: string(newBinding)})
 		}
-		oldPayload := canonicalSchemaBytes(oldEK.PayloadSchema)
-		newPayload := canonicalSchemaBytes(newEK.PayloadSchema)
+		oldPayload := schemautil.ToJSONStripped(oldEK.PayloadSchema)
+		newPayload := schemautil.ToJSONStripped(newEK.PayloadSchema)
 		if !bytes.Equal(oldPayload, newPayload) {
 			changes = append(changes, Change{Field: "event_kinds." + kind + ".payload_schema", Material: true, From: string(oldPayload), To: string(newPayload)})
 		}
@@ -368,60 +369,3 @@ func eventKindMap(kinds []sdkmanifest.EventKindDecl) map[string]sdkmanifest.Even
 	return m
 }
 
-// canonicalSchemaBytes produces a deterministic JSON byte representation of a
-// *yaml.Node JSON Schema suitable for material comparison. Two schemas are
-// materially equal if and only if their canonical bytes are equal.
-//
-// Strategy:
-//  1. nil node → nil (nil ↔ nil compares as equal, nil ↔ non-nil as different).
-//  2. YAML-marshal the node to bytes via yaml.v3.
-//  3. Unmarshal those bytes into map[string]any (generic tree).
-//  4. Recursively strip "description" and "default" keys at every depth; sort map keys.
-//  5. json.Marshal the cleaned tree — Go's json package emits map keys alphabetically.
-//
-// Errors in marshal/unmarshal are treated as an empty schema (nil return) so
-// a parse failure on one side always differs from a valid schema on the other.
-func canonicalSchemaBytes(node *yaml.Node) []byte {
-	if node == nil {
-		return nil
-	}
-	raw, err := yaml.Marshal(node)
-	if err != nil {
-		return nil
-	}
-	var tree any
-	if err := yaml.Unmarshal(raw, &tree); err != nil {
-		return nil
-	}
-	cleaned := stripCosmeticKeys(tree)
-	out, err := json.Marshal(cleaned)
-	if err != nil {
-		return nil
-	}
-	return out
-}
-
-// stripCosmeticKeys recursively removes "description" and "default" keys from
-// every map node in the tree. Map keys are sorted for determinism (json.Marshal
-// already sorts map[string]any keys, but we make it explicit).
-func stripCosmeticKeys(v any) any {
-	switch val := v.(type) {
-	case map[string]any:
-		out := make(map[string]any, len(val))
-		for k, child := range val {
-			if k == "description" || k == "default" {
-				continue
-			}
-			out[k] = stripCosmeticKeys(child)
-		}
-		return out
-	case []any:
-		out := make([]any, len(val))
-		for i, elem := range val {
-			out[i] = stripCosmeticKeys(elem)
-		}
-		return out
-	default:
-		return v
-	}
-}

--- a/internal/plugin/schemautil/schemautil.go
+++ b/internal/plugin/schemautil/schemautil.go
@@ -1,0 +1,93 @@
+// Package schemautil provides shared helpers for converting *yaml.Node JSON
+// Schema values to canonical JSON bytes. Two variants are offered:
+//
+//   - ToJSON: faithful round-trip for use with schema compilers.
+//   - ToJSONStripped: strips cosmetic keys (description, default) for
+//     material-change detection.
+package schemautil
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ToJSON converts a *yaml.Node to canonical JSON bytes suitable for feeding to
+// a JSON Schema compiler. A nil node is treated as an empty object schema
+// (validates anything). Returns an error when the node cannot be marshalled.
+func ToJSON(node *yaml.Node) ([]byte, error) {
+	if node == nil {
+		return []byte(`{}`), nil
+	}
+	raw, err := yaml.Marshal(node)
+	if err != nil {
+		return nil, fmt.Errorf("yaml marshal: %w", err)
+	}
+	var tree any
+	if err := yaml.Unmarshal(raw, &tree); err != nil {
+		return nil, fmt.Errorf("yaml unmarshal: %w", err)
+	}
+	out, err := json.Marshal(tree)
+	if err != nil {
+		return nil, fmt.Errorf("json marshal: %w", err)
+	}
+	return out, nil
+}
+
+// ToJSONStripped produces a deterministic JSON byte representation of a
+// *yaml.Node JSON Schema for material comparison. Two schemas are materially
+// equal if and only if their canonical bytes are equal.
+//
+// Strategy:
+//  1. nil node → nil (nil ↔ nil compares as equal, nil ↔ non-nil as different).
+//  2. YAML-marshal the node to bytes via yaml.v3.
+//  3. Unmarshal those bytes into map[string]any (generic tree).
+//  4. Recursively strip "description" and "default" keys at every depth.
+//  5. json.Marshal the cleaned tree — Go's json package emits map keys alphabetically.
+//
+// Errors in marshal/unmarshal are treated as an empty schema (nil return) so
+// a parse failure on one side always differs from a valid schema on the other.
+func ToJSONStripped(node *yaml.Node) []byte {
+	if node == nil {
+		return nil
+	}
+	raw, err := yaml.Marshal(node)
+	if err != nil {
+		return nil
+	}
+	var tree any
+	if err := yaml.Unmarshal(raw, &tree); err != nil {
+		return nil
+	}
+	cleaned := stripCosmeticKeys(tree)
+	out, err := json.Marshal(cleaned)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// stripCosmeticKeys recursively removes "description" and "default" keys from
+// every map node in the tree.
+func stripCosmeticKeys(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, child := range val {
+			if k == "description" || k == "default" {
+				continue
+			}
+			out[k] = stripCosmeticKeys(child)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = stripCosmeticKeys(elem)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/internal/plugin/schemautil/schemautil_test.go
+++ b/internal/plugin/schemautil/schemautil_test.go
@@ -1,0 +1,112 @@
+package schemautil_test
+
+import (
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/plugin/schemautil"
+	"gopkg.in/yaml.v3"
+)
+
+func parseNode(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return &doc
+}
+
+func TestToJSON_NilNode(t *testing.T) {
+	got, err := schemautil.ToJSON(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != `{}` {
+		t.Errorf("got %q, want {}", got)
+	}
+}
+
+func TestToJSON_Simple(t *testing.T) {
+	node := parseNode(t, `type: string`)
+	got, err := schemautil.ToJSON(node)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `{"type":"string"}`
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestToJSON_PreservesDescriptionAndDefault(t *testing.T) {
+	node := parseNode(t, "type: string\ndescription: A field\ndefault: hello")
+	got, err := schemautil.ToJSON(node)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// description and default must be present in the full round-trip.
+	for _, key := range []string{`"description"`, `"default"`} {
+		if !contains(string(got), key) {
+			t.Errorf("expected %s in ToJSON output %q", key, got)
+		}
+	}
+}
+
+func TestToJSONStripped_NilNode(t *testing.T) {
+	if got := schemautil.ToJSONStripped(nil); got != nil {
+		t.Errorf("expected nil for nil node, got %q", got)
+	}
+}
+
+func TestToJSONStripped_StripsDescriptionAndDefault(t *testing.T) {
+	node := parseNode(t, "type: string\ndescription: A field\ndefault: hello")
+	got := schemautil.ToJSONStripped(node)
+	if got == nil {
+		t.Fatal("unexpected nil result")
+	}
+	for _, key := range []string{`"description"`, `"default"`} {
+		if contains(string(got), key) {
+			t.Errorf("expected %s to be stripped from ToJSONStripped output %q", key, got)
+		}
+	}
+	if !contains(string(got), `"type"`) {
+		t.Errorf("expected type key to be present in %q", got)
+	}
+}
+
+func TestToJSONStripped_EqualSchemasMaterially(t *testing.T) {
+	a := parseNode(t, "type: object\nproperties:\n  x:\n    type: string\n    description: old desc\n    default: foo")
+	b := parseNode(t, "type: object\nproperties:\n  x:\n    type: string\n    description: new desc\n    default: bar")
+
+	aBytes := schemautil.ToJSONStripped(a)
+	bBytes := schemautil.ToJSONStripped(b)
+
+	if string(aBytes) != string(bBytes) {
+		t.Errorf("schemas with only cosmetic differences should be materially equal:\na=%q\nb=%q", aBytes, bBytes)
+	}
+}
+
+func TestToJSONStripped_DifferentSchemasMaterially(t *testing.T) {
+	a := parseNode(t, "type: string")
+	b := parseNode(t, "type: integer")
+
+	if string(schemautil.ToJSONStripped(a)) == string(schemautil.ToJSONStripped(b)) {
+		t.Error("schemas with different types should not be materially equal")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsHelper(s, sub))
+}
+
+func containsHelper(s, sub string) bool {
+	for i := range s {
+		if i+len(sub) <= len(s) && s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Creates `internal/plugin/schemautil` with `ToJSON` (faithful round-trip) and `ToJSONStripped` (strips cosmetic keys for material comparison)
- Updates `internal/plugin/configvalidate` and `internal/plugin/manifest/diff` to import the shared package
- Removes ~50 LOC of duplication and resolves the TODO at `configvalidate.go:258`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/plugin/schemautil/...` — new package tests cover nil input, simple schemas, cosmetic-key stripping, material equality, and material inequality
- [ ] `go test ./internal/plugin/configvalidate/...` and `./internal/plugin/manifest/...` pass unchanged

Fixes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)