### PR TITLE
refactor: collapse manifest *yaml.Node UnmarshalYAML boilerplate into rawNode (#460)

### DIFF
--- a/plugin-sdk/manifest/manifest.go
+++ b/plugin-sdk/manifest/manifest.go
@@ -117,12 +117,11 @@ type Manifest struct {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler so that *yaml.Node fields are
-// correctly decoded. The default yaml.v3 decoder does not populate *yaml.Node
-// struct fields; this custom decoder uses value intermediaries and converts.
+// correctly decoded. yaml.v3 does not populate *yaml.Node struct fields; the
+// plain struct below uses rawNode for those fields so the decoder can reach
+// them. See rawnode.go for the full explanation of the quirk.
 func (m *Manifest) UnmarshalYAML(value *yaml.Node) error {
-	// manifestAlias mirrors Manifest with *yaml.Node fields replaced by
-	// yaml.Node (value type) so yaml.v3 populates them correctly.
-	type manifestAlias struct {
+	type plain struct {
 		SchemaVersion      string          `yaml:"schema_version"`
 		Name               string          `yaml:"name"`
 		Version            string          `yaml:"version"`
@@ -135,35 +134,32 @@ func (m *Manifest) UnmarshalYAML(value *yaml.Node) error {
 		EventKinds         []EventKindDecl `yaml:"event_kinds,omitempty"`
 		Channels           []ChannelDecl   `yaml:"channels,omitempty"`
 		Tier2              []string        `yaml:"tier2_capabilities,omitempty"`
-		ConfigSchema       yaml.Node       `yaml:"config_schema,omitempty"`
-		SubscriptionSchema yaml.Node       `yaml:"subscription_schema,omitempty"`
+		ConfigSchema       rawNode         `yaml:"config_schema,omitempty"`
+		SubscriptionSchema rawNode         `yaml:"subscription_schema,omitempty"`
 		SBOM               string          `yaml:"sbom,omitempty"`
 	}
-	var alias manifestAlias
-	if err := value.Decode(&alias); err != nil {
+	var p plain
+	if err := value.Decode(&p); err != nil {
 		return err
 	}
-	m.SchemaVersion = alias.SchemaVersion
-	m.Name = alias.Name
-	m.Version = alias.Version
-	m.Description = alias.Description
-	m.Author = alias.Author
-	m.License = alias.License
-	m.Services = alias.Services
-	m.Auth = alias.Auth
-	m.Tools = alias.Tools
-	m.EventKinds = alias.EventKinds
-	m.Channels = alias.Channels
-	m.Tier2 = alias.Tier2
-	m.SBOM = alias.SBOM
-	if alias.ConfigSchema.Kind != 0 {
-		node := alias.ConfigSchema
-		m.ConfigSchema = &node
-	}
-	if alias.SubscriptionSchema.Kind != 0 {
-		node := alias.SubscriptionSchema
-		m.SubscriptionSchema = &node
-	}
+	m.SchemaVersion = p.SchemaVersion
+	m.Name = p.Name
+	m.Version = p.Version
+	m.Description = p.Description
+	m.Author = p.Author
+	m.License = p.License
+	m.Services = p.Services
+	m.Auth = p.Auth
+	m.Tools = p.Tools
+	m.EventKinds = p.EventKinds
+	m.Channels = p.Channels
+	m.Tier2 = p.Tier2
+	m.SBOM = p.SBOM
+	// An absent field leaves .Node == nil. An explicit YAML null (~) still
+	// yields a non-nil *yaml.Node (a null ScalarNode), identical to the prior
+	// Kind != 0 behaviour, so dropping that guard is not a behaviour change.
+	m.ConfigSchema = p.ConfigSchema.Node
+	m.SubscriptionSchema = p.SubscriptionSchema.Node
 	return nil
 }
 
@@ -246,28 +242,24 @@ type ToolDecl struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler for ToolDecl.
 func (t *ToolDecl) UnmarshalYAML(value *yaml.Node) error {
-	type toolAlias struct {
-		Name             string    `yaml:"name"`
-		Description      string    `yaml:"description,omitempty"`
-		InputSchema      yaml.Node `yaml:"input_schema,omitempty"`
-		OutputSchema     yaml.Node `yaml:"output_schema,omitempty"`
-		ApprovalRequired bool      `yaml:"approval_required,omitempty"`
+	type plain struct {
+		Name             string  `yaml:"name"`
+		Description      string  `yaml:"description,omitempty"`
+		InputSchema      rawNode `yaml:"input_schema,omitempty"`
+		OutputSchema     rawNode `yaml:"output_schema,omitempty"`
+		ApprovalRequired bool    `yaml:"approval_required,omitempty"`
 	}
-	var alias toolAlias
-	if err := value.Decode(&alias); err != nil {
+	var p plain
+	if err := value.Decode(&p); err != nil {
 		return err
 	}
-	t.Name = alias.Name
-	t.Description = alias.Description
-	t.ApprovalRequired = alias.ApprovalRequired
-	if alias.InputSchema.Kind != 0 {
-		node := alias.InputSchema
-		t.InputSchema = &node
-	}
-	if alias.OutputSchema.Kind != 0 {
-		node := alias.OutputSchema
-		t.OutputSchema = &node
-	}
+	t.Name = p.Name
+	t.Description = p.Description
+	t.ApprovalRequired = p.ApprovalRequired
+	// Absent fields leave .Node == nil; an explicit null (~) yields a non-nil
+	// null ScalarNode — identical to the prior Kind != 0 behaviour.
+	t.InputSchema = p.InputSchema.Node
+	t.OutputSchema = p.OutputSchema.Node
 	return nil
 }
 
@@ -306,30 +298,25 @@ type Example struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler for EventKindDecl.
 func (e *EventKindDecl) UnmarshalYAML(value *yaml.Node) error {
-	type ekAlias struct {
-		Kind          string      `yaml:"kind"`
-		Description   string      `yaml:"description,omitempty"`
-		BindingSchema yaml.Node   `yaml:"binding_schema,omitempty"`
-		PayloadSchema yaml.Node   `yaml:"payload_schema,omitempty"`
-		Examples      []yaml.Node `yaml:"examples,omitempty"`
+	type plain struct {
+		Kind          string    `yaml:"kind"`
+		Description   string    `yaml:"description,omitempty"`
+		BindingSchema rawNode   `yaml:"binding_schema,omitempty"`
+		PayloadSchema rawNode   `yaml:"payload_schema,omitempty"`
+		Examples      []rawNode `yaml:"examples,omitempty"`
 	}
-	var alias ekAlias
-	if err := value.Decode(&alias); err != nil {
+	var p plain
+	if err := value.Decode(&p); err != nil {
 		return err
 	}
-	e.Kind = alias.Kind
-	e.Description = alias.Description
-	if alias.BindingSchema.Kind != 0 {
-		node := alias.BindingSchema
-		e.BindingSchema = &node
-	}
-	if alias.PayloadSchema.Kind != 0 {
-		node := alias.PayloadSchema
-		e.PayloadSchema = &node
-	}
-	for _, ex := range alias.Examples {
-		ex := ex
-		e.Examples = append(e.Examples, &ex)
+	e.Kind = p.Kind
+	e.Description = p.Description
+	// Absent fields leave .Node == nil; an explicit null (~) yields a non-nil
+	// null ScalarNode — identical to the prior Kind != 0 behaviour.
+	e.BindingSchema = p.BindingSchema.Node
+	e.PayloadSchema = p.PayloadSchema.Node
+	for _, ex := range p.Examples {
+		e.Examples = append(e.Examples, ex.Node)
 	}
 	return nil
 }
@@ -442,20 +429,19 @@ func (m *Manifest) HasTier2(cap string) bool {
 
 // UnmarshalYAML implements yaml.Unmarshaler for ChannelDecl.
 func (c *ChannelDecl) UnmarshalYAML(value *yaml.Node) error {
-	type chanAlias struct {
-		ImplementsNotify  bool      `yaml:"implements_notify,omitempty"`
-		ImplementsRequest bool      `yaml:"implements_request,omitempty"`
-		ConfigSchema      yaml.Node `yaml:"config_schema,omitempty"`
+	type plain struct {
+		ImplementsNotify  bool    `yaml:"implements_notify,omitempty"`
+		ImplementsRequest bool    `yaml:"implements_request,omitempty"`
+		ConfigSchema      rawNode `yaml:"config_schema,omitempty"`
 	}
-	var alias chanAlias
-	if err := value.Decode(&alias); err != nil {
+	var p plain
+	if err := value.Decode(&p); err != nil {
 		return err
 	}
-	c.ImplementsNotify = alias.ImplementsNotify
-	c.ImplementsRequest = alias.ImplementsRequest
-	if alias.ConfigSchema.Kind != 0 {
-		node := alias.ConfigSchema
-		c.ConfigSchema = &node
-	}
+	c.ImplementsNotify = p.ImplementsNotify
+	c.ImplementsRequest = p.ImplementsRequest
+	// Absent field leaves .Node == nil; an explicit null (~) yields a non-nil
+	// null ScalarNode — identical to the prior Kind != 0 behaviour.
+	c.ConfigSchema = p.ConfigSchema.Node
 	return nil
 }

--- a/plugin-sdk/manifest/rawnode.go
+++ b/plugin-sdk/manifest/rawnode.go
@@ -1,0 +1,28 @@
+package manifest
+
+import "gopkg.in/yaml.v3"
+
+// rawNode is a decode-only wrapper that concentrates the yaml.v3 "*yaml.Node
+// struct fields decode as nil" quirk in one place. When yaml.v3 decodes into a
+// struct, pointer fields of type *yaml.Node are never populated — the decoder
+// skips them. Using rawNode as the intermediate field type works around this:
+// UnmarshalYAML receives the concrete *yaml.Node and stores a copy.
+//
+// Usage: declare a local plain struct inside each UnmarshalYAML method with
+// node-bearing fields typed as rawNode (or []rawNode). After decoding, access
+// the node via .Node and assign to the public *yaml.Node field.
+//
+// rawNode is intentionally unexported and carries no MarshalYAML — it is used
+// only inside per-method decode structs and never reaches the encode path.
+type rawNode struct {
+	Node *yaml.Node
+}
+
+// UnmarshalYAML copies the incoming node value into r.Node. The copy (n := *v)
+// detaches the node from yaml.v3's internal decode state so the caller can
+// safely store a pointer to it.
+func (r *rawNode) UnmarshalYAML(v *yaml.Node) error {
+	n := *v
+	r.Node = &n
+	return nil
+}

--- a/plugin-sdk/manifest/rawnode_test.go
+++ b/plugin-sdk/manifest/rawnode_test.go
@@ -1,0 +1,159 @@
+package manifest_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+)
+
+// TestAllNodeFieldsRoundTrip exercises every *yaml.Node field across all four
+// types that carry them (Manifest, ToolDecl, EventKindDecl, ChannelDecl).
+// This closes the OutputSchema and PayloadSchema coverage gap present before
+// the rawNode refactor, and validates that the new decode path is equivalent
+// to the old alias-struct approach for each field.
+//
+// The test:
+//  1. Unmarshals a YAML literal that sets all seven node-bearing fields.
+//  2. Asserts each field is non-nil (and Examples has the right length).
+//  3. Marshals back to YAML and asserts each schema's distinctive content is
+//     present.
+//  4. Unmarshals the marshal output again and re-marshals, asserting byte
+//     equality (round-trip stability).
+func TestAllNodeFieldsRoundTrip(t *testing.T) {
+	// This YAML sets every *yaml.Node field in the manifest type hierarchy:
+	//   Manifest:      config_schema, subscription_schema
+	//   ToolDecl:      input_schema, output_schema
+	//   EventKindDecl: binding_schema, payload_schema, examples (2 entries)
+	//   ChannelDecl:   config_schema
+	const src = `schema_version: v1
+name: allfields-plugin
+version: 0.1.0
+services:
+  channel: v1
+  tool: v1
+  trigger: v1
+auth:
+  mode: instance_credentials
+  strategy: none
+config_schema:
+  description: manifest-config
+  type: object
+subscription_schema:
+  description: manifest-subscription
+  type: object
+tools:
+  - name: do_it
+    description: a tool
+    input_schema:
+      description: tool-input
+      type: object
+    output_schema:
+      description: tool-output
+      type: object
+event_kinds:
+  - kind: thing_happened
+    description: something happened
+    binding_schema:
+      description: event-binding
+      type: object
+    payload_schema:
+      description: event-payload
+      type: object
+    examples:
+      - name: alpha
+        payload: {}
+      - name: beta
+        payload: {}
+channels:
+  - implements_notify: true
+    config_schema:
+      description: channel-config
+      type: object
+`
+
+	var m manifest.Manifest
+	if err := manifest.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// --- assert all node fields are non-nil after unmarshal ---
+
+	if m.ConfigSchema == nil {
+		t.Error("Manifest.ConfigSchema is nil")
+	}
+	if m.SubscriptionSchema == nil {
+		t.Error("Manifest.SubscriptionSchema is nil")
+	}
+
+	if len(m.Tools) == 0 {
+		t.Fatal("Tools is empty")
+	}
+	tool := m.Tools[0]
+	if tool.InputSchema == nil {
+		t.Error("ToolDecl.InputSchema is nil")
+	}
+	if tool.OutputSchema == nil {
+		t.Error("ToolDecl.OutputSchema is nil")
+	}
+
+	if len(m.EventKinds) == 0 {
+		t.Fatal("EventKinds is empty")
+	}
+	ek := m.EventKinds[0]
+	if ek.BindingSchema == nil {
+		t.Error("EventKindDecl.BindingSchema is nil")
+	}
+	if ek.PayloadSchema == nil {
+		t.Error("EventKindDecl.PayloadSchema is nil")
+	}
+	if len(ek.Examples) != 2 {
+		t.Errorf("len(EventKindDecl.Examples) = %d, want 2", len(ek.Examples))
+	}
+
+	if len(m.Channels) == 0 {
+		t.Fatal("Channels is empty")
+	}
+	if m.Channels[0].ConfigSchema == nil {
+		t.Error("ChannelDecl.ConfigSchema is nil")
+	}
+
+	// --- marshal and assert each schema's distinctive content survives ---
+
+	out1, err := manifest.Marshal(&m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	checks := []struct {
+		desc    string
+		snippet string
+	}{
+		{"Manifest.ConfigSchema", "manifest-config"},
+		{"Manifest.SubscriptionSchema", "manifest-subscription"},
+		{"ToolDecl.InputSchema", "tool-input"},
+		{"ToolDecl.OutputSchema", "tool-output"},
+		{"EventKindDecl.BindingSchema", "event-binding"},
+		{"EventKindDecl.PayloadSchema", "event-payload"},
+		{"ChannelDecl.ConfigSchema", "channel-config"},
+	}
+	for _, c := range checks {
+		if !bytes.Contains(out1, []byte(c.snippet)) {
+			t.Errorf("%s: content %q missing from marshal output:\n%s", c.desc, c.snippet, out1)
+		}
+	}
+
+	// --- Marshal → Unmarshal → Marshal is bytes.Equal (round-trip stability) ---
+
+	var m2 manifest.Manifest
+	if err := manifest.Unmarshal(out1, &m2); err != nil {
+		t.Fatalf("second Unmarshal: %v", err)
+	}
+	out2, err := manifest.Marshal(&m2)
+	if err != nil {
+		t.Fatalf("second Marshal: %v", err)
+	}
+	if !bytes.Equal(out1, out2) {
+		t.Fatalf("round-trip not stable:\nfirst marshal:\n%s\nsecond marshal:\n%s", out1, out2)
+	}
+}


### PR DESCRIPTION
Closes #460

## Summary

Collapse the repeated `*yaml.Node` mirror-alias `UnmarshalYAML` boilerplate in `plugin-sdk/manifest` into a single unexported `rawNode` wrapper that owns the yaml.v3 quirk (it does not populate `*yaml.Node` struct fields directly). The four custom unmarshalers — `Manifest`, `ToolDecl`, `EventKindDecl`, `ChannelDecl` — now decode into a small local `plain` struct whose node-bearing fields are typed `rawNode` (or `[]rawNode` for `Examples`), then assign through `.Node`. The per-method full-mirror alias structs and the `Kind != 0` guards are gone.

## Non-breaking by design

Public field types stay `*yaml.Node` / `[]*yaml.Node` and the `UnmarshalYAML(value *yaml.Node) error` signatures are unchanged. `rawNode` is unexported. All ~15 host consumer sites (`internal/plugin/schemautil`, `configvalidate`, `internal/plugin/manifest/diff.go`, `audience_handler.go`, `plugin_handler.go`, `main.go`, `binding`, `dispatcher`) and the first-party plugins (`plugins/ntfy`, `plugins/slack`) compile **unchanged**. The marshal path (`yaml.go`, `json.go`) is untouched, so canonical output is byte-for-byte identical — signing-hash stability preserved.

## Interpretation note for reviewers

The issue's headline suggested making `rawNode` the *field type*. That would have changed the public surface and broken the ~15 consumers + both plugins — directly contradicting the issue's own workspace-constraint criteria ("keep `*yaml.Node` accessors", "must not break plugins/ntfy or plugins/slack"). This PR honors the binding workspace constraint: keep `*yaml.Node` fields, delegate decode to `rawNode` internally. Every other acceptance criterion is met. Also: the issue said "×5 types"; there are in fact **4** Go types with custom unmarshalers (the alias mirrors 15 fields in `Manifest`).

## Tests

All pre-existing manifest tests pass **unmodified** (the byte-stability/regression proof: `TestMarshalTwiceByteEqual`, `TestRoundTripStable`, `TestCanonicalize`, `TestCanonicalizePreservesSchemaNodes`, …). New `TestAllNodeFieldsRoundTrip` sets all seven node-bearing fields, asserts each survives, and asserts `Marshal→Unmarshal→Marshal` byte-equality — closing the previously-untested `OutputSchema`/`PayloadSchema` gap. Full `go.work` workspace `go vet`/`build`/`test` green via the commit hook.

## Dev-loop metadata

Generated by the agentic dev loop. Pipeline: architect → plan-review (**APPROVE**) → implement → code-review (**APPROVE**, 0 loop-backs). CLAUDE.md: no updates needed.
