### PR TITLE
feat: enforce value-level parameter scoping in NarrowSchema (ADR-017) (#12)

### DIFF
--- a/internal/execution/agent/agent_test.go
+++ b/internal/execution/agent/agent_test.go
@@ -3456,6 +3456,48 @@ func pluginSchemaWith(keys ...string) map[string]any {
 	}
 }
 
+// assertPluginPropertyEnum checks that properties[key] in the narrowed schema
+// carries the expected enum entries. Entries are compared by JSON marshaling
+// (same semantics as ValidateCall) so yaml-int / json-float64 comparisons work.
+func assertPluginPropertyEnum(t *testing.T, schema json.RawMessage, key string, wantEnum []any) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("assertPluginPropertyEnum: unmarshal: %v", err)
+	}
+	propsMap, ok := m["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("assertPluginPropertyEnum: schema has no properties map")
+	}
+	propRaw, ok := propsMap[key]
+	if !ok {
+		t.Fatalf("assertPluginPropertyEnum: property %q not found", key)
+	}
+	propMap, ok := propRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("assertPluginPropertyEnum: property %q is not a map", key)
+	}
+	enumRaw, ok := propMap["enum"]
+	if !ok {
+		t.Fatalf("assertPluginPropertyEnum: property %q has no 'enum' key", key)
+	}
+	gotEnum, ok := enumRaw.([]any)
+	if !ok {
+		t.Fatalf("assertPluginPropertyEnum: property %q 'enum' is not []any", key)
+	}
+	if len(gotEnum) != len(wantEnum) {
+		t.Errorf("property %q enum len = %d, want %d (got %v, want %v)", key, len(gotEnum), len(wantEnum), gotEnum, wantEnum)
+		return
+	}
+	for i, want := range wantEnum {
+		wantBytes, _ := json.Marshal(want)
+		gotBytes, _ := json.Marshal(gotEnum[i])
+		if string(wantBytes) != string(gotBytes) {
+			t.Errorf("property %q enum[%d] = %v (json:%s), want %v (json:%s)", key, i, gotEnum[i], gotBytes, want, wantBytes)
+		}
+	}
+}
+
 // TestNew_NarrowsPluginToolSchema verifies that New() applies ADR-017 parameter
 // scoping to plugin tools: narrowedSchema is set to the policy-constrained view,
 // while tool.InputSchema retains the full raw schema. Mirrors TestNarrowSchema in
@@ -3464,12 +3506,26 @@ func TestNew_NarrowsPluginToolSchema(t *testing.T) {
 	baseSchema := pluginSchemaWith("namespace", "pod", "force")
 	noPropsSchema := map[string]any{"type": "object"} // no "properties" key
 
+	// Schema with force as boolean so force:true passes type-mismatch validation.
+	boolForceSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"namespace": map[string]any{"type": "string"},
+			"pod":       map[string]any{"type": "string"},
+			"force":     map[string]any{"type": "boolean"},
+		},
+		"required": []any{"namespace", "pod"},
+	}
+
 	tests := []struct {
 		name          string
 		schema        map[string]any
 		params        map[string]any
 		wantKeys      []string // nil means don't check properties
 		wantUnchanged bool     // narrowedSchema must equal marshaled schema
+		// wantEnumFor is a set of per-property enum assertions. Each entry maps a
+		// property key to the expected enum slice. Checked after wantKeys.
+		wantEnumFor map[string][]any
 	}{
 		{
 			name:          "nil Params — schema unchanged",
@@ -3484,28 +3540,36 @@ func TestNew_NarrowsPluginToolSchema(t *testing.T) {
 			wantUnchanged: true,
 		},
 		{
-			name:     "single key in Params — only that property survives",
-			schema:   baseSchema,
-			params:   map[string]any{"namespace": "x"},
-			wantKeys: []string{"namespace"},
+			// ADR-017: scalar param becomes a single-element enum constraining the
+			// LLM-facing schema. Explicit assertion guards against a regression where
+			// the enum is dropped and the property reverts to a free-form string.
+			name:        "single key in Params — only that property survives",
+			schema:      baseSchema,
+			params:      map[string]any{"namespace": "x"},
+			wantKeys:    []string{"namespace"},
+			wantEnumFor: map[string][]any{"namespace": {"x"}},
 		},
 		{
-			name:     "multiple keys in Params — only listed properties survive",
-			schema:   baseSchema,
-			params:   map[string]any{"namespace": "x", "pod": "y"},
-			wantKeys: []string{"namespace", "pod"},
+			name:        "multiple keys in Params — only listed properties survive",
+			schema:      baseSchema,
+			params:      map[string]any{"namespace": "x", "pod": "y"},
+			wantKeys:    []string{"namespace", "pod"},
+			wantEnumFor: map[string][]any{"namespace": {"x"}, "pod": {"y"}},
 		},
 		{
-			name:     "Params key not in schema — silently dropped",
-			schema:   baseSchema,
-			params:   map[string]any{"namespace": "x", "nonexistent": "y"},
-			wantKeys: []string{"namespace"},
+			name:        "Params key not in schema — silently dropped",
+			schema:      baseSchema,
+			params:      map[string]any{"namespace": "x", "nonexistent": "y"},
+			wantKeys:    []string{"namespace"},
+			wantEnumFor: map[string][]any{"namespace": {"x"}},
 		},
 		{
-			name:     "Params drops a required key — required entry removed",
-			schema:   baseSchema,
-			params:   map[string]any{"force": true},
-			wantKeys: []string{"force"},
+			// Uses boolForceSchema so force:true (boolean) matches type:boolean.
+			name:        "Params drops a required key — required entry removed",
+			schema:      boolForceSchema,
+			params:      map[string]any{"force": true},
+			wantKeys:    []string{"force"},
+			wantEnumFor: map[string][]any{"force": {true}},
 		},
 		{
 			name:          "schema with no properties — returned unchanged",
@@ -3560,6 +3624,12 @@ func TestNew_NarrowsPluginToolSchema(t *testing.T) {
 
 			assertSchemaProperties(t, entry.narrowedSchema, tc.wantKeys)
 
+			// Per-property enum assertions: verifies that scalar/slice params produced
+			// the expected enum values in the LLM-facing schema (ADR-017 enforcement).
+			for propKey, wantEnum := range tc.wantEnumFor {
+				assertPluginPropertyEnum(t, entry.narrowedSchema, propKey, wantEnum)
+			}
+
 			// Raw InputSchema must always be the full original schema.
 			if string(entry.tool.InputSchema) != string(rawSchema) {
 				t.Errorf("InputSchema modified; got %s, want %s", entry.tool.InputSchema, rawSchema)
@@ -3608,6 +3678,9 @@ func TestNew_PluginSchemaCannotBypassScoping(t *testing.T) {
 	// narrowedSchema must expose only "namespace".
 	entry := ba.toolsByName["my-plugin.do-thing"]
 	assertSchemaProperties(t, entry.narrowedSchema, []string{"namespace"})
+	// The namespace property must carry enum:["x"] — guards against a regression
+	// where the enum is silently dropped and the property reverts to free-form.
+	assertPluginPropertyEnum(t, entry.narrowedSchema, "namespace", []any{"x"})
 
 	// buildToolDefinitions feeds the narrowedSchema to the LLM — check that too.
 	defs := ba.buildToolDefinitions()
@@ -3622,6 +3695,8 @@ func TestNew_PluginSchemaCannotBypassScoping(t *testing.T) {
 		t.Fatal("plugin tool definition not found in buildToolDefinitions output")
 	}
 	assertSchemaProperties(t, pluginDef.InputSchema, []string{"namespace"})
+	// Verify that the enum constraint survives the path through buildToolDefinitions.
+	assertPluginPropertyEnum(t, pluginDef.InputSchema, "namespace", []any{"x"})
 }
 
 // TestHandleToolCall_PluginTool_ApprovalGated verifies that the approval

--- a/internal/mcp/narrow.go
+++ b/internal/mcp/narrow.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -10,6 +11,22 @@ import (
 // returned unchanged (zero allocation for the common case). If the schema has
 // no "properties" key, or it is not a map, the original schema is also
 // returned unchanged.
+//
+// For each key k in params that exists in the schema's properties:
+//   - params[k] == nil  → preserve the original property unchanged (key-allowlist only).
+//   - params[k] is []any  → build an enum from those elements.
+//   - params[k] is a scalar (string/bool/int/float64)  → single-element enum.
+//
+// Enum-building produces a FRESH property map containing only "type", "enum",
+// and "description" (all copied verbatim from the original). Extra constraints
+// like format/minLength/pattern are dropped — they are redundant against an enum.
+//
+// Config errors (returned as errors, surfaced as build-time run failures):
+//   - orig property is not a map[string]any (e.g. boolean schema)
+//   - param value is a non-nil, non-scalar, non-slice type (nested map)
+//   - empty []any value list
+//   - []any with mixed JSON kinds (e.g. [1,"two"] rejected; [1,2.5] allowed)
+//   - value kind does not match the schema's declared "type"
 func NarrowSchema(schema json.RawMessage, params map[string]any) (json.RawMessage, error) {
 	if len(params) == 0 {
 		return schema, nil
@@ -31,10 +48,61 @@ func NarrowSchema(schema json.RawMessage, params map[string]any) (json.RawMessag
 
 	// Build narrowed properties containing only keys present in both params and the schema.
 	narrowedProps := make(map[string]any, len(params))
-	for k := range params {
-		if v, exists := propsMap[k]; exists {
-			narrowedProps[k] = v
+	for k, paramVal := range params {
+		orig, exists := propsMap[k]
+		if !exists {
+			continue
 		}
+
+		// nil means key-allowlist only — preserve the original property. Check nil
+		// before the scalar branch so a bare YAML `key:` (which parses as nil) does
+		// not accidentally become enum:[null].
+		if paramVal == nil {
+			narrowedProps[k] = orig
+			continue
+		}
+
+		// orig must be a map for us to build a constrained enum property. Boolean
+		// schemas (true/false) and other non-map values are unsupported.
+		origMap, ok := orig.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("param %q: original schema property is not an object (boolean schemas are unsupported)", k)
+		}
+
+		// Determine the enum entries from the param value.
+		var entries []any
+		switch v := paramVal.(type) {
+		case []any:
+			entries = v
+		case string, bool, int, float64:
+			entries = []any{v}
+		default:
+			// Nested maps and other complex values are out of scope for v1.
+			return nil, fmt.Errorf("param %q: nested or unsupported value type %T (nested value scoping not supported)", k, paramVal)
+		}
+
+		if len(entries) == 0 {
+			return nil, fmt.Errorf("param %q: empty value list", k)
+		}
+
+		// Validate that all entries share the same JSON kind, and that the kind is
+		// compatible with the schema's declared type (if any).
+		if err := validateEnumEntries(k, entries, origMap); err != nil {
+			return nil, err
+		}
+
+		// Build a FRESH property map. Only carry forward "type", "enum", and
+		// "description" — other JSON Schema keywords (format, minLength, pattern, …)
+		// are redundant against an enum and are intentionally dropped (ADR-017).
+		narrowedProp := make(map[string]any, 3)
+		if t, ok := origMap["type"]; ok {
+			narrowedProp["type"] = t
+		}
+		narrowedProp["enum"] = entries
+		if desc, ok := origMap["description"]; ok {
+			narrowedProp["description"] = desc
+		}
+		narrowedProps[k] = narrowedProp
 	}
 	schemaMap["properties"] = narrowedProps
 
@@ -64,9 +132,116 @@ func NarrowSchema(schema json.RawMessage, params map[string]any) (json.RawMessag
 	return out, nil
 }
 
+// jsonKind returns a canonical kind string for a Go value as it would appear
+// in JSON: "string", "number", "bool", or "null". Returns "" for types that
+// are not valid JSON scalar primitives.
+func jsonKind(v any) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case int, float64:
+		// Both Go int and float64 marshal to a JSON number.
+		return "number"
+	case bool:
+		return "bool"
+	case nil:
+		return "null"
+	default:
+		return ""
+	}
+}
+
+// validateEnumEntries checks that every entry in entries shares the same JSON
+// kind, and that the kind is compatible with the schema's declared "type" (if
+// present). type may be a string or a []any of strings (union type).
+func validateEnumEntries(paramKey string, entries []any, origMap map[string]any) error {
+	// Verify all entries share the same JSON kind. [1, 2.5] is allowed because
+	// both Go int and float64 are JSON numbers. [1, "two"] is rejected.
+	firstKind := jsonKind(entries[0])
+	if firstKind == "" {
+		return fmt.Errorf("param %q: entry %v has unsupported type %T for JSON enum", paramKey, entries[0], entries[0])
+	}
+	for i, entry := range entries[1:] {
+		k := jsonKind(entry)
+		if k == "" {
+			return fmt.Errorf("param %q: entry %v at index %d has unsupported type %T for JSON enum", paramKey, entry, i+1, entry)
+		}
+		if k != firstKind {
+			return fmt.Errorf("param %q: mixed JSON kinds in value list (entry 0 is %s, entry %d is %s)", paramKey, firstKind, i+1, k)
+		}
+	}
+
+	// Check that the entry kind is compatible with the schema's declared type.
+	// If "type" is absent we skip the check.
+	typeRaw, hasType := origMap["type"]
+	if !hasType {
+		return nil
+	}
+
+	// Collect declared types into a slice (handles both "string" and ["string","null"]).
+	var declaredTypes []string
+	switch t := typeRaw.(type) {
+	case string:
+		declaredTypes = []string{t}
+	case []any:
+		for _, item := range t {
+			if s, ok := item.(string); ok {
+				declaredTypes = append(declaredTypes, s)
+			}
+		}
+	default:
+		// Unknown type format — skip check.
+		return nil
+	}
+
+	// Check each entry against the declared types. A numeric entry satisfies both
+	// "integer" and "number" because JSON has a single number type; yaml.v3 gives
+	// us Go int for whole numbers and float64 for decimals — both are valid for
+	// either schema type.
+	for _, entry := range entries {
+		if !kindMatchesDeclaredTypes(jsonKind(entry), declaredTypes) {
+			return fmt.Errorf("param %q: value %v (%s) is incompatible with schema type %v", paramKey, entry, jsonKind(entry), typeRaw)
+		}
+	}
+	return nil
+}
+
+// kindMatchesDeclaredTypes returns true if the JSON kind of an enum entry is
+// compatible with at least one of the declared schema types.
+func kindMatchesDeclaredTypes(kind string, declaredTypes []string) bool {
+	for _, dt := range declaredTypes {
+		switch dt {
+		case "string":
+			if kind == "string" {
+				return true
+			}
+		case "number", "integer":
+			// JSON number: both Go int and float64 satisfy integer and number.
+			if kind == "number" {
+				return true
+			}
+		case "boolean":
+			if kind == "bool" {
+				return true
+			}
+		case "null":
+			if kind == "null" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ValidateCall checks that every key in input is present in the narrowed
 // schema's properties. If input is empty, or the schema has no properties,
-// it returns nil. This performs key-presence validation only — no type checks.
+// it returns nil. After key-presence validation, it checks that any input
+// value whose property carries an "enum" is a member of that enum.
+//
+// Enum membership is tested via JSON marshaling: both the input value and each
+// candidate enum entry are marshaled to JSON and compared byte-by-byte. This
+// avoids YAML-int / JSON-float64 round-trip mismatches (yaml.v3 gives Go int;
+// json.Unmarshal gives float64; json.Marshal("22") is identical for both).
 func ValidateCall(narrowedSchema json.RawMessage, input map[string]any) error {
 	if len(input) == 0 {
 		return nil
@@ -89,10 +264,61 @@ func ValidateCall(narrowedSchema json.RawMessage, input map[string]any) error {
 		return nil
 	}
 
+	// First pass: key-presence check. An undeclared key is rejected immediately
+	// with the original "not permitted" error before any marshal work occurs.
 	for k := range input {
 		if _, allowed := propsMap[k]; !allowed {
 			return fmt.Errorf("input key %q is not permitted by the narrowed schema", k)
 		}
 	}
+
+	// Second pass: enum-membership check for properties that carry an "enum".
+	for k, inputVal := range input {
+		propRaw, ok := propsMap[k]
+		if !ok {
+			continue
+		}
+		propMap, ok := propRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		enumRaw, ok := propMap["enum"]
+		if !ok {
+			continue
+		}
+		enumEntries, ok := enumRaw.([]any)
+		if !ok {
+			continue
+		}
+
+		matched, err := isInEnum(inputVal, enumEntries)
+		if err != nil {
+			return fmt.Errorf("enum check for %q: %w", k, err)
+		}
+		if !matched {
+			return fmt.Errorf("input value for %q is not permitted by the policy enum constraint", k)
+		}
+	}
 	return nil
+}
+
+// isInEnum reports whether val is byte-equal (after JSON marshaling) to any
+// entry in entries. A marshal error propagates upward — it is never silently
+// treated as a non-match, because a broken value that can't be marshaled should
+// not be allowed through security enforcement.
+func isInEnum(val any, entries []any) (bool, error) {
+	valBytes, err := json.Marshal(val)
+	if err != nil {
+		return false, fmt.Errorf("marshal input value: %w", err)
+	}
+	for _, entry := range entries {
+		entryBytes, err := json.Marshal(entry)
+		if err != nil {
+			return false, fmt.Errorf("marshal enum entry: %w", err)
+		}
+		if bytes.Equal(valBytes, entryBytes) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/mcp/narrow_test.go
+++ b/internal/mcp/narrow_test.go
@@ -49,6 +49,125 @@ func assertSchemaProperties(t *testing.T, schema json.RawMessage, wantKeys []str
 	}
 }
 
+// assertPropertyEnum unmarshals schema and checks that properties[key] has the
+// expected "enum" array. wantEnum entries are compared via JSON marshaling to
+// match the round-trip semantics used by NarrowSchema and ValidateCall.
+func assertPropertyEnum(t *testing.T, schema json.RawMessage, key string, wantEnum []any) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("assertPropertyEnum: unmarshal: %v", err)
+	}
+	propsMap, ok := m["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyEnum: schema has no properties map")
+	}
+	propRaw, ok := propsMap[key]
+	if !ok {
+		t.Fatalf("assertPropertyEnum: property %q not found", key)
+	}
+	propMap, ok := propRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyEnum: property %q is not a map", key)
+	}
+	enumRaw, ok := propMap["enum"]
+	if !ok {
+		t.Fatalf("assertPropertyEnum: property %q has no 'enum' key", key)
+	}
+	gotEnum, ok := enumRaw.([]any)
+	if !ok {
+		t.Fatalf("assertPropertyEnum: property %q 'enum' is not []any", key)
+	}
+
+	if len(gotEnum) != len(wantEnum) {
+		t.Errorf("property %q enum length = %d, want %d (got %v, want %v)", key, len(gotEnum), len(wantEnum), gotEnum, wantEnum)
+		return
+	}
+	for i, want := range wantEnum {
+		wantBytes, _ := json.Marshal(want)
+		gotBytes, _ := json.Marshal(gotEnum[i])
+		if string(wantBytes) != string(gotBytes) {
+			t.Errorf("property %q enum[%d] = %v (json: %s), want %v (json: %s)", key, i, gotEnum[i], gotBytes, want, wantBytes)
+		}
+	}
+}
+
+// assertPropertyType unmarshals schema and checks that properties[key] has the
+// expected "type" value. wantType may be a string or slice.
+func assertPropertyType(t *testing.T, schema json.RawMessage, key string, wantType any) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("assertPropertyType: unmarshal: %v", err)
+	}
+	propsMap, ok := m["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyType: schema has no properties map")
+	}
+	propRaw, ok := propsMap[key]
+	if !ok {
+		t.Fatalf("assertPropertyType: property %q not found", key)
+	}
+	propMap, ok := propRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyType: property %q is not a map", key)
+	}
+	wantBytes, _ := json.Marshal(wantType)
+	gotBytes, _ := json.Marshal(propMap["type"])
+	if string(wantBytes) != string(gotBytes) {
+		t.Errorf("property %q type = %v, want %v", key, propMap["type"], wantType)
+	}
+}
+
+// assertPropertyDescription checks that properties[key] has the expected "description".
+func assertPropertyDescription(t *testing.T, schema json.RawMessage, key string, wantDesc string) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("assertPropertyDescription: unmarshal: %v", err)
+	}
+	propsMap, ok := m["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyDescription: schema has no properties map")
+	}
+	propRaw, ok := propsMap[key]
+	if !ok {
+		t.Fatalf("assertPropertyDescription: property %q not found", key)
+	}
+	propMap, ok := propRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyDescription: property %q is not a map", key)
+	}
+	gotDesc, _ := propMap["description"].(string)
+	if gotDesc != wantDesc {
+		t.Errorf("property %q description = %q, want %q", key, gotDesc, wantDesc)
+	}
+}
+
+// assertPropertyNoKey checks that properties[key] does NOT have the named sub-key.
+func assertPropertyNoKey(t *testing.T, schema json.RawMessage, propKey, subKey string) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("assertPropertyNoKey: unmarshal: %v", err)
+	}
+	propsMap, ok := m["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyNoKey: schema has no properties map")
+	}
+	propRaw, ok := propsMap[propKey]
+	if !ok {
+		t.Fatalf("assertPropertyNoKey: property %q not found", propKey)
+	}
+	propMap, ok := propRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("assertPropertyNoKey: property %q is not a map", propKey)
+	}
+	if _, found := propMap[subKey]; found {
+		t.Errorf("property %q unexpectedly contains key %q", propKey, subKey)
+	}
+}
+
 func TestNarrowSchema(t *testing.T) {
 	// Shared base schema used across cases.
 	baseSchema := json.RawMessage(`{
@@ -70,6 +189,9 @@ func TestNarrowSchema(t *testing.T) {
 		wantKeys      []string
 		wantRequired  []string // nil means don't check; empty means key must be absent
 		wantUnchanged bool     // true means result must be byte-identical to input
+		wantEnumFor   map[string][]any // key → expected enum entries (nil means skip)
+		wantErr       bool
+		errContains   string
 	}{
 		{
 			name:          "nil params returns schema unchanged",
@@ -83,12 +205,16 @@ func TestNarrowSchema(t *testing.T) {
 			params:        map[string]any{},
 			wantUnchanged: true,
 		},
+		// --- Existing scalar-param cases updated with explicit enum assertions ---
+		// These four cases previously only checked key-set; they now also verify
+		// that each scalar param value becomes a single-element enum (ADR-017).
 		{
 			name:         "params with namespace only",
 			schema:       baseSchema,
 			params:       map[string]any{"namespace": "x"},
 			wantKeys:     []string{"namespace"},
 			wantRequired: []string{"namespace"},
+			wantEnumFor:  map[string][]any{"namespace": {"x"}},
 		},
 		{
 			name:         "params with namespace and pod",
@@ -96,6 +222,7 @@ func TestNarrowSchema(t *testing.T) {
 			params:       map[string]any{"namespace": "x", "pod": "y"},
 			wantKeys:     []string{"namespace", "pod"},
 			wantRequired: []string{"namespace", "pod"},
+			wantEnumFor:  map[string][]any{"namespace": {"x"}, "pod": {"y"}},
 		},
 		{
 			name:         "nonexistent param key is silently dropped",
@@ -103,12 +230,7 @@ func TestNarrowSchema(t *testing.T) {
 			params:       map[string]any{"namespace": "x", "nonexistent": "y"},
 			wantKeys:     []string{"namespace"},
 			wantRequired: []string{"namespace"},
-		},
-		{
-			name:          "schema without properties is returned unchanged",
-			schema:        noPropsSchema,
-			params:        map[string]any{"namespace": "x"},
-			wantUnchanged: true,
+			wantEnumFor:  map[string][]any{"namespace": {"x"}},
 		},
 		{
 			name:         "force only — not in required, required key removed",
@@ -116,12 +238,148 @@ func TestNarrowSchema(t *testing.T) {
 			params:       map[string]any{"force": true},
 			wantKeys:     []string{"force"},
 			wantRequired: []string{}, // expected absent
+			wantEnumFor:  map[string][]any{"force": {true}},
+		},
+		// --- nil value: key-allowlist only, no enum ---
+		{
+			name:   "nil value preserves original property unchanged",
+			schema: baseSchema,
+			params: map[string]any{"namespace": nil},
+			// The original property {"type":"string"} must come through intact.
+			wantKeys: []string{"namespace"},
+			// wantEnumFor intentionally absent: property must have no enum key.
+		},
+		// --- Slice of strings → enum ---
+		{
+			name: "slice of strings becomes enum with description preserved and minLength dropped",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"namespace": {"type": "string", "description": "target namespace", "minLength": 1}
+				}
+			}`),
+			params:      map[string]any{"namespace": []any{"worker-01", "worker-02"}},
+			wantKeys:    []string{"namespace"},
+			wantEnumFor: map[string][]any{"namespace": {"worker-01", "worker-02"}},
+		},
+		// --- Numeric heterogeneity: [1, 2.5] must succeed (both JSON number-kind) ---
+		{
+			name: "numeric heterogeneity int and float64 is allowed",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"port": {"type": "number"}
+				}
+			}`),
+			params:      map[string]any{"port": []any{int(80), float64(443.5)}},
+			wantKeys:    []string{"port"},
+			wantEnumFor: map[string][]any{"port": {int(80), float64(443.5)}},
+		},
+		// --- Numeric enum compatible with both type:integer and type:number ---
+		{
+			name: "numeric enum matches schema type integer",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"port": {"type": "integer"}
+				}
+			}`),
+			params:      map[string]any{"port": []any{int(22), int(80)}},
+			wantKeys:    []string{"port"},
+			wantEnumFor: map[string][]any{"port": {int(22), int(80)}},
+		},
+		{
+			name: "numeric enum matches schema type number",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"port": {"type": "number"}
+				}
+			}`),
+			params:      map[string]any{"port": []any{int(22), int(80)}},
+			wantKeys:    []string{"port"},
+			wantEnumFor: map[string][]any{"port": {int(22), int(80)}},
+		},
+		// --- type as array union: member and non-member ---
+		{
+			name: "type-union array: string value matches [string null] union",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"region": {"type": ["string", "null"]}
+				}
+			}`),
+			params:      map[string]any{"region": "us-east-1"},
+			wantKeys:    []string{"region"},
+			wantEnumFor: map[string][]any{"region": {"us-east-1"}},
+		},
+		// --- schema without properties ---
+		{
+			name:          "schema without properties is returned unchanged",
+			schema:        noPropsSchema,
+			params:        map[string]any{"namespace": "x"},
+			wantUnchanged: true,
+		},
+		// --- Error cases ---
+		{
+			name:        "empty slice is a config error",
+			schema:      baseSchema,
+			params:      map[string]any{"namespace": []any{}},
+			wantErr:     true,
+			errContains: "empty value list",
+		},
+		{
+			name:        "mixed-type slice int and string is a config error",
+			schema:      baseSchema,
+			params:      map[string]any{"namespace": []any{int(1), "two"}},
+			wantErr:     true,
+			errContains: "mixed JSON kinds",
+		},
+		{
+			name: "value kind different from schema type is a config error",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"namespace": {"type": "string"}
+				}
+			}`),
+			params:      map[string]any{"namespace": []any{int(22), int(80)}},
+			wantErr:     true,
+			errContains: "incompatible with schema type",
+		},
+		{
+			name: "type-union non-member is a config error",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"count": {"type": ["integer", "null"]}
+				}
+			}`),
+			params:      map[string]any{"count": "not-a-number"},
+			wantErr:     true,
+			errContains: "incompatible with schema type",
+		},
+		{
+			name:        "nested map param value is a config error",
+			schema:      baseSchema,
+			params:      map[string]any{"namespace": map[string]any{"foo": "bar"}},
+			wantErr:     true,
+			errContains: "nested value scoping not supported",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := NarrowSchema(tc.schema, tc.params)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NarrowSchema returned nil, want error containing %q", tc.errContains)
+				}
+				if tc.errContains != "" && !containsStr(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("NarrowSchema returned unexpected error: %v", err)
 			}
@@ -134,6 +392,11 @@ func TestNarrowSchema(t *testing.T) {
 			}
 
 			assertSchemaProperties(t, got, tc.wantKeys)
+
+			// Per-property enum assertions for all cases where wantEnumFor is set.
+			for propKey, wantEnum := range tc.wantEnumFor {
+				assertPropertyEnum(t, got, propKey, wantEnum)
+			}
 
 			if tc.wantRequired != nil {
 				var m map[string]any
@@ -181,12 +444,81 @@ func TestNarrowSchema(t *testing.T) {
 	}
 }
 
+// TestNarrowSchema_DescriptionPreservedMinLengthDropped explicitly verifies the
+// "drop extra constraints, keep description" behavior (ADR-017).
+func TestNarrowSchema_DescriptionPreservedMinLengthDropped(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"namespace": {
+				"type": "string",
+				"description": "the target namespace",
+				"minLength": 1,
+				"pattern": "^[a-z]"
+			}
+		}
+	}`)
+
+	got, err := NarrowSchema(schema, map[string]any{"namespace": []any{"worker-01", "worker-02"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertPropertyType(t, got, "namespace", "string")
+	assertPropertyDescription(t, got, "namespace", "the target namespace")
+	assertPropertyEnum(t, got, "namespace", []any{"worker-01", "worker-02"})
+	// Extra constraints must be stripped.
+	assertPropertyNoKey(t, got, "namespace", "minLength")
+	assertPropertyNoKey(t, got, "namespace", "pattern")
+}
+
+// TestNarrowSchema_NilPreservesOriginal explicitly verifies that a nil param
+// value means key-allowlist only: the original property arrives at the output
+// without an "enum" key added.
+func TestNarrowSchema_NilPreservesOriginal(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"namespace": {"type": "string", "minLength": 3}
+		}
+	}`)
+
+	got, err := NarrowSchema(schema, map[string]any{"namespace": nil})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertSchemaProperties(t, got, []string{"namespace"})
+	// Must not have an enum key — it is the original property unchanged.
+	assertPropertyNoKey(t, got, "namespace", "enum")
+	// Original constraints (minLength) are preserved because the whole property
+	// object was copied verbatim.
+	var m map[string]any
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	props := m["properties"].(map[string]any)
+	prop := props["namespace"].(map[string]any)
+	if v, ok := prop["minLength"]; !ok || v == nil {
+		t.Errorf("expected minLength to be preserved for nil param, got prop=%v", prop)
+	}
+}
+
 func TestValidateCall(t *testing.T) {
 	// Shared schema with namespace and pod properties (no required).
 	validSchema := json.RawMessage(`{
 		"type": "object",
 		"properties": {
 			"namespace": {"type": "string"},
+			"pod":       {"type": "string"}
+		}
+	}`)
+
+	// Schema with an enum constraint on namespace (mimics NarrowSchema output).
+	enumSchema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"namespace": {"type": "string", "enum": ["worker-01", "worker-02"]},
 			"pod":       {"type": "string"}
 		}
 	}`)
@@ -200,6 +532,7 @@ func TestValidateCall(t *testing.T) {
 		wantErr     bool
 		errContains string
 	}{
+		// --- Existing key-presence cases (unchanged behavior) ---
 		{
 			name:    "valid input with all declared keys",
 			schema:  validSchema,
@@ -242,6 +575,51 @@ func TestValidateCall(t *testing.T) {
 			name:    "schema without properties returns nil for any input",
 			schema:  noPropsSchema,
 			input:   map[string]any{"anything": "val"},
+			wantErr: false,
+		},
+		// --- Enum membership cases ---
+		{
+			name:    "value in enum is accepted",
+			schema:  enumSchema,
+			input:   map[string]any{"namespace": "worker-01"},
+			wantErr: false,
+		},
+		{
+			name:        "value not in enum is rejected",
+			schema:      enumSchema,
+			input:       map[string]any{"namespace": "production"},
+			wantErr:     true,
+			errContains: "not permitted by the policy enum constraint",
+		},
+		{
+			// JSON numbers: yaml.v3 parses whole numbers as Go int; json.Unmarshal
+			// re-hydrates them as float64. Both marshal to the same JSON bytes, so
+			// byte comparison correctly identifies them as equal.
+			name: "float64 input matches integer enum entry (yaml-int round-trip safe)",
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"port": {"type": "integer", "enum": [22, 80]}
+				}
+			}`),
+			// Simulate the post-json.Unmarshal state where the int from YAML has
+			// become float64 in the agent's decoded input.
+			input:   map[string]any{"port": float64(22)},
+			wantErr: false,
+		},
+		{
+			name: "property without enum is not enum-checked",
+			// pod has no enum; any string value is accepted.
+			schema:  enumSchema,
+			input:   map[string]any{"pod": "anything-goes"},
+			wantErr: false,
+		},
+		{
+			// Enum constrains the value only when it is present; omitting the key
+			// is fine (required-ness is governed by the required array, not enum).
+			name:    "enum property omitted from input is accepted",
+			schema:  enumSchema,
+			input:   map[string]any{"pod": "web-1"},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Closes #12

## Summary

Completes **ADR-017** (policy-level parameter scoping). A `params` block was previously a **key-only allowlist** — the listed values were ignored, so a policy like:

```yaml
- tool: kubectl.delete_pod
  params:
    namespace: ["worker-01", "worker-02", "worker-03"]
```

…still presented `namespace` as a free-form string, and the agent could call `delete_pod(namespace: "production")`. Now:

- **`NarrowSchema`** converts param values into a JSON Schema `enum` on the narrowed schema the agent sees: a scalar → single-element enum, a `[]any` → the enum, `nil` → unchanged (pure key-allowlist). The output property keeps only `type`/`enum`/`description` (other constraints dropped). Config errors — empty list, mixed-kind list, value-kind ≠ schema type, nested-map value — fail the run **at narrow time** (build-time), surfacing a clear policy-config error rather than a confusing runtime failure.
- **`ValidateCall`** rejects any supplied argument whose value isn't in the enum, surfaced as a `schema_violation` step (via the existing mapping at `agent.go:583`).

## Security-critical detail: equality

Enum membership compares `json.Marshal(input)` byte-wise against `json.Marshal(enumEntry)` (never `==`/`reflect.DeepEqual`). This is correct because policy values arrive as yaml `int` but round-trip through the JSON schema to `float64`, and agent input is `float64` too — the same marshaler yields identical bytes (`int(22)` and `float64(22)` both → `"22"`). Verified safe for large integers (>2^53) and `-0` (both sides take the same JSON path). Marshal errors propagate upward (fail-closed), and a code-review fail-open audit found no path that lets a disallowed value through.

Notes: numeric enums satisfy both `type:integer` and `type:number`; `type` may be a string or a union array; an enum constrains a value only when the property is supplied (omission governed by `required`, unchanged).

## Scope

All logic stays in `internal/mcp/narrow.go` (only new import: `bytes`). **No source changes** to `agent/agent.go` or `agent/tools.go` — the existing call sites already wire `NarrowSchema`/`ValidateCall` for both MCP and plugin tools, so this hardens plugin tool param scoping too. `agent_test.go` gains test-only enum assertions.

## Tests

`narrow_test.go`: all four existing scalar cases updated with explicit enum assertions, plus the full matrix (strings→enum w/ minLength dropped, nil-preserves-original, `[1,2.5]` numeric heterogeneity OK, integer/number unification, type-union match/non-member, empty/mixed/type-mismatch/nested-map errors, and ValidateCall membership incl. the float64-vs-int round-trip guard). `agent_test.go`: enum-content assertions in `TestNew_NarrowsPluginToolSchema` and `TestNew_PluginSchemaCannotBypassScoping`. All 50 workspace packages pass with `-race`.

> Doc nits found during review (not fixed here): the issue cited `ValidateCall` mapping at `agent.go:452` (actually `:583-585`) and ADR-017 at `docs/ADR_Tracker.md` (actually `docs/developer/ADR_Tracker.md`).

## Dev-loop metadata

Pipeline: architect (verified the issue's claims against code; confirmed the json-equality approach experimentally) → plan-review (**REVISE**: enumerate all four changed scalar test cases + agent_test enum assertions; `[1,2.5]` case; jsonEqual error propagation) → implement → code-review (**APPROVE**, 0 loop-backs; dedicated fail-open audit). CLAUDE.md: no updates needed. Generated by the agentic dev loop.
