### PR TITLE
perf: data-model cleanup for plugin manifests and run history (#362)

### DIFF
--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -82,8 +82,10 @@ type PluginQuerier interface {
 	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
 	// Audit write (used by AcceptNewKey to record the key rotation).
 	InsertPluginAuditEvent(ctx context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error)
-	// Audit read (used by AcceptManifest to find the pending candidate).
-	ListPluginAuditEventsByType(ctx context.Context, arg db.ListPluginAuditEventsByTypeParams) ([]db.PluginAuditEvent, error)
+	// Pending manifest read (used by AcceptManifest to retrieve the candidate).
+	GetPluginPendingManifest(ctx context.Context, pluginID string) (db.PluginPendingManifest, error)
+	// Pending manifest delete (best-effort cleanup after AcceptManifest commits).
+	DeletePluginPendingManifest(ctx context.Context, pluginID string) error
 	// Plugin manifest write (used by AcceptManifest to commit the candidate snapshot).
 	UpdatePluginManifest(ctx context.Context, arg db.UpdatePluginManifestParams) (int64, error)
 	// Instance subscription scope write (used by PutSubscriptionScope).
@@ -515,9 +517,9 @@ type acceptManifestResponse struct {
 }
 
 // AcceptManifest handles POST /api/v1/admin/plugins/{id}/accept-manifest.
-// It commits the candidate manifest (stored in the most recent
-// plugin_manifest_material_change audit event) as the new snapshot, then
-// transitions instances out of pending_manifest_approval.
+// It commits the candidate manifest (stored in the plugin_pending_manifests
+// table by handleManifestMaterialChange) as the new snapshot, then transitions
+// instances out of pending_manifest_approval.
 //
 // Instances with no newly-required config fields move to healthy.
 // Instances for which new required config fields appear move to pending_config_migration.
@@ -535,13 +537,7 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	candidatePayload, err := h.findCandidateManifestEvent(ctx, pluginID)
-	if err != nil {
-		writeCandidateError(w, err)
-		return
-	}
-
-	candidateBytes, newManifest, err := decodeCandidateManifest(candidatePayload)
+	pendingRow, candidateBytes, newManifest, err := h.loadPendingManifest(ctx, pluginID)
 	if err != nil {
 		writeCandidateError(w, err)
 		return
@@ -577,6 +573,14 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Best-effort: delete the pending-manifest row now that the candidate is committed.
+	// We do not fail the request on error because the snapshot is already in plugins.manifest_snapshot.
+	// A leftover row is harmless: the next material change will overwrite it via the upsert.
+	if delErr := h.q.DeletePluginPendingManifest(ctx, pluginID); delErr != nil {
+		slog.WarnContext(ctx, "accept-manifest: delete pending manifest row failed",
+			"plugin_id", pluginID, "err", delErr)
+	}
+
 	targetState := model.PluginHealthStateHealthy
 	if len(newlyRequired) > 0 {
 		targetState = model.PluginHealthStatePendingConfigMigration
@@ -595,11 +599,10 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 		pendingConfig = transitioned
 	}
 
-	oldVersion, _ := candidatePayload["old_version"].(string)
 	h.writeAuditEvent(ctx, auditManifestAccepted, "info", nowStr, map[string]any{
 		"plugin_id":                pluginID,
 		"name":                     plugin.Name,
-		"old_version":              oldVersion,
+		"old_version":              pendingRow.OldVersion,
 		"new_version":              newManifest.Version,
 		"instances_unblocked":      unblocked,
 		"instances_pending_config": pendingConfig,
@@ -635,65 +638,35 @@ func writeCandidateError(w http.ResponseWriter, err error) {
 	httputil.WriteError(w, http.StatusInternalServerError, err.Error(), "")
 }
 
-// findCandidateManifestEvent scans the most recent material-change audit events
-// for one matching pluginID. plugin_audit_events has no plugin_id column, so
-// filtering happens in Go.
-// TODO(v2): add a plugin-scoped query to avoid this in-Go filter on busy installs.
-func (h *PluginHandler) findCandidateManifestEvent(ctx context.Context, pluginID string) (map[string]any, error) {
-	events, err := h.q.ListPluginAuditEventsByType(ctx, db.ListPluginAuditEventsByTypeParams{
-		EventType: auditManifestMaterialChange,
-		Offset:    0,
-		Limit:     200,
-	})
+// loadPendingManifest retrieves the pending candidate manifest for pluginID from
+// the plugin_pending_manifests table. Returns the DB row, the raw manifest bytes,
+// and the parsed manifest. Maps sql.ErrNoRows to 409 (no pending change) so the
+// caller can surface the right status without re-checking the error type.
+func (h *PluginHandler) loadPendingManifest(ctx context.Context, pluginID string) (db.PluginPendingManifest, []byte, sdkmanifest.Manifest, error) {
+	row, err := h.q.GetPluginPendingManifest(ctx, pluginID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.PluginPendingManifest{}, nil, sdkmanifest.Manifest{}, &candidateLookupError{
+			status: http.StatusConflict,
+			msg:    "no pending manifest change found for this plugin",
+		}
+	}
 	if err != nil {
-		return nil, &candidateLookupError{
+		return db.PluginPendingManifest{}, nil, sdkmanifest.Manifest{}, &candidateLookupError{
 			status: http.StatusInternalServerError,
-			msg:    "failed to list audit events",
+			msg:    "failed to load pending manifest",
 		}
 	}
 
-	// Events are ordered DESC by created_at; first match for this plugin is newest.
-	for i := range events {
-		var payload map[string]any
-		if jsonErr := json.Unmarshal([]byte(events[i].PayloadJson), &payload); jsonErr != nil {
-			continue
-		}
-		if payload["plugin_id"] == pluginID {
-			return payload, nil
-		}
-	}
-	return nil, &candidateLookupError{
-		status: http.StatusConflict,
-		msg:    "no pending manifest change found for this plugin",
-	}
-}
-
-// decodeCandidateManifest extracts and parses the candidate manifest from the
-// audit event payload.
-func decodeCandidateManifest(payload map[string]any) ([]byte, sdkmanifest.Manifest, error) {
-	candidateB64, _ := payload["candidate_manifest_b64"].(string)
-	if candidateB64 == "" {
-		return nil, sdkmanifest.Manifest{}, &candidateLookupError{
-			status: http.StatusUnprocessableEntity,
-			msg:    "candidate manifest not found in audit event",
-		}
-	}
-	candidateBytes, err := base64.StdEncoding.DecodeString(candidateB64)
-	if err != nil {
-		return nil, sdkmanifest.Manifest{}, &candidateLookupError{
-			status: http.StatusUnprocessableEntity,
-			msg:    "candidate manifest: invalid base64",
-		}
-	}
+	candidateBytes := []byte(row.CandidateManifest)
 	var m sdkmanifest.Manifest
 	if parseErr := sdkmanifest.Unmarshal(candidateBytes, &m); parseErr != nil {
-		return nil, sdkmanifest.Manifest{}, &candidateLookupError{
+		return db.PluginPendingManifest{}, nil, sdkmanifest.Manifest{}, &candidateLookupError{
 			status: http.StatusUnprocessableEntity,
 			msg:    "candidate manifest: parse failed",
 			detail: parseErr.Error(),
 		}
 	}
-	return candidateBytes, m, nil
+	return row, candidateBytes, m, nil
 }
 
 // putSubscriptionScopeRequest is the JSON body for

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -29,10 +29,11 @@ import (
 
 // fakePluginQuerier is an in-memory PluginQuerier for tests.
 type fakePluginQuerier struct {
-	instances   map[string]db.PluginInstance
-	plugins     map[string]db.Plugin
-	auditEvents []db.PluginAuditEvent
-	policies    []db.Policy
+	instances       map[string]db.PluginInstance
+	plugins         map[string]db.Plugin
+	auditEvents     []db.PluginAuditEvent
+	pendingManifests map[string]db.PluginPendingManifest
+	policies        []db.Policy
 	// audienceEntries maps instance_id → list of audience entries for that instance.
 	audienceEntries map[string][]db.ListAudienceEntriesByInstanceRow
 	// casFailOn is the plugin ID that should return 0 rows for UpdatePluginTrustedPubkey
@@ -50,9 +51,22 @@ type fakePluginQuerier struct {
 
 func newFakePluginQuerier() *fakePluginQuerier {
 	return &fakePluginQuerier{
-		instances:       make(map[string]db.PluginInstance),
-		plugins:         make(map[string]db.Plugin),
-		audienceEntries: make(map[string][]db.ListAudienceEntriesByInstanceRow),
+		instances:        make(map[string]db.PluginInstance),
+		plugins:          make(map[string]db.Plugin),
+		pendingManifests: make(map[string]db.PluginPendingManifest),
+		audienceEntries:  make(map[string][]db.ListAudienceEntriesByInstanceRow),
+	}
+}
+
+// seedPendingManifest registers a pending manifest row for a plugin.
+func (f *fakePluginQuerier) seedPendingManifest(pluginID string, candidateYAML []byte, oldVersion, newVersion string) {
+	f.pendingManifests[pluginID] = db.PluginPendingManifest{
+		PluginID:          pluginID,
+		CandidateManifest: string(candidateYAML),
+		OldVersion:        oldVersion,
+		NewVersion:        newVersion,
+		CreatedAt:         "2026-05-05T00:00:00Z",
+		UpdatedAt:         "2026-05-05T00:00:00Z",
 	}
 }
 
@@ -131,18 +145,17 @@ func (f *fakePluginQuerier) InsertPluginAuditEvent(_ context.Context, arg db.Ins
 	return ev, nil
 }
 
-func (f *fakePluginQuerier) ListPluginAuditEventsByType(_ context.Context, arg db.ListPluginAuditEventsByTypeParams) ([]db.PluginAuditEvent, error) {
-	var result []db.PluginAuditEvent
-	for i := len(f.auditEvents) - 1; i >= 0; i-- {
-		ev := f.auditEvents[i]
-		if ev.EventType == arg.EventType {
-			result = append(result, ev)
-		}
-		if int64(len(result)) >= arg.Limit {
-			break
-		}
+func (f *fakePluginQuerier) GetPluginPendingManifest(_ context.Context, pluginID string) (db.PluginPendingManifest, error) {
+	row, ok := f.pendingManifests[pluginID]
+	if !ok {
+		return db.PluginPendingManifest{}, sql.ErrNoRows
 	}
-	return result, nil
+	return row, nil
+}
+
+func (f *fakePluginQuerier) DeletePluginPendingManifest(_ context.Context, pluginID string) error {
+	delete(f.pendingManifests, pluginID)
+	return nil
 }
 
 func (f *fakePluginQuerier) UpdatePluginInstanceSubscriptionScope(_ context.Context, arg db.UpdatePluginInstanceSubscriptionScopeParams) (int64, error) {
@@ -1027,26 +1040,6 @@ func withChiParams(r *http.Request, params map[string]string) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 }
 
-// candidateManifestAuditEvent builds a fake plugin_manifest_material_change audit
-// event payload containing the given candidate manifest bytes for the given plugin.
-func candidateManifestAuditEvent(pluginID string, candidateManifest []byte) db.PluginAuditEvent {
-	payload, _ := json.Marshal(map[string]any{
-		"plugin_id":                    pluginID,
-		"name":                         "test-plugin",
-		"old_version":                  "1.0.0",
-		"new_version":                  "2.0.0",
-		"material_fields":              []string{"services.tool"},
-		"cosmetic_fields":              []string{},
-		"candidate_manifest_b64":       base64.StdEncoding.EncodeToString(candidateManifest),
-		"newly_required_config_fields": []string{},
-	})
-	return db.PluginAuditEvent{
-		EventType:   "plugin_manifest_material_change",
-		Severity:    "high",
-		PayloadJson: string(payload),
-		CreatedAt:   "2026-05-05T00:00:00Z",
-	}
-}
 
 const (
 	// v1 manifest for accept-manifest tests.
@@ -1081,8 +1074,8 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 			HealthState: string(model.PluginHealthStatePendingManifestApproval),
 			Version:     0,
 		})
-		// Seed the audit event as if a material change was previously detected.
-		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-1", []byte(v2ManifestYAML)))
+		// Seed the pending manifest row as if a material change was previously detected.
+		q.seedPendingManifest("plugin-1", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 
 		h := NewPluginHandler(q, nil, fixedClock)
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/accept-manifest", bytes.NewBufferString(`{}`))
@@ -1136,7 +1129,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 			HealthState: string(model.PluginHealthStatePendingManifestApproval),
 			Version:     0,
 		})
-		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-2", []byte(v2ManifestWithRequiredField)))
+		q.seedPendingManifest("plugin-2", []byte(v2ManifestWithRequiredField), "1.0.0", "2.0.0")
 
 		h := NewPluginHandler(q, nil, fixedClock)
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-2/accept-manifest", bytes.NewBufferString(`{}`))
@@ -1204,7 +1197,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 			PluginVersion:    "1.0.0",
 			Version:          0,
 		})
-		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-4", []byte(v2ManifestYAML)))
+		q.seedPendingManifest("plugin-4", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 		q.casFailOn = "plugin-4" // trigger CAS miss on UpdatePluginManifest
 
 		h := NewPluginHandler(q, nil, fixedClock)
@@ -1228,7 +1221,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 			Status:           "pending_review",
 			Version:          1,
 		})
-		q.auditEvents = append(q.auditEvents, candidateManifestAuditEvent("plugin-5", []byte(v2ManifestYAML)))
+		q.seedPendingManifest("plugin-5", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 
 		h := NewPluginHandler(q, nil, fixedClock)
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-5/accept-manifest", bytes.NewBufferString(`{}`))
@@ -1258,6 +1251,103 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		wantActorID := "user-admin-1"
 		if found.ActorUserID == nil || *found.ActorUserID != wantActorID {
 			t.Errorf("actor_user_id = %v, want %q", found.ActorUserID, wantActorID)
+		}
+	})
+
+	// Verifies that a high volume of unrelated audit events for other plugins
+	// does not affect AcceptManifest — it now reads from plugin_pending_manifests
+	// (point-read by plugin_id) rather than scanning audit events.
+	t.Run("high audit volume for other plugins does not affect result", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-target",
+			Name:             "target-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			PluginVersion:    "1.0.0",
+			Status:           "pending_review",
+			Version:          1,
+		})
+		// Seed many audit events for OTHER plugins (would have buried the target under the old scan).
+		for i := range 300 {
+			ev := db.PluginAuditEvent{
+				EventType:   "plugin_manifest_material_change",
+				Severity:    "high",
+				PayloadJson: fmt.Sprintf(`{"plugin_id":"other-plugin-%d","candidate_manifest_b64":"..."}`, i),
+				CreatedAt:   "2026-05-01T00:00:00Z",
+			}
+			q.auditEvents = append(q.auditEvents, ev)
+		}
+		// Only the target plugin has a pending manifest row.
+		q.seedPendingManifest("plugin-target", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-target"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+		data := parseDataResponse(t, rec)
+		var resp acceptManifestResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.AcceptedManifestVersion != "2.0.0" {
+			t.Errorf("accepted_manifest_version = %q, want 2.0.0", resp.AcceptedManifestVersion)
+		}
+	})
+
+	t.Run("no pending row returns 409", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-nopending",
+			Name:             "no-pending-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			Version:          0,
+		})
+		// No pending manifest row seeded.
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-nopending"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusConflict {
+			t.Errorf("status = %d, want 409 when no pending row", rec.Code)
+		}
+	})
+
+	t.Run("accept then second accept returns 409", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-twiceaccept",
+			Name:             "twice-accept-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			PluginVersion:    "1.0.0",
+			Status:           "pending_review",
+			Version:          1,
+		})
+		q.seedPendingManifest("plugin-twiceaccept", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
+
+		h := NewPluginHandler(q, nil, fixedClock)
+		// First accept succeeds and deletes the pending row.
+		req1 := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
+		req1 = withChiParams(req1, map[string]string{"id": "plugin-twiceaccept"})
+		rec1 := httptest.NewRecorder()
+		h.AcceptManifest(rec1, req1)
+		if rec1.Code != http.StatusOK {
+			t.Fatalf("first accept: status = %d, want 200; body: %s", rec1.Code, rec1.Body.String())
+		}
+		// Second accept finds no pending row and must return 409.
+		req2 := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
+		req2 = withChiParams(req2, map[string]string{"id": "plugin-twiceaccept"})
+		rec2 := httptest.NewRecorder()
+		h.AcceptManifest(rec2, req2)
+		if rec2.Code != http.StatusConflict {
+			t.Errorf("second accept: status = %d, want 409 (row deleted after first accept)", rec2.Code)
 		}
 	})
 }

--- a/internal/db/migrations/0001_initial.sql
+++ b/internal/db/migrations/0001_initial.sql
@@ -428,6 +428,28 @@ CREATE INDEX idx_pae_instance_created ON plugin_audit_events(plugin_instance_id,
 CREATE INDEX idx_pae_event_created    ON plugin_audit_events(event_type, created_at);
 
 -- ---------------------------------------------------------------------------
+-- Plugin pending manifests
+--
+-- Holds the single pending candidate manifest per plugin while it awaits admin
+-- approval. PRIMARY KEY(plugin_id) enforces at-most-one pending candidate;
+-- ON DELETE CASCADE clears the row automatically when a plugin is uninstalled.
+-- Candidate bytes are stored raw (NOT base64) — they only lived in the audit
+-- event payload as base64 for JSON embedding; the table is the new source of
+-- truth. Accepted via POST /api/v1/admin/plugins/{id}/accept-manifest, after
+-- which the row is deleted best-effort (leftover rows self-correct on next
+-- material change via the ON CONFLICT DO UPDATE upsert).
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE plugin_pending_manifests (
+    plugin_id          TEXT PRIMARY KEY REFERENCES plugins(id) ON DELETE CASCADE,
+    candidate_manifest TEXT NOT NULL,   -- raw candidate manifest bytes (NOT base64)
+    old_version        TEXT NOT NULL,
+    new_version        TEXT NOT NULL,
+    created_at         TEXT NOT NULL,   -- ISO 8601 UTC
+    updated_at         TEXT NOT NULL    -- ISO 8601 UTC
+);
+
+-- ---------------------------------------------------------------------------
 -- Plugin audiences and pending requests
 -- ---------------------------------------------------------------------------
 

--- a/internal/db/migrations/0038_add_plugin_pending_manifests.go
+++ b/internal/db/migrations/0038_add_plugin_pending_manifests.go
@@ -1,0 +1,49 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+)
+
+// AddPluginPendingManifests creates the plugin_pending_manifests table on
+// existing deployments. New deployments get it from 0001_initial.sql; this
+// migration is a no-op for them (ShouldSkip detects the existing table).
+//
+// The table replaces the audit-event scan in findCandidateManifestEvent with
+// a single indexed point-read per plugin. See issue #362 for the full rationale.
+type AddPluginPendingManifests struct{}
+
+func (m *AddPluginPendingManifests) Version() int { return 28 }
+func (m *AddPluginPendingManifests) Name() string { return "add_plugin_pending_manifests" }
+
+func (m *AddPluginPendingManifests) ShouldSkip(ctx context.Context, db *sql.DB) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='plugin_pending_manifests'`,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check plugin_pending_manifests existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (m *AddPluginPendingManifests) Up(ctx context.Context, tx *sql.Tx) error {
+	ddl := `
+CREATE TABLE plugin_pending_manifests (
+    plugin_id          TEXT PRIMARY KEY REFERENCES plugins(id) ON DELETE CASCADE,
+    candidate_manifest TEXT NOT NULL,
+    old_version        TEXT NOT NULL,
+    new_version        TEXT NOT NULL,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+)`
+
+	if _, err := tx.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("create plugin_pending_manifests: %w", err)
+	}
+
+	slog.Info("migrated: created plugin_pending_manifests table")
+	return nil
+}

--- a/internal/db/migrations/registry.go
+++ b/internal/db/migrations/registry.go
@@ -31,5 +31,6 @@ func All() []Migration {
 		&AddPendingReauthorizeHealthState{},
 		&AddPluginBinaryPath{},
 		&AddInactiveHealthState{},
+		&AddPluginPendingManifests{},
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -133,6 +133,15 @@ type PluginOauthNonce struct {
 	CreatedAt  string `json:"created_at"`
 }
 
+type PluginPendingManifest struct {
+	PluginID          string `json:"plugin_id"`
+	CandidateManifest string `json:"candidate_manifest"`
+	OldVersion        string `json:"old_version"`
+	NewVersion        string `json:"new_version"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+}
+
 type PluginPendingRequest struct {
 	ID               string  `json:"id"`
 	PluginInstanceID string  `json:"plugin_instance_id"`

--- a/internal/db/plugins.sql.go
+++ b/internal/db/plugins.sql.go
@@ -142,6 +142,15 @@ func (q *Queries) DeletePluginInstance(ctx context.Context, id string) (int64, e
 	return result.RowsAffected()
 }
 
+const deletePluginPendingManifest = `-- name: DeletePluginPendingManifest :exec
+DELETE FROM plugin_pending_manifests WHERE plugin_id = ?1
+`
+
+func (q *Queries) DeletePluginPendingManifest(ctx context.Context, pluginID string) error {
+	_, err := q.db.ExecContext(ctx, deletePluginPendingManifest, pluginID)
+	return err
+}
+
 const getPluginByID = `-- name: GetPluginByID :one
 SELECT id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, binary_path, version, created_at, updated_at FROM plugins WHERE id = ?1
 `
@@ -269,6 +278,24 @@ func (q *Queries) GetPluginInstanceByName(ctx context.Context, arg GetPluginInst
 		&i.HealthDetail,
 		&i.LastOauthCallbackUrl,
 		&i.Version,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getPluginPendingManifest = `-- name: GetPluginPendingManifest :one
+SELECT plugin_id, candidate_manifest, old_version, new_version, created_at, updated_at FROM plugin_pending_manifests WHERE plugin_id = ?1
+`
+
+func (q *Queries) GetPluginPendingManifest(ctx context.Context, pluginID string) (PluginPendingManifest, error) {
+	row := q.db.QueryRowContext(ctx, getPluginPendingManifest, pluginID)
+	var i PluginPendingManifest
+	err := row.Scan(
+		&i.PluginID,
+		&i.CandidateManifest,
+		&i.OldVersion,
+		&i.NewVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -850,4 +877,39 @@ func (q *Queries) UpdatePluginTrustedPubkey(ctx context.Context, arg UpdatePlugi
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const upsertPluginPendingManifest = `-- name: UpsertPluginPendingManifest :exec
+INSERT INTO plugin_pending_manifests (plugin_id, candidate_manifest, old_version, new_version, created_at, updated_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+ON CONFLICT(plugin_id) DO UPDATE SET
+    candidate_manifest = excluded.candidate_manifest,
+    old_version        = excluded.old_version,
+    new_version        = excluded.new_version,
+    updated_at         = excluded.updated_at
+`
+
+type UpsertPluginPendingManifestParams struct {
+	PluginID          string `json:"plugin_id"`
+	CandidateManifest string `json:"candidate_manifest"`
+	OldVersion        string `json:"old_version"`
+	NewVersion        string `json:"new_version"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+}
+
+// UpsertPluginPendingManifest inserts or replaces the pending candidate manifest
+// for a plugin. ON CONFLICT(plugin_id) updates the candidate bytes and versions
+// so a second material change before the admin accepts simply overwrites the
+// previous candidate rather than accumulating rows.
+func (q *Queries) UpsertPluginPendingManifest(ctx context.Context, arg UpsertPluginPendingManifestParams) error {
+	_, err := q.db.ExecContext(ctx, upsertPluginPendingManifest,
+		arg.PluginID,
+		arg.CandidateManifest,
+		arg.OldVersion,
+		arg.NewVersion,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	return err
 }

--- a/internal/db/queries/plugins.sql
+++ b/internal/db/queries/plugins.sql
@@ -133,3 +133,22 @@ SELECT * FROM plugin_instances
 WHERE last_oauth_callback_url IS NOT NULL
   AND health_state IN ('healthy', 'unsigned_permissive', 'crashed', 'circuit_broken')
 ORDER BY plugin_id, instance_name;
+
+-- UpsertPluginPendingManifest inserts or replaces the pending candidate manifest
+-- for a plugin. ON CONFLICT(plugin_id) updates the candidate bytes and versions
+-- so a second material change before the admin accepts simply overwrites the
+-- previous candidate rather than accumulating rows.
+-- name: UpsertPluginPendingManifest :exec
+INSERT INTO plugin_pending_manifests (plugin_id, candidate_manifest, old_version, new_version, created_at, updated_at)
+VALUES (:plugin_id, :candidate_manifest, :old_version, :new_version, :created_at, :updated_at)
+ON CONFLICT(plugin_id) DO UPDATE SET
+    candidate_manifest = excluded.candidate_manifest,
+    old_version        = excluded.old_version,
+    new_version        = excluded.new_version,
+    updated_at         = excluded.updated_at;
+
+-- name: GetPluginPendingManifest :one
+SELECT * FROM plugin_pending_manifests WHERE plugin_id = :plugin_id;
+
+-- name: DeletePluginPendingManifest :exec
+DELETE FROM plugin_pending_manifests WHERE plugin_id = :plugin_id;

--- a/internal/db/queries/runs.sql
+++ b/internal/db/queries/runs.sql
@@ -131,14 +131,22 @@ WHERE created_at >= sqlc.arg('since')
 GROUP BY bucket, status, model
 ORDER BY bucket ASC;
 
--- ListRunsByPolicy returns runs for a single policy ordered newest-first, used
--- by the plugin host-service RunHistoryRead handler. The Go handler merges
--- per-policy result sets and truncates to the requested limit.
+-- ListRunsByPolicy returns runs for a single policy ordered newest-first.
+-- Kept for single-policy callers; the multi-policy host path uses ListRunsByPolicies.
 -- name: ListRunsByPolicy :many
 SELECT id, policy_id, status, started_at, completed_at, created_at FROM runs
 WHERE policy_id = sqlc.arg('policy_id')
 ORDER BY created_at DESC
 LIMIT sqlc.arg('limit');
+
+-- ListRunsByPolicies returns runs for a set of policies in a single query,
+-- ordered newest-first. Used by the plugin host-service RunHistoryRead handler
+-- to replace the previous N+1 per-policy query loop (issue #362). The caller
+-- guards against an empty slice to skip the roundtrip.
+-- name: ListRunsByPolicies :many
+SELECT id, policy_id, status, started_at, completed_at, created_at FROM runs
+WHERE policy_id IN (sqlc.slice('policy_ids'))
+ORDER BY created_at DESC LIMIT sqlc.arg('limit');
 
 -- ListAttentionItems returns pending approval requests and pending feedback
 -- requests joined with their parent runs and policies for the attention queue.

--- a/internal/db/runs.sql.go
+++ b/internal/db/runs.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"strings"
 )
 
 const countActiveRuns = `-- name: CountActiveRuns :one
@@ -658,6 +659,71 @@ func (q *Queries) ListRunsByDurationDesc(ctx context.Context, arg ListRunsByDura
 	return items, nil
 }
 
+const listRunsByPolicies = `-- name: ListRunsByPolicies :many
+SELECT id, policy_id, status, started_at, completed_at, created_at FROM runs
+WHERE policy_id IN (/*SLICE:policy_ids*/?)
+ORDER BY created_at DESC LIMIT ?2
+`
+
+type ListRunsByPoliciesParams struct {
+	PolicyIds []string `json:"policy_ids"`
+	Limit     int64    `json:"limit"`
+}
+
+type ListRunsByPoliciesRow struct {
+	ID          string  `json:"id"`
+	PolicyID    string  `json:"policy_id"`
+	Status      string  `json:"status"`
+	StartedAt   string  `json:"started_at"`
+	CompletedAt *string `json:"completed_at"`
+	CreatedAt   string  `json:"created_at"`
+}
+
+// ListRunsByPolicies returns runs for a set of policies in a single query,
+// ordered newest-first. Used by the plugin host-service RunHistoryRead handler
+// to replace the previous N+1 per-policy query loop (issue #362). The caller
+// guards against an empty slice to skip the roundtrip.
+func (q *Queries) ListRunsByPolicies(ctx context.Context, arg ListRunsByPoliciesParams) ([]ListRunsByPoliciesRow, error) {
+	query := listRunsByPolicies
+	var queryParams []interface{}
+	if len(arg.PolicyIds) > 0 {
+		for _, v := range arg.PolicyIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:policy_ids*/?", strings.Repeat(",?", len(arg.PolicyIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:policy_ids*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.Limit)
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRunsByPoliciesRow
+	for rows.Next() {
+		var i ListRunsByPoliciesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.PolicyID,
+			&i.Status,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunsByPolicy = `-- name: ListRunsByPolicy :many
 SELECT id, policy_id, status, started_at, completed_at, created_at FROM runs
 WHERE policy_id = ?1
@@ -679,9 +745,8 @@ type ListRunsByPolicyRow struct {
 	CreatedAt   string  `json:"created_at"`
 }
 
-// ListRunsByPolicy returns runs for a single policy ordered newest-first, used
-// by the plugin host-service RunHistoryRead handler. The Go handler merges
-// per-policy result sets and truncates to the requested limit.
+// ListRunsByPolicy returns runs for a single policy ordered newest-first.
+// Kept for single-policy callers; the multi-policy host path uses ListRunsByPolicies.
 func (q *Queries) ListRunsByPolicy(ctx context.Context, arg ListRunsByPolicyParams) ([]ListRunsByPolicyRow, error) {
 	rows, err := q.db.QueryContext(ctx, listRunsByPolicy, arg.PolicyID, arg.Limit)
 	if err != nil {

--- a/internal/plugin/hostsvc/feedback_audit_concurrency_test.go
+++ b/internal/plugin/hostsvc/feedback_audit_concurrency_test.go
@@ -268,6 +268,10 @@ func (f *fakeInstanceQuerier) ListRunsByPolicy(ctx context.Context, arg db.ListR
 	return f.q.ListRunsByPolicy(ctx, arg)
 }
 
+func (f *fakeInstanceQuerier) ListRunsByPolicies(ctx context.Context, arg db.ListRunsByPoliciesParams) ([]db.ListRunsByPoliciesRow, error) {
+	return f.q.ListRunsByPolicies(ctx, arg)
+}
+
 func (f *fakeInstanceQuerier) ListAllActiveUsersWithRoles(ctx context.Context) ([]db.ListAllActiveUsersWithRolesRow, error) {
 	return f.q.ListAllActiveUsersWithRoles(ctx)
 }

--- a/internal/plugin/hostsvc/handlers_tier2.go
+++ b/internal/plugin/hostsvc/handlers_tier2.go
@@ -2,7 +2,6 @@ package hostsvc
 
 import (
 	"context"
-	"sort"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -76,33 +75,24 @@ func (s *Server) RunHistoryRead(ctx context.Context, req *hostv1.RunHistoryReadR
 		limit = 100
 	}
 
-	// Fetch per-policy rows and merge them. Because each SQL call returns rows
-	// ordered by created_at DESC, we merge all slices and sort once at the end.
-	// Worst case: len(scopedIDs)*100 rows in memory before truncation.
-	var merged []db.ListRunsByPolicyRow
-	for _, policyID := range scopedIDs {
-		rows, err := s.q.ListRunsByPolicy(ctx, db.ListRunsByPolicyParams{
-			PolicyID: policyID,
-			Limit:    limit,
-		})
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "list runs for policy %s: %v", policyID, err)
-		}
-		merged = append(merged, rows...)
+	// Guard against empty scope: ListRunsByPolicies with zero IDs would hit
+	// IN (NULL) which is valid SQL but pointless; skip the DB roundtrip.
+	if len(scopedIDs) == 0 {
+		return &hostv1.RunHistoryReadResponse{Runs: nil}, nil
 	}
 
-	// Sort merged results by created_at DESC, matching the SQL ORDER BY.
-	// RFC3339 strings sort lexicographically so string comparison is correct.
-	sort.Slice(merged, func(i, j int) bool {
-		return merged[i].CreatedAt > merged[j].CreatedAt
+	// Single query across all scoped policies; ORDER BY created_at DESC LIMIT
+	// in SQL means no Go-side sort or truncation needed.
+	rows, err := s.q.ListRunsByPolicies(ctx, db.ListRunsByPoliciesParams{
+		PolicyIds: scopedIDs,
+		Limit:     limit,
 	})
-
-	if int64(len(merged)) > limit {
-		merged = merged[:limit]
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list runs: %v", err)
 	}
 
-	summaries := make([]*hostv1.RunSummary, 0, len(merged))
-	for _, r := range merged {
+	summaries := make([]*hostv1.RunSummary, 0, len(rows))
+	for _, r := range rows {
 		finishedAt := ""
 		if r.CompletedAt != nil {
 			finishedAt = *r.CompletedAt

--- a/internal/plugin/hostsvc/server.go
+++ b/internal/plugin/hostsvc/server.go
@@ -61,6 +61,7 @@ type Querier interface {
 	GetPluginByID(ctx context.Context, id string) (db.Plugin, error)
 	ListPolicies(ctx context.Context) ([]db.Policy, error)
 	ListRunsByPolicy(ctx context.Context, arg db.ListRunsByPolicyParams) ([]db.ListRunsByPolicyRow, error)
+	ListRunsByPolicies(ctx context.Context, arg db.ListRunsByPoliciesParams) ([]db.ListRunsByPoliciesRow, error)
 	ListAllActiveUsersWithRoles(ctx context.Context) ([]db.ListAllActiveUsersWithRolesRow, error)
 	ListActiveUsersByRole(ctx context.Context, role string) ([]db.ListActiveUsersByRoleRow, error)
 }

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -76,6 +76,11 @@ type fakeQuerier struct {
 	runsByPolicy    map[string][]db.ListRunsByPolicyRow
 	runsByPolicyErr error
 
+	// runsByPoliciesCalls counts ListRunsByPolicies invocations.
+	runsByPoliciesCalls int
+	runsByPoliciesRows  []db.ListRunsByPoliciesRow
+	runsByPoliciesErr   error
+
 	allUsersWithRoles    []db.ListAllActiveUsersWithRolesRow
 	allUsersWithRolesErr error
 
@@ -160,6 +165,21 @@ func (f *fakeQuerier) ListActiveUsersByRole(_ context.Context, _ string) ([]db.L
 
 func (f *fakeQuerier) GetPluginPendingRequest(_ context.Context, _ string) (db.PluginPendingRequest, error) {
 	return f.pluginPendingRequest, f.pluginPendingRequestErr
+}
+
+func (f *fakeQuerier) ListRunsByPolicies(_ context.Context, arg db.ListRunsByPoliciesParams) ([]db.ListRunsByPoliciesRow, error) {
+	f.mu.Lock()
+	f.runsByPoliciesCalls++
+	f.mu.Unlock()
+	if f.runsByPoliciesErr != nil {
+		return nil, f.runsByPoliciesErr
+	}
+	rows := f.runsByPoliciesRows
+	// Respect the SQL LIMIT.
+	if arg.Limit > 0 && int64(len(rows)) > arg.Limit {
+		rows = rows[:arg.Limit]
+	}
+	return rows, nil
 }
 
 // compile-time check
@@ -2000,10 +2020,8 @@ func TestRunHistoryRead_ScopedPolicyMatch(t *testing.T) {
 		policies: []db.Policy{
 			{ID: "pol-mine", Yaml: policyYAMLWithTool("myplugin.do_thing")},
 		},
-		runsByPolicy: map[string][]db.ListRunsByPolicyRow{
-			"pol-mine": {
-				{ID: "run-1", PolicyID: "pol-mine", Status: "complete", StartedAt: "2024-06-01T10:00:00Z", CompletedAt: &completedAt, CreatedAt: "2024-06-01T09:55:00Z"},
-			},
+		runsByPoliciesRows: []db.ListRunsByPoliciesRow{
+			{ID: "run-1", PolicyID: "pol-mine", Status: "complete", StartedAt: "2024-06-01T10:00:00Z", CompletedAt: &completedAt, CreatedAt: "2024-06-01T09:55:00Z"},
 		},
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
@@ -2030,9 +2048,9 @@ func TestRunHistoryRead_SubscribedScoping(t *testing.T) {
 	startedAt := "2024-06-01T10:00:00Z"
 	createdAt := "2024-06-01T09:55:00Z"
 
-	// makeRun produces a single ListRunsByPolicyRow for the given policy ID.
-	makeRun := func(runID, policyID string) db.ListRunsByPolicyRow {
-		return db.ListRunsByPolicyRow{
+	// makeRun produces a single ListRunsByPoliciesRow for the given policy ID.
+	makeRun := func(runID, policyID string) db.ListRunsByPoliciesRow {
+		return db.ListRunsByPoliciesRow{
 			ID:        runID,
 			PolicyID:  policyID,
 			Status:    "complete",
@@ -2083,15 +2101,18 @@ capabilities:
 			t.Parallel()
 
 			policyID := "pol-1"
+			// Only seed a run when the policy is expected to be in scope.
+			var policiesRows []db.ListRunsByPoliciesRow
+			if tc.wantRuns > 0 {
+				policiesRows = []db.ListRunsByPoliciesRow{makeRun("run-1", policyID)}
+			}
 			q := &fakeQuerier{
 				instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
 				plugin:   db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("run_history_read")},
 				policies: []db.Policy{
 					{ID: policyID, Yaml: tc.policyYAML},
 				},
-				runsByPolicy: map[string][]db.ListRunsByPolicyRow{
-					policyID: {makeRun("run-1", policyID)},
-				},
+				runsByPoliciesRows: policiesRows,
 			}
 			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
 
@@ -2115,8 +2136,8 @@ func TestRunHistoryRead_RequestedPolicyNotInScope(t *testing.T) {
 		policies: []db.Policy{
 			{ID: "pol-mine", Yaml: policyYAMLWithTool("myplugin.do_thing")},
 		},
-		runsByPolicy: map[string][]db.ListRunsByPolicyRow{
-			"pol-mine": {{ID: "run-1", PolicyID: "pol-mine", Status: "complete", StartedAt: "2024-06-01T00:00:00Z", CreatedAt: "2024-06-01T00:00:00Z"}},
+		runsByPoliciesRows: []db.ListRunsByPoliciesRow{
+			{ID: "run-1", PolicyID: "pol-mine", Status: "complete", StartedAt: "2024-06-01T00:00:00Z", CreatedAt: "2024-06-01T00:00:00Z"},
 		},
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
@@ -2137,9 +2158,9 @@ func TestRunHistoryRead_LimitClamping(t *testing.T) {
 	t.Parallel()
 
 	// Build 150 rows for the scoped policy.
-	rows := make([]db.ListRunsByPolicyRow, 150)
+	rows := make([]db.ListRunsByPoliciesRow, 150)
 	for i := range rows {
-		rows[i] = db.ListRunsByPolicyRow{
+		rows[i] = db.ListRunsByPoliciesRow{
 			ID:        fmt.Sprintf("run-%03d", i),
 			PolicyID:  "pol-mine",
 			Status:    "complete",
@@ -2152,9 +2173,7 @@ func TestRunHistoryRead_LimitClamping(t *testing.T) {
 		instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
 		plugin:   db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("run_history_read")},
 		policies: []db.Policy{{ID: "pol-mine", Yaml: policyYAMLWithTool("myplugin.do_thing")}},
-		runsByPolicy: map[string][]db.ListRunsByPolicyRow{
-			"pol-mine": rows,
-		},
+		runsByPoliciesRows: rows,
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
 
@@ -2189,7 +2208,7 @@ func TestRunHistoryRead_MergeOrderAcrossPolicies(t *testing.T) {
 	t.Parallel()
 
 	// Two policies with runs whose created_at order differs from started_at order.
-	// This verifies the merge sorts by created_at (not started_at).
+	// SQL ORDER BY created_at DESC returns the correct order in a single query.
 	//
 	// created_at order (newest-first): run-b1 > run-a2 > run-a1
 	// started_at order (newest-first): run-a2 > run-b1 > run-a1  (differs!)
@@ -2200,14 +2219,11 @@ func TestRunHistoryRead_MergeOrderAcrossPolicies(t *testing.T) {
 			{ID: "pol-a", Yaml: policyYAMLWithTool("myplugin.tool_a")},
 			{ID: "pol-b", Yaml: policyYAMLWithTool("myplugin.tool_b")},
 		},
-		runsByPolicy: map[string][]db.ListRunsByPolicyRow{
-			"pol-a": {
-				{ID: "run-a2", PolicyID: "pol-a", Status: "complete", StartedAt: "2024-06-03T00:00:00Z", CreatedAt: "2024-06-02T12:00:00Z"},
-				{ID: "run-a1", PolicyID: "pol-a", Status: "complete", StartedAt: "2024-06-01T00:00:00Z", CreatedAt: "2024-06-01T00:00:00Z"},
-			},
-			"pol-b": {
-				{ID: "run-b1", PolicyID: "pol-b", Status: "complete", StartedAt: "2024-06-02T00:00:00Z", CreatedAt: "2024-06-03T00:00:00Z"},
-			},
+		// SQL returns the merged result pre-sorted by created_at DESC.
+		runsByPoliciesRows: []db.ListRunsByPoliciesRow{
+			{ID: "run-b1", PolicyID: "pol-b", Status: "complete", StartedAt: "2024-06-02T00:00:00Z", CreatedAt: "2024-06-03T00:00:00Z"},
+			{ID: "run-a2", PolicyID: "pol-a", Status: "complete", StartedAt: "2024-06-03T00:00:00Z", CreatedAt: "2024-06-02T12:00:00Z"},
+			{ID: "run-a1", PolicyID: "pol-a", Status: "complete", StartedAt: "2024-06-01T00:00:00Z", CreatedAt: "2024-06-01T00:00:00Z"},
 		},
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
@@ -2220,12 +2236,69 @@ func TestRunHistoryRead_MergeOrderAcrossPolicies(t *testing.T) {
 		t.Fatalf("runs = %d, want 3", len(resp.GetRuns()))
 	}
 	// Expect order by created_at DESC: run-b1 (Jun 3), run-a2 (Jun 2 noon), run-a1 (Jun 1).
-	// If the merge sorted by started_at instead, the order would be run-a2, run-b1, run-a1 — wrong.
 	want := []string{"run-b1", "run-a2", "run-a1"}
 	for i, r := range resp.GetRuns() {
 		if r.GetRunId() != want[i] {
-			t.Errorf("runs[%d].run_id = %q, want %q (merge must sort by created_at, not started_at)", i, r.GetRunId(), want[i])
+			t.Errorf("runs[%d].run_id = %q, want %q (SQL sorts by created_at DESC)", i, r.GetRunId(), want[i])
 		}
+	}
+}
+
+// TestRunHistoryRead_SingleQueryForMultiPolicy asserts that RunHistoryRead issues
+// exactly one ListRunsByPolicies call regardless of how many policies are in scope,
+// replacing the old N+1 per-policy loop.
+func TestRunHistoryRead_SingleQueryForMultiPolicy(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
+		plugin:   db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("run_history_read")},
+		policies: []db.Policy{
+			{ID: "pol-a", Yaml: policyYAMLWithTool("myplugin.tool_a")},
+			{ID: "pol-b", Yaml: policyYAMLWithTool("myplugin.tool_b")},
+			{ID: "pol-c", Yaml: policyYAMLWithTool("myplugin.tool_c")},
+		},
+		runsByPoliciesRows: []db.ListRunsByPoliciesRow{
+			{ID: "run-1", PolicyID: "pol-a", Status: "complete", StartedAt: "2024-06-01T00:00:00Z", CreatedAt: "2024-06-01T00:00:00Z"},
+		},
+	}
+	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+	resp, err := srv.RunHistoryRead(context.Background(), &hostv1.RunHistoryReadRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetRuns()) != 1 {
+		t.Errorf("runs = %d, want 1", len(resp.GetRuns()))
+	}
+	// Exactly one DB call for three scoped policies — not three.
+	if q.runsByPoliciesCalls != 1 {
+		t.Errorf("ListRunsByPolicies calls = %d, want 1 (must not N+1)", q.runsByPoliciesCalls)
+	}
+}
+
+// TestRunHistoryRead_ZeroScopedPoliciesSkipsDB asserts that when no policies are
+// in scope the early-return fires before touching the database.
+func TestRunHistoryRead_ZeroScopedPoliciesSkipsDB(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
+		plugin:   db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("run_history_read")},
+		// No policies in the list — scopedIDs will be empty.
+		policies: []db.Policy{},
+	}
+	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+	resp, err := srv.RunHistoryRead(context.Background(), &hostv1.RunHistoryReadRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetRuns()) != 0 {
+		t.Errorf("runs = %d, want 0", len(resp.GetRuns()))
+	}
+	if q.runsByPoliciesCalls != 0 {
+		t.Errorf("ListRunsByPolicies calls = %d, want 0 (empty scope must skip DB)", q.runsByPoliciesCalls)
 	}
 }
 

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -498,8 +498,10 @@ func (in *Installer) handlePubkeyMismatch(ctx context.Context, existing db.Plugi
 
 // handleManifestMaterialChange blocks the manifest update and transitions all
 // eligible instances to pending_manifest_approval. The candidate manifest is
-// persisted in the audit-event payload (as base64) rather than the plugins row;
-// the running generation continues serving the existing snapshot until an admin
+// persisted in the plugin_pending_manifests table as an indexed point-read so
+// AcceptManifest can retrieve it directly without scanning the audit log; the
+// audit event is still written as the operator-visible signal of the change.
+// The running generation continues serving the existing snapshot until an admin
 // calls POST /api/v1/admin/plugins/{id}/accept-manifest.
 //
 // oldManifest is the already-parsed existing snapshot — passed in to avoid a
@@ -525,6 +527,23 @@ func (in *Installer) handleManifestMaterialChange(ctx context.Context, existing 
 	}); err != nil {
 		return "", fmt.Errorf("record manifest_material_change audit for %q: %w", existing.Name, err)
 	}
+
+	// Persist the candidate bytes directly so AcceptManifest can do a single
+	// indexed point-read instead of scanning the audit-event log. The bytes are
+	// stored raw (not base64) because base64 was only needed for the JSON payload.
+	// ON CONFLICT DO UPDATE means a second material change before accept simply
+	// overwrites the previous candidate.
+	if err := in.q.UpsertPluginPendingManifest(ctx, db.UpsertPluginPendingManifestParams{
+		PluginID:          existing.ID,
+		CandidateManifest: string(candidateBytes),
+		OldVersion:        existing.PluginVersion,
+		NewVersion:        m.Version,
+		CreatedAt:         nowStr,
+		UpdatedAt:         nowStr,
+	}); err != nil {
+		return "", fmt.Errorf("upsert pending manifest for %q: %w", existing.Name, err)
+	}
+
 	return existing.ID, nil
 }
 

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -1232,6 +1232,103 @@ func TestInstall_HotReload_MaterialChange_EmitsHighSeverityAuditEvent(t *testing
 	}
 }
 
+// TestInstall_HotReload_MaterialChange_UpsertsPendingManifest verifies that a
+// material manifest change writes a plugin_pending_manifests row with the raw
+// candidate bytes and the correct old/new versions.
+func TestInstall_HotReload_MaterialChange_UpsertsPendingManifest(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	v1Manifest := []byte("schema_version: v1\nname: pending-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "pending-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	v2Manifest := []byte("schema_version: v1\nname: pending-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath2 := buildSignedTarWithContent(t, "pending-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2 (material change): %v", err)
+	}
+
+	plugin, err := q.GetPluginByName(context.Background(), "pending-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+
+	row, err := q.GetPluginPendingManifest(context.Background(), plugin.ID)
+	if err != nil {
+		t.Fatalf("GetPluginPendingManifest: %v", err)
+	}
+	// Candidate bytes stored raw, not base64.
+	if string(v2Manifest) != row.CandidateManifest {
+		t.Errorf("candidate_manifest = %q, want raw v2 bytes", row.CandidateManifest)
+	}
+	if row.OldVersion != "1.0.0" {
+		t.Errorf("old_version = %q, want 1.0.0", row.OldVersion)
+	}
+	if row.NewVersion != "2.0.0" {
+		t.Errorf("new_version = %q, want 2.0.0", row.NewVersion)
+	}
+}
+
+// TestInstall_HotReload_MaterialChange_SecondChangeOverwritesPendingRow verifies
+// that a second material change overwrites the pending row via ON CONFLICT DO UPDATE
+// (upsert semantics) rather than inserting a second row.
+func TestInstall_HotReload_MaterialChange_SecondChangeOverwritesPendingRow(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	pk, sk, err := signing.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	pubkeyBytes := signing.MarshalPublicKey(pk, "test key")
+
+	v1Manifest := []byte("schema_version: v1\nname: overwrite-plugin\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath1 := buildSignedTarWithContent(t, "overwrite-plugin", v1Manifest, []byte("binary v1"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	// First material change (v1 → v2).
+	v2Manifest := []byte("schema_version: v1\nname: overwrite-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath2 := buildSignedTarWithContent(t, "overwrite-plugin", v2Manifest, []byte("binary v2"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v2: %v", err)
+	}
+
+	// Second material change (v1 → v3, reading existing.PluginVersion from the plugins row, not the pending-manifest row).
+	v3Manifest := []byte("schema_version: v1\nname: overwrite-plugin\nversion: 3.0.0\nservices:\n  tool: v3\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath3 := buildSignedTarWithContent(t, "overwrite-plugin", v3Manifest, []byte("binary v3"), pubkeyBytes, sk.SecretKey, sk.KeyID)
+	if _, err := inst.Install(context.Background(), tarPath3); err != nil {
+		t.Fatalf("Install v3: %v", err)
+	}
+
+	plugin, err := q.GetPluginByName(context.Background(), "overwrite-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+
+	// Only one pending row must exist — the second install overwrites the first.
+	row, err := q.GetPluginPendingManifest(context.Background(), plugin.ID)
+	if err != nil {
+		t.Fatalf("GetPluginPendingManifest after two changes: %v", err)
+	}
+	if row.NewVersion != "3.0.0" {
+		t.Errorf("new_version = %q, want 3.0.0 (second change must overwrite first)", row.NewVersion)
+	}
+	if string(v3Manifest) != row.CandidateManifest {
+		t.Errorf("candidate_manifest does not contain v3 bytes")
+	}
+}
+
 // TestInstall_HotReload_MaterialChange_NewlyRequiredConfigField_PayloadIncludesField
 // verifies that the audit event payload includes newly-required config fields when
 // the new manifest's config_schema gains a required property.

--- a/schemas/sql_schemas.sql
+++ b/schemas/sql_schemas.sql
@@ -459,6 +459,28 @@ CREATE INDEX idx_pae_instance_created ON plugin_audit_events(plugin_instance_id,
 CREATE INDEX idx_pae_event_created    ON plugin_audit_events(event_type, created_at);
 
 -- ---------------------------------------------------------------------------
+-- Plugin pending manifests
+--
+-- Holds the single pending candidate manifest per plugin while it awaits admin
+-- approval. PRIMARY KEY(plugin_id) enforces at-most-one pending candidate;
+-- ON DELETE CASCADE clears the row automatically when a plugin is uninstalled.
+-- Candidate bytes are stored raw (NOT base64) — they only lived in the audit
+-- event payload as base64 for JSON embedding; the table is the new source of
+-- truth. Accepted via POST /api/v1/admin/plugins/{id}/accept-manifest, after
+-- which the row is deleted best-effort (leftover rows self-correct on next
+-- material change via the ON CONFLICT DO UPDATE upsert).
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE plugin_pending_manifests (
+    plugin_id          TEXT PRIMARY KEY REFERENCES plugins(id) ON DELETE CASCADE,
+    candidate_manifest TEXT NOT NULL,   -- raw candidate manifest bytes (NOT base64)
+    old_version        TEXT NOT NULL,
+    new_version        TEXT NOT NULL,
+    created_at         TEXT NOT NULL,   -- ISO 8601 UTC
+    updated_at         TEXT NOT NULL    -- ISO 8601 UTC
+);
+
+-- ---------------------------------------------------------------------------
 -- Plugin audiences and pending requests (spec §6.1, §4.2, §11.5)
 --
 -- plugin_audiences — first-class shared resources. Each audience is a named


### PR DESCRIPTION
Closes #362

## Summary
Two scalability/correctness fixes in the plugin subsystem.

### Finding 1 — candidate manifest storage
`findCandidateManifestEvent` scanned up to 200 `plugin_manifest_material_change` audit events and filtered by `plugin_id` in Go (decoding each `payload_json`). With many pending changes — or >200 events in the window — it returned the wrong event or none (a 409 to a legitimate admin call). Because the audit log is append-only but the candidate is a **mutable singleton**, even adding a `plugin_id` index wouldn't fix re-serving a stale, already-accepted candidate.

**Fix:** a dedicated `plugin_pending_manifests` table keyed by `plugin_id` (PRIMARY KEY, `ON DELETE CASCADE`). The candidate is upserted on material change, point-read on accept, and deleted after a successful accept (best-effort — the snapshot commit already succeeded, and `UNIQUE` means the next change overwrites any leftover). The `plugin_manifest_material_change` audit event is still written as the operator-visible signal. Candidate bytes are stored raw (the base64 step existed only for JSON embedding).

### Finding 2 — N+1 in RunHistoryRead
`RunHistoryRead` issued one `ListRunsByPolicy` query per scoped policy. **Fix:** a single `ListRunsByPolicies` query using `sqlc.slice` (IN-list); `ORDER BY created_at DESC LIMIT` replaces the Go-side merge/sort/truncate. An empty policy scope short-circuits without a DB call. Result set is identical (top `limit` runs across scoped policies by `created_at`).

## DB changes
- New table `plugin_pending_manifests` in `0001_initial.sql` and `schemas/sql_schemas.sql` (identical DDL).
- Migration `0038_add_plugin_pending_manifests.go` (idempotent `ShouldSkip` probe), appended last in the registry.
- New sqlc queries; `internal/db/*.go` regenerated. `sqlc.slice` confirmed working on the pinned sqlc 1.30.0 sqlite engine; empty slice safely yields `IN (NULL)`.

## Tests
- AcceptManifest: high unrelated-audit-volume still returns the right candidate (proves the scan is gone); no pending row → 409; accept-then-second-accept → 409 (stale re-serve fixed).
- RunHistoryRead: exactly one DB call for a multi-policy instance; empty scope → no DB call.
- install: material change upserts a pending row with raw bytes + correct versions; a second change overwrites (not duplicates).

<details>
<summary>Architecture plan & review notes</summary>

Branched off `plugin-architecture`. Chose the dedicated-table option (b) over an audit-events `plugin_id` column (a), because the candidate is a mutable singleton mismatched with an append-only log. Plan adversarially reviewed → one revision (confirmed migration version 28, verified `sqlc.slice` empirically, enumerated all fake-querier updates incl. `feedback_audit_concurrency_test.go`). Code review requested changes once (two stale doc comments now corrected). ADR-002/003 respected: migration uses raw DDL (exempt); all runtime DB access through sqlc.
</details>

Review cycles: 1 plan revision, 1 code-review cycle. CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.