### PR TITLE
fix(plugin): quiesce trigger ingress before drain and join OAuth scanners on shutdown (#500)

### DIFF
--- a/internal/plugin/oauth/scanner.go
+++ b/internal/plugin/oauth/scanner.go
@@ -47,8 +47,20 @@ func NewRefreshScanner(store *DBStore, q ScannerQuerier, getPublicURL func() str
 // Start launches the background refresh goroutine. It runs until ctx is
 // cancelled and is designed to be called once at startup (analogous to
 // approvalScanner.Start).
+//
+// Prefer Run when the caller needs a join point on shutdown (it blocks until
+// ctx is cancelled and the in-flight scan finishes). Start is the fire-and-forget
+// variant retained for callers that do not join the goroutine.
 func (rs *RefreshScanner) Start(ctx context.Context) {
 	go rs.run(ctx)
+}
+
+// Run executes the refresh loop synchronously, returning only when ctx is
+// cancelled (after any in-flight scan tick completes). It is the blocking
+// counterpart to Start so a caller can own the goroutine and join it on
+// shutdown — see pluginruntime.go's bgWG wiring (#500).
+func (rs *RefreshScanner) Run(ctx context.Context) {
+	rs.run(ctx)
 }
 
 func (rs *RefreshScanner) run(ctx context.Context) {

--- a/internal/plugin/oauth/scanner_test.go
+++ b/internal/plugin/oauth/scanner_test.go
@@ -19,6 +19,37 @@ func (f *fakeScannerQuerier) ListPluginInstancesWithExpiringCredentials(_ contex
 	return f.rows, nil
 }
 
+// TestRefreshScanner_Run_ReturnsOnContextCancel proves Run (the blocking,
+// joinable variant added for #500) returns promptly once its context is
+// cancelled. pluginruntime.go relies on this so shutdown() can join the
+// scanner goroutine via bgWG instead of abandoning it mid-refresh.
+func TestRefreshScanner_Run_ReturnsOnContextCancel(t *testing.T) {
+	clock := func() time.Time { return time.Unix(1000000, 0) }
+	q := &fakeOAuthQuerier{}
+	store := NewDBStore(q, noopEncrypt, noopDecrypt, q, clock)
+	sq := &fakeScannerQuerier{rows: nil}
+	// Long interval so the loop is parked in its select on ctx.Done() rather
+	// than mid-scan — exactly the steady state shutdown must unblock.
+	scanner := NewRefreshScanner(store, sq, func() string { return "" }, time.Hour, 15*time.Minute)
+	scanner.timeNow = clock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	returned := make(chan struct{})
+	go func() {
+		scanner.Run(ctx)
+		close(returned)
+	}()
+
+	cancel()
+
+	select {
+	case <-returned:
+		// Run observed the cancellation and exited — the join point works.
+	case <-time.After(2 * time.Second):
+		t.Fatal("RefreshScanner.Run did not return within 2s of context cancellation")
+	}
+}
+
 func TestRefreshScanner_NoRows_NoPanic(t *testing.T) {
 	baseTime := time.Unix(1000000, 0)
 	clock := func() time.Time { return baseTime }

--- a/internal/plugin/trigger/supervisor_test.go
+++ b/internal/plugin/trigger/supervisor_test.go
@@ -392,6 +392,59 @@ func TestSupervisor_ContextCancel(t *testing.T) {
 	}
 }
 
+// TestSupervisor_StopAll_JoinsWithoutRootCancel proves StopAll synchronously
+// cancels and joins a live stream goroutine WITHOUT a prior rootCtx cancel.
+//
+// This is the exact contract the shutdown quiesce relies on (#500): main.go
+// calls TriggerSupervisor.StopAll() before the run-drain wait while the root
+// ctx may still be effectively live for in-flight work. StopAll must drive the
+// goroutine to exit on its own (via the per-stream child ctx) and block until
+// it has, so no further RunLauncher.Launch can land after StopAll returns.
+func TestSupervisor_StopAll_JoinsWithoutRootCancel(t *testing.T) {
+	t.Parallel()
+
+	srv := &blockingServer{}
+	client, stop := startFakeTriggerServer(t, srv)
+	defer stop()
+
+	lookup := &fakeInstanceLookup{client: client, pluginID: "test-plugin"}
+	dispatcher := &fakeEventDispatcher{}
+	q := &supQuerier{}
+
+	// RootCtx stays live for the whole test — we never cancel it. StopAll alone
+	// must drive the goroutine to exit.
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+
+	sup := plugintrigger.NewSupervisor(plugintrigger.Config{
+		Querier:             q,
+		BackoffInitial:      time.Microsecond,
+		BackoffMax:          time.Millisecond,
+		UnhealthyAfter:      3,
+		TestInstanceLookup:  lookup,
+		TestEventDispatcher: dispatcher,
+		RootCtx:             rootCtx,
+	})
+
+	sup.Start(context.Background(), "inst-1")
+
+	// Let the goroutine reach stream.Recv (blocked in blockingServer).
+	time.Sleep(30 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		sup.StopAll()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// StopAll returned only after the goroutine exited — quiesce works.
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopAll did not join the stream goroutine within 5s (no rootCtx cancel)")
+	}
+}
+
 // TestSupervisor_UnhealthyAfterConsecutiveFailures verifies that the health
 // setter is called with Unhealthy after UnhealthyAfter consecutive EOF streams.
 func TestSupervisor_UnhealthyAfterConsecutiveFailures(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -476,6 +476,17 @@ func run(cfg config.Config) error {
 	// this does NOT cancel in-flight agent runs — CancelAll handles that below.
 	cancel()
 
+	// Quiesce plugin trigger ingress BEFORE draining runs. cancel() above only
+	// signals the supervisor's stream goroutines cooperatively; a goroutine could
+	// still pass its ctx check and reach RunLauncher.Launch — which does the
+	// RunManager wg.Add — after runManager.Wait() returns below. That add-after-Wait
+	// leaves the run unawaited and racing dispatch-pool teardown. quiesceTriggers
+	// calls TriggerSupervisor.StopAll(), which synchronously cancels and joins every
+	// stream goroutine, so no new Launch can land once it returns. Doing this before
+	// CancelAll means any run that does land during the quiesce window is still
+	// cancelled by CancelAll and awaited by the drain below (#500). No-op when rt is nil.
+	rt.quiesceTriggers()
+
 	// Signal all in-flight agent runs to stop.
 	runManager.CancelAll()
 

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/admin"
@@ -89,6 +90,13 @@ type pluginRuntime struct {
 	// loader is the Loader constructed by startPluginRuntime. run() reads
 	// Manager() and Installer() from it.
 	loader *pluginpkg.Loader
+
+	// bgWG joins the long-lived OAuth background goroutines (nonce janitor +
+	// refresh scanner) so shutdown() can wait for them to exit rather than
+	// abandoning them mid-DB-write. Both goroutines are parented to the root
+	// ctx; shutdown() relies on main.go having cancelled that ctx first, then
+	// joins bgWG under a bounded deadline (#500).
+	bgWG sync.WaitGroup
 }
 
 // Manager returns the process.Manager started by the Loader. Callers that
@@ -230,7 +238,14 @@ func startPluginRuntime(
 		dec := func(c string) (string, error) { return admin.Decrypt(encryptionKey, c) }
 		oauthStore := pluginoauth.NewDBStore(store.Queries(), enc, dec, store.Queries(), time.Now)
 		oauthNonces := pluginoauth.NewDBNonceStore(store.Queries(), time.Now)
-		go oauthNonces.StartJanitor(ctx, time.Minute)
+		// Own the janitor goroutine under bgWG so shutdown() can join it rather
+		// than abandoning a mid-Prune DB write (#500). The janitor selects on
+		// ctx.Done() and returns promptly once the root ctx is cancelled.
+		rt.bgWG.Add(1)
+		go func() {
+			defer rt.bgWG.Done()
+			oauthNonces.StartJanitor(ctx, time.Minute)
+		}()
 		oauthHMACKey := pluginoauth.DeriveHMACKey(encryptionKey)
 		getPublicURL := func() string {
 			u, _ := systemSettings.GetPublicURL(context.Background())
@@ -243,7 +258,15 @@ func startPluginRuntime(
 			cfg.OAuthRefreshInterval,
 			cfg.OAuthRefreshLead,
 		)
-		oauthScanner.Start(ctx)
+		// Own the refresh-scanner goroutine under bgWG (same rationale as the
+		// janitor above): Run blocks until ctx is cancelled, after the in-flight
+		// scan tick finishes, so shutdown() can join it instead of racing a
+		// mid-refresh token write (#500).
+		rt.bgWG.Add(1)
+		go func() {
+			defer rt.bgWG.Done()
+			oauthScanner.Run(ctx)
+		}()
 		rt.OAuthHandler = admin.NewPluginOAuthHandler(store.Queries(), oauthMgr, getPublicURL)
 		rt.CredentialsHandler = admin.NewPluginCredentialsHandler(store.Queries(), oauthStore)
 
@@ -306,9 +329,51 @@ func (rt *pluginRuntime) wireTriggerSupervisor(
 	}()
 }
 
-// shutdown stops the trigger supervisor, the plugin manager subprocesses, and
-// finally the dispatch pool, in that order. This order matches the original
-// main.go shutdown sequence and must be preserved.
+// quiesceTriggers stops every avenue by which a plugin trigger event can reach
+// RunLauncher.Launch, synchronously, and MUST be called before the run-drain
+// wait in main.go.
+//
+// Why before the drain: a trigger event that reaches Launch registers the run
+// with RunManager (wg.Add) only inside the call. An event arriving at Launch
+// AFTER runManager.Wait() returns but BEFORE trigger ingress is stopped is a
+// WaitGroup add-after-Wait: that run is never awaited and races teardown of the
+// dispatch pool it depends on. The root ctx cancel only *signals* goroutines
+// cooperatively — it does not close the window atomically.
+//
+// There are two trigger-event ingresses, and this closes both:
+//
+//  1. The supervisor's per-instance Start streams. StopAll cancels each stream's
+//     child ctx and joins (<-doneCh) every goroutine, so once it returns no
+//     stream goroutine is alive to call Launch.
+//
+//  2. The substrate-initiated hostsvc.EmitEvent RPC (e.g. Slack Socket Mode),
+//     which forwards to the trigger Dispatcher via the trigger sink. Clearing
+//     the sink (SetTriggerSink(nil)) makes EmitEvent fall through to its
+//     publisher-only (SSE) path so it no longer reaches Launch. SetTriggerSink
+//     is RWMutex-guarded and safe to call concurrently with EmitEvent; at most
+//     one EmitEvent that already read a non-nil sink can still be mid-Launch,
+//     which is the same bounded-Launch property as case 1 (Launch returns after
+//     registering + spawning the agent goroutine; it does not block on the run).
+//
+// quiesceTriggers is a no-op when rt is nil, tolerates a nil supervisor / nil
+// HostSvc, and is safe to call more than once (StopAll on the now-empty instance
+// map is a no-op; clearing an already-nil sink is a no-op) (#500).
+func (rt *pluginRuntime) quiesceTriggers() {
+	if rt == nil {
+		return
+	}
+	// Clear the EmitEvent → Dispatcher sink first so no new substrate event can
+	// be forwarded to Launch while we are joining the stream goroutines.
+	if rt.HostSvc != nil {
+		rt.HostSvc.SetTriggerSink(nil)
+	}
+	if rt.TriggerSupervisor != nil {
+		rt.TriggerSupervisor.StopAll()
+	}
+}
+
+// shutdown stops the trigger supervisor, joins the OAuth background goroutines,
+// the plugin manager subprocesses, and finally the dispatch pool, in that order.
 //
 // shutdown is a no-op when rt is nil.
 func (rt *pluginRuntime) shutdown() {
@@ -317,8 +382,27 @@ func (rt *pluginRuntime) shutdown() {
 	}
 
 	// Stop trigger stream goroutines before tearing down plugin subprocesses.
+	// Normally main.go has already called quiesceTriggers before the drain wait;
+	// this call is the idempotent backstop (StopAll on an empty map is a no-op)
+	// for any path that shuts the runtime down without a prior quiesce.
 	if rt.TriggerSupervisor != nil {
 		rt.TriggerSupervisor.StopAll()
+	}
+
+	// Join the OAuth background goroutines (nonce janitor + refresh scanner). The
+	// root ctx was cancelled in main.go before shutdown() runs, so both loops have
+	// already been signalled to exit; this join just confirms they have returned
+	// rather than abandoning them mid-DB-write. Bound the wait so a goroutine stuck
+	// inside an in-flight DB call cannot hang shutdown indefinitely.
+	bgDone := make(chan struct{})
+	go func() {
+		rt.bgWG.Wait()
+		close(bgDone)
+	}()
+	select {
+	case <-bgDone:
+	case <-time.After(5 * time.Second):
+		slog.Warn("plugin OAuth background goroutines did not exit within 5s; proceeding with shutdown")
 	}
 
 	// Stop all plugin subprocesses before closing the dispatch pool. This order


### PR DESCRIPTION
## Summary

Fixes two distinct shutdown-lifecycle gaps in the plugin runtime (issue #500): a drain-ordering race that could leave a trigger-fired run unawaited, and two OAuth background goroutines that shutdown never joined.

### Fix 1 — quiesce trigger ingress *before* the drain wait (add-after-Wait race)

Before this change the shutdown sequence was:

```
cancel()                                  // only *signals* supervisor stream goroutines
runManager.CancelAll()
go { poller.Wait(); cronRunner.Wait(); runManager.Wait(); close(runsDrained) }
select { runsDrained | DrainTimeout }     // drain wait
rt.shutdown()                             // StopAll() ran HERE, after the drain
```

`cancel()` only signals the trigger supervisor's stream goroutines cooperatively. A goroutine blocked in `triggerDispatcher.Handle → RunLauncher.Launch` could pass its ctx check and reach `Launch` — which does the `RunManager` `wg.Add` — **after** `runManager.Wait()` returned but **before** `StopAll()` ran. That is a `WaitGroup` add-after-Wait: the run is never awaited and races teardown of the dispatch pool it needs.

The fix introduces `rt.quiesceTriggers()`, called **before** the drain wait, which closes **both** trigger-event ingresses:

1. **Supervisor Start streams** — `TriggerSupervisor.StopAll()` is synchronous: it cancels each stream's child ctx and joins (`<-doneCh`) every goroutine. Once it returns, no stream goroutine is alive to call `Launch`.
2. **Substrate-initiated `hostsvc.EmitEvent`** (e.g. Slack Socket Mode) — discovered during adversarial review as a *second* `Launch` ingress that `StopAll` does not cover. `SetTriggerSink(nil)` makes `EmitEvent` fall through to its publisher-only (SSE) path so it no longer reaches `Launch`. `SetTriggerSink` is RWMutex-guarded and explicitly safe to call concurrently with `EmitEvent`.

New ordering:

```
cancel()
rt.quiesceTriggers()      // NEW: clear EmitEvent sink + StopAll (sync join)
runManager.CancelAll()
... drain wait ...
rt.shutdown()             // StopAll is now an idempotent backstop
```

`quiesceTriggers` runs **before** `CancelAll` so any run that does land during the (bounded) quiesce window is still cancelled by `CancelAll` and awaited by the drain.

### Fix 2 — join the OAuth janitor + refresh scanner on shutdown

The nonce janitor (`go oauthNonces.StartJanitor`) and refresh scanner (`oauthScanner.Start(ctx)`) were parented to the root ctx with **no** join point — shutdown could return while they were mid-DB-write.

**Decision: join, not fire-and-forget.** Both loops `select` on `ctx.Done()` and do work only on a ticker tick, so they return promptly once the root ctx is cancelled — joining is cheap and the join is not invasive (a single `WaitGroup`), so per the issue's stated preference I added the join rather than documenting them as droppable. Both goroutines are now owned under a new `pluginRuntime.bgWG`; `shutdown()` joins it under a **bounded 5s deadline** so a goroutine stuck inside an in-flight DB call cannot hang shutdown. Added a blocking `RefreshScanner.Run` as the joinable counterpart to the fire-and-forget `Start` (existing `Start` callers unchanged).

The root ctx is cancelled in `main.go` *before* `rt.shutdown()`, so by the time the join runs both loops have already been signalled — the join just confirms exit.

<details>
<summary>Plan + adversarial review</summary>

**Mapped current ordering** in `main.go` (~471-512) and `pluginruntime.go` (`shutdown`), confirmed `TriggerSupervisor.StopAll()` is a synchronous cancel-and-join (`supervisor.go`), and that `RunLauncher.Launch` registers the run + spawns the agent goroutine and **returns immediately** (does not block on `ba.Run`).

**Adversarial findings addressed:**
- *Does quiescing first introduce a new deadlock?* No. `StopAll` blocks at most one `Launch` duration (bounded DB writes + agent construction); `Launch` does not wait on any drain primitive → no cycle.
- *Second Launch ingress?* Yes — `hostsvc.EmitEvent → SinkAdapter → Dispatcher → Launch`. `StopAll` alone would not close it; added `SetTriggerSink(nil)`.
- *Can the OAuth join hang shutdown?* Bounded with a 5s `select` against the join, on top of the ctx-driven exit — a stuck DB call cannot hang shutdown indefinitely.
- *`GLEIPNIR_DRAIN_TIMEOUT` respected?* Yes — quiesce runs before the drain `select { runsDrained | DrainTimeout }`; the timeout still bounds the in-flight-run wait.
- *poller/cron same risk?* Their `Wait()` blocks on their own WaitGroup wrapping the launch-issuing loop, awaited before `runManager.Wait()` — already safe; out of scope.

</details>

## Review cycles

Two inline code-review passes. Cycle 1 confirmed the WaitGroup/ctx discipline and the bounded join. Cycle 2 caught the second `Launch` ingress (`hostsvc.EmitEvent`) and extended `quiesceTriggers` to clear the trigger sink, then verified `SetTriggerSink` concurrency-safety and the clear-sink-before-StopAll ordering.

## Tests — what's covered / not

**Added:**
- `TestSupervisor_StopAll_JoinsWithoutRootCancel` — proves `StopAll` synchronously cancels and joins a *live* stream goroutine **without** a prior rootCtx cancel (the exact contract the quiesce relies on; existing `TestSupervisor_ContextCancel` only covered StopAll *after* rootCtx cancel).
- `TestRefreshScanner_Run_ReturnsOnContextCancel` — proves the new joinable `Run` returns promptly on ctx cancellation.

**Not covered (noted, no silent gaps):** there is no unit-test harness for the full `main.go` drain sequence or `pluginRuntime.shutdown()` end-to-end (it wires the real loader/manager/DB). The new ordering is exercised indirectly via the two primitives above plus the full `-race` suite; a full integration test of the shutdown sequence is impractical without a substantial harness.

## Test gate

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race -count=1 ./...` ✓ (exit 0; no FAIL, no DATA RACE, no panic)

## CLAUDE.md

No change needed: no new env var was added, and `GLEIPNIR_DRAIN_TIMEOUT`'s documented semantics are unchanged. The shutdown reordering is internal and not described in the architecture notes.

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
