### PR TITLE
fix(hostsvc): harden Tier-2 RPC authorization edge cases

### DIFF
--- a/internal/plugin/hostsvc/handlers.go
+++ b/internal/plugin/hostsvc/handlers.go
@@ -743,15 +743,23 @@ type scopeProbe struct {
 // policyGrantsInstance reports whether the policy YAML blob grants at least one
 // tool whose name begins with "<instanceName>.". Used to verify that a
 // feedback_request's run belongs to a policy scoped to the calling instance.
+//
+// strings.Cut is used intentionally: an empty instanceName must not match
+// anything (the left segment of "foo" cut on "." is "foo", not ""), and an
+// instance named "foo" must not match tools intended for "foo.bar" via a shared
+// prefix (only the first dot-segment is compared).
 func policyGrantsInstance(policyYAML, instanceName string) bool {
+	if instanceName == "" {
+		return false
+	}
 	var probe scopeProbe
 	if err := yaml.Unmarshal([]byte(policyYAML), &probe); err != nil {
 		// Unparseable policy YAML → treat as no match (reject).
 		return false
 	}
-	prefix := instanceName + "."
 	for _, t := range probe.Capabilities.Tools {
-		if strings.HasPrefix(t.Tool, prefix) {
+		ns, _, ok := strings.Cut(t.Tool, ".")
+		if ok && ns == instanceName {
 			return true
 		}
 	}
@@ -769,7 +777,7 @@ func (s *Server) policyIDsForInstance(ctx context.Context, inst db.PluginInstanc
 		return nil, status.Errorf(codes.Internal, "list policies: %v", err)
 	}
 
-	prefix := inst.InstanceName + "."
+	instanceName := inst.InstanceName
 	var ids []string
 	for _, pol := range policies {
 		var probe scopeProbe
@@ -778,9 +786,13 @@ func (s *Server) policyIDsForInstance(ctx context.Context, inst db.PluginInstanc
 			continue
 		}
 
+		// Use strings.Cut to match only the first dot-segment, mirroring the
+		// fix in policyGrantsInstance: prevents empty-instance and prefix-overlap
+		// false positives.
 		matched := false
 		for _, t := range probe.Capabilities.Tools {
-			if strings.HasPrefix(t.Tool, prefix) {
+			ns, _, ok := strings.Cut(t.Tool, ".")
+			if ok && ns == instanceName {
 				matched = true
 				break
 			}
@@ -907,6 +919,13 @@ func (s *Server) UserDirectoryRead(ctx context.Context, req *hostv1.UserDirector
 	}
 
 	var entries []*hostv1.UserEntry
+
+	validRoles := map[string]bool{
+		"admin": true, "operator": true, "approver": true, "auditor": true,
+	}
+	if rf := req.GetRoleFilter(); rf != "" && !validRoles[rf] {
+		return nil, status.Errorf(codes.InvalidArgument, "unknown role %q", rf)
+	}
 
 	if req.GetRoleFilter() == "" {
 		rows, err := s.q.ListAllActiveUsersWithRoles(ctx)

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -2349,6 +2349,180 @@ func TestUserDirectoryRead_ManifestParseError(t *testing.T) {
 	}
 }
 
+// TestUserDirectoryRead_UnknownRole verifies that a non-empty role_filter value
+// that is not one of the four known Gleipnir roles is rejected with
+// InvalidArgument. This prevents plugins from probing for arbitrary role values
+// via the ListActiveUsersByRole query (issue #357).
+func TestUserDirectoryRead_UnknownRole(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		filter   string
+		wantCode codes.Code
+	}{
+		{"empty filter passes through", "", codes.OK},
+		{"admin is valid", "admin", codes.OK},
+		{"operator is valid", "operator", codes.OK},
+		{"approver is valid", "approver", codes.OK},
+		{"auditor is valid", "auditor", codes.OK},
+		{"unknown role rejected", "superuser", codes.InvalidArgument},
+		{"numeric role rejected", "123", codes.InvalidArgument},
+		{"injection attempt rejected", "admin'; DROP TABLE users; --", codes.InvalidArgument},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &fakeQuerier{
+				instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
+				plugin:   db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("user_directory_read")},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.UserDirectoryRead(context.Background(), &hostv1.UserDirectoryReadRequest{
+				RoleFilter: tc.filter,
+			})
+			if tc.wantCode == codes.OK {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+			st, ok := status.FromError(err)
+			if !ok || st.Code() != tc.wantCode {
+				t.Errorf("expected %v, got %v", tc.wantCode, err)
+			}
+		})
+	}
+}
+
+// TestPolicyGrantsInstanceEdgeCases verifies that policyGrantsInstance correctly
+// rejects empty instanceName and does not match prefix-overlapping instance names
+// (issue #357).
+//
+// policyGrantsInstance is unexported; it is exercised through WriteAuditStep's
+// scope check on the native feedback_response path. The querier is configured so
+// the plugin-substrate path falls through (sql.ErrNoRows on GetPluginPendingRequest)
+// and the test reaches the policyGrantsInstance guard.
+func TestPolicyGrantsInstanceEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	policyWithTools := func(tools ...string) string {
+		var sb strings.Builder
+		sb.WriteString("capabilities:\n  tools:\n")
+		for _, tool := range tools {
+			sb.WriteString("  - tool: " + tool + "\n")
+		}
+		return sb.String()
+	}
+
+	cases := []struct {
+		name         string
+		policyYAML   string
+		instanceName string
+		wantGranted  bool
+	}{
+		{
+			name:         "empty instanceName never matches",
+			policyYAML:   policyWithTools("foo.tool1"),
+			instanceName: "",
+			wantGranted:  false,
+		},
+		{
+			name:         "exact first segment matches",
+			policyYAML:   policyWithTools("foo.tool1"),
+			instanceName: "foo",
+			wantGranted:  true,
+		},
+		{
+			// "foo.bar" is a dotted instanceName; strings.Cut on "foo.bar.tool1"
+			// yields first segment "foo" ≠ "foo.bar", so the grant must be rejected.
+			// Old HasPrefix("foo.bar.tool1", "foo.bar.") would match; Cut fixes it.
+			name:         "dotted instanceName 'foo.bar' must not match tool 'foo.bar.tool1'",
+			policyYAML:   policyWithTools("foo.bar.tool1"),
+			instanceName: "foo.bar",
+			wantGranted:  false,
+		},
+		{
+			// instance "foo" correctly owns tool "foo.bar.tool1" (first segment = "foo").
+			name:         "instance 'foo' owns multi-part tool 'foo.bar.tool1'",
+			policyYAML:   policyWithTools("foo.bar.tool1"),
+			instanceName: "foo",
+			wantGranted:  true,
+		},
+		{
+			name:         "tool with no dot never matches any instance",
+			policyYAML:   policyWithTools("toolnodot"),
+			instanceName: "toolnodot",
+			wantGranted:  false,
+		},
+		{
+			name:         "empty policy YAML returns false",
+			policyYAML:   "",
+			instanceName: "foo",
+			wantGranted:  false,
+		},
+		{
+			name:         "unparseable YAML returns false",
+			policyYAML:   "{{not: valid: yaml:::",
+			instanceName: "foo",
+			wantGranted:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance: db.PluginInstance{
+					ID:           "iid-1",
+					PluginID:     "plug-1",
+					InstanceName: tc.instanceName,
+				},
+				// plugin-substrate path must fall through to native path.
+				pluginPendingRequestErr: sql.ErrNoRows,
+				// native path: feedback request is pending.
+				feedbackRequest: db.FeedbackRequest{
+					ID:     "req-1",
+					RunID:  "run-1",
+					Status: "pending",
+				},
+				run: db.Run{
+					ID:       "run-1",
+					PolicyID: "pol-1",
+					Status:   "running",
+				},
+				policy: db.Policy{
+					ID:   "pol-1",
+					Yaml: tc.policyYAML,
+				},
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.WriteAuditStep(context.Background(), &hostv1.WriteAuditStepRequest{
+				StepType:  "feedback_response",
+				RequestId: "req-1",
+			})
+			if tc.wantGranted {
+				// The scope check passed. Any subsequent error (e.g. writeFeedbackResponseStep
+				// needing a real DB) is fine — we only care the guard did not fire PermissionDenied.
+				if st, ok := status.FromError(err); ok && st.Code() == codes.PermissionDenied {
+					t.Errorf("expected scope check to pass, got PermissionDenied")
+				}
+			} else {
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != codes.PermissionDenied {
+					t.Errorf("expected PermissionDenied from scope check, got %v", err)
+				}
+			}
+		})
+	}
+}
+
 // --- tests: EmitEvent rate limiting ---
 
 // TestEmitEvent_RateLimit_Integration fires 250 EmitEvent calls against a Server


### PR DESCRIPTION
## Summary

- **`policyGrantsInstance` / `policyIDsForInstance` prefix check:** replaced `strings.HasPrefix(t.Tool, instanceName+".")` with an explicit empty-`instanceName` guard plus `strings.Cut` on the first dot-segment. This closes two holes: (1) an empty `instanceName` could produce prefix `"."` and match any dotted tool name; (2) a dotted `instanceName` (e.g. `"foo.bar"`) could match tools owned by a different first-segment instance `"foo"` because the old prefix `"foo.bar."` would be satisfied by `"foo.bar.tool"` — but `strings.Cut` on the tool yields `ns="foo"` ≠ `"foo.bar"`.
- **`UserDirectoryRead` role_filter validation:** unknown `role_filter` values now return `codes.InvalidArgument` immediately, preventing plugins from probing for arbitrary role names via the parameterised `ListActiveUsersByRole` query.

## Test plan

- Table-driven `TestPolicyGrantsInstanceEdgeCases`: covers empty instanceName, exact first-segment match, dotted instanceName blocked by Cut, multi-part tool owned by simple instance, no-dot tool, empty/unparseable YAML.
- Table-driven `TestUserDirectoryRead_UnknownRole`: covers all four valid roles pass through, unknown role rejected, numeric and injection-attempt strings rejected.
- All existing Tier-2 tests pass: `go test ./internal/plugin/hostsvc/...`.

Fixes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)