### PR TITLE
fix: core run-state, trigger, and provider correctness bugs (#484, #485, #488, #490)

### DIFF
--- a/internal/db/queries/run_steps.sql
+++ b/internal/db/queries/run_steps.sql
@@ -3,6 +3,23 @@ INSERT INTO run_steps (id, run_id, step_number, type, content, token_cost, creat
 VALUES (:id, :run_id, :step_number, :type, :content, :token_cost, :created_at)
 RETURNING *;
 
+-- name: CreateRunStepNextNumber :one
+-- Inserts a run step deriving step_number atomically as MAX(step_number)+1 for
+-- the run (0 for the first step). Used by writers that do NOT share the agent
+-- AuditWriter's in-memory counter (e.g. the timeout scanner) so out-of-band
+-- inserts can never reuse or collide with an existing number. See issue #484.
+INSERT INTO run_steps (id, run_id, step_number, type, content, token_cost, created_at)
+VALUES (
+  :id,
+  :run_id,
+  COALESCE((SELECT MAX(step_number) + 1 FROM run_steps WHERE run_id = :run_id), 0),
+  :type,
+  :content,
+  :token_cost,
+  :created_at
+)
+RETURNING *;
+
 -- name: ListRunSteps :many
 SELECT * FROM run_steps
 WHERE run_id = :run_id

--- a/internal/db/run_steps.sql.go
+++ b/internal/db/run_steps.sql.go
@@ -59,6 +59,55 @@ func (q *Queries) CreateRunStep(ctx context.Context, arg CreateRunStepParams) (R
 	return i, err
 }
 
+const createRunStepNextNumber = `-- name: CreateRunStepNextNumber :one
+INSERT INTO run_steps (id, run_id, step_number, type, content, token_cost, created_at)
+VALUES (
+  ?1,
+  ?2,
+  COALESCE((SELECT MAX(step_number) + 1 FROM run_steps WHERE run_id = ?2), 0),
+  ?3,
+  ?4,
+  ?5,
+  ?6
+)
+RETURNING id, run_id, step_number, type, content, token_cost, created_at
+`
+
+type CreateRunStepNextNumberParams struct {
+	ID        string `json:"id"`
+	RunID     string `json:"run_id"`
+	Type      string `json:"type"`
+	Content   string `json:"content"`
+	TokenCost int64  `json:"token_cost"`
+	CreatedAt string `json:"created_at"`
+}
+
+// Inserts a run step deriving step_number atomically as MAX(step_number)+1 for
+// the run (0 for the first step). Used by writers that do NOT share the agent
+// AuditWriter's in-memory counter (e.g. the timeout scanner) so out-of-band
+// inserts can never reuse or collide with an existing number. See issue #484.
+func (q *Queries) CreateRunStepNextNumber(ctx context.Context, arg CreateRunStepNextNumberParams) (RunStep, error) {
+	row := q.db.QueryRowContext(ctx, createRunStepNextNumber,
+		arg.ID,
+		arg.RunID,
+		arg.Type,
+		arg.Content,
+		arg.TokenCost,
+		arg.CreatedAt,
+	)
+	var i RunStep
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.StepNumber,
+		&i.Type,
+		&i.Content,
+		&i.TokenCost,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getLatestRunStep = `-- name: GetLatestRunStep :one
 SELECT id, run_id, step_number, type, content, token_cost, created_at FROM run_steps WHERE run_id = ?1 ORDER BY step_number DESC LIMIT 1
 `

--- a/internal/execution/agent/agent.go
+++ b/internal/execution/agent/agent.go
@@ -261,13 +261,10 @@ func (a *BoundAgent) runAPILoop(
 		})
 
 		if resp.StopReason == llm.StopReasonEndTurn {
-			if err := a.audit.Write(ctx, Step{
-				RunID:   runID,
-				Type:    model.StepTypeComplete,
-				Content: map[string]string{"message": "agent completed task"},
-			}); err != nil {
-				return a.failRun(ctx, fmt.Errorf("writing complete step: %w", err))
-			}
+			// Transition first, then write the complete step. If the CAS loses to a
+			// concurrent writer (e.g. the timeout scanner moving the run to failed),
+			// we must NOT persist a "complete" step — doing so would leave a trace
+			// that contradicts the run's real terminal status (#485).
 			if err := a.sm.Transition(ctx, model.RunStatusComplete, ""); err != nil {
 				if errors.Is(err, ErrTransitionConflict) {
 					// Another writer (e.g. the timeout scanner) already transitioned
@@ -278,6 +275,17 @@ func (a *BoundAgent) runAPILoop(
 					return nil
 				}
 				return fmt.Errorf("transitioning run to complete: %w", err)
+			}
+			// The run is now authoritatively complete; the trace write is consistent
+			// with its status. A failure here is a logging problem, not a reason to
+			// fail an already-completed run.
+			if err := a.audit.Write(ctx, Step{
+				RunID:   runID,
+				Type:    model.StepTypeComplete,
+				Content: map[string]string{"message": "agent completed task"},
+			}); err != nil {
+				logctx.Logger(ctx).WarnContext(ctx, "failed to write complete step after successful transition",
+					"run_id", runID, "err", err)
 			}
 			return nil
 		}

--- a/internal/execution/agent/agent_test.go
+++ b/internal/execution/agent/agent_test.go
@@ -421,6 +421,84 @@ func TestRun_SingleTurnEndTurn(t *testing.T) {
 	}
 }
 
+// hookOnceLLMClient runs hook exactly once, on the first CreateMessage call,
+// before delegating to the embedded mock. It lets a test inject a concurrent
+// state change at a deterministic point inside the agent loop.
+type hookOnceLLMClient struct {
+	*testutil.MockLLMClient
+	hook func()
+	once sync.Once
+}
+
+func (h *hookOnceLLMClient) CreateMessage(ctx context.Context, req llm.MessageRequest) (*llm.MessageResponse, error) {
+	h.once.Do(h.hook)
+	return h.MockLLMClient.CreateMessage(ctx, req)
+}
+
+// TestRun_EndTurn_TransitionConflict_NoCompleteStep verifies that when the
+// end-turn complete transition loses the CAS to a concurrent terminal writer
+// (e.g. the timeout scanner moving the run to failed), the agent does NOT
+// persist a "complete" step. A complete step on a failed run would leave a
+// trace that contradicts the run's real status. Regression guard for #485.
+func TestRun_EndTurn_TransitionConflict_NoCompleteStep(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusPending)
+
+	w := NewAuditWriter(s.Queries())
+
+	// The hook fires during the LLM call — after the agent has transitioned the
+	// run to running but before it attempts the end-turn complete transition. A
+	// separate state machine moves the run to failed, bumping the version so the
+	// agent's complete CAS loses.
+	mock := testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 20))
+	client := &hookOnceLLMClient{MockLLMClient: mock, hook: func() {
+		run, err := s.GetRun(context.Background(), "r1")
+		if err != nil {
+			t.Errorf("hook GetRun: %v", err)
+			return
+		}
+		external := NewRunStateMachine("r1", model.RunStatus(run.Status), s.DB(), s.Queries(), WithInitialVersion(run.Version))
+		if err := external.Transition(context.Background(), model.RunStatusFailed, "external writer won"); err != nil {
+			t.Errorf("external transition to failed: %v", err)
+		}
+	}}
+
+	ba, err := New(Config{
+		LLMClient:    client,
+		Policy:       minimalPolicy(),
+		Audit:        w,
+		StateMachine: NewRunStateMachine("r1", model.RunStatusPending, s.DB(), s.Queries()),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Run returns nil: losing the CAS to a concurrent terminal writer is not an
+	// agent failure (ADR-038).
+	if err := ba.Run(context.Background(), "r1", "do stuff"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	run, err := s.GetRun(context.Background(), "r1")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.Status != string(model.RunStatusFailed) {
+		t.Errorf("run status = %q, want %q (external writer should have won)", run.Status, model.RunStatusFailed)
+	}
+
+	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: "r1", After: -1, Limit: listAll})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	for _, st := range steps {
+		if st.Type == string(model.StepTypeComplete) {
+			t.Errorf("found a complete step on a failed run; trace contradicts status (#485)")
+		}
+	}
+}
+
 func TestRun_ToolCallLoop(t *testing.T) {
 	// Fake MCP server that handles tools/call.
 	mcpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/llm/google/client.go
+++ b/internal/llm/google/client.go
@@ -71,7 +71,11 @@ func (c *GeminiClient) CreateMessage(ctx context.Context, req llm.MessageRequest
 	// ToolCallBlock/ToolResultBlock use the sanitized wire-format names.
 	names := llm.BuildNameMapping(req.Tools, "")
 	contents := buildContents(req.History, names)
-	config := buildConfig(req, hints, names)
+	config, err := buildConfig(req, hints, names)
+	if err != nil {
+		err = fmt.Errorf("building request config: %w", err)
+		return
+	}
 
 	sdkResp, sdkErr := c.generator.GenerateContent(ctx, req.Model, contents, config)
 	if sdkErr != nil {
@@ -104,7 +108,10 @@ func (c *GeminiClient) StreamMessage(ctx context.Context, req llm.MessageRequest
 	hints, _ := req.Hints.(*GeminiHints)
 	names := llm.BuildNameMapping(req.Tools, "")
 	contents := buildContents(req.History, names)
-	config := buildConfig(req, hints, names)
+	config, err := buildConfig(req, hints, names)
+	if err != nil {
+		return nil, fmt.Errorf("building request config: %w", err)
+	}
 
 	seq := c.generator.GenerateContentStream(ctx, req.Model, contents, config)
 	out := make(chan llm.MessageChunk, 16)
@@ -242,7 +249,7 @@ func mapRoleToGenai(role llm.Role) string {
 }
 
 // buildConfig constructs the GenerateContentConfig for a request.
-func buildConfig(req llm.MessageRequest, hints *GeminiHints, names llm.ToolNameMapping) *genai.GenerateContentConfig {
+func buildConfig(req llm.MessageRequest, hints *GeminiHints, names llm.ToolNameMapping) (*genai.GenerateContentConfig, error) {
 	config := &genai.GenerateContentConfig{}
 
 	if req.MaxTokens > 0 {
@@ -258,7 +265,11 @@ func buildConfig(req llm.MessageRequest, hints *GeminiHints, names llm.ToolNameM
 	}
 
 	if len(req.Tools) > 0 {
-		config.Tools = buildTools(req.Tools)
+		tools, err := buildTools(req.Tools)
+		if err != nil {
+			return nil, err
+		}
+		config.Tools = tools
 	}
 
 	if hints != nil {
@@ -281,13 +292,13 @@ func buildConfig(req llm.MessageRequest, hints *GeminiHints, names llm.ToolNameM
 		}
 	}
 
-	return config
+	return config, nil
 }
 
 // buildTools groups all ToolDefinitions into a single genai.Tool with all
 // FunctionDeclarations. Tool names are sanitized to comply with Gemini's
 // naming requirements (alphanumeric + underscore only).
-func buildTools(tools []llm.ToolDefinition) []*genai.Tool {
+func buildTools(tools []llm.ToolDefinition) ([]*genai.Tool, error) {
 	decls := make([]*genai.FunctionDeclaration, 0, len(tools))
 	for _, t := range tools {
 		decl := &genai.FunctionDeclaration{
@@ -295,16 +306,23 @@ func buildTools(tools []llm.ToolDefinition) []*genai.Tool {
 			Description: t.Description,
 		}
 		if len(t.InputSchema) > 0 {
+			// Treat schema translation failures as hard errors, matching the
+			// Anthropic and OpenAI providers. Registering a tool with a nil
+			// parameter schema would let the model call it with unvalidated
+			// arguments, silently weakening ADR-017's parameter enforcement (#490).
 			var schemaMap map[string]any
-			if err := json.Unmarshal(t.InputSchema, &schemaMap); err == nil {
-				if schema, err := translateJSONSchemaToGenaiSchema(schemaMap); err == nil {
-					decl.Parameters = schema
-				}
+			if err := json.Unmarshal(t.InputSchema, &schemaMap); err != nil {
+				return nil, fmt.Errorf("unmarshalling schema for tool %s: %w", t.Name, err)
 			}
+			schema, err := translateJSONSchemaToGenaiSchema(schemaMap)
+			if err != nil {
+				return nil, fmt.Errorf("translating schema for tool %s: %w", t.Name, err)
+			}
+			decl.Parameters = schema
 		}
 		decls = append(decls, decl)
 	}
-	return []*genai.Tool{{FunctionDeclarations: decls}}
+	return []*genai.Tool{{FunctionDeclarations: decls}}, nil
 }
 
 // translateResponse converts a Gemini API response into the provider-neutral

--- a/internal/llm/google/client_test.go
+++ b/internal/llm/google/client_test.go
@@ -235,7 +235,10 @@ func TestBuildConfig_SystemPrompt(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := llm.MessageRequest{SystemPrompt: tc.systemPrompt}
-			config := buildConfig(req, nil, llm.ToolNameMapping{SanitizedToOriginal: map[string]string{}, OriginalToSanitized: map[string]string{}})
+			config, err := buildConfig(req, nil, llm.ToolNameMapping{SanitizedToOriginal: map[string]string{}, OriginalToSanitized: map[string]string{}})
+			if err != nil {
+				t.Fatalf("buildConfig returned error: %v", err)
+			}
 
 			if tc.wantNil {
 				if config.SystemInstruction != nil {
@@ -262,7 +265,10 @@ func TestBuildConfig_SystemPrompt(t *testing.T) {
 
 func TestBuildConfig_MaxTokens(t *testing.T) {
 	req := llm.MessageRequest{MaxTokens: 1024}
-	config := buildConfig(req, nil, llm.ToolNameMapping{SanitizedToOriginal: map[string]string{}, OriginalToSanitized: map[string]string{}})
+	config, err := buildConfig(req, nil, llm.ToolNameMapping{SanitizedToOriginal: map[string]string{}, OriginalToSanitized: map[string]string{}})
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
 
 	if config.MaxOutputTokens != 1024 {
 		t.Errorf("expected MaxOutputTokens=1024, got %d", config.MaxOutputTokens)
@@ -270,7 +276,10 @@ func TestBuildConfig_MaxTokens(t *testing.T) {
 
 	// Zero MaxTokens should leave MaxOutputTokens unset.
 	reqZero := llm.MessageRequest{MaxTokens: 0}
-	configZero := buildConfig(reqZero, nil, llm.ToolNameMapping{SanitizedToOriginal: map[string]string{}, OriginalToSanitized: map[string]string{}})
+	configZero, err := buildConfig(reqZero, nil, llm.ToolNameMapping{SanitizedToOriginal: map[string]string{}, OriginalToSanitized: map[string]string{}})
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
 	if configZero.MaxOutputTokens != 0 {
 		t.Errorf("expected MaxOutputTokens=0 when MaxTokens is zero, got %d", configZero.MaxOutputTokens)
 	}
@@ -282,7 +291,10 @@ func TestBuildTools(t *testing.T) {
 		{Name: "search", Description: "Search the web", InputSchema: schema},
 	}
 
-	genaiTools := buildTools(tools)
+	genaiTools, err := buildTools(tools)
+	if err != nil {
+		t.Fatalf("buildTools returned error: %v", err)
+	}
 
 	if len(genaiTools) != 1 {
 		t.Fatalf("expected 1 tool, got %d", len(genaiTools))
@@ -302,6 +314,28 @@ func TestBuildTools(t *testing.T) {
 	}
 	if decls[0].Parameters.Type != genai.TypeObject {
 		t.Errorf("expected TypeObject, got %v", decls[0].Parameters.Type)
+	}
+}
+
+// TestBuildTools_InvalidSchemaError verifies that an unparseable tool input
+// schema is a hard error rather than being silently swallowed — registering a
+// tool with nil Parameters would let the model call it with unvalidated
+// arguments, weakening ADR-017's parameter enforcement. Regression guard for
+// #490; matches the Anthropic and OpenAI providers' behavior.
+func TestBuildTools_InvalidSchemaError(t *testing.T) {
+	tools := []llm.ToolDefinition{
+		{Name: "broken", Description: "bad schema", InputSchema: json.RawMessage(`{not valid json`)},
+	}
+
+	genaiTools, err := buildTools(tools)
+	if err == nil {
+		t.Fatal("expected error for invalid tool schema, got nil")
+	}
+	if genaiTools != nil {
+		t.Errorf("expected nil tools on error, got %+v", genaiTools)
+	}
+	if !strings.Contains(err.Error(), "broken") {
+		t.Errorf("expected error to name the offending tool, got %q", err.Error())
 	}
 }
 
@@ -1425,7 +1459,10 @@ func TestBuildConfig_ThinkingLevel(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			config := buildConfig(llm.MessageRequest{}, tc.hints, noMapping)
+			config, err := buildConfig(llm.MessageRequest{}, tc.hints, noMapping)
+			if err != nil {
+				t.Fatalf("buildConfig returned error: %v", err)
+			}
 
 			if tc.wantConfigNil {
 				if config.ThinkingConfig != nil {

--- a/internal/timeout/scanner.go
+++ b/internal/timeout/scanner.go
@@ -287,26 +287,24 @@ func (s *Scanner) resolveTimeout(ctx context.Context, item ExpiredItem) error {
 		return nil
 	}
 
-	// Insert an error RunStep so the run's trace explains why it failed.
-	stepCount, err := s.store.Queries().CountRunSteps(ctx, item.RunID)
-	if err != nil {
-		return fmt.Errorf("count run steps: %w", err)
-	}
-
+	// Insert an error RunStep so the run's trace explains why it failed. The
+	// scanner does not share the agent AuditWriter's in-memory step counter, so
+	// it derives step_number from MAX(step_number)+1 inside the insert rather
+	// than from a separate COUNT(*) read — the latter races the agent's writes
+	// and mismatches the counter whenever the trace has a numbering gap (#484).
 	errMsg := s.cfg.ErrorMessage(item.ToolName)
 	content, _ := json.Marshal(map[string]string{
 		"message": errMsg,
 		"code":    s.cfg.ErrorCode,
 	})
 
-	if _, err := s.store.Queries().CreateRunStep(ctx, db.CreateRunStepParams{
-		ID:         model.NewULID(),
-		RunID:      item.RunID,
-		StepNumber: stepCount,
-		Type:       string(model.StepTypeError),
-		Content:    string(content),
-		TokenCost:  0,
-		CreatedAt:  now,
+	if _, err := s.store.Queries().CreateRunStepNextNumber(ctx, db.CreateRunStepNextNumberParams{
+		ID:        model.NewULID(),
+		RunID:     item.RunID,
+		Type:      string(model.StepTypeError),
+		Content:   string(content),
+		TokenCost: 0,
+		CreatedAt: now,
 	}); err != nil {
 		return fmt.Errorf("create error step: %w", err)
 	}

--- a/internal/timeout/scanner_test.go
+++ b/internal/timeout/scanner_test.go
@@ -369,6 +369,43 @@ func TestScanner_StepNumberContinuesExistingSteps(t *testing.T) {
 	}
 }
 
+// TestScanner_StepNumberSkipsGap proves the error step is numbered from
+// MAX(step_number)+1, not COUNT(*). When the trace has a numbering gap (which
+// the agent's AuditWriter produces if a step's content fails to marshal after
+// its counter already advanced), COUNT(*) would reuse an existing number and
+// collide; MAX+1 does not. Regression guard for #484.
+func TestScanner_StepNumberSkipsGap(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusWaitingForApproval)
+	insertApprovalRequest(t, s, "a1", "r1", "tool_w", pastTimestamp())
+
+	// Steps numbered 0, 1, 3 — a gap at 2. COUNT(*) is 3, which would collide
+	// with the existing step 3; MAX(step_number)+1 must yield 4.
+	_, err := s.DB().Exec(
+		`INSERT INTO run_steps(id, run_id, step_number, type, content, created_at)
+		 VALUES ('s0', 'r1', 0, 'thought', '{}', '2024-01-01T00:00:00Z'),
+		        ('s1', 'r1', 1, 'tool_call', '{}', '2024-01-01T00:00:00Z'),
+		        ('s3', 'r1', 3, 'tool_result', '{}', '2024-01-01T00:00:00Z')`,
+	)
+	if err != nil {
+		t.Fatalf("insert existing steps: %v", err)
+	}
+
+	scanner := timeout.NewScanner(s, time.Minute, approvalConfig(s))
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	var stepNumber int64
+	if err := s.DB().QueryRow(`SELECT step_number FROM run_steps WHERE run_id = 'r1' AND type = 'error'`).Scan(&stepNumber); err != nil {
+		t.Fatalf("query error step: %v", err)
+	}
+	if stepNumber != 4 {
+		t.Errorf("error step step_number = %d, want 4 (MAX+1, not COUNT)", stepNumber)
+	}
+}
+
 // TestScanner_ConcurrentScans_SingleTimeout verifies that N concurrent Scan
 // calls racing on a single expired approval row each produce exactly one
 // timeout approval, one failed run, one error step, and one run.status_changed

--- a/internal/trigger/scheduled.go
+++ b/internal/trigger/scheduled.go
@@ -199,6 +199,11 @@ func (s *Scheduler) fire(ctx context.Context, policyID string, parsed *model.Par
 		case errors.Is(err, run.ErrConcurrencySkipActive):
 			slog.Info("scheduled: skipping fire, active run exists (concurrency: skip)",
 				"policy_id", policyID, "fire_at", fireTime)
+			// The fire time was consumed (skipped); it will not be retried. Pause
+			// the policy if all fire_at times are now exhausted, just like the
+			// queue and successful-launch paths — otherwise the policy stays
+			// "active" forever with no future timers and never fires again (#488).
+			s.pauseIfExhausted(ctx, policyID, parsed)
 		case errors.Is(err, run.ErrConcurrencyQueueActive):
 			if enqErr := s.launcher.Enqueue(ctx, run.LaunchParams{
 				PolicyID:       policyID,

--- a/internal/trigger/scheduled_test.go
+++ b/internal/trigger/scheduled_test.go
@@ -335,6 +335,63 @@ func TestScheduler_ConcurrencySkip_BlocksWhenActive(t *testing.T) {
 	}
 }
 
+// TestScheduler_ConcurrencySkip_AutoPausesWhenExhausted verifies that when the
+// last fire_at time is skipped because a run is active (concurrency: skip), the
+// policy still auto-pauses — the skipped time is consumed and will not retry, so
+// an exhausted policy must not linger "active" forever with no future timers.
+// Regression guard for #488.
+func TestScheduler_ConcurrencySkip_AutoPausesWhenExhausted(t *testing.T) {
+	store, registry := setupSchedulerFixture(t)
+
+	future := time.Now().Add(2 * time.Second)
+	yaml := scheduledPolicyYAMLWithConcurrency("skip-exhaust-policy", []time.Time{future}, "skip")
+	insertTestScheduledPolicy(t, store, "pol-skip-exhaust", "skip-exhaust-policy", yaml)
+
+	// Active run forces the only fire_at into the ErrConcurrencySkipActive branch.
+	insertTestRun(t, store, "r-active-skip-exhaust", "pol-skip-exhaust", model.RunStatusRunning)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	manager := run.NewRunManager()
+	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                manager,
+		AgentFactory:           schedulerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
+	scheduler := trigger.NewScheduler(store, launcher, resolver)
+
+	if err := scheduler.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for the policy to be paused (removed from active scheduled policies).
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		policies, err := store.GetScheduledActivePolicies(ctx)
+		if err != nil {
+			t.Fatalf("GetScheduledActivePolicies: %v", err)
+		}
+		found := false
+		for _, p := range policies {
+			if p.ID == "pol-skip-exhaust" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return // success — policy auto-paused after the skipped fire exhausted it
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Error("expected policy to auto-pause after its only fire time was skipped (concurrency: skip)")
+}
+
 // TestScheduler_ConcurrencySkip_ProceedsWhenIdle verifies that a scheduled
 // trigger with concurrency: skip proceeds normally when no active run exists.
 func TestScheduler_ConcurrencySkip_ProceedsWhenIdle(t *testing.T) {


### PR DESCRIPTION
Fixes a batch of four independent correctness bugs surfaced by code review. Each is its own commit with a regression test.

## Bugs fixed

- **#484 — Timeout scanner step-number race.** The scanner numbered its error step from `SELECT COUNT(*)`, while the agent's `AuditWriter` uses an in-memory monotonic counter. The two diverge whenever the trace has a numbering gap (the AuditWriter advances its counter *before* marshalling content, so a marshal failure leaves a gap and `COUNT(*)` then reuses an existing `step_number`). New `CreateRunStepNextNumber` query derives `step_number` atomically as `MAX(step_number)+1` inside the INSERT.
- **#485 — `complete` step written before the run-state CAS.** If the complete transition lost the CAS to a concurrent terminal writer (e.g. the timeout scanner), the run ended up `failed` while its trace ended with "agent completed task". Now transitions first and persists the `complete` step only on success.
- **#488 — Scheduled `concurrency: skip` never auto-pauses an exhausted policy.** The skip branch only logged; it never called `pauseIfExhausted` like the queue/launch paths, so an exhausted policy stayed "active" forever with no future timers. Now calls `pauseIfExhausted` in the skip branch too.
- **#490 — Google provider swallowed tool-schema translation errors.** `buildTools` discarded unmarshal/translation errors and registered the tool with a nil parameter schema, silently weakening ADR-017 parameter enforcement on one provider. Now propagates the error like the Anthropic/OpenAI providers.

## Testing

Each fix has a targeted regression test:
- `TestScanner_StepNumberSkipsGap`
- `TestRun_EndTurn_TransitionConflict_NoCompleteStep`
- `TestScheduler_ConcurrencySkip_AutoPausesWhenExhausted`
- `TestBuildTools_InvalidSchemaError`

Full `go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)