### PR TITLE
feat: in-process plugintest harness drives the Service; removes dual-gRPC setup() boilerplate (#459)

### DIFF
--- a/plugin-sdk/examples/minimal-tool/service_test.go
+++ b/plugin-sdk/examples/minimal-tool/service_test.go
@@ -3,81 +3,26 @@ package main
 import (
 	"context"
 	"log/slog"
-	"net"
 	"testing"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 )
 
-// setup starts an in-process gRPC server hosting both the fake host and the
-// tool service (via the ergonomic adapter). It returns the tool client, the
-// fake host, and a cleanup function.
-func setup(t *testing.T, hostOpts ...plugintest.Option) (toolv1.ToolServiceClient, *plugintest.FakeHost, func()) {
-	t.Helper()
-
-	host := plugintest.NewFakeHost(hostOpts...)
-
-	// Start the host gRPC server.
-	hostLis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen for host: %v", err)
-	}
-	hostSrv := grpc.NewServer()
-	host.Register(hostSrv)
-	go func() { _ = hostSrv.Serve(hostLis) }()
-
-	// Dial the host and build the hostv1 client used by ToolService.
-	hostConn, err := grpc.NewClient(hostLis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("dial host: %v", err)
-	}
-	hostClient := hostv1.NewHostServiceClient(hostConn)
-
-	// Start the tool service gRPC server via the exported adapter constructor.
-	// This gives the test a live gRPC round-trip through the ergonomic seam.
-	toolLis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen for tool: %v", err)
-	}
-	toolSrv := grpc.NewServer()
-	toolv1.RegisterToolServiceServer(toolSrv, serve.NewToolServer(NewToolService(hostClient)))
-	go func() { _ = toolSrv.Serve(toolLis) }()
-
-	// Dial the tool service.
-	toolConn, err := grpc.NewClient(toolLis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("dial tool: %v", err)
-	}
-	toolClient := toolv1.NewToolServiceClient(toolConn)
-
-	cleanup := func() {
-		toolConn.Close()
-		toolSrv.Stop()
-		hostConn.Close()
-		hostSrv.Stop()
-	}
-	return toolClient, host, cleanup
-}
-
 func TestEchoTool_Happy(t *testing.T) {
-	toolClient, host, cleanup := setup(t,
+	h := plugintest.NewToolHarness(t, func(hc hostv1.HostServiceClient) tool.Service {
+		return NewToolService(hc)
+	},
 		plugintest.WithInstanceConfigJSON(`{"greeting":"hi"}`),
 		plugintest.WithRunContext(plugintest.RunContext{
 			RunID:    "r-1",
 			PolicyID: "p-1",
 		}),
 	)
-	defer cleanup()
 
-	resp, err := toolClient.Call(context.Background(), &toolv1.CallRequest{
+	resp, err := h.Client.Call(context.Background(), &toolv1.CallRequest{
 		ToolName:  "echo",
 		InputJson: `{"message":"hello world"}`,
 	})
@@ -91,15 +36,16 @@ func TestEchoTool_Happy(t *testing.T) {
 		t.Error("expected non-empty output_json")
 	}
 
-	host.AssertMetricEmitted(t, "echo_calls_total", map[string]string{"tool": "echo"})
-	host.AssertLogContains(t, slog.LevelInfo, "echo handled")
+	h.Host.AssertMetricEmitted(t, "echo_calls_total", map[string]string{"tool": "echo"})
+	h.Host.AssertLogContains(t, slog.LevelInfo, "echo handled")
 }
 
 func TestEchoTool_MalformedInput(t *testing.T) {
-	toolClient, host, cleanup := setup(t)
-	defer cleanup()
+	h := plugintest.NewToolHarness(t, func(hc hostv1.HostServiceClient) tool.Service {
+		return NewToolService(hc)
+	})
 
-	resp, err := toolClient.Call(context.Background(), &toolv1.CallRequest{
+	resp, err := h.Client.Call(context.Background(), &toolv1.CallRequest{
 		ToolName:  "echo",
 		InputJson: `not-valid-json`,
 	})
@@ -110,14 +56,15 @@ func TestEchoTool_MalformedInput(t *testing.T) {
 		t.Fatal("expected error envelope for malformed JSON, got nil")
 	}
 
-	host.AssertNoMetricEmitted(t, "echo_calls_total")
+	h.Host.AssertNoMetricEmitted(t, "echo_calls_total")
 }
 
 func TestEchoTool_ListTools(t *testing.T) {
-	toolClient, _, cleanup := setup(t)
-	defer cleanup()
+	h := plugintest.NewToolHarness(t, func(hc hostv1.HostServiceClient) tool.Service {
+		return NewToolService(hc)
+	})
 
-	resp, err := toolClient.ListTools(context.Background(), &toolv1.ListToolsRequest{})
+	resp, err := h.Client.ListTools(context.Background(), &toolv1.ListToolsRequest{})
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}

--- a/plugin-sdk/testing/doc.go
+++ b/plugin-sdk/testing/doc.go
@@ -10,12 +10,31 @@
 //
 // # Minimal usage
 //
-//	host := plugintest.NewFakeHost(
+//	h := plugintest.NewToolHarness(t,
+//	    func(hc hostv1.HostServiceClient) tool.Service { return NewToolService(hc) },
 //	    plugintest.WithInstanceConfigJSON(`{"greeting":"hi"}`),
-//	    plugintest.WithRunContext(plugintest.RunContext{RunID: "r-1"}),
 //	)
-//	// wire host into a gRPC server, invoke your service, then:
-//	host.AssertMetricEmitted(t, "echo_calls_total", map[string]string{"tool":"echo"})
+//	out, err := h.Call(ctx, "echo", []byte(`{"message":"hi"}`))
+//	h.Host.AssertMetricEmitted(t, "echo_calls_total", map[string]string{"tool": "echo"})
+//
+// NewToolHarness (and the analogous NewChannelHarness / NewTriggerHarness)
+// wires the author's service against a live FakeHost over in-process bufconn
+// gRPC, registers a single t.Cleanup that tears everything down, and returns
+// a typed client plus the FakeHost for assertions.
+//
+// # Host callbacks in harness tests
+//
+// Harness gRPC contexts carry no gleipnir-call-id header, so serve.WithCallContext
+// is a graceful no-op — it leaves the context unchanged rather than injecting a
+// call ID. Host RPCs (EmitMetric, Log, …) still reach the FakeHost over the live
+// connection, so AssertMetricEmitted / AssertLogContains assertions pass normally.
+//
+// # Raw wire exception
+//
+// plugin-sdk/cmd/gleipnir-plugin/cmd/internal/runfixture deliberately uses the
+// real go-plugin subprocess transport and is intentionally NOT migrated to the
+// harness. It exists to exercise the full plugin subprocess launch path (the
+// binary, not the service logic) and must remain on the raw wire.
 //
 // # Spec reference
 //

--- a/plugin-sdk/testing/harness.go
+++ b/plugin-sdk/testing/harness.go
@@ -1,0 +1,277 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
+)
+
+// ToolHarness wires an author's tool.Service against a live FakeHost, all
+// in-process over bufconn. Use NewToolHarness to create one.
+type ToolHarness struct {
+	// Host is the FakeHost the service calls back to. Use it after each
+	// test call to inspect metrics, logs, and events.
+	Host *FakeHost
+	// Client is the live gRPC ToolServiceClient connected to the author's service.
+	// Use it when you need to inspect raw proto responses (e.g. resp.GetError()).
+	Client toolv1.ToolServiceClient
+}
+
+// NewToolHarness starts an in-process ToolService backed by a FakeHost. The
+// factory receives the live host client so it can call GetInstanceConfig,
+// EmitMetric, and other host RPCs exactly as it does in production.
+//
+// A single t.Cleanup closes both servers (service first, then host) so tests
+// do not need their own teardown.
+func NewToolHarness(t *testing.T, factory func(hostv1.HostServiceClient) tool.Service, opts ...Option) *ToolHarness {
+	t.Helper()
+
+	host := NewFakeHost(opts...)
+	hostClient, hostConn, hostSrv, hostLis := newHostConn(t, host)
+
+	svc := factory(hostClient)
+	svcConn, svcSrv, svcLis := serveInProcess(t, func(s *grpc.Server) {
+		toolv1.RegisterToolServiceServer(s, serve.NewToolServer(svc))
+	})
+
+	// Single closure: service torn down before host so in-flight callbacks do
+	// not race with the host shutdown.
+	t.Cleanup(func() {
+		svcConn.Close()
+		svcSrv.Stop()
+		hostConn.Close()
+		hostSrv.Stop()
+		svcLis.Close()
+		hostLis.Close()
+	})
+
+	return &ToolHarness{
+		Host:   host,
+		Client: toolv1.NewToolServiceClient(svcConn),
+	}
+}
+
+// Call is a convenience wrapper around Client.Call that unwraps the response
+// envelope. On success it returns the raw output JSON bytes. On an application-
+// level error (resp.Error != nil) it returns a Go error with the envelope
+// message so callers do not need to inspect proto fields for the common case.
+// Use h.Client.Call directly when you need to inspect the ErrorEnvelope itself.
+func (h *ToolHarness) Call(ctx context.Context, name string, input []byte) ([]byte, error) {
+	resp, err := h.Client.Call(ctx, &toolv1.CallRequest{
+		ToolName:  name,
+		InputJson: string(input),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if e := resp.GetError(); e != nil {
+		return nil, fmt.Errorf("tool error (%v): %s", e.GetCode(), e.GetMessage())
+	}
+	return []byte(resp.GetOutputJson()), nil
+}
+
+// ListTools is a convenience wrapper around Client.ListTools that projects the
+// proto response to []tool.ToolSpec so callers do not need to import toolv1.
+func (h *ToolHarness) ListTools(ctx context.Context) ([]tool.ToolSpec, error) {
+	resp, err := h.Client.ListTools(ctx, &toolv1.ListToolsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	specs := make([]tool.ToolSpec, len(resp.GetTools()))
+	for i, s := range resp.GetTools() {
+		specs[i] = tool.ToolSpec{
+			Name:        s.GetName(),
+			Description: s.GetDescription(),
+			InputSchema: s.GetInputSchema(),
+		}
+	}
+	return specs, nil
+}
+
+// ChannelHarness wires an author's channel.Service against a live FakeHost,
+// all in-process over bufconn. Use NewChannelHarness to create one.
+type ChannelHarness struct {
+	// Host is the FakeHost the service calls back to.
+	Host *FakeHost
+	// Client is the live gRPC ChannelServiceClient. Use it when you need to
+	// inspect raw proto responses (e.g. resp.GetOk(), resp.GetError()).
+	Client channelv1.ChannelServiceClient
+}
+
+// NewChannelHarness starts an in-process ChannelService backed by a FakeHost.
+// The factory closes over any test-scoped dependencies (e.g. an httptest.Client)
+// and receives the live host client so the service can call GetInstanceConfig,
+// GetCredentials, and other host RPCs.
+//
+// A single t.Cleanup closes both servers (service first, then host).
+func NewChannelHarness(t *testing.T, factory func(hostv1.HostServiceClient) channel.Service, opts ...Option) *ChannelHarness {
+	t.Helper()
+
+	host := NewFakeHost(opts...)
+	hostClient, hostConn, hostSrv, hostLis := newHostConn(t, host)
+
+	svc := factory(hostClient)
+	svcConn, svcSrv, svcLis := serveInProcess(t, func(s *grpc.Server) {
+		channelv1.RegisterChannelServiceServer(s, serve.NewChannelServer(svc))
+	})
+
+	t.Cleanup(func() {
+		svcConn.Close()
+		svcSrv.Stop()
+		hostConn.Close()
+		hostSrv.Stop()
+		svcLis.Close()
+		hostLis.Close()
+	})
+
+	return &ChannelHarness{
+		Host:   host,
+		Client: channelv1.NewChannelServiceClient(svcConn),
+	}
+}
+
+// Notify is a convenience wrapper around Client.Notify that returns nil on
+// success and a Go error carrying the envelope message on failure.
+// Use h.Client.Notify directly when you need to inspect the ErrorEnvelope.
+func (h *ChannelHarness) Notify(ctx context.Context, n channel.Notification) error {
+	resp, err := h.Client.Notify(ctx, &channelv1.NotifyRequest{
+		EventType:         n.EventType,
+		PayloadJson:       string(n.Payload),
+		ChannelConfigJson: string(n.ChannelConfig),
+	})
+	if err != nil {
+		return err
+	}
+	if !resp.GetOk() {
+		if e := resp.GetError(); e != nil {
+			return fmt.Errorf("notify error (%v): %s", e.GetCode(), e.GetMessage())
+		}
+		return fmt.Errorf("notify returned ok=false with no error detail")
+	}
+	return nil
+}
+
+// Request is a convenience wrapper around Client.Request that returns nil on
+// ack and a Go error carrying the envelope message on failure.
+// Use h.Client.Request directly when you need to inspect the ErrorEnvelope.
+func (h *ChannelHarness) Request(ctx context.Context, r channel.FeedbackRequest) error {
+	resp, err := h.Client.Request(ctx, &channelv1.RequestRequest{
+		RequestId:         r.RequestID,
+		Prompt:            r.Prompt,
+		ChannelConfigJson: string(r.ChannelConfig),
+	})
+	if err != nil {
+		return err
+	}
+	if !resp.GetAcked() {
+		if e := resp.GetError(); e != nil {
+			return fmt.Errorf("request error (%v): %s", e.GetCode(), e.GetMessage())
+		}
+		return fmt.Errorf("request returned acked=false with no error detail")
+	}
+	return nil
+}
+
+// TriggerHarness wires an author's trigger.Service against a live FakeHost,
+// all in-process over bufconn. Use NewTriggerHarness to create one.
+type TriggerHarness struct {
+	// Host is the FakeHost the service calls back to.
+	Host *FakeHost
+	// Client is the live gRPC TriggerServiceClient. Start is a server-streaming
+	// call; use it directly to control the stream lifecycle.
+	Client triggerv1.TriggerServiceClient
+}
+
+// NewTriggerHarness starts an in-process TriggerService backed by a FakeHost.
+// A single t.Cleanup closes both servers (service first, then host).
+func NewTriggerHarness(t *testing.T, factory func(hostv1.HostServiceClient) trigger.Service, opts ...Option) *TriggerHarness {
+	t.Helper()
+
+	host := NewFakeHost(opts...)
+	hostClient, hostConn, hostSrv, hostLis := newHostConn(t, host)
+
+	svc := factory(hostClient)
+	svcConn, svcSrv, svcLis := serveInProcess(t, func(s *grpc.Server) {
+		triggerv1.RegisterTriggerServiceServer(s, serve.NewTriggerServer(svc))
+	})
+
+	t.Cleanup(func() {
+		svcConn.Close()
+		svcSrv.Stop()
+		hostConn.Close()
+		hostSrv.Stop()
+		svcLis.Close()
+		hostLis.Close()
+	})
+
+	return &TriggerHarness{
+		Host:   host,
+		Client: triggerv1.NewTriggerServiceClient(svcConn),
+	}
+}
+
+// ── internal wiring ───────────────────────────────────────────────────────────
+
+// newHostConn starts a bufconn gRPC server hosting the given FakeHost and
+// returns a live HostServiceClient, the underlying client conn, the server,
+// and the listener. The caller is responsible for closing them in t.Cleanup.
+func newHostConn(t *testing.T, host *FakeHost) (hostv1.HostServiceClient, *grpc.ClientConn, *grpc.Server, *bufconn.Listener) {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	host.Register(srv)
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough:///",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("newHostConn: dial: %v", err)
+	}
+	return hostv1.NewHostServiceClient(conn), conn, srv, lis
+}
+
+// serveInProcess starts a bufconn gRPC server with the given registration
+// closure and returns a live *grpc.ClientConn (not yet wrapped in a typed
+// client), the server, and the listener. The caller wraps the conn in the
+// appropriate typed client and tears everything down in t.Cleanup.
+func serveInProcess(t *testing.T, register func(*grpc.Server)) (*grpc.ClientConn, *grpc.Server, *bufconn.Listener) {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	register(srv)
+	go func() { _ = srv.Serve(lis) }()
+
+	// "passthrough:///" is mandatory when using WithContextDialer + grpc.NewClient
+	// so the client skips DNS resolution and passes the target directly to the
+	// dialer (see grpc v1.79.3 test/gracefulstop_test.go for the canonical pattern).
+	conn, err := grpc.NewClient("passthrough:///",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("serveInProcess: dial: %v", err)
+	}
+	return conn, srv, lis
+}

--- a/plugin-sdk/testing/harness_test.go
+++ b/plugin-sdk/testing/harness_test.go
@@ -1,0 +1,208 @@
+package testing_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
+	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
+	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
+)
+
+// ── in-file fake services ─────────────────────────────────────────────────────
+
+// fakeToolService is a minimal tool.Service used only by harness_test. It:
+//   - lists a single "ping" tool
+//   - echoes the raw input bytes as output
+//   - calls EmitMetric and Log via serve.WithCallContext so the test can verify
+//     host callbacks round-trip through the harness. WithCallContext is a
+//     graceful no-op when the gRPC context carries no gleipnir-call-id (which
+//     is the case in harness tests), so AssertMetricEmitted/AssertLogContains
+//     still pass — the host just receives the RPCs without a call-id annotation.
+type fakeToolService struct {
+	host hostv1.HostServiceClient
+}
+
+func (s *fakeToolService) ListTools(_ context.Context) ([]tool.ToolSpec, error) {
+	return []tool.ToolSpec{
+		{Name: "ping", Description: "returns the input unchanged", InputSchema: `{}`},
+	}, nil
+}
+
+func (s *fakeToolService) Call(ctx context.Context, _ string, input []byte) ([]byte, error) {
+	hostCtx := serve.WithCallContext(ctx)
+	_, _ = s.host.EmitMetric(hostCtx, &hostv1.EmitMetricRequest{
+		Name:  "ping_calls_total",
+		Value: 1,
+	})
+	_, _ = s.host.Log(hostCtx, &hostv1.LogRequest{
+		Level: hostv1.LogLevel_LOG_LEVEL_INFO,
+		Msg:   "ping handled",
+	})
+	return input, nil
+}
+
+// fakeChannelService is a minimal channel.Service that calls GetInstanceConfig
+// on every Notify so the test can verify host connectivity.
+type fakeChannelService struct {
+	host hostv1.HostServiceClient
+}
+
+func (s *fakeChannelService) Notify(ctx context.Context, _ channel.Notification) error {
+	hostCtx := serve.WithCallContext(ctx)
+	_, err := s.host.GetInstanceConfig(hostCtx, &hostv1.GetInstanceConfigRequest{})
+	return err
+}
+
+func (s *fakeChannelService) Request(_ context.Context, _ channel.FeedbackRequest) error {
+	return nil
+}
+
+// fakeTriggerService is a minimal trigger.Service that emits one event then
+// returns when ctx is cancelled. The event payload is the watch_scope JSON.
+type fakeTriggerService struct{}
+
+func (s *fakeTriggerService) Start(ctx context.Context, scope trigger.StartScope, emit func(trigger.Event) error) error {
+	payload, _ := json.Marshal(map[string]string{"scope": string(scope.WatchScope)})
+	_ = emit(trigger.Event{
+		EventID:   "evt-1",
+		EventKind: "test.event",
+		Payload:   payload,
+	})
+	<-ctx.Done()
+	return nil
+}
+
+// ── TestToolHarness_RoundTrip ─────────────────────────────────────────────────
+
+func TestToolHarness_RoundTrip(t *testing.T) {
+	h := plugintest.NewToolHarness(t, func(hc hostv1.HostServiceClient) tool.Service {
+		return &fakeToolService{host: hc}
+	}, plugintest.WithInstanceConfigJSON(`{"env":"test"}`))
+
+	// Direct proto call — asserts the happy path.
+	resp, err := h.Client.Call(context.Background(), &toolv1.CallRequest{
+		ToolName:  "ping",
+		InputJson: `{"x":1}`,
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.GetError() != nil {
+		t.Fatalf("unexpected error envelope: %v", resp.GetError().GetMessage())
+	}
+	if resp.GetOutputJson() != `{"x":1}` {
+		t.Errorf("output_json: want %q, got %q", `{"x":1}`, resp.GetOutputJson())
+	}
+
+	// Host callback assertions: EmitMetric and Log both went through the live
+	// host gRPC connection inside the harness.
+	h.Host.AssertMetricEmitted(t, "ping_calls_total", nil)
+	h.Host.AssertLogContains(t, slog.LevelInfo, "ping handled")
+
+	// Convenience helper path.
+	out, err := h.Call(context.Background(), "ping", []byte(`{"y":2}`))
+	if err != nil {
+		t.Fatalf("h.Call: %v", err)
+	}
+	if string(out) != `{"y":2}` {
+		t.Errorf("h.Call output: want %q, got %q", `{"y":2}`, string(out))
+	}
+}
+
+// ── TestToolHarness_ListTools ─────────────────────────────────────────────────
+
+func TestToolHarness_ListTools(t *testing.T) {
+	h := plugintest.NewToolHarness(t, func(hc hostv1.HostServiceClient) tool.Service {
+		return &fakeToolService{host: hc}
+	})
+
+	specs, err := h.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 tool, got %d", len(specs))
+	}
+	if specs[0].Name != "ping" {
+		t.Errorf("want tool name %q, got %q", "ping", specs[0].Name)
+	}
+}
+
+// ── TestChannelHarness_RoundTrip ──────────────────────────────────────────────
+
+func TestChannelHarness_RoundTrip(t *testing.T) {
+	h := plugintest.NewChannelHarness(t, func(hc hostv1.HostServiceClient) channel.Service {
+		return &fakeChannelService{host: hc}
+	}, plugintest.WithInstanceConfigJSON(`{"key":"val"}`))
+
+	// The service calls GetInstanceConfig on every Notify; if the host
+	// connection is broken this returns a gRPC error, which Notify propagates
+	// as a plugin error that wraps inside ok=false. So ok=true proves the host
+	// round-trip worked.
+	err := h.Notify(context.Background(), channel.Notification{EventType: "test.event"})
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+}
+
+// ── TestTriggerHarness_Start ──────────────────────────────────────────────────
+
+func TestTriggerHarness_Start(t *testing.T) {
+	h := plugintest.NewTriggerHarness(t, func(hc hostv1.HostServiceClient) trigger.Service {
+		return &fakeTriggerService{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := h.Client.Start(ctx, &triggerv1.StartRequest{
+		WatchScopeJson: `{"ch":"#ops"}`,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if resp.GetEventKind() != "test.event" {
+		t.Errorf("event_kind: want %q, got %q", "test.event", resp.GetEventKind())
+	}
+	if resp.GetEventId() != "evt-1" {
+		t.Errorf("event_id: want %q, got %q", "evt-1", resp.GetEventId())
+	}
+
+	// Cancelling the context closes the stream and unblocks ctx.Done() inside
+	// fakeTriggerService.Start.
+	cancel()
+}
+
+// ── TestHarness_Cleanup ───────────────────────────────────────────────────────
+
+// TestHarness_Cleanup is a smoke test: if the single t.Cleanup closure
+// double-closes or panics the test binary would fail with a runtime error.
+// By running through a sub-test that completes cleanly we confirm the cleanup
+// runs without issue.
+func TestHarness_Cleanup(t *testing.T) {
+	t.Run("tool", func(t *testing.T) {
+		h := plugintest.NewToolHarness(t, func(hc hostv1.HostServiceClient) tool.Service {
+			return &fakeToolService{host: hc}
+		})
+		// One successful call so the cleanup has live connections to close.
+		_, _ = h.Client.ListTools(context.Background(), &toolv1.ListToolsRequest{})
+	})
+
+	t.Run("channel", func(t *testing.T) {
+		h := plugintest.NewChannelHarness(t, func(hc hostv1.HostServiceClient) channel.Service {
+			return &fakeChannelService{host: hc}
+		})
+		_ = h.Notify(context.Background(), channel.Notification{})
+	})
+}

--- a/plugins/ntfy/service_test.go
+++ b/plugins/ntfy/service_test.go
@@ -3,81 +3,15 @@ package main
 import (
 	"context"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 )
-
-// setup starts in-process gRPC servers for both the fake host and the channel
-// service (via the ergonomic adapter). ntfyBackend is an optional httptest.Server
-// used as the fake ntfy endpoint; pass nil to create a ChannelService with no
-// backend configured. Returns the channel client, the fake host, and a cleanup function.
-func setup(t *testing.T, ntfyBackend *httptest.Server, hostOpts ...plugintest.Option) (channelv1.ChannelServiceClient, *plugintest.FakeHost, func()) {
-	t.Helper()
-
-	host := plugintest.NewFakeHost(hostOpts...)
-
-	// Start host gRPC server.
-	hostLis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen for host: %v", err)
-	}
-	hostSrv := grpc.NewServer()
-	host.Register(hostSrv)
-	go func() { _ = hostSrv.Serve(hostLis) }()
-
-	// Dial the host and build the hostv1 client used by ChannelService.
-	hostConn, err := grpc.NewClient(hostLis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("dial host: %v", err)
-	}
-	hostClient := hostv1.NewHostServiceClient(hostConn)
-
-	// Build the channel service, using the test HTTP client so requests go to
-	// the httptest.Server instead of the real internet.
-	var httpClient *http.Client
-	if ntfyBackend != nil {
-		httpClient = ntfyBackend.Client()
-	}
-	svc := NewChannelService(hostClient, httpClient)
-
-	// Start channel service gRPC server via the exported adapter constructor.
-	// This gives the test a live gRPC round-trip through the ergonomic seam,
-	// validating channelHandlerAdapter in addition to ChannelService logic.
-	chanLis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen for channel: %v", err)
-	}
-	chanSrv := grpc.NewServer()
-	channelv1.RegisterChannelServiceServer(chanSrv, serve.NewChannelServer(svc))
-	go func() { _ = chanSrv.Serve(chanLis) }()
-
-	// Dial the channel service.
-	chanConn, err := grpc.NewClient(chanLis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("dial channel: %v", err)
-	}
-	chanClient := channelv1.NewChannelServiceClient(chanConn)
-
-	cleanup := func() {
-		chanConn.Close()
-		chanSrv.Stop()
-		hostConn.Close()
-		hostSrv.Stop()
-	}
-	return chanClient, host, cleanup
-}
 
 // TestNotify_Happy verifies a successful notification: correct URL path, Title
 // header, Authorization header, and body forwarded to the ntfy server.
@@ -93,13 +27,18 @@ func TestNotify_Happy(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	chanClient, _, cleanup := setup(t, backend,
+	h := plugintest.NewChannelHarness(t, func(hc hostv1.HostServiceClient) channel.Service {
+		var httpClient *http.Client
+		if backend != nil {
+			httpClient = backend.Client()
+		}
+		return NewChannelService(hc, httpClient)
+	},
 		plugintest.WithInstanceConfigJSON(`{"server_url":"`+backend.URL+`","default_topic":"alerts"}`),
 		plugintest.WithCredentialsJSON(`{"api_key":"k-test"}`),
 	)
-	defer cleanup()
 
-	resp, err := chanClient.Notify(context.Background(), &channelv1.NotifyRequest{
+	resp, err := h.Client.Notify(context.Background(), &channelv1.NotifyRequest{
 		PayloadJson: `{"title":"Alert","body":"something happened"}`,
 	})
 	if err != nil {
@@ -133,13 +72,18 @@ func TestNotify_PerAudienceTopicOverride(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	chanClient, _, cleanup := setup(t, backend,
+	h := plugintest.NewChannelHarness(t, func(hc hostv1.HostServiceClient) channel.Service {
+		var httpClient *http.Client
+		if backend != nil {
+			httpClient = backend.Client()
+		}
+		return NewChannelService(hc, httpClient)
+	},
 		plugintest.WithInstanceConfigJSON(`{"server_url":"`+backend.URL+`","default_topic":"alerts"}`),
 		plugintest.WithCredentialsJSON(`{}`),
 	)
-	defer cleanup()
 
-	resp, err := chanClient.Notify(context.Background(), &channelv1.NotifyRequest{
+	resp, err := h.Client.Notify(context.Background(), &channelv1.NotifyRequest{
 		ChannelConfigJson: `{"topic":"oncall"}`,
 		PayloadJson:       `{"body":"paging oncall"}`,
 	})
@@ -165,14 +109,19 @@ func TestNotify_NoTopicConfigured(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	chanClient, _, cleanup := setup(t, backend,
+	h := plugintest.NewChannelHarness(t, func(hc hostv1.HostServiceClient) channel.Service {
+		var httpClient *http.Client
+		if backend != nil {
+			httpClient = backend.Client()
+		}
+		return NewChannelService(hc, httpClient)
+	},
 		// No default_topic in instance config; no topic in channel config.
 		plugintest.WithInstanceConfigJSON(`{"server_url":"`+backend.URL+`"}`),
 		plugintest.WithCredentialsJSON(`{}`),
 	)
-	defer cleanup()
 
-	resp, err := chanClient.Notify(context.Background(), &channelv1.NotifyRequest{
+	resp, err := h.Client.Notify(context.Background(), &channelv1.NotifyRequest{
 		PayloadJson: `{"body":"test"}`,
 	})
 	if err != nil {
@@ -197,13 +146,18 @@ func TestNotify_NtfyServerError(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	chanClient, _, cleanup := setup(t, backend,
+	h := plugintest.NewChannelHarness(t, func(hc hostv1.HostServiceClient) channel.Service {
+		var httpClient *http.Client
+		if backend != nil {
+			httpClient = backend.Client()
+		}
+		return NewChannelService(hc, httpClient)
+	},
 		plugintest.WithInstanceConfigJSON(`{"server_url":"`+backend.URL+`","default_topic":"alerts"}`),
 		plugintest.WithCredentialsJSON(`{}`),
 	)
-	defer cleanup()
 
-	resp, err := chanClient.Notify(context.Background(), &channelv1.NotifyRequest{
+	resp, err := h.Client.Notify(context.Background(), &channelv1.NotifyRequest{
 		PayloadJson: `{"body":"test"}`,
 	})
 	if err != nil {
@@ -230,14 +184,19 @@ func TestNotify_NoAPIKey(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	chanClient, _, cleanup := setup(t, backend,
+	h := plugintest.NewChannelHarness(t, func(hc hostv1.HostServiceClient) channel.Service {
+		var httpClient *http.Client
+		if backend != nil {
+			httpClient = backend.Client()
+		}
+		return NewChannelService(hc, httpClient)
+	},
 		plugintest.WithInstanceConfigJSON(`{"server_url":"`+backend.URL+`","default_topic":"alerts"}`),
 		// Empty credentials — no api_key.
 		plugintest.WithCredentialsJSON(`{}`),
 	)
-	defer cleanup()
 
-	resp, err := chanClient.Notify(context.Background(), &channelv1.NotifyRequest{
+	resp, err := h.Client.Notify(context.Background(), &channelv1.NotifyRequest{
 		PayloadJson: `{"body":"no auth test"}`,
 	})
 	if err != nil {


### PR DESCRIPTION
Closes #459

## Summary

`plugintest.NewFakeHost` only faked the host side, so every plugin test re-hand-rolled a ~50-line two-server gRPC `setup()` (host listener+server+dial+client, service listener+server+dial+client, cleanup). This adds an in-process harness that wires both for you.

- **`NewToolHarness` / `NewChannelHarness` / `NewTriggerHarness`** (`plugin-sdk/testing/harness.go`): each takes a `func(hostv1.HostServiceClient) <Service>` factory — mirroring production wiring so the author's Service still receives a live host client and can call back (`GetCredentials`/`EmitMetric`/`Log`/…). It stands up a live `FakeHost` and the ergonomic Service over **bufconn**, returns `{Host, Client}`, and tears everything down via a single `t.Cleanup`.
- **Ergonomic helpers** (`h.Call`, `h.ListTools`, `h.Notify`, `h.Request`) for the "few lines" path, with the raw typed `Client` still public for tests that inspect the proto envelope.
- **Migrations (the dogfood):** `examples/minimal-tool` and `plugins/ntfy` tests drop their `setup()` blocks and use the harness — every existing assertion preserved verbatim. Two real consumers prove the seam.

## Design notes

- `grpc.NewClient` uses the mandatory `"passthrough:///"` target with `WithContextDialer` (without it, gRPC attempts DNS resolution and fails — the canonical bufconn pattern).
- Single `t.Cleanup` closure tears down service-then-host, so in-flight host callbacks finish before the host connection closes (no race window).
- Additive: `NewFakeHost`/`Register`/assertions/options and `internal/fakehost` are unchanged; `plugins/slack` untouched; no `go.mod` change (`bufconn` ships in the already-required grpc module). `testing → serve` is one-directional (no cycle).
- `plugin-sdk/cmd/gleipnir-plugin/cmd/internal/runfixture` stays the deliberate raw go-plugin subprocess exception (named in `doc.go`).

## Tests

`harness_test.go` self-tests all three harnesses (round-trip, host callbacks through the live connection, trigger streaming, cleanup) with in-file fakes. The migrated example + ntfy suites are the integration proof. Full `go.work` workspace `go vet`/`build`/`test` green via the commit hook; all suites pass with `-race`.

## Dev-loop metadata

Pipeline: architect → plan-review (**REVISE**: mandatory `"passthrough:///"` target; single-closure `t.Cleanup` ordering; concrete runfixture path) → implement → code-review (**APPROVE**, 0 loop-backs; reviewer ran `-race` and verified assertion-by-assertion migration fidelity). CLAUDE.md: no updates needed. Generated by the agentic dev loop.
