### PR TITLE
fix: scaffold generates compilable plugins on the ergonomic seam + golden build test (#458)

### DIFF
--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/scaffold_test.go
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/scaffold_test.go
@@ -2,7 +2,9 @@ package scaffold_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -152,6 +154,93 @@ func TestValidateName(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Errorf("name=%q: unexpected error: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestGeneratedProjectBuilds scaffolds each kind into a temp dir, wires the
+// in-repo plugin-sdk via a synthetic go.work (so the generated project resolves
+// the SDK locally without needing a module proxy), then runs go build, go vet,
+// and go test. This is the canonical guard against "scaffold generates broken code".
+//
+// Skip guards keep CI fast: the test is skipped when the go binary is absent or
+// when -short is passed.
+func TestGeneratedProjectBuilds(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go binary not found in PATH; skipping build test")
+	}
+	if testing.Short() {
+		t.Skip("skipping scaffold build test in -short mode")
+	}
+
+	// Locate the plugin-sdk module root via the source file path.
+	// scaffold_test.go is at: plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/
+	// Four levels up (scaffold → internal → gleipnir-plugin → cmd → plugin-sdk)
+	// lands at the plugin-sdk module root.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	sdkRoot, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve sdkRoot: %v", err)
+	}
+
+	// Verify we actually found the right directory before trusting it.
+	goModPath := filepath.Join(sdkRoot, "go.mod")
+	goModBytes, err := os.ReadFile(goModPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", goModPath, err)
+	}
+	if !strings.Contains(string(goModBytes), "module github.com/felag-engineering/gleipnir/plugin-sdk") {
+		t.Fatalf("sdkRoot %q does not look like the plugin-sdk module (go.mod module line not found)", sdkRoot)
+	}
+
+	for _, kind := range []string{"tool", "channel", "trigger", "combo"} {
+		kind := kind
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			tempRoot := t.TempDir()
+			plugDir := filepath.Join(tempRoot, "plug")
+
+			// Generate the scaffold. No SDKReplace: the go.work below owns the
+			// replace directive so generated go.mod stays clean.
+			if err := scaffold.Generate(scaffold.Opts{
+				Name:   "plug",
+				Kind:   kind,
+				Dir:    plugDir,
+				Module: "example.com/plug",
+			}); err != nil {
+				t.Fatalf("Generate kind=%s: %v", kind, err)
+			}
+
+			// Write a synthetic go.work that makes the Go toolchain resolve the
+			// plugin-sdk from the in-repo path. The replace directive here stands
+			// in for the usual --sdk-replace flag, keeping generated go.mod clean.
+			goWork := "go 1.25.10\n\nuse (\n\t./plug\n)\n\nreplace github.com/felag-engineering/gleipnir/plugin-sdk => " + sdkRoot + "\n"
+			goWorkPath := filepath.Join(tempRoot, "go.work")
+			if err := os.WriteFile(goWorkPath, []byte(goWork), 0o644); err != nil {
+				t.Fatalf("write go.work: %v", err)
+			}
+
+			// GOWORK tells the toolchain to use our synthetic workspace so that
+			// it does not walk up and find the repo's own go.work (which does not
+			// list the temp module).
+			env := append(os.Environ(), "GOWORK="+goWorkPath)
+
+			for _, subcmd := range [][]string{
+				{"go", "build", "./..."},
+				{"go", "vet", "./..."},
+				{"go", "test", "./..."},
+			} {
+				cmd := exec.Command(subcmd[0], subcmd[1:]...)
+				cmd.Dir = plugDir
+				cmd.Env = env
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("kind=%s: %v failed:\n%s", kind, subcmd, out)
+				}
 			}
 		})
 	}

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/main.go.tmpl
@@ -3,21 +3,23 @@ package main
 import (
 	"net/http"
 
-	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 
 func main() {
-	// serve.Serve is the last call in every plugin binary. Passing
-	// --emit-manifest as the first argument causes it to write the manifest
-	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	// serve.Serve wires up the go-plugin transport, registers ChannelService, and
+	// blocks until the host disconnects or a signal is received.
+	//
+	// Passing --emit-manifest as the first argument causes it to write the
+	// manifest JSON to stdout and exit (used by gleipnir-plugin gen-manifest).
+	//
+	// WithChannelHandler is the ergonomic seam: implement channel.Service without
+	// touching proto types directly.
 	serve.Serve(
 		serve.WithManifest(pluginManifest),
-		serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
-			// TODO: replace with your ChannelService constructor. The host
-			// client is used for GetInstanceConfig, GetCredentials, and
-			// other Host RPCs.
+		serve.WithChannelHandler(func(host hostv1.HostServiceClient) channel.Service {
 			return NewChannelService(host, http.DefaultClient)
 		}),
 	)

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/manifest.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/manifest.go.tmpl
@@ -1,23 +1,26 @@
 package main
 
-// declareManifest returns the builder-style manifest declarations for this
-// plugin. gleipnir-plugin gen-manifest invokes the binary with --emit-manifest
-// which calls serve.EmitManifest(), which calls this function.
-//
-// TODO: replace with real manifest builder API when serve.EmitManifest is
-// implemented (Phase 3 loader PR, #170).
-func declareManifest() interface{} {
-	return map[string]interface{}{
-		"schema_version": "v1",
-		"name":           "{{.Name}}",
-		"version":        "0.1.0",
-		"services":       map[string]string{"channel": "v1"},
-		"auth":           map[string]string{"mode": "instance_credentials", "strategy": "none"},
-		"channels": []map[string]interface{}{
-			{
-				"implements_notify":  true,
-				"implements_request": true, // delete if not implementing Request
-			},
+import "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+
+// pluginManifest declares this plugin's metadata and capabilities.
+// Pass it to serve.WithManifest so --emit-manifest can write manifest.json
+// and so the host learns what services and channels this binary provides.
+var pluginManifest = manifest.Manifest{
+	SchemaVersion: "v1",
+	Name:          "{{.Name}}",
+	Version:       "0.1.0",
+	Description:   "{{.Name}} Gleipnir plugin.",
+	Services: manifest.Services{
+		Channel: "v1",
+	},
+	Auth: manifest.AuthDecl{
+		Mode:     "instance_credentials",
+		Strategy: "none",
+	},
+	Channels: []manifest.ChannelDecl{
+		{
+			ImplementsNotify:  true,
+			ImplementsRequest: true,
 		},
-	}
+	},
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/service.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/service.go.tmpl
@@ -2,30 +2,46 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"net/http"
+
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
 )
 
-// ChannelService implements the ChannelService gRPC contract.
-//
-// Delete the methods you don't implement and update manifest.go accordingly.
-// TODO: replace stubbed methods with real implementations.
-type ChannelService struct{}
+// ChannelService implements channel.Service with Notify and Request stubs.
+// Delete Request and update manifest.go if you only implement Notify.
+type ChannelService struct {
+	host       hostv1.HostServiceClient
+	httpClient *http.Client
+}
+
+// NewChannelService creates a ChannelService that uses hostClient for host RPCs
+// and httpClient for outbound HTTP calls.
+// Stub methods do not dereference host, so NewChannelService(nil, nil) is safe in tests.
+func NewChannelService(hostClient hostv1.HostServiceClient, httpClient *http.Client) *ChannelService {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &ChannelService{host: hostClient, httpClient: httpClient}
+}
 
 // Notify delivers a fire-and-forget notification.
 // Failures are audited and metric-counted but do NOT fail the run.
-func (s *ChannelService) Notify(_ context.Context, msg []byte) error {
+func (s *ChannelService) Notify(_ context.Context, n channel.Notification) error {
 	// TODO: implement Notify.
-	_ = msg
+	_ = n
 	return nil
 }
 
-// Request sends a notification and asynchronously awaits a human response.
-// The plugin acks the request within 5s, then later calls WriteAuditStep with
-// a feedback_response step carrying the request_id.
-func (s *ChannelService) Request(_ context.Context, requestID string, msg []byte) error {
-	// TODO: implement Request.
-	// Delete this method if you only implement Notify.
-	_ = requestID
-	_ = msg
-	return fmt.Errorf("Request: not yet implemented")
+// Request opens a request/response feedback channel. The plugin must
+// synchronously ack (return nil) within 5s, then later call WriteAuditStep
+// with a feedback_response step carrying the request_id.
+//
+// Remove this method and set ImplementsRequest: false in manifest.go if you
+// only implement Notify.
+func (s *ChannelService) Request(_ context.Context, r channel.FeedbackRequest) error {
+	// TODO: implement Request, or delete this method for Notify-only plugins.
+	_ = r
+	return pluginerr.Unimplemented("Request not yet implemented")
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/service_test.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/channel/service_test.go.tmpl
@@ -3,12 +3,31 @@ package main
 import (
 	"context"
 	"testing"
+
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 )
 
 func TestNotify(t *testing.T) {
-	svc := &ChannelService{}
-	// Notify must not return an error for a well-formed message.
-	if err := svc.Notify(context.Background(), []byte(`{"text":"hello"}`)); err != nil {
+	// NewChannelService(nil, nil) is safe: stub Notify does not dereference host.
+	svc := NewChannelService(nil, nil)
+
+	err := svc.Notify(context.Background(), channel.Notification{
+		EventType: "test",
+		Payload:   []byte(`{"text":"hello"}`),
+	})
+	if err != nil {
 		t.Errorf("Notify: %v", err)
+	}
+}
+
+func TestRequestUnimplemented(t *testing.T) {
+	svc := NewChannelService(nil, nil)
+
+	err := svc.Request(context.Background(), channel.FeedbackRequest{
+		RequestID: "req-1",
+		Prompt:    "approve?",
+	})
+	if err == nil {
+		t.Error("expected error from stub Request, got nil")
 	}
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/main.go.tmpl
@@ -3,29 +3,28 @@ package main
 import (
 	"net/http"
 
-	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
-	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
-	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )
 
 func main() {
-	// serve.Serve is the last call in every plugin binary. Passing
-	// --emit-manifest as the first argument causes it to write the manifest
-	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	// serve.Serve wires up the go-plugin transport, registers all three services,
+	// and blocks until the host disconnects or a signal is received.
+	//
+	// Passing --emit-manifest as the first argument causes it to write the
+	// manifest JSON to stdout and exit (used by gleipnir-plugin gen-manifest).
 	serve.Serve(
 		serve.WithManifest(pluginManifest),
-		serve.WithChannelService(func(host hostv1.HostServiceClient) channelv1.ChannelServiceServer {
-			// TODO: replace with your ChannelService constructor.
-			return NewChannelService(host, http.DefaultClient)
-		}),
-		serve.WithToolService(func(host hostv1.HostServiceClient) toolv1.ToolServiceServer {
-			// TODO: replace with your ToolService constructor.
+		serve.WithToolHandler(func(host hostv1.HostServiceClient) tool.Service {
 			return NewToolService(host)
 		}),
-		serve.WithTriggerService(func(host hostv1.HostServiceClient) triggerv1.TriggerServiceServer {
-			// TODO: replace with your TriggerService constructor.
+		serve.WithChannelHandler(func(host hostv1.HostServiceClient) channel.Service {
+			return NewChannelService(host, http.DefaultClient)
+		}),
+		serve.WithTriggerHandler(func(host hostv1.HostServiceClient) trigger.Service {
 			return NewTriggerService(host)
 		}),
 	)

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/manifest.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/manifest.go.tmpl
@@ -1,39 +1,40 @@
 package main
 
-// declareManifest returns the builder-style manifest declarations for this
-// combo plugin (tool + channel + trigger). gleipnir-plugin gen-manifest invokes
-// the binary with --emit-manifest which calls serve.EmitManifest().
-//
-// TODO: replace with real manifest builder API when serve.EmitManifest is
-// implemented (Phase 3 loader PR, #170).
-func declareManifest() interface{} {
-	return map[string]interface{}{
-		"schema_version": "v1",
-		"name":           "{{.Name}}",
-		"version":        "0.1.0",
-		"services": map[string]string{
-			"tool":    "v1",
-			"channel": "v1",
-			"trigger": "v1",
+import "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+
+// pluginManifest declares this plugin's metadata and capabilities.
+// Pass it to serve.WithManifest so --emit-manifest can write manifest.json
+// and so the host learns what services this binary provides.
+var pluginManifest = manifest.Manifest{
+	SchemaVersion: "v1",
+	Name:          "{{.Name}}",
+	Version:       "0.1.0",
+	Description:   "{{.Name}} Gleipnir plugin.",
+	Services: manifest.Services{
+		Tool:    "v1",
+		Channel: "v1",
+		Trigger: "v1",
+	},
+	Auth: manifest.AuthDecl{
+		Mode:     "instance_credentials",
+		Strategy: "none",
+	},
+	Tools: []manifest.ToolDecl{
+		{
+			Name:        "example_tool",
+			Description: "An example tool — replace with your implementation.",
 		},
-		"auth": map[string]string{"mode": "instance_credentials", "strategy": "none"},
-		"tools": []map[string]string{
-			{
-				"name":        "example_tool",
-				"description": "An example tool — replace with your implementation.",
-			},
+	},
+	Channels: []manifest.ChannelDecl{
+		{
+			ImplementsNotify:  true,
+			ImplementsRequest: true,
 		},
-		"channels": []map[string]interface{}{
-			{
-				"implements_notify":  true,
-				"implements_request": true,
-			},
+	},
+	EventKinds: []manifest.EventKindDecl{
+		{
+			Kind:        "example_event",
+			Description: "An example event kind — replace with your implementation.",
 		},
-		"event_kinds": []map[string]interface{}{
-			{
-				"kind":        "example_event",
-				"description": "An example event kind — replace with your implementation.",
-			},
-		},
-	}
+	},
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/service.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/service.go.tmpl
@@ -3,56 +3,113 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
+
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )
 
-// ToolService implements the ToolService gRPC contract.
-// TODO: replace with real implementations.
-type ToolService struct{}
-
-func (s *ToolService) ListTools(_ context.Context) ([]string, error) {
-	return []string{"example_tool"}, nil
+// ToolService implements tool.Service.
+// Replace the stub methods with your real implementation.
+type ToolService struct {
+	host hostv1.HostServiceClient
 }
 
-func (s *ToolService) Call(_ context.Context, tool string, input []byte) ([]byte, error) {
-	switch tool {
+// NewToolService creates a ToolService that uses hostClient for host RPCs.
+// Stub methods do not dereference host, so NewToolService(nil) is safe in tests.
+func NewToolService(hostClient hostv1.HostServiceClient) *ToolService {
+	return &ToolService{host: hostClient}
+}
+
+// ListTools returns the tools this plugin exposes. Must match manifest.go.
+func (s *ToolService) ListTools(_ context.Context) ([]tool.ToolSpec, error) {
+	return []tool.ToolSpec{
+		{
+			Name:        "example_tool",
+			Description: "An example tool — replace with your implementation.",
+			InputSchema: `{"type":"object","properties":{},"additionalProperties":false}`,
+		},
+	}, nil
+}
+
+// Call dispatches a tool call to the appropriate handler.
+func (s *ToolService) Call(_ context.Context, name string, input []byte) ([]byte, error) {
+	switch name {
 	case "example_tool":
+		// TODO: implement example_tool.
 		_ = input
 		return []byte(`{"result":"ok"}`), nil
 	default:
-		return nil, fmt.Errorf("unknown tool: %s", tool)
+		return nil, pluginerr.InvalidArg(fmt.Sprintf("unknown tool: %q", name))
 	}
 }
 
-// ChannelService implements the ChannelService gRPC contract.
-// Delete Notify or Request if you only implement one.
-// TODO: replace with real implementations.
-type ChannelService struct{}
+// ChannelService implements channel.Service with Notify and Request stubs.
+// Delete Request and update manifest.go if you only implement Notify.
+type ChannelService struct {
+	host       hostv1.HostServiceClient
+	httpClient *http.Client
+}
 
-func (s *ChannelService) Notify(_ context.Context, msg []byte) error {
-	_ = msg
+// NewChannelService creates a ChannelService that uses hostClient for host RPCs
+// and httpClient for outbound HTTP calls.
+// Stub methods do not dereference host, so NewChannelService(nil, nil) is safe in tests.
+func NewChannelService(hostClient hostv1.HostServiceClient, httpClient *http.Client) *ChannelService {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &ChannelService{host: hostClient, httpClient: httpClient}
+}
+
+// Notify delivers a fire-and-forget notification.
+func (s *ChannelService) Notify(_ context.Context, n channel.Notification) error {
+	// TODO: implement Notify.
+	_ = n
 	return nil
 }
 
-func (s *ChannelService) Request(_ context.Context, requestID string, msg []byte) error {
-	_ = requestID
-	_ = msg
-	return fmt.Errorf("Request: not yet implemented")
+// Request opens a request/response feedback channel.
+func (s *ChannelService) Request(_ context.Context, r channel.FeedbackRequest) error {
+	// TODO: implement Request, or delete this method for Notify-only plugins.
+	_ = r
+	return pluginerr.Unimplemented("Request not yet implemented")
 }
 
-// TriggerService implements the TriggerService gRPC contract.
-// TODO: replace with real substrate subscription logic.
-type TriggerService struct{}
+// TriggerService implements trigger.Service with an example poll loop.
+// Replace the loop with your real substrate subscription logic.
+type TriggerService struct {
+	host hostv1.HostServiceClient
+}
 
-func (s *TriggerService) Start(ctx context.Context, emit func(kind string, payload []byte) error) error {
+// NewTriggerService creates a TriggerService that uses hostClient for host RPCs.
+// Stub methods do not dereference host, so NewTriggerService(nil) is safe in tests.
+func NewTriggerService(hostClient hostv1.HostServiceClient) *TriggerService {
+	return &TriggerService{host: hostClient}
+}
+
+// Start opens the event stream. It blocks until ctx is cancelled or emit returns an error.
+func (s *TriggerService) Start(ctx context.Context, scope trigger.StartScope, emit func(trigger.Event) error) error {
+	// Example: emit an event every 60 seconds. Replace with real substrate logic.
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
+
+	var seq int
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := emit("example_event", []byte(`{"example":true}`)); err != nil {
+			seq++
+			ev := trigger.Event{
+				EventID:   fmt.Sprintf("example-%d", seq),
+				EventKind: "example_event",
+				Payload:   []byte(`{"example":true}`),
+			}
+			if err := emit(ev); err != nil {
 				return err
 			}
 		}

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/service_test.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/combo/service_test.go.tmpl
@@ -4,10 +4,15 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )
 
 func TestToolService(t *testing.T) {
-	svc := &ToolService{}
+	// NewToolService(nil) is safe: stub methods do not dereference host.
+	svc := NewToolService(nil)
+
 	tools, err := svc.ListTools(context.Background())
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
@@ -15,6 +20,10 @@ func TestToolService(t *testing.T) {
 	if len(tools) == 0 {
 		t.Fatal("ListTools returned empty list")
 	}
+	if tools[0].Name != "example_tool" {
+		t.Errorf("want tools[0].Name == %q, got %q", "example_tool", tools[0].Name)
+	}
+
 	out, err := svc.Call(context.Background(), "example_tool", nil)
 	if err != nil {
 		t.Fatalf("Call example_tool: %v", err)
@@ -25,17 +34,30 @@ func TestToolService(t *testing.T) {
 }
 
 func TestChannelNotify(t *testing.T) {
-	svc := &ChannelService{}
-	if err := svc.Notify(context.Background(), []byte(`{"text":"hello"}`)); err != nil {
+	// NewChannelService(nil, nil) is safe: stub Notify does not dereference host.
+	svc := NewChannelService(nil, nil)
+
+	err := svc.Notify(context.Background(), channel.Notification{
+		EventType: "test",
+		Payload:   []byte(`{"text":"hello"}`),
+	})
+	if err != nil {
 		t.Errorf("Notify: %v", err)
 	}
 }
 
 func TestTriggerCancellation(t *testing.T) {
-	svc := &TriggerService{}
+	// NewTriggerService(nil) is safe: Start does not dereference host.
+	svc := NewTriggerService(nil)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	err := svc.Start(ctx, func(_ string, _ []byte) error { return nil })
+
+	err := svc.Start(ctx, trigger.StartScope{}, func(trigger.Event) error {
+		return nil
+	})
+
+	// Start must return when ctx expires — DeadlineExceeded or Canceled both acceptable.
 	if err == nil {
 		t.Error("expected non-nil error when context cancelled")
 	}

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/common/go.mod.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/common/go.mod.tmpl
@@ -1,6 +1,6 @@
 module {{.Module}}
 
-go 1.22.0
+go 1.25.10
 
 require github.com/felag-engineering/gleipnir/plugin-sdk v0.0.0-dev
 {{- if .SDKReplace}}

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/main.go.tmpl
@@ -2,18 +2,22 @@ package main
 
 import (
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
-	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 )
 
 func main() {
-	// serve.Serve is the last call in every plugin binary. Passing
-	// --emit-manifest as the first argument causes it to write the manifest
-	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	// serve.Serve wires up the go-plugin transport, registers ToolService, and
+	// blocks until the host disconnects or a signal is received.
+	//
+	// Passing --emit-manifest as the first argument causes it to write the
+	// manifest JSON to stdout and exit (used by gleipnir-plugin gen-manifest).
+	//
+	// WithToolHandler is the ergonomic seam: implement tool.Service without
+	// touching proto types directly.
 	serve.Serve(
 		serve.WithManifest(pluginManifest),
-		serve.WithToolService(func(host hostv1.HostServiceClient) toolv1.ToolServiceServer {
-			// TODO: replace with your ToolService constructor.
+		serve.WithToolHandler(func(host hostv1.HostServiceClient) tool.Service {
 			return NewToolService(host)
 		}),
 	)

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/manifest.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/manifest.go.tmpl
@@ -1,25 +1,26 @@
 package main
 
-// declareManifest returns the builder-style manifest declarations for this
-// plugin. gleipnir-plugin gen-manifest invokes the binary with --emit-manifest
-// which calls serve.EmitManifest(), which calls this function.
-//
-// Add tools here; run `make gen-manifest` to regenerate manifest.yaml.
-//
-// TODO: replace with real manifest builder API when serve.EmitManifest is
-// implemented (Phase 3 loader PR, #170).
-func declareManifest() interface{} {
-	return map[string]interface{}{
-		"schema_version": "v1",
-		"name":           "{{.Name}}",
-		"version":        "0.1.0",
-		"services":       map[string]string{"tool": "v1"},
-		"auth":           map[string]string{"mode": "instance_credentials", "strategy": "none"},
-		"tools": []map[string]string{
-			{
-				"name":        "example_tool",
-				"description": "An example tool — replace with your implementation.",
-			},
+import "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+
+// pluginManifest declares this plugin's metadata and capabilities.
+// Pass it to serve.WithManifest so --emit-manifest can write manifest.json
+// and so the host learns what services and tools this binary provides.
+var pluginManifest = manifest.Manifest{
+	SchemaVersion: "v1",
+	Name:          "{{.Name}}",
+	Version:       "0.1.0",
+	Description:   "{{.Name}} Gleipnir plugin.",
+	Services: manifest.Services{
+		Tool: "v1",
+	},
+	Auth: manifest.AuthDecl{
+		Mode:     "instance_credentials",
+		Strategy: "none",
+	},
+	Tools: []manifest.ToolDecl{
+		{
+			Name:        "example_tool",
+			Description: "An example tool — replace with your implementation.",
 		},
-	}
+	},
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/service.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/service.go.tmpl
@@ -3,31 +3,45 @@ package main
 import (
 	"context"
 	"fmt"
+
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 )
 
-// ToolService implements the ToolService gRPC contract.
-//
-// TODO: replace stubbed methods with real implementations.
-// Each tool declared in manifest.go needs a corresponding case in Call.
-type ToolService struct{}
+// ToolService implements tool.Service with a single example_tool.
+// Replace the stub methods with your real implementation.
+type ToolService struct {
+	host hostv1.HostServiceClient
+}
 
-// ListTools returns the list of tool names this plugin implements.
-// The list must match what is declared in manifest.go / manifest.yaml.
-func (s *ToolService) ListTools(_ context.Context) ([]string, error) {
-	return []string{"example_tool"}, nil
+// NewToolService creates a ToolService that uses hostClient for host RPCs.
+// Stub methods do not dereference host, so NewToolService(nil) is safe in tests.
+func NewToolService(hostClient hostv1.HostServiceClient) *ToolService {
+	return &ToolService{host: hostClient}
+}
+
+// ListTools returns the tools this plugin exposes. Must match manifest.go.
+func (s *ToolService) ListTools(_ context.Context) ([]tool.ToolSpec, error) {
+	return []tool.ToolSpec{
+		{
+			Name:        "example_tool",
+			Description: "An example tool — replace with your implementation.",
+			InputSchema: `{"type":"object","properties":{},"additionalProperties":false}`,
+		},
+	}, nil
 }
 
 // Call dispatches a tool call to the appropriate handler.
-func (s *ToolService) Call(_ context.Context, tool string, input []byte) ([]byte, error) {
-	switch tool {
+// Return pluginerr.InvalidArg for unknown or malformed input; the serve adapter
+// maps it to an application-level ErrorEnvelope with ERROR_CODE_INVALID_ARG.
+func (s *ToolService) Call(_ context.Context, name string, input []byte) ([]byte, error) {
+	switch name {
 	case "example_tool":
-		return s.exampleTool(input)
+		// TODO: implement example_tool.
+		_ = input
+		return []byte(`{"result":"ok"}`), nil
 	default:
-		return nil, fmt.Errorf("unknown tool: %s", tool)
+		return nil, pluginerr.InvalidArg(fmt.Sprintf("unknown tool: %q", name))
 	}
-}
-
-func (s *ToolService) exampleTool(_ []byte) ([]byte, error) {
-	// TODO: implement example_tool.
-	return []byte(`{"result": "ok"}`), nil
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/service_test.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/tool/service_test.go.tmpl
@@ -6,7 +6,8 @@ import (
 )
 
 func TestExampleTool(t *testing.T) {
-	svc := &ToolService{}
+	// NewToolService(nil) is safe: stub methods do not dereference host.
+	svc := NewToolService(nil)
 
 	tools, err := svc.ListTools(context.Background())
 	if err != nil {
@@ -14,6 +15,9 @@ func TestExampleTool(t *testing.T) {
 	}
 	if len(tools) == 0 {
 		t.Fatal("ListTools returned empty list")
+	}
+	if tools[0].Name != "example_tool" {
+		t.Errorf("want tools[0].Name == %q, got %q", "example_tool", tools[0].Name)
 	}
 
 	out, err := svc.Call(context.Background(), "example_tool", nil)
@@ -26,7 +30,7 @@ func TestExampleTool(t *testing.T) {
 }
 
 func TestUnknownTool(t *testing.T) {
-	svc := &ToolService{}
+	svc := NewToolService(nil)
 	_, err := svc.Call(context.Background(), "does_not_exist", nil)
 	if err == nil {
 		t.Error("expected error for unknown tool, got nil")

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/main.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/main.go.tmpl
@@ -2,18 +2,22 @@ package main
 
 import (
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
-	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )
 
 func main() {
-	// serve.Serve is the last call in every plugin binary. Passing
-	// --emit-manifest as the first argument causes it to write the manifest
-	// JSON to stdout and exit, which is what gleipnir-plugin gen-manifest uses.
+	// serve.Serve wires up the go-plugin transport, registers TriggerService, and
+	// blocks until the host disconnects or a signal is received.
+	//
+	// Passing --emit-manifest as the first argument causes it to write the
+	// manifest JSON to stdout and exit (used by gleipnir-plugin gen-manifest).
+	//
+	// WithTriggerHandler is the ergonomic seam: implement trigger.Service without
+	// touching proto types directly.
 	serve.Serve(
 		serve.WithManifest(pluginManifest),
-		serve.WithTriggerService(func(host hostv1.HostServiceClient) triggerv1.TriggerServiceServer {
-			// TODO: replace with your TriggerService constructor.
+		serve.WithTriggerHandler(func(host hostv1.HostServiceClient) trigger.Service {
 			return NewTriggerService(host)
 		}),
 	)

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/manifest.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/manifest.go.tmpl
@@ -1,23 +1,26 @@
 package main
 
-// declareManifest returns the builder-style manifest declarations for this
-// plugin. gleipnir-plugin gen-manifest invokes the binary with --emit-manifest
-// which calls serve.EmitManifest(), which calls this function.
-//
-// TODO: replace with real manifest builder API when serve.EmitManifest is
-// implemented (Phase 3 loader PR, #170).
-func declareManifest() interface{} {
-	return map[string]interface{}{
-		"schema_version": "v1",
-		"name":           "{{.Name}}",
-		"version":        "0.1.0",
-		"services":       map[string]string{"trigger": "v1"},
-		"auth":           map[string]string{"mode": "instance_credentials", "strategy": "none"},
-		"event_kinds": []map[string]interface{}{
-			{
-				"kind":        "example_event",
-				"description": "An example event kind — replace with your implementation.",
-			},
+import "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+
+// pluginManifest declares this plugin's metadata and capabilities.
+// Pass it to serve.WithManifest so --emit-manifest can write manifest.json
+// and so the host learns what services and event kinds this binary provides.
+var pluginManifest = manifest.Manifest{
+	SchemaVersion: "v1",
+	Name:          "{{.Name}}",
+	Version:       "0.1.0",
+	Description:   "{{.Name}} Gleipnir plugin.",
+	Services: manifest.Services{
+		Trigger: "v1",
+	},
+	Auth: manifest.AuthDecl{
+		Mode:     "instance_credentials",
+		Strategy: "none",
+	},
+	EventKinds: []manifest.EventKindDecl{
+		{
+			Kind:        "example_event",
+			Description: "An example event kind — replace with your implementation.",
 		},
-	}
+	},
 }

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/service.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/service.go.tmpl
@@ -2,31 +2,46 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )
 
-// TriggerService implements the TriggerService gRPC contract.
-//
-// Start is a long-lived stream. The plugin emits events via the provided emit
-// callback; the host routes them to matching policies.
-//
-// TODO: replace the example poll loop with real substrate subscription logic.
-type TriggerService struct{}
+// TriggerService implements trigger.Service with an example poll loop.
+// Replace the loop with your real substrate subscription logic.
+type TriggerService struct {
+	host hostv1.HostServiceClient
+}
 
-// Start begins the trigger event stream. It blocks until ctx is cancelled.
-// emit(kind, payload) forwards an event to the host.
-func (s *TriggerService) Start(ctx context.Context, emit func(kind string, payload []byte) error) error {
+// NewTriggerService creates a TriggerService that uses hostClient for host RPCs.
+// Stub methods do not dereference host, so NewTriggerService(nil) is safe in tests.
+func NewTriggerService(hostClient hostv1.HostServiceClient) *TriggerService {
+	return &TriggerService{host: hostClient}
+}
+
+// Start opens the event stream. It blocks until ctx is cancelled or emit returns
+// an error (which signals the host closed the stream).
+// Replace the ticker with real substrate subscription logic.
+func (s *TriggerService) Start(ctx context.Context, scope trigger.StartScope, emit func(trigger.Event) error) error {
 	// Example: emit an event every 60 seconds. Replace with real substrate logic.
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
 
+	var seq int
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			payload := []byte(`{"example": true}`)
-			if err := emit("example_event", payload); err != nil {
+			seq++
+			ev := trigger.Event{
+				EventID:   fmt.Sprintf("example-%d", seq),
+				EventKind: "example_event",
+				Payload:   []byte(`{"example":true}`),
+			}
+			if err := emit(ev); err != nil {
 				return err
 			}
 		}

--- a/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/service_test.go.tmpl
+++ b/plugin-sdk/cmd/gleipnir-plugin/internal/scaffold/templates/trigger/service_test.go.tmpl
@@ -4,22 +4,22 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )
 
 func TestTriggerServiceCancellation(t *testing.T) {
-	svc := &TriggerService{}
+	// NewTriggerService(nil) is safe: Start does not dereference host.
+	svc := NewTriggerService(nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	var emitted []string
-	err := svc.Start(ctx, func(kind string, _ []byte) error {
-		emitted = append(emitted, kind)
+	err := svc.Start(ctx, trigger.StartScope{}, func(trigger.Event) error {
 		return nil
 	})
 
-	// Start should return when ctx is cancelled — context.DeadlineExceeded or
-	// context.Canceled are both acceptable.
+	// Start must return when ctx expires — DeadlineExceeded or Canceled both acceptable.
 	if err == nil {
 		t.Error("expected non-nil error when context cancelled, got nil")
 	}


### PR DESCRIPTION
Closes #458

## Summary

`gleipnir-plugin new --kind tool` (and the other kinds) generated a project that **did not compile** — `undefined: pluginManifest`, `undefined: NewToolService` — because the templates were written to an ergonomic shape the SDK didn't yet provide, and there was no test that built generated output. Now that the ergonomic Service seam exists (#457 / ADR-050), this rewrites all four `--kind` templates to target it and adds a golden build test.

## Changes

- **All four `--kind` template sets** (tool / channel / trigger / combo) rewritten to compile against the ergonomic seam:
  - `manifest.go.tmpl` → typed `var pluginManifest = manifest.Manifest{...}` (consistent with `main.go.tmpl`'s `serve.WithManifest(pluginManifest)`).
  - `service.go.tmpl` → implements `tool.Service` / `channel.Service` / `trigger.Service` with the `NewXService(...)` constructors `main.go.tmpl` calls; stub bodies never dereference the host (so `NewXService(nil)` is test-safe). `Call`/`Request` use `pluginerr` codes.
  - `main.go.tmpl` → `serve.WithToolHandler`/`WithChannelHandler`/`WithTriggerHandler`; raw `toolv1`/`channelv1`/`triggerv1` imports dropped.
  - `service_test.go.tmpl` → constructs via `NewXService(nil)` and exercises the ergonomic methods.
- **Golden test** `TestGeneratedProjectBuilds` (table over the four kinds): scaffolds each kind into a temp dir, wires the in-repo `plugin-sdk` via a **synthetic `go.work` + `GOWORK=`** (the approach that actually works under Go 1.25 — a plain `GOPROXY=off` build fails because Go ignores the go.mod of any dir below a `go.work` ancestor not in `use`), then runs `go build`/`go vet`/`go test`. Skip-guarded on `go`-on-PATH and `-short`. A broken scaffold can no longer ship.
- **Drive-by:** bumped `common/go.mod.tmpl` `go 1.22.0 → 1.25.10` to match `plugin-sdk/go.mod` (prevents a version error for users scaffolding outside a workspace).

## Scope

Confined to the scaffold templates + `scaffold_test.go`. The ergonomic seam itself, `plugins/ntfy`, `plugins/slack`, and `examples/minimal-tool` are untouched; full `go.work` workspace `go vet`/`build`/`test` green via the commit hook.

## Dev-loop metadata

Pipeline: architect → plan-review (**REVISE**: the offline-build mechanism — switched from `GOPROXY=off` to synthetic `go.work`+`GOWORK` after the reviewer empirically proved the former fails on Go 1.25; corrected `runtime.Caller` path depth 5→4) → implement → code-review (**APPROVE**, 0 loop-backs; reviewer ran the golden test). CLAUDE.md: no updates needed. Generated by the agentic dev loop.
