### PR TITLE
fix: loader sweep selects highest version per name + downgrade guard (#461)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.51.0
+	golang.org/x/mod v0.35.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0

--- a/internal/plugin/loader/extract.go
+++ b/internal/plugin/loader/extract.go
@@ -11,7 +11,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	manifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 )
+
+// maxTarballBytes caps cumulative uncompressed bytes extracted from a plugin
+// tarball. Defends against gzip-bomb payloads (spec §5.1 size guidance).
+const maxTarballBytes = 100 << 20 // 100 MiB
+
+// maxTarballFiles caps the number of entries (files + directories) extracted
+// from a plugin tarball. Defends against inode-exhaustion DoS where a small
+// tarball can encode millions of zero-byte entries that pass the byte cap.
+const maxTarballFiles = 10_000
 
 // ExtractTarball extracts a gzip-compressed tarball at tarPath into destDir.
 //
@@ -128,6 +139,100 @@ func fileMode(mode int64) os.FileMode {
 		return 0o755
 	}
 	return 0o644
+}
+
+// ReadManifestFromTarball peeks inside a .tar.gz and returns the parsed
+// manifest.Manifest without fully extracting the archive to disk. It reads
+// only the manifest.yaml entry from the tar stream, applying the same
+// maxTarballBytes / maxTarballFiles guards used by full extraction so a
+// gzip-bomb cannot stall the startup sweep.
+//
+// Two tarball layouts are supported (mirroring resolveBundleRoot in install.go):
+//   - Flat: manifest.yaml sits at the archive root.
+//   - Nested: every file lives under a single top-level directory; manifest.yaml
+//     is the only file named "manifest.yaml" under that prefix.
+//
+// Returns an error (never panics) when the archive is unreadable, has no
+// manifest.yaml within the caps, or the YAML cannot be parsed. The caller
+// (initial sweep) logs the error and skips the tarball.
+func ReadManifestFromTarball(tarPath string) (*manifest.Manifest, error) {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var totalBytes int64
+	var entryCount int
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar entry: %w", err)
+		}
+
+		entryCount++
+		if entryCount > maxTarballFiles {
+			return nil, fmt.Errorf("tarball exceeds %d-entry cap", maxTarballFiles)
+		}
+
+		// Apply the cumulative byte cap to non-manifest entries too so a
+		// gzip-bomb stuffed before manifest.yaml does not stall the sweep.
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		totalBytes += hdr.Size
+		if totalBytes > maxTarballBytes {
+			return nil, fmt.Errorf("tarball exceeds %d-byte uncompressed size cap", maxTarballBytes)
+		}
+
+		name := filepath.ToSlash(hdr.Name)
+		// Accept flat layout ("manifest.yaml") or single-top-level-dir layout
+		// ("slack-1.0.1/manifest.yaml"). The path must have at most one leading
+		// directory component and must end with "manifest.yaml".
+		parts := strings.SplitN(name, "/", 3)
+		isManifest := (len(parts) == 1 && parts[0] == "manifest.yaml") ||
+			(len(parts) == 2 && parts[1] == "manifest.yaml")
+		if !isManifest {
+			continue
+		}
+
+		// Read the manifest bytes from the tar stream (bounded by the remaining cap).
+		remaining := maxTarballBytes - totalBytes + hdr.Size // hdr.Size already counted above
+		lr := &io.LimitedReader{R: tr, N: remaining + 1}
+		data, readErr := io.ReadAll(lr)
+		if readErr != nil {
+			return nil, fmt.Errorf("read manifest.yaml: %w", readErr)
+		}
+		if lr.N == 0 {
+			return nil, fmt.Errorf("manifest.yaml exceeds size cap")
+		}
+
+		var m manifest.Manifest
+		if parseErr := manifest.Unmarshal(data, &m); parseErr != nil {
+			return nil, fmt.Errorf("parse manifest.yaml: %w", parseErr)
+		}
+		if m.Name == "" {
+			return nil, fmt.Errorf("manifest.name is required")
+		}
+		if m.Version == "" {
+			return nil, fmt.Errorf("manifest.version is required")
+		}
+		return &m, nil
+	}
+
+	return nil, fmt.Errorf("manifest.yaml not found in tarball")
 }
 
 // writeFile copies at most limitBytes from src into a new file at path.

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -65,15 +65,6 @@ type BundleVerifier interface {
 }
 
 const (
-	// maxTarballBytes caps cumulative uncompressed bytes extracted from a plugin
-	// tarball. Defends against gzip-bomb payloads (spec §5.1 size guidance).
-	maxTarballBytes = 100 << 20 // 100 MiB
-
-	// maxTarballFiles caps the number of entries (files + directories) extracted
-	// from a plugin tarball. Defends against inode-exhaustion DoS where a small
-	// tarball can encode millions of zero-byte entries that pass the byte cap.
-	maxTarballFiles = 10_000
-
 	// Plugin status values that mirror the DB CHECK constraint.
 	statusPendingReview = "pending_review"
 	statusActive        = "active"
@@ -85,6 +76,7 @@ const (
 	auditPubkeyMismatch         = "plugin_pubkey_mismatch"
 	auditManifestMaterialChange = "plugin_manifest_material_change"
 	auditManifestCosmeticChange = "plugin_manifest_cosmetic_change"
+	auditDowngradeRefused       = "plugin_downgrade_refused"
 
 	// Audit severity levels.
 	severityHigh = "high"
@@ -416,6 +408,31 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 			}
 		}
 		return existing.ID, false, existing.Status, nil
+	}
+
+	// Downgrade guard: refuse to install a lower semver over a higher installed version.
+	// Only enforced when both versions are valid semver; if either is non-semver
+	// (e.g. a hand-edited legacy version string) we fall through to the existing update
+	// path rather than blocking — version was historically cosmetic (manifest/diff.go)
+	// and we must not break pre-semver installs. The guard fires before the pubkey check
+	// so a lower-version tarball with a different key produces a downgrade-refused event
+	// rather than a pubkey-mismatch event (downgrade is the primary rejection reason).
+	if isValidSemver(m.Version) && isValidSemver(existing.PluginVersion) {
+		if compareVersions(m.Version, existing.PluginVersion) < 0 {
+			slog.WarnContext(ctx, "plugin downgrade refused",
+				"name", m.Name,
+				"installed_version", existing.PluginVersion,
+				"rejected_version", m.Version,
+			)
+			if err := in.recordAuditEvent(ctx, auditDowngradeRefused, severityHigh, nowStr, map[string]any{
+				"name":              m.Name,
+				"installed_version": existing.PluginVersion,
+				"rejected_version":  m.Version,
+			}); err != nil {
+				return "", false, "", fmt.Errorf("record downgrade_refused audit for %q: %w", m.Name, err)
+			}
+			return existing.ID, false, existing.Status, nil
+		}
 	}
 
 	// TOFU pubkey trust check: only applies to verified (signed) bundles.

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -2057,3 +2057,132 @@ func TestInstall_TmpDirUnderPluginsDir(t *testing.T) {
 		t.Errorf("binary_path = %q; want prefix %q (must be under pluginsDir, not /tmp)", *row.BinaryPath, pluginsDir)
 	}
 }
+
+// TestInstall_Downgrade_Refused verifies that installing a lower semver over a
+// higher installed version is rejected: the DB row stays at the higher version,
+// no binary is displaced, onInstalled is not called for the refused install,
+// and a plugin_downgrade_refused audit event with high severity is emitted.
+func TestInstall_Downgrade_Refused(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, true) // allowUnsigned to keep the test focused on version ordering
+
+	// Install 1.1 first (no callback registered yet, so we can baseline separately).
+	tarPath11 := unsignedPluginTarball(t, "downgrade-plugin", "1.1")
+	if _, err := inst.Install(context.Background(), tarPath11); err != nil {
+		t.Fatalf("Install 1.1: %v", err)
+	}
+
+	row11, err := q.GetPluginByName(context.Background(), "downgrade-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after 1.1: %v", err)
+	}
+	dbVersionAfterFirstInstall := row11.Version
+	savedBinaryPath := row11.BinaryPath
+
+	// Register the callback now — any call hereafter is from the downgrade attempt.
+	callCount := 0
+	inst.OnInstalled(func(_ context.Context, _ string) { callCount++ })
+
+	// Now attempt to install 1.0 — must be refused.
+	tarPath10 := unsignedPluginTarball(t, "downgrade-plugin", "1.0")
+	if _, err := inst.Install(context.Background(), tarPath10); err != nil {
+		t.Fatalf("Install 1.0 (downgrade attempt): unexpected error %v", err)
+	}
+
+	row10, err := q.GetPluginByName(context.Background(), "downgrade-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after downgrade attempt: %v", err)
+	}
+
+	// Plugin version must remain at 1.1.
+	if row10.PluginVersion != "1.1" {
+		t.Errorf("plugin_version = %q after downgrade attempt, want 1.1", row10.PluginVersion)
+	}
+	// DB row version counter must not have advanced (no update was issued).
+	if row10.Version != dbVersionAfterFirstInstall {
+		t.Errorf("db version counter = %d, want %d (no row update should have occurred)", row10.Version, dbVersionAfterFirstInstall)
+	}
+	// binary_path must be unchanged.
+	if savedBinaryPath != nil && row10.BinaryPath != nil && *row10.BinaryPath != *savedBinaryPath {
+		t.Errorf("binary_path changed after downgrade attempt: got %q, want %q", *row10.BinaryPath, *savedBinaryPath)
+	}
+
+	// onInstalled must not have fired for the refused downgrade.
+	if callCount != 0 {
+		t.Errorf("onInstalled called %d time(s) after a refused downgrade; want 0", callCount)
+	}
+
+	// A plugin_downgrade_refused audit event with high severity must exist.
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditDowngradeRefused,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list downgrade_refused events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected a plugin_downgrade_refused audit event, got none")
+	}
+	if events[0].Severity != "high" {
+		t.Errorf("audit severity = %q, want high", events[0].Severity)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(events[0].PayloadJson), &payload); err != nil {
+		t.Fatalf("parse downgrade_refused audit payload: %v", err)
+	}
+	if payload["name"] != "downgrade-plugin" {
+		t.Errorf("audit payload name = %q, want downgrade-plugin", payload["name"])
+	}
+	if payload["installed_version"] != "1.1" {
+		t.Errorf("audit payload installed_version = %q, want 1.1", payload["installed_version"])
+	}
+	if payload["rejected_version"] != "1.0" {
+		t.Errorf("audit payload rejected_version = %q, want 1.0", payload["rejected_version"])
+	}
+}
+
+// TestInstall_NonSemver_FallsThrough verifies that when either of the installed
+// or incoming version strings is not valid semver, the downgrade guard does not
+// fire and the install proceeds normally through the existing update path.
+// Version was historically cosmetic (manifest/diff.go), and we must not block
+// pre-semver or hand-edited version strings.
+func TestInstall_NonSemver_FallsThrough(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, true) // allowUnsigned for simplicity
+
+	// Install a non-semver version first.
+	tar1 := unsignedPluginTarball(t, "nonsemver-plugin", "hand-edited-v1")
+	if _, err := inst.Install(context.Background(), tar1); err != nil {
+		t.Fatalf("Install hand-edited-v1: %v", err)
+	}
+
+	// Install another non-semver version — guard must not block it.
+	tar2 := unsignedPluginTarball(t, "nonsemver-plugin", "hand-edited-v0")
+	if _, err := inst.Install(context.Background(), tar2); err != nil {
+		t.Fatalf("Install hand-edited-v0 (non-semver fallthrough): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "nonsemver-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+	// The second install must have gone through (no downgrade guard for non-semver).
+	if row.PluginVersion != "hand-edited-v0" {
+		t.Errorf("plugin_version = %q, want hand-edited-v0 (non-semver guard must fall through)", row.PluginVersion)
+	}
+
+	// No downgrade_refused events should have been emitted.
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditDowngradeRefused,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list downgrade_refused events: %v", err)
+	}
+	if len(events) > 0 {
+		t.Errorf("got %d downgrade_refused events for non-semver install, want 0", len(events))
+	}
+}

--- a/internal/plugin/loader/semver.go
+++ b/internal/plugin/loader/semver.go
@@ -1,0 +1,55 @@
+package loader
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// isValidSemver reports whether v is a valid semantic version string.
+// Manifest versions are bare (e.g. "1.9", "0.1.0"); we normalise by prepending
+// "v" because golang.org/x/mod/semver requires the leading "v" prefix.
+func isValidSemver(v string) bool {
+	return semver.IsValid(normSemver(v))
+}
+
+// compareVersions returns -1, 0, or +1 comparing version string a to b.
+// It implements a total order across both valid and invalid semver strings:
+//
+//  1. Both valid semver → semver.Compare (defeats the lexical trap where
+//     "1.10" < "1.9" under plain string comparison).
+//  2. Exactly one valid → the valid one is greater.
+//  3. Both invalid → strings.Compare on the original strings, giving a
+//     deterministic fallback for hand-renamed / non-semver tarballs.
+//
+// Step 3 uses the original (un-normalised) strings so the order is stable
+// across repeated sweeps even when semver.Compare would return 0 for two
+// different invalid inputs (which would break determinism).
+func compareVersions(a, b string) int {
+	aValid := isValidSemver(a)
+	bValid := isValidSemver(b)
+
+	switch {
+	case aValid && bValid:
+		return semver.Compare(normSemver(a), normSemver(b))
+	case aValid && !bValid:
+		return 1
+	case !aValid && bValid:
+		return -1
+	default:
+		// Both invalid: fall back to a simple lexical compare so the result is
+		// total and deterministic rather than the 0 that semver.Compare would
+		// return for two invalid strings.
+		return strings.Compare(a, b)
+	}
+}
+
+// normSemver prepends "v" if v does not already start with one, which is what
+// golang.org/x/mod/semver requires. Manifest versions are typically bare like
+// "1.9" or "0.1.0".
+func normSemver(v string) string {
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
+}

--- a/internal/plugin/loader/semver_test.go
+++ b/internal/plugin/loader/semver_test.go
@@ -1,0 +1,121 @@
+package loader
+
+import (
+	"testing"
+)
+
+func TestIsValidSemver(t *testing.T) {
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"1.0.0", true},
+		{"1.9", true},
+		{"1.10.0", true},
+		{"0.1.0-alpha", true},
+		{"v1.0.0", true},  // already has "v" prefix
+		{"", false},
+		{"not-semver", false},
+		{"1.9-final", false},
+		{"invalid-b", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.v, func(t *testing.T) {
+			got := isValidSemver(tc.v)
+			if got != tc.want {
+				t.Errorf("isValidSemver(%q) = %v, want %v", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		name    string
+		a, b    string
+		wantCmp int // sign: -1, 0, +1
+	}{
+		{
+			name:    "semver lexical trap: 1.9 < 1.10",
+			a:       "1.9",
+			b:       "1.10",
+			wantCmp: -1,
+		},
+		{
+			name:    "equal versions",
+			a:       "1.0.0",
+			b:       "1.0.0",
+			wantCmp: 0,
+		},
+		{
+			name:    "2.0.0 > 1.9.9",
+			a:       "2.0.0",
+			b:       "1.9.9",
+			wantCmp: 1,
+		},
+		{
+			name:    "valid beats invalid",
+			a:       "1.0.0",
+			b:       "not-a-semver",
+			wantCmp: 1,
+		},
+		{
+			name:    "invalid loses to valid",
+			a:       "not-a-semver",
+			b:       "1.0.0",
+			wantCmp: -1,
+		},
+		{
+			// Both invalid: result must be the strings.Compare result, NOT 0.
+			// A naive semver.Compare wrapper would return 0 for two invalid inputs
+			// which would break determinism in the sweep.
+			name:    "both invalid: strings.Compare fallback (b < a lexically)",
+			a:       "invalid-b",
+			b:       "invalid-a",
+			wantCmp: 1, // "invalid-b" > "invalid-a" lexicographically
+		},
+		{
+			name:    "both invalid: strings.Compare fallback (a < b lexically)",
+			a:       "invalid-a",
+			b:       "invalid-b",
+			wantCmp: -1,
+		},
+		{
+			name:    "both invalid equal strings",
+			a:       "hand-edited",
+			b:       "hand-edited",
+			wantCmp: 0,
+		},
+		{
+			name:    "v-prefixed vs bare: same version",
+			a:       "v1.2.3",
+			b:       "1.2.3",
+			wantCmp: 0,
+		},
+		{
+			name:    "1.0 < 1.1",
+			a:       "1.0",
+			b:       "1.1",
+			wantCmp: -1,
+		},
+	}
+
+	sign := func(n int) int {
+		if n < 0 {
+			return -1
+		}
+		if n > 0 {
+			return 1
+		}
+		return 0
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sign(compareVersions(tc.a, tc.b))
+			if got != tc.wantCmp {
+				t.Errorf("compareVersions(%q, %q) sign = %d, want %d", tc.a, tc.b, got, tc.wantCmp)
+			}
+		})
+	}
+}

--- a/internal/plugin/loader/watcher.go
+++ b/internal/plugin/loader/watcher.go
@@ -98,6 +98,12 @@ func (w *Watcher) Setup() (*fsnotify.Watcher, error) {
 // It takes the fsnotify.Watcher created by Setup, spawns the dispatch goroutine,
 // performs an initial sweep of any existing tarballs, then enters the event loop.
 //
+// Initial sweep: for each unique plugin name found in the drop directory, only
+// the highest-version tarball (by semver comparison) is scheduled. Unreadable
+// tarballs and lower-version duplicates are logged at Warn so operators can see
+// what the sweep chose and why. This makes the sweep deterministic regardless of
+// filename or os.ReadDir order.
+//
 // Run must not be called more than once on the same Watcher: it writes w.ctx and
 // w.fire at startup, and a second call would stomp those fields while the first
 // call's AfterFunc callbacks are still reading them.
@@ -140,17 +146,11 @@ func (w *Watcher) Run(ctx context.Context, fw *fsnotify.Watcher) error {
 		}
 	}()
 
-	// Initial sweep: enqueue tarballs already present before the watcher starts.
-	// The dispatch goroutine is already running so AfterFunc sends will be drained.
-	entries, err := os.ReadDir(w.dir)
-	if err != nil {
-		return fmt.Errorf("read plugins dir %q: %w", w.dir, err)
-	}
-	for _, e := range entries {
-		if !e.IsDir() && isTarball(e.Name()) {
-			abs := filepath.Join(w.dir, e.Name())
-			w.schedule(abs)
-		}
+	// Initial sweep: for each plugin name, select only the highest-version
+	// tarball so a cold start is deterministic regardless of filename order.
+	// The dispatch goroutine is already running so schedule() sends are drained.
+	if err := w.sweepDir(); err != nil {
+		return err
 	}
 
 	for {
@@ -231,4 +231,89 @@ func (w *Watcher) cancelAllTimers() {
 func isTarball(name string) bool {
 	lower := strings.ToLower(name)
 	return strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz")
+}
+
+// sweepCandidate holds the winning tarball path and version for one plugin name.
+type sweepCandidate struct {
+	path    string
+	version string
+}
+
+// sweepDir reads the drop directory, selects the highest-version tarball per
+// plugin name, and schedules only the winners. Unreadable tarballs are logged
+// at Warn and skipped; lower-version duplicates are also logged at Warn so
+// operators can see what was ignored and why.
+func (w *Watcher) sweepDir() error {
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		return fmt.Errorf("read plugins dir %q: %w", w.dir, err)
+	}
+
+	// winners maps plugin name → the current best candidate.
+	winners := make(map[string]sweepCandidate)
+
+	for _, e := range entries {
+		if e.IsDir() || !isTarball(e.Name()) {
+			continue
+		}
+		abs := filepath.Join(w.dir, e.Name())
+
+		m, peekErr := ReadManifestFromTarball(abs)
+		if peekErr != nil {
+			w.logger.Warn("plugin sweep: skipping unreadable tarball",
+				"path", abs, "err", peekErr)
+			continue
+		}
+
+		existing, seen := winners[m.Name]
+		if !seen {
+			winners[m.Name] = sweepCandidate{path: abs, version: m.Version}
+			continue
+		}
+
+		cmp := compareVersions(m.Version, existing.version)
+		switch {
+		case cmp > 0:
+			// Incoming is higher — demote the previous winner.
+			w.logger.Warn("plugin sweep: ignoring lower-version tarball",
+				"name", m.Name,
+				"version", existing.version,
+				"chosen_version", m.Version,
+				"path", existing.path,
+			)
+			winners[m.Name] = sweepCandidate{path: abs, version: m.Version}
+		case cmp == 0:
+			// Same version from a different file — keep the lexically-first path
+			// for stable determinism and log the duplicate.
+			if abs < existing.path {
+				w.logger.Warn("plugin sweep: ignoring duplicate-version tarball",
+					"name", m.Name,
+					"version", m.Version,
+					"chosen_path", abs,
+					"ignored_path", existing.path,
+				)
+				winners[m.Name] = sweepCandidate{path: abs, version: m.Version}
+			} else {
+				w.logger.Warn("plugin sweep: ignoring duplicate-version tarball",
+					"name", m.Name,
+					"version", m.Version,
+					"chosen_path", existing.path,
+					"ignored_path", abs,
+				)
+			}
+		default:
+			// Incoming is lower — keep current winner.
+			w.logger.Warn("plugin sweep: ignoring lower-version tarball",
+				"name", m.Name,
+				"version", m.Version,
+				"chosen_version", existing.version,
+				"path", abs,
+			)
+		}
+	}
+
+	for _, c := range winners {
+		w.schedule(c.path)
+	}
+	return nil
 }

--- a/internal/plugin/loader/watcher_test.go
+++ b/internal/plugin/loader/watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -94,11 +95,15 @@ func TestWatcher_DebouncesBurstWrites(t *testing.T) {
 func TestWatcher_InitialSweep(t *testing.T) {
 	dir := t.TempDir()
 
-	// Drop the tarball BEFORE the watcher starts.
+	// Drop a real tarball BEFORE the watcher starts. The sweep now calls
+	// ReadManifestFromTarball so garbage bytes no longer schedule anything —
+	// we need a parseable manifest.yaml inside the archive.
 	tarPath := filepath.Join(dir, "pre-existing.tar.gz")
-	if err := os.WriteFile(tarPath, []byte("content"), 0o644); err != nil {
-		t.Fatalf("write pre-existing tarball: %v", err)
-	}
+	manifestBytes := []byte("schema_version: v1\nname: pre-existing\nversion: 1.0.0\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: "pre-existing", content: []byte("fake binary"), mode: 0o755},
+	})
 
 	stub := &stubInstaller{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -280,4 +285,114 @@ func TestWatcher_RemoveCancelsPendingTimer(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+// makeManifestTarball writes a minimal (unsigned) tarball with the given
+// name and version into dir, returning the absolute path.
+func makeManifestTarball(t *testing.T, dir, filename, name, version string) string {
+	t.Helper()
+	manifestBytes := []byte("schema_version: v1\nname: " + name + "\nversion: " + version + "\nservices:\n  tool: v1\nauth:\n  mode: instance_credentials\n  strategy: none\n")
+	tarPath := filepath.Join(dir, filename)
+	writeTarball(t, tarPath, []tarEntry{
+		{name: "manifest.yaml", content: manifestBytes, mode: 0o644},
+		{name: name, content: []byte("fake binary for " + name), mode: 0o755},
+	})
+	return tarPath
+}
+
+// sweepPaths runs the watcher over a pre-populated directory and collects the
+// set of absolute paths that were scheduled for install. It cancels after the
+// debounce window has elapsed for all expected installs.
+func sweepPaths(t *testing.T, dir string, expectedCount int) []string {
+	t.Helper()
+	stub := &stubInstaller{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := NewWatcher(dir, stub.install, WithDebounce(testDebounce))
+	done := runWatcher(t, ctx, w)
+
+	// Wait long enough for all debounce timers to fire.
+	stub.waitForCount(expectedCount, testDebounce*20)
+
+	cancel()
+	<-done
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	return append([]string(nil), stub.calls...)
+}
+
+// TestWatcher_Sweep_TwoVersions verifies that when two tarballs for the same
+// plugin name are present, only the higher version is scheduled.
+func TestWatcher_Sweep_TwoVersions(t *testing.T) {
+	dir := t.TempDir()
+	makeManifestTarball(t, dir, "myplugin-1.0.tar.gz", "myplugin", "1.0")
+	makeManifestTarball(t, dir, "myplugin-1.1.tar.gz", "myplugin", "1.1")
+
+	paths := sweepPaths(t, dir, 1)
+	if len(paths) != 1 {
+		t.Fatalf("sweep scheduled %d tarballs, want 1", len(paths))
+	}
+	if !strings.Contains(paths[0], "1.1") {
+		t.Errorf("sweep scheduled %q; want the 1.1 tarball", paths[0])
+	}
+}
+
+// TestWatcher_Sweep_SemverLexicalTrap verifies that 1.10 beats 1.9 even though
+// "1.10" < "1.9" under plain lexical ordering.
+func TestWatcher_Sweep_SemverLexicalTrap(t *testing.T) {
+	dir := t.TempDir()
+	makeManifestTarball(t, dir, "slack-1.9.tar.gz", "slack", "1.9")
+	makeManifestTarball(t, dir, "slack-1.10.tar.gz", "slack", "1.10")
+
+	paths := sweepPaths(t, dir, 1)
+	if len(paths) != 1 {
+		t.Fatalf("sweep scheduled %d tarballs, want 1", len(paths))
+	}
+	if !strings.Contains(paths[0], "1.10") {
+		t.Errorf("sweep scheduled %q; want the 1.10 tarball (semver ordering, not lexical)", paths[0])
+	}
+}
+
+// TestWatcher_Sweep_FilenameOrderIndependence verifies that the sweep picks the
+// highest version regardless of which filename sorts first under os.ReadDir.
+// Here "slack-1.10.tar.gz" < "slack-1.9.tar.gz" lexically, so without version
+// selection the last-processed file would be the wrong choice.
+func TestWatcher_Sweep_FilenameOrderIndependence(t *testing.T) {
+	dir := t.TempDir()
+	// Filenames sort as: "slack-1.10.tar.gz" < "slack-1.9.tar.gz" alphabetically.
+	// Without version selection the sweep would install 1.9 last, overwriting 1.10.
+	makeManifestTarball(t, dir, "slack-1.10.tar.gz", "slack", "1.10")
+	makeManifestTarball(t, dir, "slack-1.9.tar.gz", "slack", "1.9")
+
+	paths := sweepPaths(t, dir, 1)
+	if len(paths) != 1 {
+		t.Fatalf("sweep scheduled %d tarballs, want 1", len(paths))
+	}
+	if !strings.Contains(paths[0], "1.10") {
+		t.Errorf("sweep scheduled %q; want the 1.10 tarball (filename order must not matter)", paths[0])
+	}
+}
+
+// TestWatcher_Sweep_GarbageSkipped verifies that an unreadable (garbage) tarball
+// alongside a valid one does not abort the sweep: the valid tarball is scheduled
+// and the garbage file is skipped.
+func TestWatcher_Sweep_GarbageSkipped(t *testing.T) {
+	dir := t.TempDir()
+	makeManifestTarball(t, dir, "valid-1.0.tar.gz", "valid", "1.0")
+
+	// Write garbage bytes that will fail gzip decoding.
+	garbagePath := filepath.Join(dir, "garbage.tar.gz")
+	if err := os.WriteFile(garbagePath, []byte("not a tarball"), 0o644); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+
+	paths := sweepPaths(t, dir, 1)
+	if len(paths) != 1 {
+		t.Fatalf("sweep scheduled %d tarballs, want 1 (garbage should be skipped)", len(paths))
+	}
+	if !strings.Contains(paths[0], "valid") {
+		t.Errorf("sweep scheduled %q; want the valid tarball", paths[0])
+	}
 }


### PR DESCRIPTION
Closes #461

## Summary

The plugin loader's startup directory sweep could silently **downgrade** a plugin on restart, because (1) the initial sweep installed tarballs in `os.ReadDir` (lexical filename) order with last-write-wins, (2) `manifest.version` is cosmetic so nothing rejected a lower version, and (3) dropped tarballs are never cleaned up. The `1.9` vs `1.10` lexical trap is the canonical failure.

This PR makes the behaviour deterministic and adds a guard:

- **Highest-version-per-name sweep** (`watcher.go` `sweepDir`): the startup sweep now reads each tarball's manifest (via a new `ReadManifestFromTarball` peek that streams the manifest without full extraction, bounded by the existing byte/file caps), groups by `manifest.name`, and schedules only the highest-SemVer tarball per name. Unreadable tarballs and ignored lower-version ones are logged at Warn so operators can see what the sweep chose and why. The live fsnotify event path is unchanged.
- **Install-time downgrade guard** (`install.go` `upsertPlugin`): a lower valid-SemVer version is refused (committed=false, no error), emitting a `plugin_downgrade_refused` (severityHigh) audit event + Warn log. Equal versions remain the existing idempotent no-op; higher versions proceed.
- **SemVer comparison** (`semver.go`): reuses `golang.org/x/mod/semver` (promoted to a direct require). `compareVersions` defines a total, deterministic order even for invalid inputs (both-valid → semver compare; one-valid → valid wins; both-invalid → `strings.Compare`), so non-SemVer / hand-renamed filenames stay order-independent.

## Behaviour changes (worth noting)

- Dropping an **older** tarball to roll back is now **refused** — rollback becomes an explicit admin action (future work), not a silent drop. (spec §5.1 / §13.5)
- The downgrade guard fires **before** the pubkey-mismatch check, so a semver-valid lower-version tarball signed with a different key produces a `plugin_downgrade_refused` event rather than a pubkey-mismatch event. Correct (downgrade is the primary rejection reason), documented here to avoid surprise.

## Out of scope

Source-tarball cleanup ("consume-on-install") — tracked as optional follow-up per the issue.

## Tests

`semver_test.go` (incl. the two-invalid case asserting a non-zero `strings.Compare` result), sweep tests (two-versions, 1.9-vs-1.10, filename-order independence, garbage-skipped), and install tests (downgrade-refused, non-semver fall-through). Full workspace `go vet`/`build`/`test` green via the commit hook; race-clean.

## Dev-loop metadata

Generated by the agentic dev loop. Pipeline: architect → plan-review (**REVISE**: explicit two-invalid fallback, constant relocation, fix an existing test) → implement → code-review (**APPROVE**, 0 loop-backs). CLAUDE.md: no updates needed.

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` (not committed). Both highest-version-per-name sweep + install-time downgrade guard; reuse `golang.org/x/mod/semver`; `manifest/diff.go` untouched (version stays cosmetic for the material/cosmetic hot-reload axis — the ordering guard is orthogonal).

</details>
