### PR TITLE
fix(plugin): cancel the derived context on every generation release (#498)

### DIFF
--- a/internal/plugin/generation/controller.go
+++ b/internal/plugin/generation/controller.go
@@ -240,15 +240,31 @@ func buildRelease(s *genState, g uint64, entry *cancelEntry) func() {
 				}
 			}
 			s.mu.Unlock()
+
+			// Release the derived context's cancel func now that the call has
+			// completed. Called outside s.mu because cancel() touches only the
+			// child context — it never reaches back into genState — so holding
+			// the mutex across it would be an unnecessary re-entrancy risk.
+			// once.Do keeps this exactly-once; if BeginDrain's force-cancel path
+			// already called entry.cancel(), the second call here is a no-op
+			// (context.CancelFunc is documented idempotent).
+			entry.cancel()
 		})
 	}
 }
 
 // removeCancelEntry removes the entry with the given id from the slice.
+// A fresh backing array is allocated on removal so the caller's original slice
+// is never mutated — avoiding the aliasing footgun of in-place append when
+// BeginDrain also holds a reference to the same backing array under s.mu.
+// When no entry matches, the input slice is returned unchanged (same header).
 func removeCancelEntry(entries []*cancelEntry, id uint64) []*cancelEntry {
 	for i, e := range entries {
 		if e.id == id {
-			return append(entries[:i], entries[i+1:]...)
+			out := make([]*cancelEntry, 0, len(entries)-1)
+			out = append(out, entries[:i]...)
+			out = append(out, entries[i+1:]...)
+			return out
 		}
 	}
 	return entries

--- a/internal/plugin/generation/controller_internal_test.go
+++ b/internal/plugin/generation/controller_internal_test.go
@@ -1,0 +1,71 @@
+package generation
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRemoveCancelEntry_DoesNotAliasInput proves that removeCancelEntry builds
+// a fresh backing array when it removes an entry, leaving the caller's original
+// slice header and backing array byte-for-byte untouched.
+func TestRemoveCancelEntry_DoesNotAliasInput(t *testing.T) {
+	noop := func() {}
+	orig := []*cancelEntry{
+		{id: 1, cancel: context.CancelFunc(noop)},
+		{id: 2, cancel: context.CancelFunc(noop)},
+		{id: 3, cancel: context.CancelFunc(noop)},
+	}
+	// Snapshot the original pointer values before the call.
+	before := append([]*cancelEntry(nil), orig...)
+
+	out := removeCancelEntry(orig, 2)
+
+	// Result must contain exactly ids 1 and 3 in order.
+	if len(out) != 2 {
+		t.Fatalf("expected len 2 after removing id 2, got %d", len(out))
+	}
+	if out[0].id != 1 || out[1].id != 3 {
+		t.Fatalf("expected ids [1 3] after removal, got [%d %d]", out[0].id, out[1].id)
+	}
+
+	// The original slice must be unchanged — same length and same pointers as
+	// the before snapshot, proving the input backing array was not shifted.
+	if len(orig) != 3 {
+		t.Fatalf("original slice length changed: expected 3, got %d", len(orig))
+	}
+	for i, ptr := range before {
+		if orig[i] != ptr {
+			t.Errorf("orig[%d] pointer changed: expected %p, got %p", i, ptr, orig[i])
+		}
+	}
+
+	// Prove distinct backing arrays: mutating out[0] must not affect orig[0].
+	sentinel := &cancelEntry{id: 99}
+	out[0] = sentinel
+	if orig[0].id != 1 {
+		t.Fatalf("mutating out[0] changed orig[0].id to %d (shared backing array)", orig[0].id)
+	}
+}
+
+// TestRemoveCancelEntry_IDNotFound_ReturnsInputUnchanged verifies the miss
+// contract: when no entry matches the id, removeCancelEntry returns the input
+// slice unchanged (same length and same element pointers).
+func TestRemoveCancelEntry_IDNotFound_ReturnsInputUnchanged(t *testing.T) {
+	noop := func() {}
+	orig := []*cancelEntry{
+		{id: 1, cancel: context.CancelFunc(noop)},
+		{id: 2, cancel: context.CancelFunc(noop)},
+	}
+	before := append([]*cancelEntry(nil), orig...)
+
+	out := removeCancelEntry(orig, 999)
+
+	if len(out) != len(orig) {
+		t.Fatalf("expected len %d on miss, got %d", len(orig), len(out))
+	}
+	for i, ptr := range before {
+		if out[i] != ptr {
+			t.Errorf("out[%d] pointer differs on miss: expected %p, got %p", i, ptr, out[i])
+		}
+	}
+}

--- a/internal/plugin/generation/controller_test.go
+++ b/internal/plugin/generation/controller_test.go
@@ -473,6 +473,106 @@ func TestBeginDrain_ConcurrentUnregister_NoPanic(t *testing.T) {
 	}
 }
 
+// TestAcquire_ReleaseCancelsWrappedContext is the load-bearing proof of the
+// cancel-func leak fix. Before the fix, wrappedCtx.Err() remained nil after
+// release() because buildRelease never called entry.cancel(). After the fix,
+// release() must cancel the derived context exactly once.
+func TestAcquire_ReleaseCancelsWrappedContext(t *testing.T) {
+	c := generation.New()
+	c.RegisterInstance("inst-leak-proof")
+
+	wrappedCtx, release, _, err := c.Acquire(context.Background(), "inst-leak-proof")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	// Before release, the wrapped context must be live.
+	if wrappedCtx.Err() != nil {
+		t.Fatalf("wrapped ctx already cancelled before release: %v", wrappedCtx.Err())
+	}
+
+	release()
+
+	// After release, the derived cancel func must have been invoked.
+	if wrappedCtx.Err() != context.Canceled {
+		t.Fatalf("expected context.Canceled after release(), got %v", wrappedCtx.Err())
+	}
+}
+
+// TestAcquire_DoubleReleaseAfterCancel_NoPanic verifies that calling release()
+// twice is safe (once.Do guard) and that the context remains Canceled after
+// both calls — the second call is a no-op.
+func TestAcquire_DoubleReleaseAfterCancel_NoPanic(t *testing.T) {
+	c := generation.New()
+	c.RegisterInstance("inst-double-release")
+
+	wrappedCtx, release, _, err := c.Acquire(context.Background(), "inst-double-release")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	release()
+	release() // must not panic
+
+	if wrappedCtx.Err() != context.Canceled {
+		t.Fatalf("expected context.Canceled after double release, got %v", wrappedCtx.Err())
+	}
+}
+
+// TestBeginDrain_ForceCancelThenRelease_NoPanic verifies that BeginDrain's
+// force-cancel path followed by a normal release() does not panic. Both paths
+// call entry.cancel(), but context.CancelFunc is documented idempotent, so the
+// double-cancel must be benign.
+//
+// Synchronisation mirrors TestBeginDrain_ForceCancelsOnGraceExceeded:
+// wait on wrappedCtx.Done() for the force-cancel signal, then call release().
+func TestBeginDrain_ForceCancelThenRelease_NoPanic(t *testing.T) {
+	c := generation.New()
+	c.RegisterInstance("inst-force-then-release")
+
+	ctx := context.Background()
+	wrappedCtx, release, _, err := c.Acquire(ctx, "inst-force-then-release")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer release() // idempotent safety net
+
+	drainResult := make(chan bool, 1)
+	go func() {
+		// 50ms grace: short enough that the held call exceeds it.
+		_, drained, err := c.BeginDrain(ctx, "inst-force-then-release", 50*time.Millisecond)
+		if err != nil {
+			drainResult <- false
+			return
+		}
+		drainResult <- drained
+	}()
+
+	// Wait for BeginDrain to force-cancel the context (grace elapsed).
+	select {
+	case <-wrappedCtx.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("force-cancel did not arrive within 10s")
+	}
+
+	// Call release() after the force-cancel — double-cancel must not panic.
+	release()
+
+	select {
+	case drained := <-drainResult:
+		if drained {
+			t.Fatal("expected drained=false for grace-exceeded scenario, got true")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("BeginDrain did not return after force-cancel + release")
+	}
+
+	// Context must still be Canceled (not affected by double-cancel).
+	if wrappedCtx.Err() != context.Canceled {
+		t.Fatalf("expected context.Canceled after force-cancel + release, got %v", wrappedCtx.Err())
+	}
+}
+
 // TestUnregisterInstance_WakesBlockedAcquires verifies that UnregisterInstance
 // causes any goroutine blocked in Acquire to return an error without leaking,
 // and that subsequent Acquire calls also return an error immediately.

--- a/internal/plugin/hostsvc/generation_interceptor_test.go
+++ b/internal/plugin/hostsvc/generation_interceptor_test.go
@@ -61,9 +61,14 @@ func TestGenerationInterceptor_HappyPath(t *testing.T) {
 
 	ctx := ctxWithInstanceID("inst-gp")
 	var handlerCtx context.Context
+	var ctxErrDuringCall error
 
 	err := runGenerationInterceptor(c, ctx, func(hctx context.Context, _ any) (any, error) {
 		handlerCtx = hctx
+		// The handler must run under a live (un-cancelled) ctx. Capture the error
+		// here, during the call — not after the interceptor returns, because the
+		// deferred release() cancels the derived ctx on the way out (issue #498).
+		ctxErrDuringCall = hctx.Err()
 		return nil, nil
 	})
 	if err != nil {
@@ -72,8 +77,14 @@ func TestGenerationInterceptor_HappyPath(t *testing.T) {
 	if handlerCtx == nil {
 		t.Fatal("handler was not called")
 	}
-	if handlerCtx.Err() != nil {
-		t.Fatalf("handler ctx already cancelled: %v", handlerCtx.Err())
+	if ctxErrDuringCall != nil {
+		t.Fatalf("handler ctx was already cancelled during the call: %v", ctxErrDuringCall)
+	}
+	// After the interceptor returns, release() has run and cancels the derived
+	// context — that is the issue #498 fix (release must not leak the cancel
+	// func). The ctx being Canceled here is the fix working, not a force-cancel.
+	if handlerCtx.Err() != context.Canceled {
+		t.Fatalf("handler ctx should be Canceled after release() returned; got: %v", handlerCtx.Err())
 	}
 
 	// After the interceptor returns the release func must have been called, so

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -575,6 +575,14 @@ func TestReloadInstance_DrainsAndRestarts(t *testing.T) {
 
 	// Release the slot before the grace deadline → drain should complete naturally.
 	time.Sleep(20 * time.Millisecond)
+	// Check liveness BEFORE releasing: a force-cancel would have cancelled this
+	// ctx while the call was still in-flight, but we release well within the grace
+	// window so the drain completes naturally and the ctx is still live here.
+	// (After release() the ctx is cancelled by the release itself — issue #498 —
+	// so this distinction is only observable before release, not after.)
+	if wrappedCtx.Err() != nil {
+		t.Errorf("held call ctx was force-cancelled before release; drain should complete naturally")
+	}
 	release()
 
 	select {
@@ -584,11 +592,6 @@ func TestReloadInstance_DrainsAndRestarts(t *testing.T) {
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("ReloadInstance did not return")
-	}
-
-	// The held call's context must NOT have been force-cancelled.
-	if wrappedCtx.Err() != nil {
-		t.Errorf("held call ctx was cancelled; drain must have completed naturally")
 	}
 
 	// processStarter should have been called twice: initial Start + post-reload Start.


### PR DESCRIPTION
Closes #498

## Summary

`generation.Controller.Acquire` wraps the request ctx with `context.WithCancel` and stores the `cancel` in a `cancelEntry`, but the `release()` closure built by `buildRelease` only removed the entry and decremented refs — it **never called `cancel()`**. The cancel func was invoked in exactly one place: `BeginDrain`'s force-cancel path. So on **every normal RPC completion** the derived context's cancel leaked (a `lostcancel`-class leak), persisting until the parent ctx was cancelled — one leak per Host RPC, per generation.

A secondary latent issue: `removeCancelEntry` used the in-place `append(entries[:i], entries[i+1:]...)` idiom, mutating the shared backing array. Safe today (both it and `BeginDrain`'s snapshot run under `s.mu`), but an aliasing footgun one refactor away from firing.

## What changed

- **`buildRelease` (controller.go)** — the `once.Do` body now calls `entry.cancel()` as its final statement, **after** `s.mu.Unlock()`. This is the missing `defer cancel()`: releasing the call now releases its context. Called after the unlock because `cancel()` needs no lock and holding a mutex across a callback is avoidable; `once.Do` keeps it exactly-once. A redundant call from `BeginDrain`'s force-cancel is harmless because `context.CancelFunc` is idempotent and entries are never reused (monotonic id, fresh allocation per `Acquire`).
- **`removeCancelEntry` (controller.go)** — builds a fresh slice (`make` + append-all-but-matched) instead of overwriting the shared backing array in place. The id-not-found contract (return input unchanged) is preserved. `slices.Delete` was deliberately rejected — it aliases in place, the exact footgun.

No new imports (the package is a documented leaf: stdlib + `log/slog` only). `Acquire`'s signature and the `release()` contract are unchanged. The hostsvc interceptor already does `defer release()` — no change there.

## Tests

- **`TestAcquire_ReleaseCancelsWrappedContext`** (load-bearing) — asserts `wrappedCtx.Err() == nil` before `release()` and `== context.Canceled` after. Would have failed against the pre-fix code.
- **`TestRemoveCancelEntry_DoesNotAliasInput`** (white-box) — mutates the returned slice and confirms the caller's original backing array is untouched; would have failed against the old in-place `append`.
- **`TestRemoveCancelEntry_IDNotFound_ReturnsInputUnchanged`**, **`TestAcquire_DoubleReleaseAfterCancel_NoPanic`** (once.Do), **`TestBeginDrain_ForceCancelThenRelease_NoPanic`** (double-cancel safety).

`go build ./...`, `go vet`, and `go test -race -count=2 ./internal/plugin/generation/` (16/16) all pass.

<details>
<summary>Architecture plan</summary>

Two-line production fix in a leaf package, but concurrency-sensitive — the plan resolved: (A) call `cancel()` after unlock, not inside the critical section; (B) double-cancel from `BeginDrain` + normal release is benign (idempotent CancelFunc, entries never reused); (C) fresh-slice construction in `removeCancelEntry` provably non-aliasing; (D) the leak is `lostcancel`-class, not a goroutine leak (`WithCancel` without a timer spawns no goroutine), so the only reliable proof is the runtime `wrappedCtx.Err()` assertion. Adversarial plan review confirmed the wrapped ctx never escapes the synchronous handler call, so cancelling on normal completion is pure `defer cancel()` semantics.
</details>

Review cycles: 1 (APPROVE). Brainstorming: not triggered (well-specified). CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop