### PR TITLE
feat: ergonomic Service adapter seam (tool/channel/trigger) over raw gRPC (#457)

### DIFF
--- a/docs/developer/ADR_Tracker.md
+++ b/docs/developer/ADR_Tracker.md
@@ -64,6 +64,7 @@ Running index of all Architecture Decision Records. Promote items from the Roadm
 | ADR-047 | Plugin observability surface — metrics prefix, cardinality cap, Log RPC instead of stdout, OTEL deferred | 🟢 Decided | v2.0 (plugins) | internal/plugin/hostsvc/metrics.go, internal/plugin/hostsvc/handlers.go (Log/EmitMetric), internal/plugin/process/logpipe.go, internal/plugin/state/metrics.go, spec §12 |
 | ADR-048 | Subscribed trigger type — internal-only name, flat picker, no JSONPath for plugin bindings, single-trigger-per-policy v1 | 🟢 Decided | v2.0 (plugins) | internal/model (TriggerType), internal/policy (parser/validator), internal/trigger (new subscribed handler), policy editor trigger picker, spec §7 |
 | ADR-049 | Redact-on-read for plugin instance config secret fields (x-gleipnir-secret) | 🟢 Decided | plugins | internal/plugin/configvalidate, internal/admin/plugin_handler, plugin-sdk/manifest, plugins/slack |
+| ADR-050 | Ergonomic Service seam coexists with raw gRPC seam in plugin-sdk | 🟢 Decided | plugins | plugin-sdk/tool, plugin-sdk/channel, plugin-sdk/trigger, plugin-sdk/pluginerr (new packages); plugin-sdk/serve (New*Server constructors, WithXHandler options); plugins/ntfy (migrated); plugins/slack (stays raw) |
 | #611    | Remove claudecode agent runtime                        | 🟢 Decided | v1.0 | internal/agent/claudecode deleted; policies using provider: claude-code now fail validation |
 | #199    | call_id propagation through gRPC metadata (spec §8.5)  | 🟢 Decided | v2.0 (plugins) | plugin-sdk/serve/callcontext.go, internal/plugin/hostsvc (new package), no new ADR — implements existing spec §8.5 contract |
 | #224    | OAuth2 authcode + clientcred host-side orchestration (spec §9.1/§9.2) | 🟢 Decided | v2.0 (plugins) | internal/plugin/oauth (new package, x/oauth2 + clientcredentials), internal/admin/plugin_oauth_handler.go, plugin_instances.credentials_encrypted, HMAC state envelope with HKDF subkey off GLEIPNIR_ENCRYPTION_KEY; no new ADR — implements existing spec §9 contract. Encryption helpers reused from internal/admin via function injection to avoid an import cycle; planned to move to internal/infra/crypto when #141 lands. |
@@ -121,6 +122,63 @@ Both write handlers (`PutInstanceConfig` and `PutInstanceConfigProperty`) synthe
 - Migrating `StoredCredentials.Token` to this mechanism (it is already write-only via the OAuth callback).
 - Nested object secrets (v1 redacts only top-level `properties`).
 - Frontend UI surface (tracked as follow-up after this API change).
+
+---
+
+## ADR-050: Ergonomic Service seam coexists with raw gRPC seam in plugin-sdk
+
+**Status:** Decided
+**Date:** 2026-05
+
+### Context
+
+The only author-facing seam for implementing plugin behaviour was the raw generated gRPC server interface injected via a host-client factory (e.g. `serve.WithToolService(func(host hostv1.HostServiceClient) toolv1.ToolServiceServer { ... })`). Authors had to implement `toolv1.ToolServiceServer` directly: deal in `*toolv1.CallRequest` / `*toolv1.CallResponse`, marshal/unmarshal `input_json` / `output_json` by hand, and construct `commonv1.ErrorEnvelope` values on every error path. The `plugin-sdk/examples/minimal-tool` service.go showed the cost: ~90 lines of proto plumbing for a trivial echo implementation.
+
+The `gleipnir-plugin new` scaffold's `service.go` template was already written to an ergonomic interface (`Call(ctx, name string, input []byte) ([]byte, error)`) that no SDK adapter satisfied, leaving the scaffold uncompilable. This gap motivated issue #457.
+
+### Decision
+
+#### 1. Proto-free ergonomic interfaces in new sub-packages
+
+Three new sub-packages — `plugin-sdk/tool`, `plugin-sdk/channel`, `plugin-sdk/trigger` — define ergonomic service interfaces (`tool.Service`, `channel.Service`, `trigger.Service`) with no proto types in their signatures. A fourth sub-package `plugin-sdk/pluginerr` provides a proto-free error-code enum and constructors (`InvalidArg`, `NotFound`, `Internal`, `Unavailable`, `Permission`, `RateLimited`, `Unimplemented`) so authors can signal structured errors without importing `gen/`.
+
+These packages are intentional leaf packages: they must not import `plugin-sdk/gen/` (the proto coupling lives only in `serve/`).
+
+#### 2. Adapters in serve/ via exported constructors
+
+`plugin-sdk/serve` receives three exported adapter constructors — `NewToolServer(tool.Service)`, `NewChannelServer(channel.Service)`, `NewTriggerServer(trigger.Service)` — that bridge the ergonomic interfaces onto the generated gRPC server interfaces. Error mapping is centralized in `serve/erroradapt.go`: `pluginerr.CodedError` maps 1:1 onto `commonv1.ErrorCode`; plain errors map to `ERROR_CODE_INTERNAL`. This is the only place in the codebase where proto error codes and ergonomic codes are coupled.
+
+`ListToolsResponse` has no `Error` field, so `ListTools` errors become a gRPC-level `codes.Internal` status (not an envelope). All other service method errors become application-level envelopes.
+
+The adapter structs stay unexported; the constructors are public. This lets tests register the real adapter for live gRPC round-trip coverage without exposing struct internals.
+
+#### 3. New ergonomic options alongside the raw options (last-option-wins)
+
+Three new option functions — `WithToolHandler`, `WithChannelHandler`, `WithTriggerHandler` — accept `func(hostv1.HostServiceClient) X.Service` factories and wrap the returned value via the exported constructors before storing it in the same `config.{tool,channel,trigger}Factory` field as the raw `WithXService` options. Zero changes to `server.go` are required: wiring, capability derivation (`Negotiate` keys off `*Factory != nil`), and the `Bind` install path are identical.
+
+Both raw and ergonomic options write the same config field. Last applied wins (newConfig applies options in order). Passing both `WithToolService` and `WithToolHandler` is valid but the earlier one is silently dropped; the doc comments warn against it.
+
+#### 4. Dogfood validation: ntfy migrated, slack stays raw
+
+`plugins/ntfy` was migrated to the ergonomic seam in the same PR (issue #457) as proof that the interface satisfies a real second consumer. `ChannelService` now implements `channel.Service`; `Request` returns `pluginerr.Unimplemented` (Notify-only plugin); `main.go` uses `WithChannelHandler`.
+
+`plugins/slack` intentionally stays on the raw `WithChannelService` seam. Slack's implementation exercises the full proto surface (direct `RequestRequest` field access, custom `NotifyResponse` construction) and the raw seam remains the right choice there. Slack's migration is tracked as a separate non-blocking follow-up.
+
+The acceptance criterion "raw variant kept as a second example if still useful" is satisfied by explicit decision: `plugins/slack` is the canonical raw consumer; no second raw example is added to `examples/`.
+
+#### 5. Host-client injection via factory, not context accessor
+
+Host-client injection uses the existing `func(hostv1.HostServiceClient) X.Service` factory pattern (same as the raw seam). The adapter does not auto-apply `serve.WithCallContext` — authors call it themselves inside service method bodies before outbound host RPCs. This preserves correct behaviour in detached goroutines (e.g. Trigger.Start background workers) where the adapter cannot know the correct propagation scope.
+
+### Deferred
+
+- Migration of `plugins/slack` to the ergonomic seam (tracked follow-up; not required to land this change).
+- Wrapper support for `FeedbackRequest.ChannelConfig` field-level helpers (v2, when feedback channel plugins are more common).
+
+### References
+
+- Spec §14.1 (SDK), §14.3 (manifest authoring), §14.6 (new scaffold)
+- Issue #457
 
 ---
 

--- a/plugin-sdk/channel/service.go
+++ b/plugin-sdk/channel/service.go
@@ -1,0 +1,75 @@
+// Package channel defines the ergonomic ChannelService interface for plugin authors.
+// It is proto-free: no types from plugin-sdk/gen/ appear in its signatures.
+// The serve package adapts this interface onto the generated channelv1.ChannelServiceServer.
+package channel
+
+import "context"
+
+// Notification carries a fire-and-forget notification from the host to the
+// plugin. Fields map 1:1 to the channelv1.NotifyRequest proto message;
+// the adapter in serve/ translates between them.
+type Notification struct {
+	// EventType classifies the notification (e.g. "run_failed", "approval_requested").
+	EventType string
+	// Payload is the notification body serialized as a JSON object.
+	// Schema is EventType-specific; authors should tolerate unknown fields
+	// to handle future Gleipnir additions gracefully.
+	Payload []byte
+	// ChannelConfig is the per-audience-entry config block validated against
+	// the plugin's manifest channel_config_schema at audience save time.
+	ChannelConfig []byte
+}
+
+// FeedbackRequest asks the plugin to open a request/response feedback channel.
+// Fields map 1:1 to the channelv1.RequestRequest proto message.
+type FeedbackRequest struct {
+	// RequestID is a host-generated token that is instance-scoped (not
+	// generation-scoped) so callbacks can be matched across hot-reloads.
+	// Echo this in WriteAuditStep when the human replies.
+	RequestID string
+	// Prompt is the message to display to the human operator.
+	Prompt string
+	// ChannelConfig is the per-audience-entry config block.
+	ChannelConfig []byte
+}
+
+// Service is the ergonomic interface plugin authors implement to deliver
+// notifications and feedback requests. Authors deal in plain Go types and
+// []byte JSON without touching proto messages or ErrorEnvelope construction.
+//
+// # Cancellation
+//
+// Both Notify and Request receive a context that the host cancels when the
+// gRPC deadline fires. Every blocking I/O operation MUST select on ctx.Done().
+//
+// # Host RPCs
+//
+// To make outbound host RPCs (GetInstanceConfig, GetCredentials, …), call
+// serve.WithCallContext(ctx) BEFORE each host RPC. The adapter does NOT apply
+// it automatically, so that authors can control context propagation in
+// detached goroutines correctly.
+//
+// # Request and UNIMPLEMENTED
+//
+// Plugins that support Notify-only SHOULD return pluginerr.Unimplemented("…")
+// from Request. The adapter translates this to an application-level
+// RequestResponse{Acked: false, Error: {UNIMPLEMENTED}} — not a gRPC-level
+// codes.Unimplemented status — because the host never routes Request to a
+// plugin whose manifest declares Notify-only channel_capabilities.
+type Service interface {
+	// Notify delivers a fire-and-forget notification. Failure does not fail
+	// the run; return a descriptive error so the host can audit and count it.
+	Notify(ctx context.Context, n Notification) error
+
+	// Request opens a request/response feedback channel. The plugin must
+	// synchronously ack (return nil) within 5s and later call the host's
+	// WriteAuditStep Host RPC with a feedback_response step when the human
+	// replies (spec §4.2).
+	//
+	// Notify-only plugins SHOULD return pluginerr.Unimplemented("Request not
+	// supported"). This produces an application-level UNIMPLEMENTED envelope,
+	// not a gRPC status error, because the host normally never calls Request on
+	// a Notify-only plugin (manifest guards it). Returning a plain error here
+	// results in ERROR_CODE_INTERNAL.
+	Request(ctx context.Context, r FeedbackRequest) error
+}

--- a/plugin-sdk/examples/minimal-tool/main.go
+++ b/plugin-sdk/examples/minimal-tool/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
-	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 )
 
 func main() {
@@ -13,12 +13,13 @@ func main() {
 	// Passing --emit-manifest as the first argument causes it to write the
 	// manifest JSON to stdout and exit (used by gleipnir-plugin gen-manifest).
 	//
-	// A bare serve.Serve() with no options is valid: the plugin responds to
-	// the handshake and Bootstrap.Bind but all service RPCs return
-	// codes.Unavailable, which is the correct documented behaviour.
+	// WithToolHandler is the ergonomic seam: authors implement tool.Service
+	// and do not touch proto types directly. The raw WithToolService option
+	// remains available for authors who need full proto control; plugins/slack
+	// is the canonical example of that path.
 	serve.Serve(
 		serve.WithManifest(pluginManifest),
-		serve.WithToolService(func(host hostv1.HostServiceClient) toolv1.ToolServiceServer {
+		serve.WithToolHandler(func(host hostv1.HostServiceClient) tool.Service {
 			return NewToolService(host)
 		}),
 	)

--- a/plugin-sdk/examples/minimal-tool/service.go
+++ b/plugin-sdk/examples/minimal-tool/service.go
@@ -5,17 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 
-	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
-	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 )
 
-// ToolService implements toolv1.ToolServiceServer with a single "echo" tool.
+// ToolService implements tool.Service with a single "echo" tool.
 // It communicates with the host via hostClient, which is provided at
-// construction time (in production by serve.Serve; in tests by loopback TCP (127.0.0.1:0)).
+// construction time (in production by serve.Serve; in tests by loopback TCP).
 type ToolService struct {
-	toolv1.UnimplementedToolServiceServer
 	host hostv1.HostServiceClient
 }
 
@@ -25,26 +24,14 @@ func NewToolService(hostClient hostv1.HostServiceClient) *ToolService {
 }
 
 // ListTools returns the single "echo" tool declaration.
-func (s *ToolService) ListTools(_ context.Context, _ *toolv1.ListToolsRequest) (*toolv1.ListToolsResponse, error) {
-	return &toolv1.ListToolsResponse{
-		Tools: []*toolv1.ToolSchema{
-			{
-				Name:        "echo",
-				Description: "Returns the message it received.",
-				InputSchema: `{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}`,
-			},
+func (s *ToolService) ListTools(_ context.Context) ([]tool.ToolSpec, error) {
+	return []tool.ToolSpec{
+		{
+			Name:        "echo",
+			Description: "Returns the message it received.",
+			InputSchema: `{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}`,
 		},
 	}, nil
-}
-
-// Cancel is a no-op for this trivial echo handler because it has no in-flight
-// goroutine state to abort.  Real plugins MUST honor ctx.Done() inside Call:
-// when the host cancels the call (run cancelled, or operator cancellation),
-// every blocking I/O performed inside Call must use that ctx so the goroutine
-// returns promptly.  The host enforces a 5s grace period before
-// force-disconnecting the gRPC connection (spec §13.8).
-func (s *ToolService) Cancel(_ context.Context, _ *toolv1.CancelRequest) (*toolv1.CancelResponse, error) {
-	return &toolv1.CancelResponse{}, nil
 }
 
 // Call handles the "echo" tool. It:
@@ -53,32 +40,20 @@ func (s *ToolService) Cancel(_ context.Context, _ *toolv1.CancelRequest) (*toolv
 //  3. Logs a confirmation line.
 //  4. Returns the echoed message as output JSON.
 //
-// Plugins MUST honor ctx.Done(): when the host cancels the call (run
-// cancelled, or operator cancellation), every blocking I/O performed inside
-// Call must use this ctx so the goroutine returns promptly.  The host
-// enforces a 5s grace before force-disconnecting (spec §13.8).
-//
-// Any JSON parse error results in a populated ErrorEnvelope in the response.
-func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv1.CallResponse, error) {
-	if req.GetToolName() != "echo" {
-		return &toolv1.CallResponse{
-			Error: &commonv1.ErrorEnvelope{
-				Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
-				Message: fmt.Sprintf("unknown tool: %q", req.GetToolName()),
-			},
-		}, nil
+// Plugins MUST honor ctx.Done(): when the host cancels the call (run cancelled
+// or operator cancellation), every blocking I/O performed inside Call must use
+// this ctx so the goroutine returns promptly. The host enforces a 5s grace
+// before force-disconnecting (spec §13.8).
+func (s *ToolService) Call(ctx context.Context, toolName string, input []byte) ([]byte, error) {
+	if toolName != "echo" {
+		return nil, pluginerr.InvalidArg(fmt.Sprintf("unknown tool: %q", toolName))
 	}
 
-	var input struct {
+	var in struct {
 		Message string `json:"message"`
 	}
-	if err := json.Unmarshal([]byte(req.GetInputJson()), &input); err != nil {
-		return &toolv1.CallResponse{
-			Error: &commonv1.ErrorEnvelope{
-				Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
-				Message: fmt.Sprintf("invalid input JSON: %v", err),
-			},
-		}, nil
+	if err := json.Unmarshal(input, &in); err != nil {
+		return nil, pluginerr.InvalidArg(fmt.Sprintf("invalid input JSON: %v", err))
 	}
 
 	// Propagate the host-injected call ID to all outgoing host RPCs so the host
@@ -88,12 +63,7 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 
 	// 1. GetInstanceConfig — exercises host connectivity.
 	if _, err := s.host.GetInstanceConfig(hostCtx, &hostv1.GetInstanceConfigRequest{}); err != nil {
-		return &toolv1.CallResponse{
-			Error: &commonv1.ErrorEnvelope{
-				Code:    commonv1.ErrorCode_ERROR_CODE_INTERNAL,
-				Message: fmt.Sprintf("GetInstanceConfig: %v", err),
-			},
-		}, nil
+		return nil, fmt.Errorf("GetInstanceConfig: %w", err)
 	}
 
 	// 2. EmitMetric.
@@ -102,12 +72,7 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 		Value:  1,
 		Labels: map[string]string{"tool": "echo"},
 	}); err != nil {
-		return &toolv1.CallResponse{
-			Error: &commonv1.ErrorEnvelope{
-				Code:    commonv1.ErrorCode_ERROR_CODE_INTERNAL,
-				Message: fmt.Sprintf("EmitMetric: %v", err),
-			},
-		}, nil
+		return nil, fmt.Errorf("EmitMetric: %w", err)
 	}
 
 	// 3. Log confirmation.
@@ -115,15 +80,10 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 		Level: hostv1.LogLevel_LOG_LEVEL_INFO,
 		Msg:   "echo handled",
 	}); err != nil {
-		return &toolv1.CallResponse{
-			Error: &commonv1.ErrorEnvelope{
-				Code:    commonv1.ErrorCode_ERROR_CODE_INTERNAL,
-				Message: fmt.Sprintf("Log: %v", err),
-			},
-		}, nil
+		return nil, fmt.Errorf("Log: %w", err)
 	}
 
 	// 4. Return the echoed output.
-	out, _ := json.Marshal(map[string]string{"echoed": input.Message})
-	return &toolv1.CallResponse{OutputJson: string(out)}, nil
+	out, _ := json.Marshal(map[string]string{"echoed": in.Message})
+	return out, nil
 }

--- a/plugin-sdk/examples/minimal-tool/service_test.go
+++ b/plugin-sdk/examples/minimal-tool/service_test.go
@@ -11,11 +11,13 @@ import (
 
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
 )
 
 // setup starts an in-process gRPC server hosting both the fake host and the
-// tool service. It returns the tool client, the fake host, and a cleanup function.
+// tool service (via the ergonomic adapter). It returns the tool client, the
+// fake host, and a cleanup function.
 func setup(t *testing.T, hostOpts ...plugintest.Option) (toolv1.ToolServiceClient, *plugintest.FakeHost, func()) {
 	t.Helper()
 
@@ -38,13 +40,14 @@ func setup(t *testing.T, hostOpts ...plugintest.Option) (toolv1.ToolServiceClien
 	}
 	hostClient := hostv1.NewHostServiceClient(hostConn)
 
-	// Start the tool service gRPC server.
+	// Start the tool service gRPC server via the exported adapter constructor.
+	// This gives the test a live gRPC round-trip through the ergonomic seam.
 	toolLis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen for tool: %v", err)
 	}
 	toolSrv := grpc.NewServer()
-	toolv1.RegisterToolServiceServer(toolSrv, NewToolService(hostClient))
+	toolv1.RegisterToolServiceServer(toolSrv, serve.NewToolServer(NewToolService(hostClient)))
 	go func() { _ = toolSrv.Serve(toolLis) }()
 
 	// Dial the tool service.

--- a/plugin-sdk/pluginerr/pluginerr.go
+++ b/plugin-sdk/pluginerr/pluginerr.go
@@ -1,0 +1,94 @@
+// Package pluginerr provides proto-free error codes and constructors for
+// plugin authors. It mirrors the error codes in commonv1.ErrorCode without
+// importing the generated proto package (gen/), keeping the ergonomic service
+// interfaces in tool/, channel/, and trigger/ free of proto coupling.
+//
+// The serve package maps pluginerr.CodedError values back onto the
+// corresponding commonv1.ErrorCode 1:1 when building an ErrorEnvelope.
+package pluginerr
+
+import "fmt"
+
+// Code classifies a plugin-side error. Values mirror commonv1.ErrorCode
+// (same numeric values so the adapter mapping in serve/ is a simple cast).
+type Code int32
+
+const (
+	// CodeUnspecified is the zero value; callers should never construct it directly.
+	CodeUnspecified Code = 0
+	// CodeInternal signals an unexpected plugin-internal failure.
+	CodeInternal Code = 1
+	// CodeInvalidArg signals that the caller passed invalid arguments.
+	CodeInvalidArg Code = 2
+	// CodeNotFound signals that the requested resource does not exist.
+	CodeNotFound Code = 3
+	// CodeUnavailable signals a transient failure; the caller may retry.
+	CodeUnavailable Code = 4
+	// CodePermission signals that the plugin lacks a required credential or scope.
+	CodePermission Code = 5
+	// CodeRateLimited signals that the substrate rate-limited the request;
+	// the caller should back off.
+	CodeRateLimited Code = 6
+	// CodeUnimplemented signals that the RPC is declared but not implemented
+	// by this plugin (e.g. Request on a Notify-only channel plugin).
+	CodeUnimplemented Code = 7
+)
+
+// CodedError is an error that carries a plugin-level error code understood by
+// the serve adapter. Plugin authors return CodedError (via the constructors
+// below) to control the ErrorCode written into the response ErrorEnvelope.
+// A plain (non-coded) error returned from a service method is treated as
+// CodeInternal by the adapter.
+type CodedError struct {
+	Code    Code
+	Message string
+}
+
+func (e *CodedError) Error() string {
+	return fmt.Sprintf("pluginerr[%d]: %s", e.Code, e.Message)
+}
+
+// InvalidArg returns a CodedError with CodeInvalidArg. Use when the caller
+// passed invalid or malformed arguments (bad JSON, unknown tool name, …).
+func InvalidArg(msg string) error {
+	return &CodedError{Code: CodeInvalidArg, Message: msg}
+}
+
+// NotFound returns a CodedError with CodeNotFound. Use when a requested
+// resource (tool, topic, channel, …) does not exist.
+func NotFound(msg string) error {
+	return &CodedError{Code: CodeNotFound, Message: msg}
+}
+
+// Internal returns a CodedError with CodeInternal. Use for unexpected
+// plugin-internal failures where the caller cannot meaningfully retry.
+func Internal(msg string) error {
+	return &CodedError{Code: CodeInternal, Message: msg}
+}
+
+// Unavailable returns a CodedError with CodeUnavailable. Use for transient
+// substrate failures that the caller may retry after backoff.
+func Unavailable(msg string) error {
+	return &CodedError{Code: CodeUnavailable, Message: msg}
+}
+
+// Permission returns a CodedError with CodePermission. Use when the plugin
+// lacks a required credential or scope to fulfil the request.
+func Permission(msg string) error {
+	return &CodedError{Code: CodePermission, Message: msg}
+}
+
+// RateLimited returns a CodedError with CodeRateLimited. Use when the
+// external substrate has rate-limited the plugin; the caller should back off.
+func RateLimited(msg string) error {
+	return &CodedError{Code: CodeRateLimited, Message: msg}
+}
+
+// Unimplemented returns a CodedError with CodeUnimplemented. Use when the
+// RPC method is declared in the proto but not implemented by this plugin
+// (e.g. Request on a Notify-only channel plugin). The serve adapter converts
+// this to an application-level UNIMPLEMENTED envelope rather than a gRPC
+// status error, so the host's response path remains normal.
+func Unimplemented(msg string) error {
+	return &CodedError{Code: CodeUnimplemented, Message: msg}
+}

--- a/plugin-sdk/serve/doc.go
+++ b/plugin-sdk/serve/doc.go
@@ -8,6 +8,31 @@
 // --emit-manifest. It writes the plugin's manifest JSON to stdout so that
 // gleipnir-plugin gen-manifest can capture and canonicalise it.
 //
+// # Ergonomic seam (recommended)
+//
+// Authors implement tool.Service, channel.Service, or trigger.Service from the
+// corresponding sub-packages and register them via the WithXHandler options:
+//
+//	serve.Serve(
+//	    serve.WithManifest(pluginManifest),
+//	    serve.WithToolHandler(func(host hostv1.HostServiceClient) tool.Service {
+//	        return NewToolService(host)
+//	    }),
+//	)
+//
+// The ergonomic seam keeps proto types, ErrorEnvelope construction, and
+// []byte↔string JSON conversion inside the serve package. Authors deal only in
+// plain Go types and pluginerr codes. See plugin-sdk/examples/minimal-tool and
+// plugins/ntfy for working examples.
+//
+// # Raw gRPC seam (advanced)
+//
+// Authors who need full control over the generated proto types can implement
+// toolv1.ToolServiceServer / channelv1.ChannelServiceServer /
+// triggerv1.TriggerServiceServer directly and register them via WithToolService
+// / WithChannelService / WithTriggerService. plugins/slack is the canonical
+// example of this path (see ADR-050).
+//
 // # Choosing an event_id for TriggerService plugins
 //
 // Every StartResponse message must carry a stable event_id that the host uses

--- a/plugin-sdk/serve/erroradapt.go
+++ b/plugin-sdk/serve/erroradapt.go
@@ -1,0 +1,61 @@
+package serve
+
+import (
+	"errors"
+
+	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
+)
+
+// errorToEnvelope converts an error returned by an ergonomic service method
+// into a *commonv1.ErrorEnvelope for embedding in a response message.
+//
+// Mapping rules:
+//   - an error chain containing a *pluginerr.CodedError → that code's
+//     commonv1.ErrorCode 1:1 (CodeInvalidArg→ERROR_CODE_INVALID_ARG, …)
+//   - any other error → ERROR_CODE_INTERNAL with Message = err.Error()
+//
+// errors.As walks the wrap chain, so a CodedError wrapped with fmt.Errorf
+// ("...: %w", pluginerr.InvalidArg(...)) is still mapped to its real code
+// rather than silently downgraded to INTERNAL.
+//
+// nil is never passed here; callers guard on err != nil before calling.
+func errorToEnvelope(err error) *commonv1.ErrorEnvelope {
+	var ce *pluginerr.CodedError
+	if errors.As(err, &ce) {
+		return &commonv1.ErrorEnvelope{
+			Code:    pluginerrCodeToProto(ce.Code),
+			Message: ce.Message,
+		}
+	}
+	return &commonv1.ErrorEnvelope{
+		Code:    commonv1.ErrorCode_ERROR_CODE_INTERNAL,
+		Message: err.Error(),
+	}
+}
+
+// pluginerrCodeToProto maps a pluginerr.Code to its proto counterpart.
+// The numeric values are intentionally kept in sync (see pluginerr package),
+// so this is a direct cast — but we keep the explicit switch to make the
+// mapping readable and catch any future divergence at compile time.
+func pluginerrCodeToProto(c pluginerr.Code) commonv1.ErrorCode {
+	switch c {
+	case pluginerr.CodeInternal:
+		return commonv1.ErrorCode_ERROR_CODE_INTERNAL
+	case pluginerr.CodeInvalidArg:
+		return commonv1.ErrorCode_ERROR_CODE_INVALID_ARG
+	case pluginerr.CodeNotFound:
+		return commonv1.ErrorCode_ERROR_CODE_NOT_FOUND
+	case pluginerr.CodeUnavailable:
+		return commonv1.ErrorCode_ERROR_CODE_UNAVAILABLE
+	case pluginerr.CodePermission:
+		return commonv1.ErrorCode_ERROR_CODE_PERMISSION
+	case pluginerr.CodeRateLimited:
+		return commonv1.ErrorCode_ERROR_CODE_RATE_LIMITED
+	case pluginerr.CodeUnimplemented:
+		return commonv1.ErrorCode_ERROR_CODE_UNIMPLEMENTED
+	default:
+		// Unknown code — treat as internal rather than silently losing the error.
+		return commonv1.ErrorCode_ERROR_CODE_INTERNAL
+	}
+}

--- a/plugin-sdk/serve/handleradapters.go
+++ b/plugin-sdk/serve/handleradapters.go
@@ -1,0 +1,155 @@
+package serve
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
+)
+
+// ── Tool adapter ──────────────────────────────────────────────────────────────
+
+// toolHandlerAdapter bridges tool.Service onto toolv1.ToolServiceServer.
+// The struct stays unexported; use NewToolServer to construct one.
+//
+// Embedding UnimplementedToolServiceServer BY VALUE (not pointer) satisfies the
+// generated testEmbeddedByValue check that fires at RegisterToolServiceServer time.
+type toolHandlerAdapter struct {
+	toolv1.UnimplementedToolServiceServer
+	svc tool.Service
+}
+
+// NewToolServer wraps svc in a toolv1.ToolServiceServer adapter. The returned
+// value can be registered directly with toolv1.RegisterToolServiceServer.
+//
+// Error mapping: svc.Call errors become application-level ErrorEnvelope values
+// inside CallResponse (not gRPC status errors). svc.ListTools errors become a
+// gRPC codes.Internal status because ListToolsResponse has no Error field.
+func NewToolServer(svc tool.Service) toolv1.ToolServiceServer {
+	return &toolHandlerAdapter{svc: svc}
+}
+
+// ListTools calls svc.ListTools and maps the result. On error it returns a
+// gRPC-level codes.Internal status (not an envelope) because ListToolsResponse
+// has no Error field.
+func (a *toolHandlerAdapter) ListTools(ctx context.Context, _ *toolv1.ListToolsRequest) (*toolv1.ListToolsResponse, error) {
+	specs, err := a.svc.ListTools(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%s", err.Error())
+	}
+
+	schemas := make([]*toolv1.ToolSchema, len(specs))
+	for i, s := range specs {
+		schemas[i] = &toolv1.ToolSchema{
+			Name:        s.Name,
+			Description: s.Description,
+			InputSchema: s.InputSchema,
+		}
+	}
+	return &toolv1.ListToolsResponse{Tools: schemas}, nil
+}
+
+// Call invokes svc.Call and maps the result to an application-level envelope.
+// Errors from svc.Call are embedded in CallResponse.Error; the gRPC call
+// itself always succeeds (nil error returned).
+func (a *toolHandlerAdapter) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv1.CallResponse, error) {
+	out, err := a.svc.Call(ctx, req.GetToolName(), []byte(req.GetInputJson()))
+	if err != nil {
+		return &toolv1.CallResponse{Error: errorToEnvelope(err)}, nil
+	}
+	return &toolv1.CallResponse{OutputJson: string(out)}, nil
+}
+
+// Cancel is a no-op because cancellation is via ctx.Done() inside Call.
+// The host sends Cancel with a 5s deadline; we acknowledge immediately and
+// trust that Call is already selecting on ctx.Done().
+func (a *toolHandlerAdapter) Cancel(_ context.Context, _ *toolv1.CancelRequest) (*toolv1.CancelResponse, error) {
+	return &toolv1.CancelResponse{}, nil
+}
+
+// ── Channel adapter ───────────────────────────────────────────────────────────
+
+// channelHandlerAdapter bridges channel.Service onto channelv1.ChannelServiceServer.
+// The struct stays unexported; use NewChannelServer to construct one.
+type channelHandlerAdapter struct {
+	channelv1.UnimplementedChannelServiceServer
+	svc channel.Service
+}
+
+// NewChannelServer wraps svc in a channelv1.ChannelServiceServer adapter.
+// The returned value can be registered directly with
+// channelv1.RegisterChannelServiceServer.
+//
+// Error mapping: errors become application-level ErrorEnvelope values inside
+// NotifyResponse / RequestResponse (not gRPC status errors), consistent with
+// the channel protocol where failures do not fail the run.
+func NewChannelServer(svc channel.Service) channelv1.ChannelServiceServer {
+	return &channelHandlerAdapter{svc: svc}
+}
+
+func (a *channelHandlerAdapter) Notify(ctx context.Context, req *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+	n := channel.Notification{
+		EventType:     req.GetEventType(),
+		Payload:       []byte(req.GetPayloadJson()),
+		ChannelConfig: []byte(req.GetChannelConfigJson()),
+	}
+	if err := a.svc.Notify(ctx, n); err != nil {
+		return &channelv1.NotifyResponse{Ok: false, Error: errorToEnvelope(err)}, nil
+	}
+	return &channelv1.NotifyResponse{Ok: true}, nil
+}
+
+func (a *channelHandlerAdapter) Request(ctx context.Context, req *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+	r := channel.FeedbackRequest{
+		RequestID:     req.GetRequestId(),
+		Prompt:        req.GetPrompt(),
+		ChannelConfig: []byte(req.GetChannelConfigJson()),
+	}
+	if err := a.svc.Request(ctx, r); err != nil {
+		return &channelv1.RequestResponse{Acked: false, Error: errorToEnvelope(err)}, nil
+	}
+	return &channelv1.RequestResponse{Acked: true}, nil
+}
+
+// ── Trigger adapter ───────────────────────────────────────────────────────────
+
+// triggerHandlerAdapter bridges trigger.Service onto triggerv1.TriggerServiceServer.
+// The struct stays unexported; use NewTriggerServer to construct one.
+type triggerHandlerAdapter struct {
+	triggerv1.UnimplementedTriggerServiceServer
+	svc trigger.Service
+}
+
+// NewTriggerServer wraps svc in a triggerv1.TriggerServiceServer adapter.
+// The returned value can be registered directly with
+// triggerv1.RegisterTriggerServiceServer.
+//
+// The Start adapter passes stream.Context() as the ctx and wraps stream.Send
+// as the emit callback. Author errors propagate as the gRPC stream return
+// status (no ErrorEnvelope — StartResponse has no Error field).
+func NewTriggerServer(svc trigger.Service) triggerv1.TriggerServiceServer {
+	return &triggerHandlerAdapter{svc: svc}
+}
+
+func (a *triggerHandlerAdapter) Start(req *triggerv1.StartRequest, stream triggerv1.TriggerService_StartServer) error {
+	scope := trigger.StartScope{
+		WatchScope: []byte(req.GetWatchScopeJson()),
+	}
+
+	emit := func(e trigger.Event) error {
+		return stream.Send(&triggerv1.StartResponse{
+			EventId:     e.EventID,
+			EventKind:   e.EventKind,
+			PayloadJson: string(e.Payload),
+		})
+	}
+
+	return a.svc.Start(stream.Context(), scope, emit)
+}

--- a/plugin-sdk/serve/handleradapters_test.go
+++ b/plugin-sdk/serve/handleradapters_test.go
@@ -1,0 +1,475 @@
+package serve
+
+// handleradapters_test.go — unit tests for the ergonomic adapter layer.
+//
+// These tests sit in package serve (not serve_test) so they can reference the
+// unexported adapter structs for compile-time interface assertions. The tests
+// themselves only call the public API: NewToolServer, NewChannelServer,
+// NewTriggerServer, and the adapted methods via the generated server interfaces.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
+)
+
+// ── compile-time interface assertions ─────────────────────────────────────────
+
+// These ensure that the unexported adapter structs satisfy the generated server
+// interfaces; a missing method surfaces here at compile time rather than at
+// RegisterXServiceServer registration time.
+var _ toolv1.ToolServiceServer = (*toolHandlerAdapter)(nil)
+var _ channelv1.ChannelServiceServer = (*channelHandlerAdapter)(nil)
+var _ triggerv1.TriggerServiceServer = (*triggerHandlerAdapter)(nil)
+
+// ── fakes ────────────────────────────────────────────────────────────────────
+
+// fakeToolService is an in-test tool.Service implementation used by the table
+// tests. It returns fixed (specs, err) from ListTools and (output, err) from Call.
+type fakeToolService struct {
+	listToolsSpecs []tool.ToolSpec
+	listToolsErr   error
+	callOutput     []byte
+	callErr        error
+}
+
+func (f *fakeToolService) ListTools(_ context.Context) ([]tool.ToolSpec, error) {
+	return f.listToolsSpecs, f.listToolsErr
+}
+
+func (f *fakeToolService) Call(_ context.Context, _ string, _ []byte) ([]byte, error) {
+	return f.callOutput, f.callErr
+}
+
+// fakeChannelService is an in-test channel.Service implementation.
+type fakeChannelService struct {
+	notifyErr  error
+	requestErr error
+}
+
+func (f *fakeChannelService) Notify(_ context.Context, _ channel.Notification) error {
+	return f.notifyErr
+}
+
+func (f *fakeChannelService) Request(_ context.Context, _ channel.FeedbackRequest) error {
+	return f.requestErr
+}
+
+// fakeTriggerService is an in-test trigger.Service implementation.
+// The emitted slice holds events to emit before returning emitErr.
+type fakeTriggerService struct {
+	emitted []trigger.Event
+	startErr error
+}
+
+func (f *fakeTriggerService) Start(_ context.Context, _ trigger.StartScope, emit func(trigger.Event) error) error {
+	for _, e := range f.emitted {
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return f.startErr
+}
+
+// fakeStartStream captures Send calls and returns a fixed context.
+// It satisfies grpc.ServerStreamingServer[triggerv1.StartResponse].
+type fakeStartStream struct {
+	sent    []*triggerv1.StartResponse
+	sendErr error
+	ctx     context.Context
+}
+
+func (s *fakeStartStream) Send(resp *triggerv1.StartResponse) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sent = append(s.sent, resp)
+	return nil
+}
+
+func (s *fakeStartStream) Context() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return context.Background()
+}
+
+// The following methods implement grpc.ServerStream but are never called in our tests.
+func (s *fakeStartStream) SetHeader(metadata.MD) error  { return nil }
+func (s *fakeStartStream) SendHeader(metadata.MD) error { return nil }
+func (s *fakeStartStream) SetTrailer(metadata.MD)       {}
+func (s *fakeStartStream) SendMsg(any) error            { return nil }
+func (s *fakeStartStream) RecvMsg(any) error            { return nil }
+
+// ── toolHandlerAdapter tests ─────────────────────────────────────────────────
+
+// TestToolAdapter_Call_ErrorMapping verifies that each pluginerr code is
+// translated to its corresponding commonv1.ErrorCode in the Call response
+// envelope, and that a plain error becomes ERROR_CODE_INTERNAL.
+func TestToolAdapter_Call_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode commonv1.ErrorCode
+	}{
+		{"InvalidArg", pluginerr.InvalidArg("bad arg"), commonv1.ErrorCode_ERROR_CODE_INVALID_ARG},
+		{"NotFound", pluginerr.NotFound("not found"), commonv1.ErrorCode_ERROR_CODE_NOT_FOUND},
+		{"Internal", pluginerr.Internal("oops"), commonv1.ErrorCode_ERROR_CODE_INTERNAL},
+		{"Unavailable", pluginerr.Unavailable("retry"), commonv1.ErrorCode_ERROR_CODE_UNAVAILABLE},
+		{"Permission", pluginerr.Permission("no access"), commonv1.ErrorCode_ERROR_CODE_PERMISSION},
+		{"RateLimited", pluginerr.RateLimited("slow down"), commonv1.ErrorCode_ERROR_CODE_RATE_LIMITED},
+		{"Unimplemented", pluginerr.Unimplemented("not impl"), commonv1.ErrorCode_ERROR_CODE_UNIMPLEMENTED},
+		{"PlainError", errors.New("something broke"), commonv1.ErrorCode_ERROR_CODE_INTERNAL},
+		// A CodedError wrapped with %w is still mapped to its real code (errors.As
+		// walks the chain), not silently downgraded to INTERNAL.
+		{"WrappedCoded", fmt.Errorf("while calling: %w", pluginerr.InvalidArg("bad arg")), commonv1.ErrorCode_ERROR_CODE_INVALID_ARG},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewToolServer(&fakeToolService{callErr: tc.err})
+			resp, err := srv.Call(context.Background(), &toolv1.CallRequest{
+				ToolName:  "test",
+				InputJson: `{}`,
+			})
+			if err != nil {
+				t.Fatalf("Call returned gRPC error: %v (want nil gRPC error, error in envelope)", err)
+			}
+			if resp.GetError() == nil {
+				t.Fatal("expected error envelope, got nil")
+			}
+			if resp.GetError().GetCode() != tc.wantCode {
+				t.Errorf("code: want %v, got %v", tc.wantCode, resp.GetError().GetCode())
+			}
+		})
+	}
+}
+
+// TestToolAdapter_Call_Success verifies that a successful Call returns
+// OutputJson and a nil Error envelope.
+func TestToolAdapter_Call_Success(t *testing.T) {
+	wantOutput := `{"echoed":"hi"}`
+	srv := NewToolServer(&fakeToolService{callOutput: []byte(wantOutput)})
+
+	resp, err := srv.Call(context.Background(), &toolv1.CallRequest{
+		ToolName:  "echo",
+		InputJson: `{"message":"hi"}`,
+	})
+	if err != nil {
+		t.Fatalf("Call gRPC error: %v", err)
+	}
+	if resp.GetError() != nil {
+		t.Fatalf("unexpected error envelope: %v", resp.GetError().GetMessage())
+	}
+	if resp.GetOutputJson() != wantOutput {
+		t.Errorf("OutputJson: want %q, got %q", wantOutput, resp.GetOutputJson())
+	}
+}
+
+// TestToolAdapter_ListTools_Success verifies that ToolSpec values are
+// translated field-by-field into ToolSchema protos.
+func TestToolAdapter_ListTools_Success(t *testing.T) {
+	specs := []tool.ToolSpec{
+		{Name: "foo", Description: "does foo", InputSchema: `{"type":"object"}`},
+		{Name: "bar", Description: "does bar", InputSchema: `{}`},
+	}
+	srv := NewToolServer(&fakeToolService{listToolsSpecs: specs})
+
+	resp, err := srv.ListTools(context.Background(), &toolv1.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools gRPC error: %v", err)
+	}
+	if len(resp.GetTools()) != len(specs) {
+		t.Fatalf("want %d tools, got %d", len(specs), len(resp.GetTools()))
+	}
+	for i, s := range specs {
+		got := resp.GetTools()[i]
+		if got.GetName() != s.Name {
+			t.Errorf("[%d] Name: want %q, got %q", i, s.Name, got.GetName())
+		}
+		if got.GetDescription() != s.Description {
+			t.Errorf("[%d] Description: want %q, got %q", i, s.Description, got.GetDescription())
+		}
+		if got.GetInputSchema() != s.InputSchema {
+			t.Errorf("[%d] InputSchema: want %q, got %q", i, s.InputSchema, got.GetInputSchema())
+		}
+	}
+}
+
+// TestToolAdapter_ListTools_Error verifies that an error from ListTools
+// becomes a gRPC codes.Internal status (not an application envelope), because
+// ListToolsResponse has no Error field.
+func TestToolAdapter_ListTools_Error(t *testing.T) {
+	srv := NewToolServer(&fakeToolService{listToolsErr: errors.New("discovery failed")})
+
+	resp, err := srv.ListTools(context.Background(), &toolv1.ListToolsRequest{})
+	if err == nil {
+		t.Fatal("expected gRPC error from ListTools, got nil; resp:", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Errorf("status code: want codes.Internal, got %s", st.Code())
+	}
+}
+
+// TestToolAdapter_Cancel_Noop verifies that Cancel always succeeds with an
+// empty response — cancellation is via ctx.Done() inside Call.
+func TestToolAdapter_Cancel_Noop(t *testing.T) {
+	srv := NewToolServer(&fakeToolService{})
+	resp, err := srv.Cancel(context.Background(), &toolv1.CancelRequest{})
+	if err != nil {
+		t.Fatalf("Cancel gRPC error: %v", err)
+	}
+	if resp == nil {
+		t.Error("Cancel returned nil response")
+	}
+}
+
+// ── channelHandlerAdapter tests ──────────────────────────────────────────────
+
+// TestChannelAdapter_Notify_ErrorMapping verifies that each pluginerr code
+// appears in the NotifyResponse envelope and that a plain error → INTERNAL.
+func TestChannelAdapter_Notify_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode commonv1.ErrorCode
+	}{
+		{"InvalidArg", pluginerr.InvalidArg("bad"), commonv1.ErrorCode_ERROR_CODE_INVALID_ARG},
+		{"Internal", pluginerr.Internal("oops"), commonv1.ErrorCode_ERROR_CODE_INTERNAL},
+		{"Unimplemented", pluginerr.Unimplemented("not impl"), commonv1.ErrorCode_ERROR_CODE_UNIMPLEMENTED},
+		{"PlainError", errors.New("plain"), commonv1.ErrorCode_ERROR_CODE_INTERNAL},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewChannelServer(&fakeChannelService{notifyErr: tc.err})
+			resp, err := srv.Notify(context.Background(), &channelv1.NotifyRequest{})
+			if err != nil {
+				t.Fatalf("Notify gRPC error: %v", err)
+			}
+			if resp.GetOk() {
+				t.Fatal("expected Ok=false, got Ok=true")
+			}
+			if resp.GetError() == nil {
+				t.Fatal("expected error envelope, got nil")
+			}
+			if resp.GetError().GetCode() != tc.wantCode {
+				t.Errorf("code: want %v, got %v", tc.wantCode, resp.GetError().GetCode())
+			}
+		})
+	}
+}
+
+// TestChannelAdapter_Notify_Success verifies that a nil error → Ok=true, no envelope.
+func TestChannelAdapter_Notify_Success(t *testing.T) {
+	srv := NewChannelServer(&fakeChannelService{notifyErr: nil})
+	resp, err := srv.Notify(context.Background(), &channelv1.NotifyRequest{
+		PayloadJson:       `{"body":"test"}`,
+		ChannelConfigJson: `{"topic":"alerts"}`,
+		EventType:         "run_failed",
+	})
+	if err != nil {
+		t.Fatalf("Notify gRPC error: %v", err)
+	}
+	if !resp.GetOk() {
+		t.Error("expected Ok=true")
+	}
+	if resp.GetError() != nil {
+		t.Errorf("unexpected error envelope: %v", resp.GetError().GetMessage())
+	}
+}
+
+// TestChannelAdapter_Request_ErrorMapping verifies that Unimplemented (the
+// common ntfy case) maps to an application-level envelope, not a gRPC status.
+func TestChannelAdapter_Request_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode commonv1.ErrorCode
+	}{
+		{"Unimplemented", pluginerr.Unimplemented("not impl"), commonv1.ErrorCode_ERROR_CODE_UNIMPLEMENTED},
+		{"Internal", pluginerr.Internal("oops"), commonv1.ErrorCode_ERROR_CODE_INTERNAL},
+		{"PlainError", errors.New("plain"), commonv1.ErrorCode_ERROR_CODE_INTERNAL},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewChannelServer(&fakeChannelService{requestErr: tc.err})
+			resp, err := srv.Request(context.Background(), &channelv1.RequestRequest{})
+			if err != nil {
+				t.Fatalf("Request gRPC error: %v (want nil gRPC error, error in envelope)", err)
+			}
+			if resp.GetAcked() {
+				t.Fatal("expected Acked=false")
+			}
+			if resp.GetError() == nil {
+				t.Fatal("expected error envelope, got nil")
+			}
+			if resp.GetError().GetCode() != tc.wantCode {
+				t.Errorf("code: want %v, got %v", tc.wantCode, resp.GetError().GetCode())
+			}
+		})
+	}
+}
+
+// TestChannelAdapter_Request_Success verifies nil error → Acked=true, no envelope.
+func TestChannelAdapter_Request_Success(t *testing.T) {
+	srv := NewChannelServer(&fakeChannelService{requestErr: nil})
+	resp, err := srv.Request(context.Background(), &channelv1.RequestRequest{
+		RequestId: "req-1",
+		Prompt:    "approve?",
+	})
+	if err != nil {
+		t.Fatalf("Request gRPC error: %v", err)
+	}
+	if !resp.GetAcked() {
+		t.Error("expected Acked=true")
+	}
+	if resp.GetError() != nil {
+		t.Errorf("unexpected error envelope: %v", resp.GetError().GetMessage())
+	}
+}
+
+// ── triggerHandlerAdapter tests ──────────────────────────────────────────────
+
+// TestTriggerAdapter_Start_EmitForwardedToStream verifies that events passed
+// to emit are forwarded via stream.Send with correct field mapping.
+func TestTriggerAdapter_Start_EmitForwardedToStream(t *testing.T) {
+	events := []trigger.Event{
+		{EventID: "id-1", EventKind: "slack_message", Payload: []byte(`{"text":"hello"}`)},
+		{EventID: "id-2", EventKind: "slack_message", Payload: []byte(`{"text":"world"}`)},
+	}
+	svc := &fakeTriggerService{emitted: events}
+	srv := NewTriggerServer(svc)
+
+	stream := &fakeStartStream{}
+	req := &triggerv1.StartRequest{WatchScopeJson: `{"channels":["#gen"]}`}
+
+	if err := srv.Start(req, stream); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	if len(stream.sent) != len(events) {
+		t.Fatalf("want %d sent messages, got %d", len(events), len(stream.sent))
+	}
+	for i, e := range events {
+		got := stream.sent[i]
+		if got.GetEventId() != e.EventID {
+			t.Errorf("[%d] EventId: want %q, got %q", i, e.EventID, got.GetEventId())
+		}
+		if got.GetEventKind() != e.EventKind {
+			t.Errorf("[%d] EventKind: want %q, got %q", i, e.EventKind, got.GetEventKind())
+		}
+		if got.GetPayloadJson() != string(e.Payload) {
+			t.Errorf("[%d] PayloadJson: want %q, got %q", i, string(e.Payload), got.GetPayloadJson())
+		}
+	}
+}
+
+// TestTriggerAdapter_Start_AuthorErrorPropagates verifies that an error
+// returned by Start propagates directly as the gRPC stream status.
+func TestTriggerAdapter_Start_AuthorErrorPropagates(t *testing.T) {
+	wantErr := errors.New("substrate disconnected")
+	svc := &fakeTriggerService{startErr: wantErr}
+	srv := NewTriggerServer(svc)
+
+	stream := &fakeStartStream{}
+	err := srv.Start(&triggerv1.StartRequest{}, stream)
+	if err == nil {
+		t.Fatal("expected error from Start, got nil")
+	}
+	if err.Error() != wantErr.Error() {
+		t.Errorf("error: want %q, got %q", wantErr.Error(), err.Error())
+	}
+}
+
+// TestTriggerAdapter_Start_SendErrorShortCircuits verifies that when stream.Send
+// returns an error, the emit function returns it and Start exits.
+func TestTriggerAdapter_Start_SendErrorShortCircuits(t *testing.T) {
+	sendErr := errors.New("stream closed")
+	events := []trigger.Event{
+		{EventID: "id-1", EventKind: "kind", Payload: []byte(`{}`)},
+		{EventID: "id-2", EventKind: "kind", Payload: []byte(`{}`)},
+	}
+	svc := &fakeTriggerService{emitted: events}
+	srv := NewTriggerServer(svc)
+
+	// Stream that fails on every Send.
+	stream := &fakeStartStream{sendErr: sendErr}
+	err := srv.Start(&triggerv1.StartRequest{}, stream)
+
+	// The emit error propagates out through Start.
+	if err == nil {
+		t.Fatal("expected error from Start after Send failure, got nil")
+	}
+	if err.Error() != sendErr.Error() {
+		t.Errorf("error: want %q, got %q", sendErr.Error(), err.Error())
+	}
+	// No messages should have been appended to stream.sent (sendErr fires before append).
+	if len(stream.sent) != 0 {
+		t.Errorf("want 0 sent messages (send failed), got %d", len(stream.sent))
+	}
+}
+
+// TestChannelAdapter_Notify_FieldMapping verifies that the proto request fields
+// are correctly mapped onto the channel.Notification passed to Notify.
+func TestChannelAdapter_Notify_FieldMapping(t *testing.T) {
+	var gotNotification channel.Notification
+	captureService := &capturingChannelService{onNotify: func(n channel.Notification) {
+		gotNotification = n
+	}}
+	srv := NewChannelServer(captureService)
+
+	_, err := srv.Notify(context.Background(), &channelv1.NotifyRequest{
+		EventType:         "run_failed",
+		PayloadJson:       `{"body":"alert"}`,
+		ChannelConfigJson: `{"topic":"ops"}`,
+	})
+	if err != nil {
+		t.Fatalf("Notify gRPC error: %v", err)
+	}
+
+	if gotNotification.EventType != "run_failed" {
+		t.Errorf("EventType: want %q, got %q", "run_failed", gotNotification.EventType)
+	}
+	if string(gotNotification.Payload) != `{"body":"alert"}` {
+		t.Errorf("Payload: want %q, got %q", `{"body":"alert"}`, string(gotNotification.Payload))
+	}
+	if string(gotNotification.ChannelConfig) != `{"topic":"ops"}` {
+		t.Errorf("ChannelConfig: want %q, got %q", `{"topic":"ops"}`, string(gotNotification.ChannelConfig))
+	}
+}
+
+// capturingChannelService lets tests inspect what was passed to the service method.
+type capturingChannelService struct {
+	onNotify func(channel.Notification)
+}
+
+func (c *capturingChannelService) Notify(_ context.Context, n channel.Notification) error {
+	if c.onNotify != nil {
+		c.onNotify(n)
+	}
+	return nil
+}
+
+func (c *capturingChannelService) Request(_ context.Context, _ channel.FeedbackRequest) error {
+	return nil
+}

--- a/plugin-sdk/serve/options.go
+++ b/plugin-sdk/serve/options.go
@@ -9,7 +9,10 @@ import (
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )
 
 // config holds the resolved options for a Serve or EmitManifest call.
@@ -74,4 +77,51 @@ func WithManifest(m manifest.Manifest) Option {
 // default is slog.Default(). Useful in tests to capture log output.
 func WithLogger(l *slog.Logger) Option {
 	return func(c *config) { c.logger = l }
+}
+
+// WithToolHandler registers an ergonomic ToolService factory. The factory
+// receives the typed HostServiceClient after Bootstrap.Bind completes, exactly
+// like WithToolService. The ergonomic tool.Service return value is wrapped via
+// NewToolServer before being stored, so it satisfies toolv1.ToolServiceServer.
+//
+// Passing both WithToolService and WithToolHandler is supported but the last
+// option applied wins (newConfig applies options in order). Do not pass both
+// for the same service type — it is confusing and the earlier one is silently
+// dropped.
+func WithToolHandler(f func(hostv1.HostServiceClient) tool.Service) Option {
+	return func(c *config) {
+		c.toolFactory = func(h hostv1.HostServiceClient) toolv1.ToolServiceServer {
+			return NewToolServer(f(h))
+		}
+	}
+}
+
+// WithChannelHandler registers an ergonomic ChannelService factory. The
+// factory receives the typed HostServiceClient after Bootstrap.Bind completes,
+// exactly like WithChannelService. The ergonomic channel.Service return value
+// is wrapped via NewChannelServer before being stored.
+//
+// Passing both WithChannelService and WithChannelHandler is supported but the
+// last option applied wins. Do not pass both for the same service type.
+func WithChannelHandler(f func(hostv1.HostServiceClient) channel.Service) Option {
+	return func(c *config) {
+		c.channelFactory = func(h hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+			return NewChannelServer(f(h))
+		}
+	}
+}
+
+// WithTriggerHandler registers an ergonomic TriggerService factory. The
+// factory receives the typed HostServiceClient after Bootstrap.Bind completes,
+// exactly like WithTriggerService. The ergonomic trigger.Service return value
+// is wrapped via NewTriggerServer before being stored.
+//
+// Passing both WithTriggerService and WithTriggerHandler is supported but the
+// last option applied wins. Do not pass both for the same service type.
+func WithTriggerHandler(f func(hostv1.HostServiceClient) trigger.Service) Option {
+	return func(c *config) {
+		c.triggerFactory = func(h hostv1.HostServiceClient) triggerv1.TriggerServiceServer {
+			return NewTriggerServer(f(h))
+		}
+	}
 }

--- a/plugin-sdk/tool/service.go
+++ b/plugin-sdk/tool/service.go
@@ -1,0 +1,64 @@
+// Package tool defines the ergonomic ToolService interface for plugin authors.
+// It is proto-free: no types from plugin-sdk/gen/ appear in its signatures.
+// The serve package adapts this interface onto the generated toolv1.ToolServiceServer.
+package tool
+
+import "context"
+
+// ToolSpec describes a single tool exposed by a plugin. Fields map 1:1 to the
+// toolv1.ToolSchema proto message; the adapter in serve/ translates between them.
+type ToolSpec struct {
+	Name        string
+	Description string
+	// InputSchema is a JSON Schema document (serialized as a JSON string)
+	// describing the tool's input parameters. The host uses this for
+	// per-policy parameter scoping (ADR-017) and agent schema narrowing.
+	InputSchema string
+}
+
+// Service is the ergonomic interface plugin authors implement to expose
+// agent-callable tools. It is deliberately minimal: authors deal in plain Go
+// types and []byte JSON without touching proto messages or ErrorEnvelope
+// construction.
+//
+// # Cancellation
+//
+// Both ListTools and Call receive a context that the host cancels when the run
+// is cancelled or the gRPC deadline fires. Every blocking I/O operation inside
+// Call MUST select on ctx.Done() so the goroutine returns promptly. The host
+// enforces a 5s grace period before force-disconnecting (spec §13.8).
+//
+// # Cancel RPC
+//
+// The generated ToolServiceServer requires a Cancel method; the adapter in
+// serve/ implements it as a no-op. The documented cancellation contract for
+// ergonomic plugins is via ctx.Done() inside Call; there is no separate
+// cancel callback.
+//
+// # Host RPCs
+//
+// To make outbound host RPCs (Log, EmitMetric, GetInstanceConfig, …), call
+// serve.WithCallContext(ctx) BEFORE each host RPC. The adapter does NOT apply
+// it automatically, so that authors can control context propagation in
+// detached goroutines correctly.
+//
+// # ListTools errors
+//
+// Errors returned from ListTools are translated to a gRPC-level
+// codes.Internal status (not an application-level ErrorEnvelope), because
+// ListToolsResponse has no Error field. Log and return a descriptive error;
+// the host will surface it as a capability discovery failure.
+type Service interface {
+	// ListTools returns all tools this plugin instance currently exposes.
+	// Called once on startup and after hot-reload.
+	ListTools(ctx context.Context) ([]ToolSpec, error)
+
+	// Call invokes the named tool with the JSON-encoded input and returns
+	// JSON-encoded output. input is the raw input_json string from the
+	// CallRequest; output is written to the output_json field of CallResponse.
+	//
+	// Return a pluginerr.CodedError for well-typed errors (InvalidArg,
+	// NotFound, …); plain errors become ERROR_CODE_INTERNAL in the response
+	// envelope. A nil error with non-nil output is the success path.
+	Call(ctx context.Context, tool string, input []byte) (output []byte, err error)
+}

--- a/plugin-sdk/trigger/service.go
+++ b/plugin-sdk/trigger/service.go
@@ -1,0 +1,64 @@
+// Package trigger defines the ergonomic TriggerService interface for plugin authors.
+// It is proto-free: no types from plugin-sdk/gen/ appear in its signatures.
+// The serve package adapts this interface onto the generated triggerv1.TriggerServiceServer.
+package trigger
+
+import "context"
+
+// Event is a single substrate event emitted by a plugin to the host. Fields
+// map 1:1 to the triggerv1.StartResponse proto message; the adapter in serve/
+// translates between them.
+type Event struct {
+	// EventID is a stable, substrate-derived identifier for this specific event
+	// occurrence. Used by the host for deduplication within a 1-hour rolling
+	// window (spec §4.3). Use a ULID where possible; fall back to SHA-256 of
+	// the canonical payload (see serve package doc for ULID guidance).
+	EventID string
+	// EventKind must match one of the event_kinds declared in the plugin manifest.
+	EventKind string
+	// Payload is the event payload serialized as a JSON object. The host
+	// evaluates per-policy bindings against this payload using field-typed
+	// operators (spec §7.3).
+	Payload []byte
+}
+
+// StartScope carries the subscription scope the host passes when opening the
+// trigger stream. Fields map 1:1 to the triggerv1.StartRequest proto message.
+type StartScope struct {
+	// WatchScope is the coarse subscription scope set by the admin on the
+	// plugin instance (e.g. {"channels": ["#incidents"]} for Slack).
+	// Validated against the plugin's manifest watch_scope_schema at instance
+	// config save time.
+	WatchScope []byte
+}
+
+// Service is the ergonomic interface plugin authors implement to emit events
+// from an external substrate. Authors deal in plain Go types and []byte JSON
+// without touching proto messages.
+//
+// # Cancellation
+//
+// Start MUST return when ctx.Done() is closed. The ctx is derived from the
+// gRPC stream; the host closes the stream on shutdown or hot-reload. Every
+// blocking I/O operation inside Start MUST select on ctx.Done() and return
+// promptly when cancelled.
+//
+// # Emit errors
+//
+// If emit(e) returns an error, the stream has been closed by the host.
+// Start SHOULD return at that point (the error from emit propagates as the
+// stream return status).
+//
+// # Host RPCs
+//
+// To make outbound host RPCs from a background goroutine started inside Start,
+// call serve.WithCallContext(ctx) passing a context derived from the stream
+// context. The adapter does NOT apply it automatically.
+type Service interface {
+	// Start opens the event stream. The plugin monitors its substrate and calls
+	// emit for each incoming event. Start runs for the lifetime of the stream;
+	// the host holds one stream open indefinitely until shutdown or hot-reload.
+	//
+	// The error returned by Start propagates as the gRPC stream return status.
+	Start(ctx context.Context, scope StartScope, emit func(Event) error) error
+}

--- a/plugins/ntfy/main.go
+++ b/plugins/ntfy/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"net/http"
 
-	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 func main() {
 	serve.Serve(
 		serve.WithManifest(pluginManifest),
-		serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
+		serve.WithChannelHandler(func(host hostv1.HostServiceClient) channel.Service {
 			return NewChannelService(host, http.DefaultClient)
 		}),
 	)

--- a/plugins/ntfy/service.go
+++ b/plugins/ntfy/service.go
@@ -8,16 +8,15 @@ import (
 	"net/http"
 	"strings"
 
-	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
-	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
-// ChannelService implements channelv1.ChannelServiceServer with Notify only.
+// ChannelService implements channel.Service with Notify only.
 // It POSTs to <server_url>/<topic> with an optional API key auth header.
 type ChannelService struct {
-	channelv1.UnimplementedChannelServiceServer
 	host       hostv1.HostServiceClient
 	httpClient *http.Client
 }
@@ -58,34 +57,23 @@ type notifyPayload struct {
 	Message string `json:"message"`
 }
 
-func internalErr(msg string) *commonv1.ErrorEnvelope {
-	return &commonv1.ErrorEnvelope{
-		Code:    commonv1.ErrorCode_ERROR_CODE_INTERNAL,
-		Message: msg,
-	}
-}
-
-func invalidArgErr(msg string) *commonv1.ErrorEnvelope {
-	return &commonv1.ErrorEnvelope{
-		Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
-		Message: msg,
-	}
-}
-
 // Notify delivers a fire-and-forget notification to ntfy.
 // Plugins MUST honor ctx.Done(): when the host cancels the call (run cancelled
 // or operator cancellation), every blocking I/O must use this ctx.
-func (s *ChannelService) Notify(ctx context.Context, req *channelv1.NotifyRequest) (*channelv1.NotifyResponse, error) {
+func (s *ChannelService) Notify(ctx context.Context, n channel.Notification) error {
+	// Propagate the host-injected call ID to all outgoing host RPCs so the host
+	// can correlate them back to this run and step. See serve.WithCallContext
+	// and plugin-system-spec.md §8.5.
 	hostCtx := serve.WithCallContext(ctx)
 
 	// 1. Fetch instance config (server URL, default topic, auth header name).
 	cfgResp, err := s.host.GetInstanceConfig(hostCtx, &hostv1.GetInstanceConfigRequest{})
 	if err != nil {
-		return &channelv1.NotifyResponse{Ok: false, Error: internalErr(fmt.Sprintf("GetInstanceConfig: %v", err))}, nil
+		return pluginerr.Internal(fmt.Sprintf("GetInstanceConfig: %v", err))
 	}
 	var cfg instanceConfig
 	if err := json.Unmarshal([]byte(cfgResp.GetConfigJson()), &cfg); err != nil {
-		return &channelv1.NotifyResponse{Ok: false, Error: internalErr(fmt.Sprintf("parse instance config: %v", err))}, nil
+		return pluginerr.Internal(fmt.Sprintf("parse instance config: %v", err))
 	}
 	if cfg.AuthHeaderName == "" {
 		cfg.AuthHeaderName = "Authorization"
@@ -94,33 +82,33 @@ func (s *ChannelService) Notify(ctx context.Context, req *channelv1.NotifyReques
 	// 2. Fetch credentials (API key is optional — ntfy supports unauthenticated topics).
 	credResp, err := s.host.GetCredentials(hostCtx, &hostv1.GetCredentialsRequest{})
 	if err != nil {
-		return &channelv1.NotifyResponse{Ok: false, Error: internalErr(fmt.Sprintf("GetCredentials: %v", err))}, nil
+		return pluginerr.Internal(fmt.Sprintf("GetCredentials: %v", err))
 	}
 	var creds credentials
 	// Tolerate empty credentials JSON (no key configured).
 	if raw := credResp.GetCredentialsJson(); raw != "" && raw != "{}" {
 		if err := json.Unmarshal([]byte(raw), &creds); err != nil {
-			return &channelv1.NotifyResponse{Ok: false, Error: internalErr(fmt.Sprintf("parse credentials: %v", err))}, nil
+			return pluginerr.Internal(fmt.Sprintf("parse credentials: %v", err))
 		}
 	}
 
 	// 3. Resolve topic: per-audience entry config overrides instance default.
 	var chanCfg channelConfig
-	if raw := req.GetChannelConfigJson(); raw != "" {
-		_ = json.Unmarshal([]byte(raw), &chanCfg) // tolerate missing/malformed
+	if raw := n.ChannelConfig; len(raw) > 0 {
+		_ = json.Unmarshal(raw, &chanCfg) // tolerate missing/malformed
 	}
 	topic := chanCfg.Topic
 	if topic == "" {
 		topic = cfg.DefaultTopic
 	}
 	if topic == "" {
-		return &channelv1.NotifyResponse{Ok: false, Error: invalidArgErr("no topic: set default_topic in instance config or topic in channel config")}, nil
+		return pluginerr.InvalidArg("no topic: set default_topic in instance config or topic in channel config")
 	}
 
 	// 4. Extract title and body from the notification payload.
 	var payload notifyPayload
-	if raw := req.GetPayloadJson(); raw != "" {
-		_ = json.Unmarshal([]byte(raw), &payload) // tolerate unknown schemas
+	if raw := n.Payload; len(raw) > 0 {
+		_ = json.Unmarshal(raw, &payload) // tolerate unknown schemas
 	}
 	body := payload.Body
 	if body == "" {
@@ -131,7 +119,7 @@ func (s *ChannelService) Notify(ctx context.Context, req *channelv1.NotifyReques
 	url := strings.TrimRight(cfg.ServerURL, "/") + "/" + topic
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
 	if err != nil {
-		return &channelv1.NotifyResponse{Ok: false, Error: internalErr(fmt.Sprintf("build request: %v", err))}, nil
+		return pluginerr.Internal(fmt.Sprintf("build request: %v", err))
 	}
 	if payload.Title != "" {
 		httpReq.Header.Set("Title", payload.Title)
@@ -142,17 +130,23 @@ func (s *ChannelService) Notify(ctx context.Context, req *channelv1.NotifyReques
 
 	httpResp, err := s.httpClient.Do(httpReq)
 	if err != nil {
-		return &channelv1.NotifyResponse{Ok: false, Error: internalErr(fmt.Sprintf("POST %s: %v", url, err))}, nil
+		return pluginerr.Internal(fmt.Sprintf("POST %s: %v", url, err))
 	}
 	defer httpResp.Body.Close()
 	_, _ = io.Copy(io.Discard, httpResp.Body)
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		return &channelv1.NotifyResponse{
-			Ok:    false,
-			Error: internalErr(fmt.Sprintf("ntfy returned HTTP %d", httpResp.StatusCode)),
-		}, nil
+		return pluginerr.Internal(fmt.Sprintf("ntfy returned HTTP %d", httpResp.StatusCode))
 	}
 
-	return &channelv1.NotifyResponse{Ok: true}, nil
+	return nil
+}
+
+// Request is not supported by ntfy — it is a Notify-only channel plugin.
+// Returning pluginerr.Unimplemented produces an application-level
+// RequestResponse{Acked: false, Error: {UNIMPLEMENTED}} envelope rather than
+// a gRPC status error. In normal operation the host never routes Request to
+// this plugin because the manifest declares Notify-only channel_capabilities.
+func (s *ChannelService) Request(_ context.Context, _ channel.FeedbackRequest) error {
+	return pluginerr.Unimplemented("ntfy supports Notify only; Request is not implemented")
 }

--- a/plugins/ntfy/service_test.go
+++ b/plugins/ntfy/service_test.go
@@ -13,13 +13,14 @@ import (
 
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
 )
 
 // setup starts in-process gRPC servers for both the fake host and the channel
-// service. ntfyBackend is an optional httptest.Server used as the fake ntfy
-// endpoint; pass nil to create a ChannelService with no backend configured.
-// Returns the channel client, the fake host, and a cleanup function.
+// service (via the ergonomic adapter). ntfyBackend is an optional httptest.Server
+// used as the fake ntfy endpoint; pass nil to create a ChannelService with no
+// backend configured. Returns the channel client, the fake host, and a cleanup function.
 func setup(t *testing.T, ntfyBackend *httptest.Server, hostOpts ...plugintest.Option) (channelv1.ChannelServiceClient, *plugintest.FakeHost, func()) {
 	t.Helper()
 
@@ -50,13 +51,15 @@ func setup(t *testing.T, ntfyBackend *httptest.Server, hostOpts ...plugintest.Op
 	}
 	svc := NewChannelService(hostClient, httpClient)
 
-	// Start channel service gRPC server.
+	// Start channel service gRPC server via the exported adapter constructor.
+	// This gives the test a live gRPC round-trip through the ergonomic seam,
+	// validating channelHandlerAdapter in addition to ChannelService logic.
 	chanLis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen for channel: %v", err)
 	}
 	chanSrv := grpc.NewServer()
-	channelv1.RegisterChannelServiceServer(chanSrv, svc)
+	channelv1.RegisterChannelServiceServer(chanSrv, serve.NewChannelServer(svc))
 	go func() { _ = chanSrv.Serve(chanLis) }()
 
 	// Dial the channel service.


### PR DESCRIPTION
Closes #457

## Summary

Adds an **ergonomic Service seam** over the raw generated gRPC servers so plugin authors write plain Go instead of proto plumbing. Today the only seam is `serve.WithToolService(func(host) toolv1.ToolServiceServer)` — authors implement the raw proto server, marshal `input_json`/`output_json` by hand, and build `commonv1.ErrorEnvelope` on every path. This PR adds:

- **New proto-free packages** (`plugin-sdk/tool`, `channel`, `trigger`, `pluginerr`): hand-written interfaces — e.g. `tool.Service.Call(ctx, name string, input []byte) ([]byte, error)` — and a `pluginerr` package so authors pick error codes without importing `gen/`.
- **Adapters + exported constructors** in `serve` (`NewToolServer`/`NewChannelServer`/`NewTriggerServer`) that map the ergonomic interfaces onto the generated `*ServiceServer`, centralizing `error → ErrorEnvelope` mapping and `[]byte ↔ *_json`.
- **New options** `serve.WithToolHandler`/`WithChannelHandler`/`WithTriggerHandler`, which set the *same* `config` factory field as the raw options (wrapping via the constructors), so `server.go` and capability negotiation are **unchanged**. Raw `With*Service` options are retained for full-proto control (last-option-wins precedence, documented).

## Dogfood / scope

- **`plugins/ntfy` migrated** to the ergonomic `channel.Service` (the "second consumer" that turns the seam from hypothetical to proven). Its test suite keeps the full gRPC round-trip by registering `serve.NewChannelServer(...)`.
- **`plugins/slack` intentionally stays on the raw seam** (tracked follow-up) — it compiles and passes unchanged, demonstrating the change is additive/non-breaking.
- `examples/minimal-tool` rewritten to the ergonomic seam (~90 → ~50 LOC).

## Design notes

- Ergonomic signatures contain **no proto types**; the proto coupling lives only in `serve/` adapters. No import cycles.
- `ListTools` errors become a `codes.Internal` gRPC status (its response has no `Error` field), distinct from `Call`/`Notify`/`Request` which return an application-level `ErrorEnvelope`.
- Error mapping uses `errors.As`, so a `CodedError` wrapped with `%w` maps to its real code rather than silently downgrading to `INTERNAL` (covered by a `WrappedCoded` test).
- Cancellation is via `ctx.Done()` inside `Call`/`Start`; authors call `serve.WithCallContext(ctx)` themselves before host RPCs (documented on the interfaces).
- Recorded as **ADR-050** (ergonomic-vs-raw coexistence).

## Tests

`serve/handleradapters_test.go` (every `pluginerr → ErrorCode` mapping, plain/wrapped → INTERNAL, ListTools-status-vs-Call-envelope distinction, trigger `emit → Send`, compile-time interface assertions). ntfy (5 cases) and minimal-tool tests exercise the live adapter via gRPC. Full `go.work` workspace `go vet`/`build`/`test` green via the commit hook; slack unchanged.

## Dev-loop metadata

Pipeline: architect → plan-review (**REVISE**: exported adapter constructors so tests keep real gRPC round-trips; ListTools-status vs envelope; ntfy keeps gRPC path) → implement → code-review (**APPROVE**; applied the reviewer's `errors.As` polish + a wrapped-error test). CLAUDE.md: no updates needed. Generated by the agentic dev loop.
