### PR TITLE
fix(plugin): repair metrics_test NewServer arity

### DIFF
--- a/internal/plugin/hostsvc/metrics_test.go
+++ b/internal/plugin/hostsvc/metrics_test.go
@@ -23,7 +23,7 @@ func newMetricsServer(t *testing.T, pluginID, instanceID string) *hostsvc.Server
 		instance: db.PluginInstance{ID: instanceID, PluginID: pluginID},
 	}
 	binder := &fakeInstanceBinder{id: instanceID, ok: true}
-	return hostsvc.NewServer(q, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
+	return hostsvc.NewServer(q, nil, testEncryptionKey, &fakeResolver{}, binder, &fakePublisher{}, nil)
 }
 
 // TestEmitMetric_MetricNameCap verifies that a plugin instance may not register


### PR DESCRIPTION
## Summary
- #440 added a `*sql.DB` parameter to `hostsvc.NewServer`
- `metrics_test.go` (added in #439) wasn't updated when #440 merged
- Result: hostsvc test build broken on `plugin-architecture`, blocking #441/#442/#443

One-line fix: pass `nil` (the same convention #440 uses for the other test fakes).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/plugin/hostsvc/`