### PR TITLE
fix(plugin): close cached channel-dispatch gRPC connections on shutdown (#497)

### DIFF
--- a/internal/plugin/dispatch/channel.go
+++ b/internal/plugin/dispatch/channel.go
@@ -84,14 +84,17 @@ type Dispatcher struct {
 	// blocks even when the caller has already timed out.
 	waiters map[string]chan string
 
-	// connMu guards the conns map.
-	connMu sync.Mutex
-	// conns caches ChannelServiceClient per instance name so repeated Notify /
-	// Request calls to the same instance reuse the same underlying gRPC
-	// connection rather than opening a new TCP connection on every dispatch.
-	// Only populated when NewChannelClient is nil (production path); the test
-	// path injects clients directly via NewChannelClient and never writes here.
-	conns map[string]channelv1.ChannelServiceClient
+	// conns caches gRPC connections (and their ChannelServiceClient wrappers)
+	// per instance name so repeated Notify / Request calls to the same instance
+	// reuse the same underlying gRPC connection rather than opening a new TCP
+	// connection on every dispatch.  Only populated when NewChannelClient is nil
+	// (production path); the test path injects clients directly via
+	// NewChannelClient and never writes into the cache.
+	//
+	// connCache stores the *grpc.ClientConn alongside the client so that
+	// Close can call conn.Close().  Storing only the client (the original
+	// bug, issue #497) made the connection unreachable and leaked it.
+	conns *connCache[channelv1.ChannelServiceClient]
 }
 
 // NewDispatcher creates a Dispatcher ready to use.
@@ -105,48 +108,29 @@ func NewDispatcher(cfg DispatcherConfig) *Dispatcher {
 	return &Dispatcher{
 		cfg:     cfg,
 		waiters: make(map[string]chan string),
-		conns:   make(map[string]channelv1.ChannelServiceClient),
+		// cfg.Connect may be nil in the test path (NewChannelClient is set instead);
+		// newConnCache does not dial at construction so nil is safe here.
+		conns: newConnCache(cfg.Connect, channelv1.NewChannelServiceClient),
 	}
 }
 
 // channelClient returns a ChannelServiceClient for the given instance.
 // When NewChannelClient is set (e.g. in tests), the factory is called directly
-// without going through Connect.  In production, the client is lazily created
-// and cached so repeated Notify / Request calls to the same instance reuse
-// the same underlying gRPC connection rather than opening a new TCP connection
-// on every dispatch (mirrors Pool.getOrCreate for the tool path).
+// without touching the connection cache.  In production the cache handles lazy
+// dial, dedup, and close-loser semantics (see connCache.getOrConnect).
 func (d *Dispatcher) channelClient(instanceName string) (channelv1.ChannelServiceClient, error) {
 	if d.cfg.NewChannelClient != nil {
 		return d.cfg.NewChannelClient(instanceName), nil
 	}
-
-	// Fast path: already cached.
-	d.connMu.Lock()
-	if c, ok := d.conns[instanceName]; ok {
-		d.connMu.Unlock()
-		return c, nil
-	}
-	d.connMu.Unlock()
-
-	// Slow path: create and cache.
-	conn, err := d.cfg.Connect(instanceName)
-	if err != nil {
-		return nil, fmt.Errorf("connecting to plugin instance %q: %w", instanceName, err)
-	}
-	c := channelv1.NewChannelServiceClient(conn)
-
-	d.connMu.Lock()
-	// Double-check: another goroutine may have won the race.
-	if existing, ok := d.conns[instanceName]; ok {
-		d.connMu.Unlock()
-		// Close the connection we just created to avoid leaking it.
-		conn.Close()
-		return existing, nil
-	}
-	d.conns[instanceName] = c
-	d.connMu.Unlock()
-	return c, nil
+	return d.conns.getOrConnect(instanceName)
 }
+
+// Close closes every cached gRPC connection opened by the channel path.
+// It is the channel-path analogue of Pool.Close and must be called during
+// plugin-runtime shutdown to avoid leaking gRPC transport goroutines.
+// Safe (no-op) when constructed with NewChannelClient (test path), and
+// idempotent: a second call returns nil and does not panic.
+func (d *Dispatcher) Close() error { return d.conns.closeAll() }
 
 // channelTarget is a resolved audience entry with the plugin instance fields
 // needed for a Notify or Request gRPC call.

--- a/internal/plugin/dispatch/channel_integration_test.go
+++ b/internal/plugin/dispatch/channel_integration_test.go
@@ -121,6 +121,10 @@ func TestDispatcher_Notify_ProductionWiring(t *testing.T) {
 		Queries: s.Queries(),
 		Connect: connFactory,
 	})
+	// After this change connCache retains the dialed connection; Close() is
+	// required so goleak.VerifyTestMain does not flag the retained gRPC goroutine.
+	// Use t.Cleanup (not defer) so it runs even if a later t.Fatalf short-circuits.
+	t.Cleanup(func() { _ = dispatcher.Close() })
 
 	rc := dispatch.RouteContext{
 		RunID:    "run-dispatch-integ",

--- a/internal/plugin/dispatch/channel_test.go
+++ b/internal/plugin/dispatch/channel_test.go
@@ -1025,6 +1025,24 @@ func TestRequest_RowInsertedBeforeGRPCCall(t *testing.T) {
 	}
 }
 
+// TestDispatcher_Close_NoConnsWhenInjected verifies that Close() returns nil
+// and is idempotent when the Dispatcher was constructed with NewChannelClient
+// (the test seam).  In this path the connection cache is never populated, so
+// Close is a no-op — the intent is that callers in production always call Close
+// and tests using the injected path are not broken by doing so.
+func TestDispatcher_Close_NoConnsWhenInjected(t *testing.T) {
+	ds := newSetup(t)
+	d := ds.newDispatcher(200*time.Millisecond, 100*time.Millisecond)
+
+	if err := d.Close(); err != nil {
+		t.Errorf("first Close() returned error: %v", err)
+	}
+	// Second call must also be a no-op.
+	if err := d.Close(); err != nil {
+		t.Errorf("second Close() returned error: %v", err)
+	}
+}
+
 // TestWait_TimerFires_CancelledCtx_RowTransitionedToTimedOut verifies that when
 // Wait's timer fires, the cleanup DB operations (TransitionTimedOut and
 // GetPluginPendingRequest) use a detached context.Background() deadline rather

--- a/internal/plugin/dispatch/conncache.go
+++ b/internal/plugin/dispatch/conncache.go
@@ -1,0 +1,110 @@
+package dispatch
+
+import (
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+// connEntry pairs a gRPC connection with the client that wraps it.
+//
+// The conn is stored alongside the client so that Close can call conn.Close().
+// Storing only the client (the original channel.go bug, issue #497) makes the
+// underlying connection unreachable after the entry is cached, so it leaks on
+// shutdown.
+type connEntry[T any] struct {
+	conn   *grpc.ClientConn
+	client T
+}
+
+// connCache is a lazily-populated, concurrency-safe cache that maps instance
+// names to gRPC client connections.  It implements the fast-path / lock /
+// double-check / connect / cache-close-loser pattern that was previously
+// duplicated in channel.go (channel-path) and pool.go (tool-path).
+//
+// The generic parameter T is the gRPC client type (e.g.
+// channelv1.ChannelServiceClient).  newClient wraps a *grpc.ClientConn into T
+// exactly once per winning entry; losers of the double-check race have their
+// connection closed immediately to avoid leaking transport goroutines.
+//
+// newClient accepts grpc.ClientConnInterface (not *grpc.ClientConn) because
+// gRPC-generated NewXxxServiceClient functions take the interface, and
+// *grpc.ClientConn implements it.  The conn field still holds the concrete
+// *grpc.ClientConn so Close can call conn.Close().
+type connCache[T any] struct {
+	mu        sync.Mutex
+	entries   map[string]connEntry[T]
+	newClient func(grpc.ClientConnInterface) T
+	connect   ConnFactory
+}
+
+// newConnCache returns a connCache ready to use.  connect may be nil in the
+// test path when NewChannelClient is set on the Dispatcher — getOrConnect is
+// never reached in that case.
+func newConnCache[T any](connect ConnFactory, newClient func(grpc.ClientConnInterface) T) *connCache[T] {
+	return &connCache[T]{
+		entries:   make(map[string]connEntry[T]),
+		newClient: newClient,
+		connect:   connect,
+	}
+}
+
+// getOrConnect returns the cached client for instanceName, dialing once if
+// needed.  Concurrent callers that race on the same name all dial, but only
+// the first to re-acquire the lock survives in the cache; every loser closes
+// the connection it just dialed to prevent goroutine leaks.
+func (c *connCache[T]) getOrConnect(instanceName string) (T, error) {
+	// Fast path: already cached.
+	c.mu.Lock()
+	if e, ok := c.entries[instanceName]; ok {
+		c.mu.Unlock()
+		return e.client, nil
+	}
+	c.mu.Unlock()
+
+	// Slow path: dial outside the lock so we do not hold it during I/O.
+	conn, err := c.connect(instanceName)
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("connecting to plugin instance %q: %w", instanceName, err)
+	}
+	client := c.newClient(conn)
+
+	// Re-acquire the lock and double-check: another goroutine may have won the
+	// race while we were dialing.
+	c.mu.Lock()
+	if existing, ok := c.entries[instanceName]; ok {
+		c.mu.Unlock()
+		// Close the connection we just created to avoid leaking it.
+		conn.Close()
+		return existing.client, nil
+	}
+	c.entries[instanceName] = connEntry[T]{conn: conn, client: client}
+	c.mu.Unlock()
+	return client, nil
+}
+
+// closeAll closes every cached connection and resets entries to an empty map.
+// It returns the first conn.Close() error encountered (mirrors Pool.Close's
+// firstErr capture), but unconditionally replaces entries with a fresh empty
+// map regardless of errors.  This ensures:
+//   - a subsequent getOrConnect re-dials rather than returning a half-closed conn
+//   - a second closeAll() is a clean no-op
+//
+// The lock is held for the whole iteration, blocking concurrent getOrConnect.
+// That is acceptable because closeAll runs only at shutdown and the number of
+// cached instances is small (homelab scale).
+func (c *connCache[T]) closeAll() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var firstErr error
+	for _, e := range c.entries {
+		if err := e.conn.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	// Always reset — even when a Close errored, callers expect a clean slate.
+	c.entries = make(map[string]connEntry[T])
+	return firstErr
+}

--- a/internal/plugin/dispatch/conncache_test.go
+++ b/internal/plugin/dispatch/conncache_test.go
@@ -1,0 +1,274 @@
+package dispatch
+
+// This file uses the internal test package (package dispatch, not dispatch_test)
+// so it can access the unexported connCache type directly, which is needed for
+// the call-counter and race assertions the plan requires.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// plainConnFactory returns a ConnFactory backed by an in-process bufconn
+// listener.  No gRPC services are registered — we only need the conn to be
+// dialable for the lifecycle tests; no RPCs are made.
+func plainConnFactory(t *testing.T) (ConnFactory, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	go func() { _ = srv.Serve(lis) }()
+
+	factory := func(_ string) (*grpc.ClientConn, error) {
+		return grpc.NewClient(
+			"passthrough:///bufnet",
+			grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+	}
+	cleanup := func() {
+		srv.Stop()
+		lis.Close()
+	}
+	return factory, cleanup
+}
+
+// newIdentityCache creates a connCache[grpc.ClientConnInterface] using the
+// identity function as newClient.  T = grpc.ClientConnInterface lets the test
+// compare returned values without a type assertion while still exercising the
+// full cache lifecycle (dial, double-check, closeAll).
+//
+// Interface equality holds for pointer-equal concrete values: two variables of
+// type grpc.ClientConnInterface that wrap the same *grpc.ClientConn compare
+// equal with ==, so conn1 != conn2 comparisons in the tests are valid.
+func newIdentityCache(factory ConnFactory) *connCache[grpc.ClientConnInterface] {
+	return newConnCache(factory, func(c grpc.ClientConnInterface) grpc.ClientConnInterface { return c })
+}
+
+// TestConnCache_CachingDedup verifies that two sequential getOrConnect calls
+// for the same instance name return the identical *grpc.ClientConn and that
+// the factory is invoked exactly once.
+func TestConnCache_CachingDedup(t *testing.T) {
+	factory, cleanup := plainConnFactory(t)
+	defer cleanup()
+
+	var callCount atomic.Int32
+	countingFactory := func(name string) (*grpc.ClientConn, error) {
+		callCount.Add(1)
+		return factory(name)
+	}
+
+	cache := newIdentityCache(countingFactory)
+	t.Cleanup(func() { _ = cache.closeAll() })
+
+	conn1, err := cache.getOrConnect("inst-a")
+	if err != nil {
+		t.Fatalf("first getOrConnect: %v", err)
+	}
+	conn2, err := cache.getOrConnect("inst-a")
+	if err != nil {
+		t.Fatalf("second getOrConnect: %v", err)
+	}
+	if conn1 != conn2 {
+		t.Error("two getOrConnect calls for the same instance should return the same conn pointer")
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("factory called %d times, want 1", got)
+	}
+}
+
+// TestConnCache_LostRaceLoserClose deterministically exercises the double-check
+// branch.  A blocking factory holds all goroutines past the fast-path miss until
+// released simultaneously; every goroutine dials.  After release, exactly one
+// entry survives in the cache (the others close their losers) and a subsequent
+// single getOrConnect must not trigger a new dial.
+//
+// We assert:
+//   - factory.callCount == goroutine count (every loser dialed)
+//   - all goroutines return the same conn pointer (the winner is cached for all)
+//   - a post-race getOrConnect does not increment callCount
+func TestConnCache_LostRaceLoserClose(t *testing.T) {
+	factory, cleanup := plainConnFactory(t)
+	defer cleanup()
+
+	const goroutines = 5
+	var callCount atomic.Int32
+	// gate is closed once all goroutines have passed the fast-path check and are
+	// waiting in the factory; releasing it causes them all to dial simultaneously.
+	gate := make(chan struct{})
+	// arrived is a barrier: each goroutine writes once after entering the factory.
+	// Buffered at the goroutine count so the write never blocks regardless of
+	// scheduling. The main goroutine drains exactly `goroutines` values before
+	// closing the gate, guaranteeing every goroutine is past the fast-path miss
+	// and blocked in the factory — a deterministic exercise of the loser-close
+	// path. This is the signal-don't-poll idiom from pool_test.go; a spin-wait
+	// here would be both flaky and able to release the gate before all goroutines
+	// arrived (making the dial count non-deterministic).
+	arrived := make(chan struct{}, goroutines)
+
+	blockingFactory := func(name string) (*grpc.ClientConn, error) {
+		callCount.Add(1)
+		arrived <- struct{}{} // signal arrival; buffered so this never blocks
+		<-gate                // block until released
+		return factory(name)
+	}
+
+	cache := newIdentityCache(blockingFactory)
+	t.Cleanup(func() { _ = cache.closeAll() })
+
+	var wg sync.WaitGroup
+	results := make([]grpc.ClientConnInterface, goroutines)
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i], errs[i] = cache.getOrConnect("inst-race")
+		}()
+	}
+
+	// Wait until all goroutines are inside the blocking factory (past the
+	// fast-path check) before releasing. Drain exactly `goroutines` arrivals;
+	// the deadline is a generous CI-tolerance bound, not a real timing assertion.
+	for i := 0; i < goroutines; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for goroutines to enter the blocking factory")
+		}
+	}
+	close(gate) // release all goroutines simultaneously
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d returned error: %v", i, err)
+		}
+	}
+
+	// All goroutines must return the same surviving conn (interface comparison).
+	survivor := results[0]
+	for i, c := range results {
+		if c != survivor {
+			t.Errorf("goroutine %d got different conn value; winner should be cached for all", i)
+		}
+	}
+
+	// Every goroutine dialed (callCount == goroutines).
+	if got := callCount.Load(); got != goroutines {
+		t.Errorf("factory called %d times, want %d (each loser must have dialed)", got, goroutines)
+	}
+
+	// A subsequent getOrConnect must reuse the cached entry without a new dial.
+	_, err := cache.getOrConnect("inst-race")
+	if err != nil {
+		t.Fatalf("post-race getOrConnect: %v", err)
+	}
+	if got := callCount.Load(); got != goroutines {
+		t.Errorf("factory called %d times after post-race call, want %d (survivor cached)", got, goroutines)
+	}
+}
+
+// TestConnCache_ConnectError verifies that a factory error is wrapped with the
+// instance name in the message, preserving the exact format consumers rely on.
+func TestConnCache_ConnectError(t *testing.T) {
+	sentinel := errors.New("dial refused")
+	failFactory := func(_ string) (*grpc.ClientConn, error) {
+		return nil, sentinel
+	}
+
+	cache := newIdentityCache(failFactory)
+	t.Cleanup(func() { _ = cache.closeAll() })
+
+	_, err := cache.getOrConnect("inst-err")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("errors.Is(err, sentinel) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "inst-err") {
+		t.Errorf("error message %q does not contain instance name %q", err.Error(), "inst-err")
+	}
+}
+
+// TestConnCache_CloseAllAndRedial verifies that closeAll resets the cache to a
+// fresh empty map, causing subsequent getOrConnect calls to re-dial.
+//
+// Functional check: call-counter increments prove the cache was cleared, not
+// conn.GetState()==Shutdown (which is async and would flake).
+func TestConnCache_CloseAllAndRedial(t *testing.T) {
+	factory, cleanup := plainConnFactory(t)
+	defer cleanup()
+
+	var callCount atomic.Int32
+	countingFactory := func(name string) (*grpc.ClientConn, error) {
+		callCount.Add(1)
+		return factory(name)
+	}
+
+	cache := newIdentityCache(countingFactory)
+
+	// Dial 3 distinct instances.
+	for _, name := range []string{"inst-1", "inst-2", "inst-3"} {
+		if _, err := cache.getOrConnect(name); err != nil {
+			t.Fatalf("getOrConnect(%q): %v", name, err)
+		}
+	}
+	if got := callCount.Load(); got != 3 {
+		t.Errorf("factory called %d times before close, want 3", got)
+	}
+
+	if err := cache.closeAll(); err != nil {
+		t.Errorf("closeAll: %v", err)
+	}
+
+	// Re-dial all 3; each must trigger a new factory call because closeAll
+	// reset the cache to an empty map.
+	for _, name := range []string{"inst-1", "inst-2", "inst-3"} {
+		if _, err := cache.getOrConnect(name); err != nil {
+			t.Fatalf("post-close getOrConnect(%q): %v", name, err)
+		}
+	}
+	if got := callCount.Load(); got != 6 {
+		t.Errorf("factory called %d times after close+redial, want 6 (3+3)", got)
+	}
+
+	// Clean up the newly opened connections.
+	if err := cache.closeAll(); err != nil {
+		t.Errorf("final closeAll: %v", err)
+	}
+}
+
+// TestConnCache_DoubleCloseSafety verifies that calling closeAll twice does not
+// panic and that the second call returns nil (nothing left to close).
+func TestConnCache_DoubleCloseSafety(t *testing.T) {
+	factory, cleanup := plainConnFactory(t)
+	defer cleanup()
+
+	cache := newIdentityCache(factory)
+
+	if _, err := cache.getOrConnect("inst-x"); err != nil {
+		t.Fatalf("getOrConnect: %v", err)
+	}
+
+	if err := cache.closeAll(); err != nil {
+		t.Errorf("first closeAll: %v", err)
+	}
+	// Second close must be a no-op — the map was reset to empty by the first call.
+	if err := cache.closeAll(); err != nil {
+		t.Errorf("second closeAll returned error: %v", err)
+	}
+}

--- a/internal/plugin/dispatch/pool.go
+++ b/internal/plugin/dispatch/pool.go
@@ -47,6 +47,14 @@ type Config struct {
 }
 
 // instanceState holds per-plugin-instance connection and concurrency state.
+//
+// Pool deliberately does NOT use connCache (internal/plugin/dispatch/conncache.go)
+// even though both paths share the fast-path/lock/double-check/connect pattern.
+// Pool needs per-instance sem, queueGate, and closeOnce fields that are
+// intrinsic to the concurrency and force-disconnect semantics (CancelRun closes
+// the conn directly via closeOnce, then evicts the entry); folding those concerns
+// into the generic cache would couple the helper to Pool's call-lifecycle policy.
+// The asymmetry is intentional.
 type instanceState struct {
 	conn      *grpc.ClientConn
 	client    toolv1.ToolServiceClient

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -41,6 +41,10 @@ type pluginRuntime struct {
 	// and reads it for the SetInflightCounter wiring and the shutdown Close call.
 	Pool *dispatch.Pool
 
+	// ChannelDispatcher routes channel Notify/Request RPCs. shutdown() closes its
+	// cached gRPC connections (channel-path analogue of Pool.Close).
+	ChannelDispatcher *dispatch.Dispatcher
+
 	// DispatchAdapter satisfies agent.PluginToolDispatcher for RunLauncherConfig.
 	DispatchAdapter agent.PluginToolDispatcher
 
@@ -205,16 +209,17 @@ func startPluginRuntime(
 	toolClassifier := &manifestClassifier{snap: pluginManifestSnap, q: store.Queries()}
 
 	rt := &pluginRuntime{
-		Pool:            pool,
-		DispatchAdapter: dispatchAdapter,
-		ApprovalAdapter: approvalAdapter,
-		FeedbackAdapter: feedbackAdapter,
-		ToolRegistrar:   pluginToolRegistrar,
-		ToolResolver:    toolResolver,
-		ToolClassifier:  toolClassifier,
-		ManifestSnap:    pluginManifestSnap,
-		HostSvc:         hostSvc,
-		loader:          loader,
+		Pool:              pool,
+		ChannelDispatcher: pluginDispatcher,
+		DispatchAdapter:   dispatchAdapter,
+		ApprovalAdapter:   approvalAdapter,
+		FeedbackAdapter:   feedbackAdapter,
+		ToolRegistrar:     pluginToolRegistrar,
+		ToolResolver:      toolResolver,
+		ToolClassifier:    toolClassifier,
+		ManifestSnap:      pluginManifestSnap,
+		HostSvc:           hostSvc,
+		loader:            loader,
 	}
 
 	// Wire OAuth handlers when an encryption key is available. The rescan hook
@@ -336,5 +341,14 @@ func (rt *pluginRuntime) shutdown() {
 	// post-StopAll.
 	if err := rt.Pool.Close(); err != nil {
 		slog.Warn("plugin dispatch pool close error", "err", err)
+	}
+
+	// Close the channel dispatcher's cached gRPC connections. StopAll above may
+	// have already torn down the underlying transports; grpc.ErrClientConnClosing
+	// from a re-close here is benign — warn-log only, do not fail shutdown.
+	if rt.ChannelDispatcher != nil {
+		if err := rt.ChannelDispatcher.Close(); err != nil {
+			slog.Warn("plugin channel dispatcher close error", "err", err)
+		}
 	}
 }


### PR DESCRIPTION
Closes #497

## Summary

`dispatch.Dispatcher` cached only the `ChannelServiceClient` (the client wrapper), not the underlying `*grpc.ClientConn`. Because the generated client exposes no `Close()`, the winning connection became **structurally unreachable** once cached — and `Dispatcher` had no `Close()` method at all. Every cached channel connection therefore leaked on shutdown / instance-removal. `Pool` already did this correctly (stores `st.conn`, closes every conn in `Pool.Close()` under `closeOnce`); the two paths reimplemented the same fast-path/double-check/connect/cache-close-loser pattern, diverging only in that one freed connections and one didn't.

## What changed

- **New `internal/plugin/dispatch/conncache.go`** — a generic `connCache[T]` that owns the connection-cache lifecycle in one place: stores the `*grpc.ClientConn` alongside the typed client, dials outside the lock, closes the loser of a connect race, and `closeAll()` closes every conn and unconditionally resets the map (so a re-dial gets a fresh conn and a second close is a clean no-op).
- **`channel.go`** — replaced the `connMu`/`conns` fields with a single `*connCache[channelv1.ChannelServiceClient]`; `channelClient` still short-circuits on the `NewChannelClient` test seam before touching the cache; added `Dispatcher.Close()`.
- **`pluginruntime.go`** — captured the dispatcher on `pluginRuntime` and call `ChannelDispatcher.Close()` in `shutdown()` right after `Pool.Close()` (nil-guarded, warn-log only — this is the half that actually stops the leak in production).
- **`pool.go`** — comment only: documents why `Pool` deliberately does **not** adopt `connCache` (it needs per-instance `sem`/`queueGate`/`closeOnce` + force-disconnect semantics the generic helper must not absorb). No logic change.
- **Tests** — table-driven `conncache_test.go` (caching/dedup, deterministic lost-race loser-close via a buffered-channel barrier, connect-error wrapping, closeAll+re-dial, double-close safety); injected-path `Dispatcher.Close()` test; and a mandatory `t.Cleanup(dispatcher.Close)` in `channel_integration_test.go` so the now-retained conn doesn't trip this package's `goleak.VerifyTestMain`.

Tests use functional re-dial / call-counter assertions rather than `conn.GetState() == Shutdown`, because `grpc.ClientConn.Close()` is asynchronous and the state transition would race the assertion.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./internal/plugin/dispatch/...` (incl. goleak) all pass; the lost-race test is stable under `go test -race -count=3`.

<details>
<summary>Architecture plan</summary>

Two-part fix per the issue: (1) give `Dispatcher` a real `Close()` by storing the conn not just the client, (2) extract the duplicated cache pattern into one shared helper — then wire `Close()` into the only shutdown path so the leak is actually drained. `Pool` is left unchanged because its cache carries load-bearing extra state (force-disconnect under `closeOnce`, `cancelWg`-gated teardown ordering) that a generic helper can't absorb without defeating its purpose; the copy-paste debt is eliminated on the channel side (the side with the bug) and `Pool`'s divergence is documented.

Adversarial plan review caught two issues that were fixed before implementation: the original test plan's `conn.GetState()==Shutdown` assertion (racy — Close is async) and a self-inflicted goleak failure in the existing integration test once the conn is actually retained.
</details>

Review cycles: 2 (cycle 1 flagged a flaky spin-wait barrier in the lost-race test; replaced with the signal-don't-poll buffered-channel barrier from `pool_test.go`). Brainstorming: not triggered (issue was well-specified). CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop