### PR TITLE
fix: error-handling improvements in plugin subsystem (#359)

### DIFF
--- a/internal/plugin/dispatch/channel.go
+++ b/internal/plugin/dispatch/channel.go
@@ -487,12 +487,18 @@ func (d *Dispatcher) Request(ctx context.Context, audienceID string, rc RouteCon
 		}
 
 		if d.cfg.WriteRunStep != nil {
-			_ = d.cfg.WriteRunStep(ctx, rc.RunID, "feedback_dispatch_error", map[string]interface{}{
+			if wErr := d.cfg.WriteRunStep(ctx, rc.RunID, "feedback_dispatch_error", map[string]interface{}{
 				"message":    preAckFailMsg,
 				"code":       "feedback_dispatch_error",
 				"instance":   firstTarget.instanceName,
 				"request_id": reqID,
-			})
+			}); wErr != nil {
+				slog.Warn("dispatch: failed to write feedback_dispatch_error audit step",
+					"run_id", rc.RunID,
+					"request_id", reqID,
+					"err", wErr,
+				)
+			}
 		}
 		return "", 0, fmt.Errorf("%w: %s", ErrPreAckFailed, preAckFailMsg)
 	}
@@ -584,10 +590,11 @@ func (d *Dispatcher) Wait(ctx context.Context, requestID string, timeout time.Du
 		if transErr := TransitionTimedOut(ctx, d.cfg.Queries, requestID); transErr != nil {
 			if errors.Is(transErr, ErrTransitionConflict) {
 				// Scanner already timed out this request and wrote the step.
+				// Return a typed sentinel so callers know not to write a second step.
 				slog.Debug("wait timer: transition conflict — scanner already timed out request",
 					"request_id", requestID,
 				)
-				return "", fmt.Errorf("plugin request timed out")
+				return "", ErrRequestAlreadyResolved
 			}
 			return "", fmt.Errorf("mark plugin request timed out: %w", transErr)
 		}
@@ -596,12 +603,18 @@ func (d *Dispatcher) Wait(ctx context.Context, requestID string, timeout time.Du
 		if d.cfg.WriteRunStep != nil {
 			req, dbErr := d.cfg.Queries.GetPluginPendingRequest(ctx, requestID)
 			if dbErr == nil {
-				_ = d.cfg.WriteRunStep(ctx, req.RunID, "plugin_request_timeout", map[string]interface{}{
+				if wErr := d.cfg.WriteRunStep(ctx, req.RunID, "plugin_request_timeout", map[string]interface{}{
 					"message":    fmt.Sprintf("plugin request timed out after %s", timeout),
 					"code":       "plugin_request_timeout",
 					"request_id": requestID,
 					"tool_name":  req.ToolName,
-				})
+				}); wErr != nil {
+					slog.Warn("dispatch: failed to write plugin_request_timeout audit step",
+						"run_id", req.RunID,
+						"request_id", requestID,
+						"err", wErr,
+					)
+				}
 			}
 		}
 		return "", fmt.Errorf("plugin request timed out")

--- a/internal/plugin/dispatch/channel_test.go
+++ b/internal/plugin/dispatch/channel_test.go
@@ -901,6 +901,12 @@ func TestWait_ScannerWon_NoRunStep(t *testing.T) {
 	if len(steps) != 0 {
 		t.Errorf("plugin_request_timeout steps = %d, want 0 (scanner already won)", len(steps))
 	}
+
+	// Scanner-won path must return the typed sentinel so callers can avoid
+	// writing a duplicate audit step.
+	if !errors.Is(waitErr, dispatch.ErrRequestAlreadyResolved) {
+		t.Errorf("Wait (scanner-won) error = %v, want errors.Is(err, dispatch.ErrRequestAlreadyResolved)", waitErr)
+	}
 }
 
 // ---- Routing outcome tests ----

--- a/internal/plugin/dispatch/errors.go
+++ b/internal/plugin/dispatch/errors.go
@@ -36,6 +36,12 @@ var ErrNoRequestCapableEntry = errors.New("plugin: no request-capable entry in a
 // Dispatcher instance, or it has already been resolved or expired.
 var ErrUnknownRequestID = errors.New("plugin: unknown request ID")
 
+// ErrRequestAlreadyResolved is returned by Dispatcher.Wait when its local
+// timer fired but the background scanner had already CAS-transitioned the
+// plugin_pending_requests row to timed_out. The scanner already wrote the
+// plugin_request_timeout audit step, so callers MUST NOT write a second one.
+var ErrRequestAlreadyResolved = errors.New("plugin: channel request already resolved by scanner")
+
 // ErrInstanceNotRunning is returned by a ConnFactory when no subprocess is
 // currently registered for the requested instance name. The host dispatcher
 // wraps this with the instance name before returning it to callers.

--- a/internal/plugin/hostsvc/handlers_feedback.go
+++ b/internal/plugin/hostsvc/handlers_feedback.go
@@ -140,6 +140,12 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 	// Look up the feedback request; reject late responses without mutating state.
 	fr, err := s.q.GetFeedbackRequest(ctx, requestID)
 	if err != nil {
+		// sql.ErrNoRows means neither substrate recognized this request_id — it was
+		// never issued or has already been purged. NotFound is more accurate than
+		// Internal and lets callers distinguish "bad ID" from "unexpected DB error".
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, status.Errorf(codes.NotFound, "unknown request_id %q", requestID)
+		}
 		return nil, status.Errorf(codes.Internal, "get feedback request: %v", err)
 	}
 	if fr.Status != "pending" {

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -623,10 +623,8 @@ func TestWriteAuditStep_NoCallID_CrossInstanceEscalation(t *testing.T) {
 
 // TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss verifies that when
 // neither the substrate (plugin_pending_requests) nor the native (feedback_requests)
-// row exists, the handler returns codes.Internal.
-//
-// TODO: spec §4.2 hints this should return feedback_response_late for a better
-// UX. Out of scope for this PR.
+// row exists, the handler returns codes.NotFound (not codes.Internal — the request_id
+// is simply unknown, which is a caller error, not a server error).
 func TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss(t *testing.T) {
 	t.Parallel()
 
@@ -642,8 +640,8 @@ func TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss(t *testing.T) {
 		RequestId: "req-unknown",
 	})
 	st, ok := status.FromError(err)
-	if !ok || st.Code() != codes.Internal {
-		t.Errorf("expected codes.Internal for unknown request_id, got %v", err)
+	if !ok || st.Code() != codes.NotFound {
+		t.Errorf("expected codes.NotFound for unknown request_id, got %v", err)
 	}
 }
 

--- a/internal/plugin/loader/watcher.go
+++ b/internal/plugin/loader/watcher.go
@@ -102,7 +102,11 @@ func (w *Watcher) Setup() (*fsnotify.Watcher, error) {
 // w.fire at startup, and a second call would stomp those fields while the first
 // call's AfterFunc callbacks are still reading them.
 func (w *Watcher) Run(ctx context.Context, fw *fsnotify.Watcher) error {
-	defer fw.Close()
+	defer func() {
+		if cerr := fw.Close(); cerr != nil {
+			w.logger.Debug("watcher: fsnotify close error", "dir", w.dir, "err", cerr)
+		}
+	}()
 
 	// fire receives absolute paths of tarballs that have settled (debounce expired).
 	// Buffer of 16 absorbs an initial sweep burst without blocking schedule callbacks.


### PR DESCRIPTION
Closes #359

## Summary
Four small, independent error-handling fixes in the plugin subsystem:

1. **gRPC code accuracy** — `GetFeedbackRequest` (hostsvc) now returns `codes.NotFound` instead of `codes.Internal` when a `request_id` has no row in either the plugin pending-requests table or the native `feedback_requests` table. Adds an explicit `errors.Is(err, sql.ErrNoRows)` branch.
2. **Swallowed audit errors** — two `_ = d.cfg.WriteRunStep(...)` calls in `dispatch/channel.go` now capture the error and `slog.Warn` with `run_id`/`request_id` (matching the package's existing convention).
3. **Typed sentinel** — `Dispatcher.Wait` returns a new `dispatch.ErrRequestAlreadyResolved` sentinel on the *scanner-won* path (local timer fired but the background scanner had already CAS-transitioned the row and written the timeout step). The CAS-winner path keeps the plain timeout error. Lets callers avoid double-writing an audit step; `errors.Is` matches through `%w` wrapping.
4. **Dropped Close() error** — the fsnotify watcher's `defer fw.Close()` now logs at debug on error instead of discarding it.

## Tests
- `hostsvc/server_test.go` — `TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss` now asserts `codes.NotFound`.
- `dispatch/channel_test.go` — `TestWait_ScannerWon_NoRunStep` now asserts `errors.Is(waitErr, dispatch.ErrRequestAlreadyResolved)`.

<details>
<summary>Architecture plan</summary>

Branched off `plugin-architecture`. handlers.go was split by #350, so the feedback handler now lives in `handlers_feedback.go`. Critical invariant verified in review: the sentinel is returned ONLY inside the `errors.Is(transErr, ErrTransitionConflict)` branch; the CAS-winner timeout return is unchanged. Adapter wiring to branch on the sentinel is downstream and out of scope. Plan adversarially reviewed (APPROVE).
</details>

Review cycles: 0 (approved first pass). CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.