### PR TITLE
refactor: concurrency hygiene in plugin/registry subsystems (#360)

### DIFF
--- a/internal/model/plugin_status.go
+++ b/internal/model/plugin_status.go
@@ -1,0 +1,18 @@
+package model
+
+// PluginStatus represents the review/lifecycle status of a plugin row.
+// Values mirror the DB CHECK constraint in sql_schemas.sql.
+type PluginStatus string
+
+const (
+	PluginStatusPendingReview PluginStatus = "pending_review"
+	// PluginStatusActive marks a plugin that has passed admin review and is
+	// eligible to run subprocesses.
+	//
+	// NOTE: internal/plugin/loader/install.go has an unexported duplicate
+	// constant (statusActive = "active"). Consolidating it to use this type
+	// is intentionally out of scope — loader is a lower layer that must not
+	// import internal/model.
+	PluginStatusActive  PluginStatus = "active"
+	PluginStatusRemoved PluginStatus = "removed"
+)

--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -170,14 +170,14 @@ func NewManager(cfg ManagerConfig) *Manager {
 // Start spawns a subprocess for the given plugin instance.
 //
 // It refuses to start if:
-//   - The plugin's status is not "active".
+//   - The plugin's status is not PluginStatusActive.
 //   - An instance with the same instance_id is already running.
 //   - The instance's current health state is in blockedHealthStates.
 //
 // On success the Instance is stored in the internal map. Callers should call
 // Stop or StopAll to terminate running instances.
 func (m *Manager) Start(ctx context.Context, plugin db.Plugin, instance db.PluginInstance, binaryPath string) error {
-	if plugin.Status != "active" {
+	if plugin.Status != string(model.PluginStatusActive) {
 		return fmt.Errorf("manager: plugin %s is not active (status=%s)", plugin.ID, plugin.Status)
 	}
 
@@ -448,7 +448,7 @@ func (m *Manager) StopAll(ctx context.Context) error {
 // returns nil regardless of per-instance errors, consistent with the
 // "best-effort bulk start" semantics at server startup.
 func (m *Manager) StartAllActive(ctx context.Context) error {
-	plugins, err := m.cfg.Querier.ListPluginsByStatus(ctx, "active")
+	plugins, err := m.cfg.Querier.ListPluginsByStatus(ctx, string(model.PluginStatusActive))
 	if err != nil {
 		return fmt.Errorf("manager: list active plugins: %w", err)
 	}

--- a/internal/plugin/process/process.go
+++ b/internal/plugin/process/process.go
@@ -286,10 +286,13 @@ func (i *Instance) Stop(ctx context.Context) error {
 	// Always revoke; identity.Revoke is idempotent.
 	defer i.cfg.IdentityIssuer.Revoke(i.token)
 
+	timer := time.NewTimer(i.cfg.StopGrace)
+	defer timer.Stop()
+
 	select {
 	case <-i.doneCh:
 		return nil
-	case <-time.After(i.cfg.StopGrace):
+	case <-timer.C:
 		return fmt.Errorf("plugin %s: did not exit within %s", i.cfg.InstanceID, i.cfg.StopGrace)
 	case <-ctx.Done():
 		return fmt.Errorf("plugin %s: stop cancelled: %w", i.cfg.InstanceID, ctx.Err())

--- a/internal/plugin/trigger/supervisor.go
+++ b/internal/plugin/trigger/supervisor.go
@@ -196,7 +196,7 @@ func NewSupervisor(cfg Config) *Supervisor {
 //
 //	go triggerSupervisor.StartAll(ctx)
 func (s *Supervisor) StartAll(ctx context.Context) error {
-	plugins, err := s.cfg.Querier.ListPluginsByStatus(ctx, "active")
+	plugins, err := s.cfg.Querier.ListPluginsByStatus(ctx, string(model.PluginStatusActive))
 	if err != nil {
 		return err
 	}

--- a/internal/toolregistry/registry.go
+++ b/internal/toolregistry/registry.go
@@ -10,7 +10,7 @@ import "sync"
 //   - MCP side: ReserveBulk on server creation / RefreshTools; ReleaseAllFor on deletion.
 //   - Plugin side: ReserveBulk on instance start; ReleaseAllFor on instance stop.
 type Registry struct {
-	mu     sync.Mutex
+	mu     sync.RWMutex
 	owners map[string]Source // dot-name → owning Source
 }
 
@@ -98,8 +98,8 @@ func (r *Registry) ReserveBulk(entries []Reservation) error {
 
 // Lookup returns the Source that currently owns dotName, and whether it exists.
 func (r *Registry) Lookup(dotName string) (Source, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 
 	src, ok := r.owners[dotName]
 	return src, ok
@@ -108,8 +108,8 @@ func (r *Registry) Lookup(dotName string) (Source, bool) {
 // Snapshot returns a shallow copy of the current ownership map. Intended for
 // use in tests to assert arbiter state without holding the lock.
 func (r *Registry) Snapshot() map[string]Source {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 
 	out := make(map[string]Source, len(r.owners))
 	for k, v := range r.owners {

--- a/internal/toolregistry/registry_test.go
+++ b/internal/toolregistry/registry_test.go
@@ -169,3 +169,44 @@ func TestConcurrent_Reserve_Race(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestConcurrent_ReadWrite_Race exercises concurrent Lookup and Snapshot
+// (RLock paths) racing against Reserve and Release (Lock paths) under the
+// race detector. No value assertions — this is purely a data-race exercise.
+func TestConcurrent_ReadWrite_Race(t *testing.T) {
+	const n = 32
+	r := toolregistry.New()
+	src := toolregistry.Source{Kind: toolregistry.KindMCP, Name: "srv"}
+
+	// Seed some initial entries so readers have something to observe.
+	for i := range n {
+		dotName := toolregistry.DotName("srv", "seed-"+string(rune('a'+i%26)))
+		_ = r.Reserve(dotName, src)
+	}
+
+	var wg sync.WaitGroup
+
+	// Writers: reserve then release unique names.
+	wg.Add(n)
+	for i := range n {
+		dotName := toolregistry.DotName("srv", "write-"+string(rune('a'+i%26)))
+		go func() {
+			defer wg.Done()
+			_ = r.Reserve(dotName, src)
+			r.Release(dotName, src)
+		}()
+	}
+
+	// Readers: Lookup and Snapshot run concurrently with the writes above.
+	wg.Add(n)
+	for i := range n {
+		dotName := toolregistry.DotName("srv", "seed-"+string(rune('a'+i%26)))
+		go func() {
+			defer wg.Done()
+			_, _ = r.Lookup(dotName)
+			_ = r.Snapshot()
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Closes #360

## Summary
Three independent concurrency-hygiene refactors. **No behavioural changes.**

1. **RWMutex on the hot-path registry** — `toolregistry.Registry.mu` is now a `sync.RWMutex`. The read-only methods `Lookup` and `Snapshot` (served on every plugin tool call) take `RLock`, so reads no longer serialize behind each other. The four mutating methods (`Reserve`, `Release`, `ReleaseAllFor`, `ReserveBulk`) keep the exclusive `Lock`.
2. **time.After → time.NewTimer** — `Instance.Stop`'s `select` used `time.After`, which holds the timer until it fires even when `doneCh` closes immediately. Switched to `time.NewTimer` + `defer timer.Stop()`, matching the canonical pattern elsewhere in the codebase. Returned error message is unchanged.
3. **Typed plugin status** — added `model.PluginStatus` (`pending_review`/`active`/`removed`, mirroring the DB CHECK constraint) and replaced raw `"active"` string comparisons in `process/manager.go` (2 sites) and `trigger/supervisor.go` (1 site) with `string(model.PluginStatusActive)`, so a rename is caught at compile time.

## Tests
- `registry_test.go` — added `TestConcurrent_ReadWrite_Race`, interleaving concurrent `Lookup`/`Snapshot` reads with `Reserve`/`Release` writes under `-race`.
- `go test -race`, `go vet ./...`, `go build ./...` all clean.

<details>
<summary>Architecture plan</summary>

Branched off `plugin-architecture`. Issue line numbers were stale and finding 3's premise was inaccurate — `model.PluginStatus` did not exist, so it was created in the canonical `internal/model` package (matching the `PluginHealthState` precedent) rather than reusing an unexported loader constant. Plan revised once after adversarial review surfaced a third `ListPluginsByStatus(ctx, "active")` call in `supervisor.go`. The existing unexported `statusActive` in `loader/install.go` is intentionally left for a future consolidation (noted via a comment).
</details>

Review cycles: 1 plan revision, 0 code-review cycles. CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.