### PR TITLE
fix(plugin): roll back feedback_response step when CAS affects 0 rows (#496)

### DIFF
--- a/internal/plugin/hostsvc/feedback_cas_orphan_test.go
+++ b/internal/plugin/hostsvc/feedback_cas_orphan_test.go
@@ -1,0 +1,136 @@
+package hostsvc_test
+
+// Residual-race test for #496 (a follow-up to #348).
+//
+// #348 fixed step_number ordering by wrapping the feedback_response INSERT and
+// the guarded UpdateFeedbackRequestStatus CAS in one transaction. A residual
+// window remained: WriteAuditStep pre-checks fr.Status == "pending" BEFORE the
+// transaction, but if the request is concurrently resolved between that
+// pre-check and the commit, the CAS (WHERE status='pending') updates 0 rows
+// while the feedback_response step still commits — an orphan audit step with no
+// corresponding state change.
+//
+// The fix captures rows-affected from the CAS; when 0, it rolls back the tx (no
+// step committed) and returns the late-callback ok=false envelope. This test
+// forces that 0-row CAS by making the pre-check observe "pending" while the real
+// DB row is already "resolved", then asserts no feedback_response step landed
+// and the caller got ok=false.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/hostsvc"
+	hostv1 "github.com/felag-engineering/gleipnir/plugin-sdk/gen/gleipnir/plugin/host/v1"
+)
+
+// forcedPendingQuerier wraps the real-DB-backed fakeInstanceQuerier but lies in
+// GetFeedbackRequest: it always reports the request as "pending" so WriteAuditStep
+// clears its fast-path pre-check, even though the underlying DB row has already
+// been transitioned to "resolved". This deterministically reproduces the
+// concurrent-resolution window that the real guarded CAS must catch.
+type forcedPendingQuerier struct {
+	*fakeInstanceQuerier
+}
+
+func (f *forcedPendingQuerier) GetFeedbackRequest(ctx context.Context, id string) (db.FeedbackRequest, error) {
+	fr, err := f.fakeInstanceQuerier.GetFeedbackRequest(ctx, id)
+	if err != nil {
+		return fr, err
+	}
+	// Mask the real (possibly already-resolved) status so the pre-check passes
+	// and execution proceeds into the transactional CAS.
+	fr.Status = "pending"
+	return fr, nil
+}
+
+// TestWriteAuditStep_CASZeroRowsDoesNotOrphanStep proves that when the guarded
+// UpdateFeedbackRequestStatus CAS affects 0 rows (the request was resolved
+// concurrently after the fr.Status pre-check), WriteAuditStep:
+//   - does NOT commit a feedback_response run_step, and
+//   - returns ok=false with the feedback_response_late envelope.
+func TestWriteAuditStep_CASZeroRowsDoesNotOrphanStep(t *testing.T) {
+	store, q := openConcurrencyStore(t)
+	instanceID := "cas-inst-" + model.NewULID()
+	instanceName := "cas-plugin"
+	runID, feedbackIDs := seedConcurrencyRun(t, q, 1, instanceID, instanceName)
+	requestID := feedbackIDs[0]
+
+	// Simulate the concurrent resolver winning: transition the request to
+	// "resolved" in the real DB BEFORE WriteAuditStep runs its CAS. The forced
+	// pre-check below will still report "pending", so we land in the residual
+	// window the fix closes.
+	resolvedResp := `{"by":"other-writer"}`
+	resolvedAt := "2026-06-10T00:00:00Z"
+	rows, err := q.UpdateFeedbackRequestStatus(context.Background(), db.UpdateFeedbackRequestStatusParams{
+		Status:     "resolved",
+		Response:   &resolvedResp,
+		ResolvedAt: &resolvedAt,
+		ID:         requestID,
+	})
+	if err != nil {
+		t.Fatalf("pre-resolve UpdateFeedbackRequestStatus: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("pre-resolve affected %d rows, want 1", rows)
+	}
+
+	binder := &fakeInstanceBinder{id: instanceID, ok: true}
+	pub := &fakePublisher{}
+	base := &fakeInstanceQuerier{
+		store:        store,
+		q:            q,
+		instanceID:   instanceID,
+		instanceName: instanceName,
+	}
+	fq := &forcedPendingQuerier{fakeInstanceQuerier: base}
+	srv := hostsvc.NewServer(fq, store.DB(), testEncryptionKey, &fakeResolver{}, binder, pub, nil)
+
+	resp, err := srv.WriteAuditStep(context.Background(), &hostv1.WriteAuditStepRequest{
+		StepType:    "feedback_response",
+		RequestId:   requestID,
+		PayloadJson: `{"late":true}`,
+	})
+	if err != nil {
+		t.Fatalf("WriteAuditStep returned RPC error: %v", err)
+	}
+
+	// The caller must observe a late-callback, not a success.
+	if resp.GetOk() {
+		t.Fatalf("expected ok=false on 0-row CAS, got ok=true")
+	}
+	if got := resp.GetError().GetMessage(); got != "feedback_response_late" {
+		t.Errorf("error message = %q, want %q", got, "feedback_response_late")
+	}
+
+	// No feedback_response step may have been committed — the tx must have rolled
+	// back. The run was seeded with no steps, so any step here is the orphan bug.
+	steps, err := q.ListRunSteps(context.Background(), db.ListRunStepsParams{
+		RunID: runID,
+		After: -1,
+		Limit: 50,
+	})
+	if err != nil {
+		t.Fatalf("ListRunSteps: %v", err)
+	}
+	for _, s := range steps {
+		if s.Type == "feedback_response" {
+			t.Fatalf("orphan feedback_response step committed (step_number=%d) despite 0-row CAS", s.StepNumber)
+		}
+	}
+
+	// And the original resolver's response must be intact — our late write must
+	// not have clobbered it.
+	fr, err := q.GetFeedbackRequest(context.Background(), requestID)
+	if err != nil {
+		t.Fatalf("GetFeedbackRequest: %v", err)
+	}
+	if fr.Status != "resolved" {
+		t.Errorf("status = %q, want resolved", fr.Status)
+	}
+	if fr.Response == nil || *fr.Response != resolvedResp {
+		t.Errorf("response = %v, want %q (original resolver's value preserved)", fr.Response, resolvedResp)
+	}
+}

--- a/internal/plugin/hostsvc/handlers_feedback.go
+++ b/internal/plugin/hostsvc/handlers_feedback.go
@@ -189,8 +189,28 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 	// Without a transaction, two concurrent writers can observe the same
 	// MAX(step_number) and attempt to insert with the same (run_id, step_number),
 	// violating the unique constraint (fixes #348, ADR-038 discipline).
-	if err := s.writeFeedbackResponseStep(ctx, fr.RunID, requestID, payloadJSON); err != nil {
+	resolved, err := s.writeFeedbackResponseStep(ctx, fr.RunID, requestID, payloadJSON)
+	if err != nil {
 		return nil, err
+	}
+	if !resolved {
+		// The guarded CAS affected 0 rows: the request was resolved by another
+		// writer in the residual window between the fr.Status pre-check above and
+		// the commit. The transaction has been rolled back, so NO feedback_response
+		// step was committed — without this guard we would write a spurious audit
+		// step with no corresponding state change (#496, residual of #348).
+		s.writeAuditEvent(ctx, inst.ID, EventTypeFeedbackResponseLate, "warning", map[string]string{
+			"request_id": requestID,
+			"reason":     "cas_lost",
+			"status":     fr.Status,
+		})
+		return &hostv1.WriteAuditStepResponse{
+			Ok: false,
+			Error: &commonv1.ErrorEnvelope{
+				Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
+				Message: EventTypeFeedbackResponseLate,
+			},
+		}, nil
 	}
 
 	// Publish so SSE subscribers and tests can observe the step.
@@ -211,18 +231,41 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 // the TOCTOU race where two concurrent writers observe the same MAX(step_number)
 // and attempt to insert with the same (run_id, step_number) value (fixes #348).
 //
+// The returned bool reports whether the guarded CAS
+// (UpdateFeedbackRequestStatus, WHERE status='pending') actually transitioned
+// the request. When it affects 0 rows another writer resolved the request in
+// the residual window after the caller's fr.Status pre-check, so the step
+// INSERT is rolled back (never committed) and (false, nil) is returned — the
+// caller then emits the late-callback ok=false envelope. This closes the
+// orphan-step window left open by #348 (#496).
+//
 // When s.sqlDB is nil (unit tests using a fake Querier), the operations run
 // without a transaction — acceptable because fake Queriers are single-threaded
-// and the race only manifests against a real SQLite connection pool.
-func (s *Server) writeFeedbackResponseStep(ctx context.Context, runID, requestID, payloadJSON string) error {
+// and the race only manifests against a real SQLite connection pool. The
+// rows-affected guard is still honored so the contract is uniform across paths.
+func (s *Server) writeFeedbackResponseStep(ctx context.Context, runID, requestID, payloadJSON string) (resolved bool, err error) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	stepID := model.NewULID()
 
 	if s.sqlDB == nil {
-		// Test path: no real DB, run without transaction.
+		// Test path: no real DB, run without transaction. Resolve the request
+		// FIRST so a 0-row CAS short-circuits before the step INSERT — there is no
+		// transaction to roll back here, so we must not write the step on CAS loss.
+		rows, err := s.q.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
+			Status:     "resolved",
+			Response:   &payloadJSON,
+			ResolvedAt: &now,
+			ID:         requestID,
+		})
+		if err != nil {
+			return false, status.Errorf(codes.Internal, "update feedback request status: %v", err)
+		}
+		if rows == 0 {
+			return false, nil
+		}
 		latestStep, err := s.latestStepNumber(ctx, runID)
 		if err != nil {
-			return status.Errorf(codes.Internal, "resolve step index: %v", err)
+			return false, status.Errorf(codes.Internal, "resolve step index: %v", err)
 		}
 		_, err = s.q.CreateRunStep(ctx, db.CreateRunStepParams{
 			ID:         stepID,
@@ -234,23 +277,14 @@ func (s *Server) writeFeedbackResponseStep(ctx context.Context, runID, requestID
 			CreatedAt:  now,
 		})
 		if err != nil {
-			return status.Errorf(codes.Internal, "create run step: %v", err)
+			return false, status.Errorf(codes.Internal, "create run step: %v", err)
 		}
-		_, err = s.q.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
-			Status:     "resolved",
-			Response:   &payloadJSON,
-			ResolvedAt: &now,
-			ID:         requestID,
-		})
-		if err != nil {
-			return status.Errorf(codes.Internal, "update feedback request status: %v", err)
-		}
-		return nil
+		return true, nil
 	}
 
 	tx, err := s.sqlDB.BeginTx(ctx, nil)
 	if err != nil {
-		return status.Errorf(codes.Internal, "begin feedback response tx: %v", err)
+		return false, status.Errorf(codes.Internal, "begin feedback response tx: %v", err)
 	}
 	defer tx.Rollback() //nolint:errcheck — Rollback is a no-op after Commit
 
@@ -260,7 +294,7 @@ func (s *Server) writeFeedbackResponseStep(ctx context.Context, runID, requestID
 	var nextStep int64
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
-			return status.Errorf(codes.Internal, "resolve step index in tx: %v", err)
+			return false, status.Errorf(codes.Internal, "resolve step index in tx: %v", err)
 		}
 		// No steps yet — first step is 0.
 		nextStep = 0
@@ -278,21 +312,28 @@ func (s *Server) writeFeedbackResponseStep(ctx context.Context, runID, requestID
 		CreatedAt:  now,
 	})
 	if err != nil {
-		return status.Errorf(codes.Internal, "create run step in tx: %v", err)
+		return false, status.Errorf(codes.Internal, "create run step in tx: %v", err)
 	}
 
-	_, err = qtx.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
+	rows, err := qtx.UpdateFeedbackRequestStatus(ctx, db.UpdateFeedbackRequestStatusParams{
 		Status:     "resolved",
 		Response:   &payloadJSON,
 		ResolvedAt: &now,
 		ID:         requestID,
 	})
 	if err != nil {
-		return status.Errorf(codes.Internal, "update feedback request status in tx: %v", err)
+		return false, status.Errorf(codes.Internal, "update feedback request status in tx: %v", err)
+	}
+	if rows == 0 {
+		// Guarded CAS lost: the request was resolved concurrently after the
+		// caller's pre-check. Return without committing so the deferred Rollback
+		// discards the feedback_response step we just staged (#496). Returning
+		// (false, nil) — not an error — lets the caller emit the late envelope.
+		return false, nil
 	}
 
 	if err := tx.Commit(); err != nil {
-		return status.Errorf(codes.Internal, "commit feedback response tx: %v", err)
+		return false, status.Errorf(codes.Internal, "commit feedback response tx: %v", err)
 	}
-	return nil
+	return true, nil
 }


### PR DESCRIPTION
Closes #496

## Summary

`writeFeedbackResponseStep` (in `internal/plugin/hostsvc/handlers_feedback.go`) inserted the `feedback_response` run-step **before** the guarded `UpdateFeedbackRequestStatus` CAS (`UPDATE ... WHERE id = :id AND status = 'pending'`) and **discarded the rows-affected**. The `fr.Status != "pending"` pre-check narrows but does not close the window: if the request is concurrently resolved between that pre-check and the commit, the CAS updates 0 rows while the step still commits — a spurious audit step with no corresponding state change.

This is a **residual of #348** (which fixed `step_number` ordering by wrapping the insert + CAS in one transaction — that fix is unchanged).

## What changed

- `writeFeedbackResponseStep` now returns `(resolved bool, err error)`. It captures rows-affected from the CAS; on **0 rows** it returns `(false, nil)` **without committing**, so the deferred `tx.Rollback()` discards the staged `feedback_response` step.
- The caller (`WriteAuditStep`) maps `resolved == false` to the late-callback **`ok=false`** response with the `feedback_response_late` envelope, and emits a `warning` audit event (`reason: cas_lost`).
- The non-transactional test path (`sqlDB == nil`, fake Querier) is reordered to run the status CAS **first** — there is no transaction to roll back there, so it must short-circuit on 0 rows before staging the step. This keeps the contract uniform across both paths.

## Test

`TestWriteAuditStep_CASZeroRowsDoesNotOrphanStep` uses a **real DB-backed store**: it pre-resolves the request in the actual DB, then masks the status to `"pending"` in the pre-check (`forcedPendingQuerier`) to deterministically land in the residual window. It asserts (1) no `feedback_response` step was committed, (2) the caller got `ok=false` with the `feedback_response_late` message, and (3) the original resolver's response was not clobbered. Fails against the pre-fix code.

## Verification

`go build ./...`, `go vet`, and `go test -race ./internal/plugin/hostsvc/` pass; the broader `internal/plugin/...` and `internal/execution/...` suites were run under `-race` (green).

<details>
<summary>Notes</summary>

The production change is small but concurrency-sensitive; the key insight is that on a real DB the deferred `Rollback` already discards the staged step when we return before `Commit`, so the fix is just "check rows-affected, don't commit on 0." The fake-path reorder is the only subtlety — it lacks a transaction, so it resolves-then-inserts rather than insert-then-resolve.
</details>

Review cycles: 1 (self-review; the implementing agent's run was interrupted post-tests, so the commit/PR was completed by the coordinator after re-verifying build + `-race` tests). CLAUDE.md: no update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop