### PR TITLE
style: gofmt the plugin subsystem to a clean lint baseline

### DIFF
--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -29,11 +29,11 @@ import (
 
 // fakePluginQuerier is an in-memory PluginQuerier for tests.
 type fakePluginQuerier struct {
-	instances       map[string]db.PluginInstance
-	plugins         map[string]db.Plugin
-	auditEvents     []db.PluginAuditEvent
+	instances        map[string]db.PluginInstance
+	plugins          map[string]db.Plugin
+	auditEvents      []db.PluginAuditEvent
 	pendingManifests map[string]db.PluginPendingManifest
-	policies        []db.Policy
+	policies         []db.Policy
 	// audienceEntries maps instance_id → list of audience entries for that instance.
 	audienceEntries map[string][]db.ListAudienceEntriesByInstanceRow
 	// casFailOn is the plugin ID that should return 0 rows for UpdatePluginTrustedPubkey
@@ -1039,7 +1039,6 @@ func withChiParams(r *http.Request, params map[string]string) *http.Request {
 	}
 	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 }
-
 
 const (
 	// v1 manifest for accept-manifest tests.

--- a/internal/plugin/configvalidate/configvalidate.go
+++ b/internal/plugin/configvalidate/configvalidate.go
@@ -249,4 +249,3 @@ func rfc6901Unescape(tok string) string {
 	tok = strings.ReplaceAll(tok, "~0", "~")
 	return tok
 }
-

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -2170,9 +2170,9 @@ func TestRunHistoryRead_LimitClamping(t *testing.T) {
 	}
 
 	q := &fakeQuerier{
-		instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
-		plugin:   db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("run_history_read")},
-		policies: []db.Policy{{ID: "pol-mine", Yaml: policyYAMLWithTool("myplugin.do_thing")}},
+		instance:           db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
+		plugin:             db.Plugin{ID: "plug-1", ManifestSnapshot: manifestWithTier2("run_history_read")},
+		policies:           []db.Policy{{ID: "pol-mine", Yaml: policyYAMLWithTool("myplugin.do_thing")}},
 		runsByPoliciesRows: rows,
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})

--- a/internal/plugin/identity/registry_test.go
+++ b/internal/plugin/identity/registry_test.go
@@ -136,7 +136,7 @@ func TestRegistry_LookupRejectsWrongLength(t *testing.T) {
 		token string
 	}{
 		{"empty", ""},
-		{"too_short_16_bytes", "AAAAAAAAAAAAAAAAAAAAAA"},  // 16 bytes base64url
+		{"too_short_16_bytes", "AAAAAAAAAAAAAAAAAAAAAA"},                                          // 16 bytes base64url
 		{"too_long_48_bytes", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}, // 48 bytes base64url
 		{"not_base64", "!!!not-valid-base64!!!"},
 	}

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -203,4 +203,3 @@ func (l *Loader) StartManager(ctx context.Context, cfg StartManagerConfig) error
 
 	return l.manager.StartAllActive(ctx)
 }
-

--- a/internal/plugin/loader/semver_test.go
+++ b/internal/plugin/loader/semver_test.go
@@ -13,7 +13,7 @@ func TestIsValidSemver(t *testing.T) {
 		{"1.9", true},
 		{"1.10.0", true},
 		{"0.1.0-alpha", true},
-		{"v1.0.0", true},  // already has "v" prefix
+		{"v1.0.0", true}, // already has "v" prefix
 		{"", false},
 		{"not-semver", false},
 		{"1.9-final", false},

--- a/internal/plugin/manifest/diff.go
+++ b/internal/plugin/manifest/diff.go
@@ -368,4 +368,3 @@ func eventKindMap(kinds []sdkmanifest.EventKindDecl) map[string]sdkmanifest.Even
 	}
 	return m
 }
-

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -216,8 +216,8 @@ func TestManager_ConcurrentStart_SingleSubprocess(t *testing.T) {
 	}
 
 	var (
-		wg      sync.WaitGroup
-		errCh   = make(chan error, 2)
+		wg    sync.WaitGroup
+		errCh = make(chan error, 2)
 	)
 
 	for range 2 {

--- a/plugin-sdk/cmd/gleipnir-plugin/cmd/gen_manifest.go
+++ b/plugin-sdk/cmd/gleipnir-plugin/cmd/gen_manifest.go
@@ -63,4 +63,3 @@ func runGenManifest(binary, out string, cmd *cobra.Command) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "wrote manifest to %s\n", out)
 	return nil
 }
-

--- a/plugin-sdk/hostwire/hostwire.go
+++ b/plugin-sdk/hostwire/hostwire.go
@@ -243,13 +243,13 @@ var PluginMap = plugin.PluginSet{
 // (GLEIPNIR_INSTANCE_ID, GLEIPNIR_PLUGIN_ID, GLEIPNIR_INSTANCE_TOKEN) are
 // injected separately via opts.Env by the caller (internal/plugin/process).
 var safeEnvKeys = []string{
-	"PATH",    // required for subprocess tool resolution
-	"HOME",    // expected by most Unix programs
-	"USER",    // expected by some runtimes
-	"TZ",      // timezone — affects log timestamps inside the plugin
-	"TMPDIR",  // standard override for temp file location
-	"LANG",    // locale — affects string handling in some libraries
-	"LC_ALL",  // locale override — takes precedence over LANG
+	"PATH",   // required for subprocess tool resolution
+	"HOME",   // expected by most Unix programs
+	"USER",   // expected by some runtimes
+	"TZ",     // timezone — affects log timestamps inside the plugin
+	"TMPDIR", // standard override for temp file location
+	"LANG",   // locale — affects string handling in some libraries
+	"LC_ALL", // locale override — takes precedence over LANG
 }
 
 // safeEnv builds a minimal environment for plugin subprocesses by extracting

--- a/plugin-sdk/manifest/manifest_test.go
+++ b/plugin-sdk/manifest/manifest_test.go
@@ -48,9 +48,9 @@ func TestCanonicalize(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       []byte
-		wantOutput  []byte   // if set, assert byte-equal
-		wantContain string   // if set, assert output contains this substring
-		wantErr     string   // if set, assert error message contains this
+		wantOutput  []byte // if set, assert byte-equal
+		wantContain string // if set, assert output contains this substring
+		wantErr     string // if set, assert error message contains this
 	}{
 		{
 			name:       "JSON unordered keys → canonical YAML",
@@ -68,7 +68,7 @@ func TestCanonicalize(t *testing.T) {
 			wantOutput: []byte(canonicalManifestYAML),
 		},
 		{
-			name:        "key-ordering normalization: zebra_tool before alpha_tool → sorted output",
+			name: "key-ordering normalization: zebra_tool before alpha_tool → sorted output",
 			input: []byte(`schema_version: v1
 name: myplugin
 version: 2.0.0

--- a/plugin-sdk/serve/handleradapters.go
+++ b/plugin-sdk/serve/handleradapters.go
@@ -6,10 +6,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
 )

--- a/plugin-sdk/serve/handleradapters_test.go
+++ b/plugin-sdk/serve/handleradapters_test.go
@@ -17,11 +17,11 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	commonv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/common/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"
@@ -72,7 +72,7 @@ func (f *fakeChannelService) Request(_ context.Context, _ channel.FeedbackReques
 // fakeTriggerService is an in-test trigger.Service implementation.
 // The emitted slice holds events to emit before returning emitErr.
 type fakeTriggerService struct {
-	emitted []trigger.Event
+	emitted  []trigger.Event
 	startErr error
 }
 

--- a/plugin-sdk/serve/options.go
+++ b/plugin-sdk/serve/options.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"

--- a/plugin-sdk/testing/harness.go
+++ b/plugin-sdk/testing/harness.go
@@ -10,11 +10,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/trigger"

--- a/plugin-sdk/testing/harness_test.go
+++ b/plugin-sdk/testing/harness_test.go
@@ -6,10 +6,10 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	toolv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/tool/v1"
 	triggerv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/trigger/v1"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/tool"

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -338,4 +338,3 @@ func (rt *pluginRuntime) shutdown() {
 		slog.Warn("plugin dispatch pool close error", "err", err)
 	}
 }
-

--- a/plugins/ntfy/main.go
+++ b/plugins/ntfy/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )
 

--- a/plugins/ntfy/service.go
+++ b/plugins/ntfy/service.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"strings"
 
-	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/pluginerr"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/serve"
 )

--- a/plugins/ntfy/service_test.go
+++ b/plugins/ntfy/service_test.go
@@ -7,10 +7,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 	channelv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/channel/v1"
 	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
 	plugintest "github.com/felag-engineering/gleipnir/plugin-sdk/testing"
-	"github.com/felag-engineering/gleipnir/plugin-sdk/channel"
 )
 
 // TestNotify_Happy verifies a successful notification: correct URL path, Title


### PR DESCRIPTION
## Summary

Pure `gofmt` cleanup. 20 files across `internal/plugin/`, `plugin-sdk/`, and `plugins/ntfy/` had drifted out of gofmt-canonical form (trailing blank lines, import ordering within groups, struct-comment alignment). This applies `gofmt -w` so the tree reaches a clean `gofmt -l` baseline.

**Formatting only — no behavior change** (31 insertions / 37 deletions; no logic touched). Generated code under `gen/` and the `*.go.tmpl` scaffold templates are untouched.

## Verification

- `gofmt -l` is now empty across every `go.work` module (root, plugin-sdk, plugins/ntfy, plugins/slack, examples/minimal-tool), excluding generated code.
- Full workspace `go vet` / `go build` / `go test` green via the commit hook.

## Why

Several of these files (the ergonomic-seam and harness additions from #457/#459, plus some pre-existing `internal/plugin` files) were committed without a gofmt pass because the commit gate runs `go vet`/`build`/`test` but not `gofmt`. This establishes the clean baseline so a format lint check can be added and pass.

> Follow-up (not in this PR): consider adding a `gofmt -l` check to CI / the Makefile so the baseline stays green.
