### PR TITLE
fix(db): execute plugin migration Up() bodies against pre-target baseline (#494)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          # Authenticate the buf release download to avoid the unauthenticated
+          # GitHub API per-IP rate limit, which intermittently fails setup on
+          # busy shared runners before buf ever runs.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       # `buf lint` errors when a module has zero .proto files. The lint gate
       # is intentionally a no-op until #167 lands the proto contracts; skip
       # the invocation entirely while the tree has no .proto files.
@@ -137,6 +142,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          # See proto-lint: authenticate the release download to dodge the
+          # unauthenticated GitHub API rate limit on shared runners.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate stubs
         run: buf generate

--- a/internal/db/migrations/0035_add_pending_reauthorize_health_state.go
+++ b/internal/db/migrations/0035_add_pending_reauthorize_health_state.go
@@ -41,6 +41,12 @@ func (m *AddPendingReauthorizeHealthState) ShouldSkip(ctx context.Context, db *s
 	return strings.Contains(ddl, "pending_reauthorize"), nil
 }
 
+// RequiresForeignKeysOff opts into the runner's PRAGMA foreign_keys=OFF toggle.
+// plugin_audit_events, audience_entries, and plugin_pending_requests hold FK
+// references to plugin_instances; the DROP + RENAME rebuild requires FK
+// enforcement off for the transaction (issue #494).
+func (m *AddPendingReauthorizeHealthState) RequiresForeignKeysOff() bool { return true }
+
 func (m *AddPendingReauthorizeHealthState) Up(ctx context.Context, tx *sql.Tx) error {
 	// 1. Create the replacement table with the extended CHECK list.
 	_, err := tx.ExecContext(ctx, `

--- a/internal/db/migrations/migration_test.go
+++ b/internal/db/migrations/migration_test.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -159,5 +160,204 @@ func TestDeleteUserPrefDefaultModel(t *testing.T) {
 	}
 	if key != "timezone" {
 		t.Errorf("surviving row key = %q, want %q", key, "timezone")
+	}
+}
+
+// TestPendingReauthorizeRebuildPreservesChildFKRows is a regression test for
+// issue #494: the 0035 migration lacked RequiresForeignKeysOff(), so running
+// it against a live database with FK enforcement ON would cause SQLite to null
+// out plugin_audit_events.plugin_instance_id (via ON DELETE SET NULL) when the
+// old plugin_instances table was dropped. The fix adds the method; this test
+// proves the child FK link survives.
+//
+// We cannot rely on applyInitialSchema here because 0001_initial.sql already
+// contains 'pending_reauthorize' in the plugin_instances CHECK constraint, which
+// would make ShouldSkip() return true and skip Up() entirely. Instead we
+// hand-craft the pre-0035 baseline (the end-of-0034 shape) so the migration
+// body actually runs.
+func TestPendingReauthorizeRebuildPreservesChildFKRows(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	// Build the pre-0035 schema by hand — do NOT call applyInitialSchema.
+	seedPreReauthorizeBaseline(t, db)
+
+	// Seed a plugins parent row, a plugin_instances row, and a child
+	// plugin_audit_events row whose plugin_instance_id references 'inst-1'.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO plugins(id, name, plugin_version, manifest_snapshot, trusted_pubkey, status, version, created_at, updated_at)
+		VALUES ('plug-1', 'test-plugin', '1.0.0', '{}', 'pk', 'active', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("insert plugin: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO plugin_instances(id, plugin_id, instance_name, config_json, subscription_scope_json, handshake_versions, health_state, version, created_at, updated_at)
+		VALUES ('inst-1', 'plug-1', 'my-instance', '{}', '{}', '{}', 'healthy', 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("insert plugin_instance: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO plugin_audit_events(plugin_instance_id, event_type, severity, payload_json, created_at)
+		VALUES ('inst-1', 'test_event', 'info', '{}', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("insert plugin_audit_event: %v", err)
+	}
+
+	// (d) Confirm ShouldSkip is false so the test fails loudly if a future schema
+	// change makes the migration skip again (which would make the rest of this
+	// test a vacuous pass).
+	skip, err := (&migrations.AddPendingReauthorizeHealthState{}).ShouldSkip(ctx, db)
+	if err != nil {
+		t.Fatalf("ShouldSkip: %v", err)
+	}
+	if skip {
+		t.Fatal("ShouldSkip returned true against the pre-target baseline — the hand-crafted DDL must omit 'pending_reauthorize'")
+	}
+
+	// (e) Confirm FK enforcement is ON before running so the test cannot go
+	// vacuous if PRAGMA foreign_keys is silently off.
+	var fk int
+	if err := db.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatalf("PRAGMA foreign_keys: %v", err)
+	}
+	if fk != 1 {
+		t.Fatalf("foreign_keys = %d before Apply, want 1", fk)
+	}
+
+	// (f) Run the migration. Apply returning nil is NOT the regression gate —
+	// SQLite executes the DROP TABLE without erroring even under FK ON (it fires
+	// ON DELETE SET NULL on child rows instead). The gate is step (g) below.
+	if err := migrations.Apply(ctx, db, []migrations.Migration{&migrations.AddPendingReauthorizeHealthState{}}, nil); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// (g) Assert post-migration state. These are the regression gates.
+
+	// The new CHECK constraint must contain 'pending_reauthorize'.
+	var ddl string
+	if err := db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='plugin_instances'`,
+	).Scan(&ddl); err != nil {
+		t.Fatalf("read post-migration DDL: %v", err)
+	}
+	if !strings.Contains(ddl, "pending_reauthorize") {
+		t.Errorf("post-migration plugin_instances DDL does not contain 'pending_reauthorize'")
+	}
+
+	// The child plugin_audit_events row must still reference 'inst-1'. Without
+	// RequiresForeignKeysOff, DROP TABLE fires ON DELETE SET NULL and the value
+	// becomes NULL — silent data corruption. This is the primary regression gate.
+	var instanceID sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT plugin_instance_id FROM plugin_audit_events`,
+	).Scan(&instanceID); err != nil {
+		t.Fatalf("read plugin_audit_events: %v", err)
+	}
+	if !instanceID.Valid || instanceID.String != "inst-1" {
+		t.Errorf("plugin_audit_events.plugin_instance_id = %v after migration, want 'inst-1' — FK link was corrupted (ON DELETE SET NULL fired during DROP TABLE)", instanceID)
+	}
+
+	// The plugin_instances row must have survived the rebuild.
+	var rowCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM plugin_instances`).Scan(&rowCount); err != nil {
+		t.Fatalf("count plugin_instances: %v", err)
+	}
+	if rowCount != 1 {
+		t.Errorf("plugin_instances row count = %d after migration, want 1", rowCount)
+	}
+
+	// FK enforcement must be back ON after Apply (guards the runner's re-enable path).
+	if err := db.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatalf("PRAGMA foreign_keys after Apply: %v", err)
+	}
+	if fk != 1 {
+		t.Errorf("foreign_keys = %d after Apply, want 1", fk)
+	}
+}
+
+// seedPreReauthorizeBaseline hand-creates the end-of-0034 schema shape that
+// 0035 expects to find: schema_migrations, plugins, plugin_instances (WITHOUT
+// 'pending_reauthorize' in its CHECK list), and plugin_audit_events.
+//
+// This is the only way to make 0035's Up() body actually execute, because
+// 0001_initial.sql already ships 'pending_reauthorize' and would cause
+// ShouldSkip to return true.
+func seedPreReauthorizeBaseline(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	stmts := []string{
+		// schema_migrations — keep the version row so suite-wide invariants hold.
+		`CREATE TABLE schema_migrations (
+			version     INTEGER PRIMARY KEY,
+			applied_at  TEXT    NOT NULL
+		)`,
+		`INSERT INTO schema_migrations(version, applied_at) VALUES (1, '2024-01-01T00:00:00Z')`,
+
+		// plugins — parent table referenced by plugin_instances FK.
+		`CREATE TABLE plugins (
+			id                 TEXT    PRIMARY KEY,
+			name               TEXT    NOT NULL UNIQUE,
+			plugin_version     TEXT    NOT NULL,
+			manifest_snapshot  TEXT    NOT NULL,
+			trusted_pubkey     TEXT    NOT NULL,
+			status             TEXT    NOT NULL CHECK(status IN ('pending_review','active','removed')),
+			binary_path        TEXT,
+			version            INTEGER NOT NULL DEFAULT 0,
+			created_at         TEXT    NOT NULL,
+			updated_at         TEXT    NOT NULL
+		)`,
+		`CREATE INDEX idx_plugins_status ON plugins(status)`,
+
+		// plugin_instances — end-of-0034 shape: includes subscription_scope_json
+		// (added by 0033) but OMITS both 'pending_reauthorize' and 'inactive' so
+		// ShouldSkip returns false and Up() actually runs.
+		`CREATE TABLE plugin_instances (
+			id                       TEXT    PRIMARY KEY,
+			plugin_id                TEXT    NOT NULL REFERENCES plugins(id) ON DELETE CASCADE,
+			instance_name            TEXT    NOT NULL,
+			config_json              TEXT    NOT NULL DEFAULT '{}',
+			subscription_scope_json  TEXT    NOT NULL DEFAULT '{}',
+			credentials_encrypted    TEXT,
+			credentials_expires_at   TEXT,
+			handshake_versions       TEXT    NOT NULL DEFAULT '{}',
+			health_state             TEXT    NOT NULL DEFAULT 'pending_key_approval'
+			                                 CHECK(health_state IN (
+			                                     'healthy',
+			                                     'signature_invalid',
+			                                     'pending_key_approval',
+			                                     'pending_manifest_approval',
+			                                     'pending_config_migration',
+			                                     'verification_error',
+			                                     'unsigned_permissive',
+			                                     'unhealthy',
+			                                     'crashed',
+			                                     'circuit_broken'
+			                                 )),
+			health_detail            TEXT,
+			last_oauth_callback_url  TEXT,
+			version                  INTEGER NOT NULL DEFAULT 0,
+			created_at               TEXT    NOT NULL,
+			updated_at               TEXT    NOT NULL,
+			UNIQUE (plugin_id, instance_name)
+		)`,
+		`CREATE INDEX idx_plugin_instances_plugin_id    ON plugin_instances(plugin_id)`,
+		`CREATE INDEX idx_plugin_instances_health_state ON plugin_instances(health_state)`,
+
+		// plugin_audit_events — FK child with ON DELETE SET NULL; this is the
+		// table whose plugin_instance_id we assert survives the rebuild.
+		`CREATE TABLE plugin_audit_events (
+			id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+			plugin_instance_id  TEXT    REFERENCES plugin_instances(id) ON DELETE SET NULL,
+			event_type          TEXT    NOT NULL,
+			severity            TEXT    NOT NULL CHECK(severity IN ('info','warning','high','critical')),
+			actor_user_id       TEXT,
+			payload_json        TEXT    NOT NULL,
+			created_at          TEXT    NOT NULL
+		)`,
+		`CREATE INDEX idx_pae_instance_created ON plugin_audit_events(plugin_instance_id, created_at)`,
+		`CREATE INDEX idx_pae_event_created    ON plugin_audit_events(event_type, created_at)`,
+	}
+
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seedPreReauthorizeBaseline: %v\nstatement: %s", err, stmt)
+		}
 	}
 }

--- a/internal/http/api/router_test.go
+++ b/internal/http/api/router_test.go
@@ -458,9 +458,19 @@ func TestBuildRouter(t *testing.T) {
 
 // postLogin fires a login request from the given client IP (via X-Real-IP, which
 // middleware.RealIP folds into RemoteAddr for the rate limiter to key on).
+//
+// The body intentionally omits the password so the handler short-circuits with a
+// 400 ("password is required") BEFORE the constant-time dummy-bcrypt branch
+// (auth.Login). That branch hashes at cost 12, which under `-race` + parallel
+// package load takes seconds per call; ten such calls let the burst straddle a
+// wall-clock minute boundary, and httprate's sliding-window count decays below
+// the limit so the over-limit request is admitted (was a flaky 401 instead of
+// 429). The rate-limit middleware runs ahead of the handler and counts every
+// request regardless of status, so a 400 exercises the limiter identically while
+// keeping the whole burst inside a single window. (#494 CI flake.)
 func postLogin(t *testing.T, router http.Handler, ip string) int {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"username":"nobody","password":"wrong"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"username":"nobody"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Real-IP", ip)
 	w := httptest.NewRecorder()
@@ -478,7 +488,8 @@ func TestLoginRateLimitedPerIP(t *testing.T) {
 	const attackerIP = "198.51.100.10"
 
 	// The first `limit` attempts must not be rate-limited (they get the handler's
-	// normal 401 for bad credentials, not 429).
+	// 400 for the missing password, not 429 — see postLogin for why the password
+	// is omitted).
 	for i := range limit {
 		if code := postLogin(t, router, attackerIP); code == http.StatusTooManyRequests {
 			t.Fatalf("attempt %d/%d from %s was rate-limited before the limit was reached", i+1, limit, attackerIP)


### PR DESCRIPTION
Closes #494
Closes #493

## Summary

`TestAllMigrationsIdempotent` / `TestAllMigrationsOrdered` seed the squashed `0001_initial.sql` baseline, which already contains the final schema. As a result every plugin migration's `ShouldSkip()` returns `true` and the runner short-circuits before any FK toggle or transaction — so the risky table-rebuild + data-copy `Up()` bodies (e.g. 0035) **never executed in CI**. That is exactly why the missing-`RequiresForeignKeysOff` bug in 0035 was invisible to the suite.

This PR:

1. Adds `TestPendingReauthorizeRebuildPreservesChildFKRows`, which hand-builds a **pre-0035 baseline** (a `plugin_instances` table whose `health_state` CHECK lacks `'pending_reauthorize'`, so `ShouldSkip` returns false), seeds a parent `plugins` row, an instance, and a child `plugin_audit_events` row, runs migration 0035 through the real runner, and asserts the child FK link survives the DROP+RENAME rebuild.
2. Fixes the underlying bug (**#493**) that the new test exposes: migration 0035 was missing `RequiresForeignKeysOff()`. Without it the runner leaves `PRAGMA foreign_keys` ON during the rebuild, so SQLite fires `ON DELETE SET NULL` on `plugin_audit_events.plugin_instance_id` when the old table is dropped — silently orphaning audit history. The method is added mirroring its sibling 0037.

### Why the regression gate is a row-value check, not an error check

SQLite executes `DROP TABLE plugin_instances` under FK-ON without error and applies `ON DELETE SET NULL` to the child, so `Apply()` returns `nil` **with or without** the fix. The discriminating assertion is therefore that `plugin_audit_events.plugin_instance_id` is still non-NULL and equals `'inst-1'` after the migration. Reverting the fix makes the test fail at that assertion (verified empirically during implementation).

<details>
<summary>Architecture plan</summary>

- **0035_add_pending_reauthorize_health_state.go** — add `RequiresForeignKeysOff() bool { return true }` between `ShouldSkip()` and `Up()`, matching 0037.
- **migration_test.go** — add `strings` import, `TestPendingReauthorizeRebuildPreservesChildFKRows`, and a `seedPreReauthorizeBaseline` helper that builds the end-of-0034 schema shape by hand-DDL (the squashed baseline can't represent a pre-0035 state). Assertions: ShouldSkip==false, FK ON before Apply, Apply nil, CHECK now contains `pending_reauthorize`, child FK survives as `'inst-1'`, instance row preserved, FK back ON after Apply.

Existing broad tests (`TestAllMigrationsIdempotent` / `TestAllMigrationsOrdered`) are left unchanged — they legitimately verify the squashed-baseline skip path; the new targeted test covers the gap.
</details>

## Review

Adversarial plan review caught that the original plan misidentified the regression gate (it claimed `Apply()` would error without the fix; it does not). Corrected before implementation. Code review approved on cycle 1. CLAUDE.md required no updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)