### PR TITLE
refactor(timeout): replace approval-specific claim hook with OnTimeoutClaimed callback

### DIFF
--- a/internal/timeout/metrics.go
+++ b/internal/timeout/metrics.go
@@ -17,3 +17,14 @@ var approvalTimeoutsTotal = promauto.With(metrics.Registry()).NewCounter(
 		Help: "Count of approval requests that expired before a decision was made.",
 	},
 )
+
+// feedbackTimeoutsTotal counts feedback requests that expired before an operator
+// responded. Incremented right after the conditional claim succeeds, even if the
+// run was already interrupted — the feedback request itself timed out regardless
+// of subsequent run state.
+var feedbackTimeoutsTotal = promauto.With(metrics.Registry()).NewCounter(
+	prometheus.CounterOpts{
+		Name: "gleipnir_feedback_timeouts_total",
+		Help: "Count of feedback requests that expired before a response was received.",
+	},
+)

--- a/internal/timeout/scanner.go
+++ b/internal/timeout/scanner.go
@@ -64,13 +64,14 @@ type Config struct {
 	// key names differ between domains ("approval_id" vs "feedback_id").
 	SSEPayload func(id string, runID string) map[string]string
 
-	// OnClaimed is an optional hook invoked once per successfully-claimed
+	// OnTimeoutClaimed is an optional hook invoked once per successfully-claimed
 	// timeout, after the conditional UPDATE wins and before downstream run
 	// side-effects (which may be skipped if the run already left the waiting
-	// state). The approval scanner uses this to increment its prometheus
-	// counter so the metric reflects approvals that genuinely timed out,
-	// independent of the run's eventual disposition.
-	OnClaimed func()
+	// state). The approval and feedback scanners use this to increment their
+	// respective prometheus counters so the metric reflects requests that
+	// genuinely timed out, independent of the run's eventual disposition. Nil
+	// is treated as a no-op.
+	OnTimeoutClaimed func(ctx context.Context)
 }
 
 // NewApprovalScanner creates a Scanner that checks for expired approval requests
@@ -110,7 +111,7 @@ func NewApprovalScanner(store *db.Store, interval time.Duration, opts ...Scanner
 				"status":      string(model.ApprovalStatusTimeout),
 			}
 		},
-		OnClaimed: approvalTimeoutsTotal.Inc,
+		OnTimeoutClaimed: func(ctx context.Context) { approvalTimeoutsTotal.Inc() },
 	}
 	return NewScanner(store, interval, cfg, opts...)
 }
@@ -153,6 +154,7 @@ func NewFeedbackScanner(store *db.Store, interval time.Duration, opts ...Scanner
 				"status":      "timed_out",
 			}
 		},
+		OnTimeoutClaimed: func(ctx context.Context) { feedbackTimeoutsTotal.Inc() },
 	}
 	return NewScanner(store, interval, cfg, opts...)
 }
@@ -305,11 +307,11 @@ func (s *Scanner) resolveTimeout(ctx context.Context, item ExpiredItem) error {
 		return nil
 	}
 
-	// Invoke the post-claim hook (e.g. the approval scanner increments its
-	// prometheus counter here) even if the run was already moved out of the
-	// waiting status — the request itself genuinely timed out.
-	if s.cfg.OnClaimed != nil {
-		s.cfg.OnClaimed()
+	// Invoke the post-claim hook (e.g. the approval/feedback scanners increment
+	// their prometheus counters here) even if the run was already moved out of
+	// the waiting status — the request itself genuinely timed out.
+	if s.cfg.OnTimeoutClaimed != nil {
+		s.cfg.OnTimeoutClaimed(ctx)
 	}
 
 	// Check whether the run is still waiting. ScanOrphanedRuns may have already

--- a/internal/timeout/scanner_test.go
+++ b/internal/timeout/scanner_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -220,6 +221,44 @@ func TestScanner_AlreadyDecided_NotReprocessed(t *testing.T) {
 	}
 	if status != "approved" {
 		t.Errorf("approval status = %q, want approved (must not be re-processed)", status)
+	}
+}
+
+func TestScanner_OnTimeoutClaimed_InvokedOncePerClaim(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusWaitingForApproval)
+	testutil.InsertRun(t, s, "r2", "p1", model.RunStatusWaitingForApproval)
+	// Two expired (claimable) and one not-yet-expired (must not fire the hook).
+	insertApprovalRequest(t, s, "a1", "r1", "tool_a", pastTimestamp())
+	insertApprovalRequest(t, s, "a2", "r2", "tool_b", pastTimestamp())
+	insertApprovalRequest(t, s, "a3", "r1", "tool_c", futureTimestamp())
+
+	var calls atomic.Int64
+	cfg := approvalConfig(s)
+	cfg.OnTimeoutClaimed = func(ctx context.Context) {
+		if ctx == nil {
+			t.Error("OnTimeoutClaimed received a nil context")
+		}
+		calls.Add(1)
+	}
+
+	scanner := timeout.NewScanner(s, time.Minute, cfg)
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("OnTimeoutClaimed invoked %d times, want 2 (one per claimed timeout)", got)
+	}
+
+	// A second scan must not re-invoke the hook: both expired items are already
+	// claimed (status='timeout'), so ListExpired returns nothing claimable.
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("second Scan: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("OnTimeoutClaimed invoked %d times after re-scan, want 2 (no double-count)", got)
 	}
 }
 


### PR DESCRIPTION
Closes #142.

## Summary

`internal/timeout/scanner.go`'s post-claim hook was approval-specific, so feedback timeouts were invisible to Prometheus and the "generic scan-and-resolve loop" abstraction leaked domain knowledge. This generalizes the hook into `OnTimeoutClaimed func(ctx context.Context)` and wires a dedicated feedback counter.

## Acceptance criteria

- **`timeout.Config` exposes `OnTimeoutClaimed func(ctx context.Context)`; nil is a no-op** — field renamed/re-signatured from `OnClaimed func()`; `resolveTimeout` guards with `if s.cfg.OnTimeoutClaimed != nil` before calling.
- **`scanner.go` contains no string match on `cfg.Name`** — verified via grep; `cfg.Name` is used only for log labels and error-wrap context, never for behavioral branching.
- **Approval timeout metric continues to fire** — `NewApprovalScanner` passes `func(ctx context.Context) { approvalTimeoutsTotal.Inc() }`; existing approval scanner tests still pass.
- **New `feedbackTimeoutsTotal` counter registered and incremented on feedback timeout** — registered in `internal/timeout/metrics.go` alongside `approvalTimeoutsTotal` via the same `promauto.With(metrics.Registry())` pattern (custom registry, ADR-037); `NewFeedbackScanner` passes `func(ctx context.Context) { feedbackTimeoutsTotal.Inc() }`.
- **Test added: fake `OnTimeoutClaimed` invoked exactly once per claimed timeout** — `TestScanner_OnTimeoutClaimed_InvokedOncePerClaim` inserts two expired + one future approval, asserts the hook fires exactly twice, and re-scans to assert no double-count for already-claimed rows. Uses the synchronous `Scan` entry point (no wall-clock sleeps).

## Notes

`main.go` is unchanged: it constructs scanners only via `NewApprovalScanner` / `NewFeedbackScanner`, which wire their counters internally.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)