### PR TITLE
fix(plugin): write timeout audit step with the detached cleanup ctx (#499)

### DIFF
--- a/internal/plugin/dispatch/channel.go
+++ b/internal/plugin/dispatch/channel.go
@@ -597,7 +597,12 @@ func (d *Dispatcher) Wait(ctx context.Context, requestID string, timeout time.Du
 		if d.cfg.WriteRunStep != nil {
 			req, dbErr := d.cfg.Queries.GetPluginPendingRequest(cleanupCtx, requestID)
 			if dbErr == nil {
-				if wErr := d.cfg.WriteRunStep(ctx, req.RunID, "plugin_request_timeout", map[string]interface{}{
+				// Use cleanupCtx, not the caller's run ctx: same reason it was
+				// created two lines up — the run ctx may already be cancelled
+				// (e.g. interrupted run) when the timer fires. Writing the
+				// timeout step with the cancelled ctx would silently fail and
+				// lose the very step this CAS winner exists to record (#499).
+				if wErr := d.cfg.WriteRunStep(cleanupCtx, req.RunID, "plugin_request_timeout", map[string]interface{}{
 					"message":    fmt.Sprintf("plugin request timed out after %s", timeout),
 					"code":       "plugin_request_timeout",
 					"request_id": requestID,

--- a/internal/plugin/dispatch/channel_test.go
+++ b/internal/plugin/dispatch/channel_test.go
@@ -1110,6 +1110,96 @@ func TestWait_TimerFires_CancelledCtx_RowTransitionedToTimedOut(t *testing.T) {
 	}
 }
 
+// TestWait_TimerFires_WriteRunStepUsesDetachedCtx is the regression test for
+// #499: when Wait's timer fires, the timeout step must be written with the
+// detached cleanup context, NOT the caller's run ctx. On an interrupted run the
+// run ctx is already cancelled by the time the timer fires, so writing the step
+// with the run ctx would silently fail and lose the very step the CAS winner
+// exists to record.
+//
+// We cannot probe the cleanup ctx AFTER Wait returns: cleanupCtx is cancelled by
+// Wait's own `defer cancelCleanup()`, so it always reads cancelled afterwards.
+// Instead we observe liveness INSIDE the WriteRunStep hook (while we are still on
+// Wait's stack and cleanupCtx is live): the hook cancels the run ctx and then
+// checks whether the ctx it was handed became Done.
+//
+//   - bug  (WriteRunStep(ctx, ...)):        handed ctx IS runCtx → Done after cancel.
+//   - fix  (WriteRunStep(cleanupCtx, ...)): handed ctx is detached → stays alive.
+//
+// The timer (30ms) fires while runCtx is still live so the timer branch wins the
+// select deterministically; the run-ctx cancellation happens entirely inside the
+// hook, after the branch is already committed.
+func TestWait_TimerFires_WriteRunStepUsesDetachedCtx(t *testing.T) {
+	ds := newSetup(t)
+
+	pluginID := insertPlugin(t, ds.store, "p1", "plug")
+	instID := insertPluginInstance(t, ds.store, "i1", pluginID, "inst-ok")
+	audID := insertAudience(t, ds.store, "aud1", "aud")
+	insertAudienceEntry(t, ds.store, "ae1", audID, instID, 0, false, true)
+
+	ds.clientMap["inst-ok"] = &fakeChannelClient{
+		requestHook: func(_ context.Context, _ *channelv1.RequestRequest) (*channelv1.RequestResponse, error) {
+			return &channelv1.RequestResponse{Acked: true}, nil
+		},
+	}
+
+	testutil.InsertPolicy(t, ds.store, "pol1", "policy-pol1", "webhook", "{}")
+	testutil.InsertRun(t, ds.store, "run1", "pol1", model.RunStatusRunning)
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+
+	var stepCtxStillLive atomic.Bool
+	var stepCalled atomic.Bool
+
+	d := dispatch.NewDispatcher(dispatch.DispatcherConfig{
+		Queries:       ds.store.Queries(),
+		NotifyTimeout: 200 * time.Millisecond,
+		PreAckTimeout: 100 * time.Millisecond,
+		WriteRunStep: func(ctx context.Context, _ string, stepType string, _ map[string]interface{}) error {
+			if stepType != "plugin_request_timeout" {
+				return nil
+			}
+			stepCalled.Store(true)
+			// Cancel the caller's run ctx now. If the dispatcher handed us runCtx
+			// (the #499 bug), our ctx becomes Done; if it handed us the detached
+			// cleanup ctx (the fix), our ctx stays alive.
+			cancelRun()
+			select {
+			case <-ctx.Done():
+				stepCtxStillLive.Store(false)
+			default:
+				stepCtxStillLive.Store(true)
+			}
+			return nil
+		},
+		NewChannelClient: func(instanceName string) channelv1.ChannelServiceClient {
+			if c := ds.clientMap[instanceName]; c != nil {
+				return c
+			}
+			return &fakeChannelClient{}
+		},
+	})
+
+	reqID, _, err := d.Request(context.Background(), audID, dispatch.RouteContext{RunID: "run1", PolicyID: "pol1", ToolName: "ask"}, "prompt", nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	_, waitErr := d.Wait(runCtx, reqID, 30*time.Millisecond)
+	if waitErr == nil {
+		t.Fatal("Wait should return an error (timeout)")
+	}
+
+	if !stepCalled.Load() {
+		t.Fatal("WriteRunStep was never called for plugin_request_timeout — the timeout step was lost")
+	}
+	if !stepCtxStillLive.Load() {
+		t.Errorf("WriteRunStep was handed the caller's run ctx (#499 regression): " +
+			"cancelling the run ctx cancelled the step ctx. It must use the detached cleanup ctx.")
+	}
+}
+
 // TestRequest_PreAckFailure_RowTransitionedToTimedOut verifies the cleanup path:
 // when the plugin returns acked=false, the already-inserted row is transitioned
 // to timed_out rather than left as a dangling pending entry.


### PR DESCRIPTION
## Summary

The `Wait` timeout branch in `internal/plugin/dispatch/channel.go` deliberately builds a **detached** `cleanupCtx` (`context.Background()` + 5s) *because the caller's run ctx may already be cancelled when the timer fires* (e.g. an interrupted run), and uses it for `TransitionTimedOut` and `GetPluginPendingRequest`. But the subsequent `WriteRunStep` call was still passed the **original run ctx**.

On an interrupted run that ctx is already cancelled, so the `plugin_request_timeout` step write fails and the timeout step — the entire point of winning the CAS — is **silently lost** behind only a `slog.Warn`.

The fix is the prescribed one-line ctx swap: `WriteRunStep` now uses `cleanupCtx`, matching the two DB calls immediately above it.

## Lifetime verification (the nuance flagged in #499)

`cleanupCtx` is created with `defer cleanupCancel()` in the same `case <-timer.C:` branch. The defer fires on **function return**, which is *after* the `WriteRunStep` call. So `cleanupCtx` is in scope and **live** at the call site. Confirmed empirically: an early version of the test probed `cleanupCtx` *after* `Wait` returned and saw it cancelled (by the defer) — proving the defer fires post-call. The shipped test therefore observes liveness from **inside** the `WriteRunStep` hook, while still on `Wait`'s stack.

## Test (the bulk of the work)

`TestWait_TimerFires_WriteRunStepUsesDetachedCtx` drives the timer branch deterministically (30ms timer, no `Resolve`), then **from inside the `WriteRunStep` hook**:
1. cancels the caller's run ctx, and
2. checks whether the ctx it was handed became `Done`.

- Bug (`WriteRunStep(ctx, ...)`): handed ctx **is** runCtx → `Done` after cancel → test **fails**.
- Fix (`WriteRunStep(cleanupCtx, ...)`): handed ctx is detached → stays alive → test **passes**.

This is select-race-independent: the timer wins the select while runCtx is still live, and the run-ctx cancellation happens entirely inside the hook after the branch is committed. Verified: the test **fails on the reverted (buggy) code** and **passes on the fix**.

## Test gate

- `go build ./...` — OK
- `go vet ./internal/plugin/dispatch/` — OK
- `go test -race -count=2 ./internal/plugin/dispatch/` — OK (includes goleak `VerifyTestMain`)
- Downstream consumers with `-race`: `internal/plugin/hostsvc`, `internal/execution/agent`, `internal/execution/run` — all OK (the change is internal to `Wait`; no signature/behavior change visible to consumers)
- Pre-existing `TestWait_TimerFires_CancelledCtx_RowTransitionedToTimedOut` still green.

## Review cycles

Self-review of the diff: production change is the exact prescribed one-line swap plus a why-comment; test diff is purely additive (no harness struct change in the final version — an interim `capturedStep.ctx` field was reverted once the in-hook approach made it unnecessary). No further iterations needed.

## CLAUDE.md

No update needed — no new package, route, env var, or ADR. Pure internal ctx-correctness fix.

## Plan

<details>
<summary>Architected plan</summary>

1. Ground in the real `Wait` method and the CAS-winner logic (only the CAS winner writes the step).
2. Apply the one-line ctx swap (`ctx` → `cleanupCtx`) at the `WriteRunStep` call, with a why-comment.
3. Design a deterministic regression test using the package's injectable seams (`NewDispatcher` + `WriteRunStep` hook). Key adversarial finding: `cleanupCtx` is cancelled by the branch's `defer` on `Wait` return, so the test must observe ctx liveness **inside** the hook, not after `Wait` returns.
4. Prove the test fails on buggy code, passes on fixed code.
5. Run the full race + goleak gate plus downstream consumers.

</details>

This is adjacent to but not covered by #358/#359 (those concern different cleanup paths); no overlap with their behavior here.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
