### PR TITLE
refactor(trigger): funnel poll, cron, scheduled through shared launch helper

### DIFF
--- a/internal/trigger/cron.go
+++ b/internal/trigger/cron.go
@@ -283,52 +283,12 @@ func (c *CronRunner) fire(ctx context.Context, policyID string, parsed *model.Pa
 		"expression":    parsed.Trigger.CronExpr,
 	})
 
-	if err := c.launcher.CheckConcurrency(ctx, policyID, parsed.Agent.Concurrency); err != nil {
-		switch {
-		case errors.Is(err, run.ErrConcurrencySkipActive):
-			slog.Info("cron: skipping fire, active run exists (concurrency: skip)",
-				"policy_id", policyID, "fired_at", firedAt)
-		case errors.Is(err, run.ErrConcurrencyQueueActive):
-			if enqErr := c.launcher.Enqueue(ctx, run.LaunchParams{
-				PolicyID:       policyID,
-				TriggerType:    model.TriggerTypeCron,
-				TriggerPayload: string(payload),
-				ParsedPolicy:   parsed,
-			}, parsed.Agent.QueueDepth); enqErr != nil {
-				if errors.Is(enqErr, run.ErrConcurrencyQueueFull) {
-					slog.Warn("cron: trigger queue is full", "policy_id", policyID, "fired_at", firedAt)
-				} else {
-					slog.Error("cron: failed to enqueue trigger", "policy_id", policyID, "fired_at", firedAt, "err", enqErr)
-				}
-			} else {
-				slog.Info("cron: trigger queued (active run exists)", "policy_id", policyID, "fired_at", firedAt)
-			}
-		default:
-			slog.Error("cron: concurrency check failed", "policy_id", policyID, "err", err)
-		}
-		return
-	}
-
-	result, err := c.launcher.Launch(ctx, run.LaunchParams{
+	launchOrQueueBackground(ctx, c.launcher, run.LaunchParams{
 		PolicyID:       policyID,
 		TriggerType:    model.TriggerTypeCron,
 		TriggerPayload: string(payload),
 		ParsedPolicy:   parsed,
-	})
-	if err != nil {
-		// run_id is populated when the failure happened after the row was
-		// created (tool resolution, agent construction). Operators can use it
-		// to find the failed run in history, where the recorded error lives.
-		slog.Error("cron: failed to launch run",
-			"policy_id", policyID,
-			"run_id", result.RunID,
-			"fired_at", firedAt,
-			"err", err,
-		)
-		return
-	}
-
-	slog.Info("cron: run launched", "run_id", result.RunID, "policy_id", policyID, "fired_at", firedAt)
+	}, parsed.Agent.Concurrency, parsed.Agent.QueueDepth, "cron", "fired_at", firedAt)
 }
 
 // Wait blocks until all active cron goroutines have exited. Call after cancelling

--- a/internal/trigger/launch.go
+++ b/internal/trigger/launch.go
@@ -120,3 +120,82 @@ func checkConcurrencyAndLaunch(
 
 	httputil.WriteJSON(w, http.StatusAccepted, map[string]string{"run_id": result.RunID})
 }
+
+// launchOutcome reports what launchOrQueueBackground did so background callers
+// can take follow-up action (e.g. the scheduler auto-pausing a policy whose
+// fire time was consumed by a skip, enqueue, or launch).
+type launchOutcome int
+
+const (
+	// outcomeSkipped: an active run exists and concurrency is "skip" — the
+	// trigger was dropped. The fire time is considered consumed.
+	outcomeSkipped launchOutcome = iota
+	// outcomeQueued: an active run exists and concurrency is "queue" — the
+	// trigger was enqueued for later. The fire time is considered consumed.
+	outcomeQueued
+	// outcomeLaunched: the run was launched immediately.
+	outcomeLaunched
+	// outcomeError: concurrency check, enqueue, or launch failed; the run did
+	// not start and was not queued. The error was already logged.
+	outcomeError
+)
+
+// launchOrQueueBackground mirrors checkConcurrencyAndLaunch for background
+// triggers (poll, cron, scheduled) that have no http.ResponseWriter: it enforces
+// the concurrency policy, enqueues or launches a run, logs the result with the
+// given logPrefix ("poller"/"cron"/"scheduled"), and returns a structured
+// outcome so callers can react. logAttrs are appended to every log line emitted
+// here so per-trigger context (e.g. "fired_at"/"fire_at") is preserved.
+func launchOrQueueBackground(
+	ctx context.Context,
+	launcher *run.RunLauncher,
+	params run.LaunchParams,
+	concurrency model.ConcurrencyPolicy,
+	queueDepth int,
+	logPrefix string,
+	logAttrs ...any,
+) launchOutcome {
+	// withAttrs prepends "policy_id" then appends the caller's extra attrs so
+	// every log line carries consistent correlation fields.
+	withAttrs := func(extra ...any) []any {
+		attrs := make([]any, 0, 2+len(logAttrs)+len(extra))
+		attrs = append(attrs, "policy_id", params.PolicyID)
+		attrs = append(attrs, logAttrs...)
+		attrs = append(attrs, extra...)
+		return attrs
+	}
+
+	if err := launcher.CheckConcurrency(ctx, params.PolicyID, concurrency); err != nil {
+		switch {
+		case errors.Is(err, run.ErrConcurrencySkipActive):
+			slog.Info(logPrefix+": skipping run, active run exists (concurrency: skip)", withAttrs()...)
+			return outcomeSkipped
+		case errors.Is(err, run.ErrConcurrencyQueueActive):
+			if enqErr := launcher.Enqueue(ctx, params, queueDepth); enqErr != nil {
+				if errors.Is(enqErr, run.ErrConcurrencyQueueFull) {
+					slog.Warn(logPrefix+": trigger queue is full", withAttrs()...)
+				} else {
+					slog.Error(logPrefix+": failed to enqueue trigger", withAttrs("err", enqErr)...)
+				}
+				return outcomeError
+			}
+			slog.Info(logPrefix+": trigger queued (active run exists)", withAttrs()...)
+			return outcomeQueued
+		default:
+			slog.Error(logPrefix+": concurrency check failed", withAttrs("err", err)...)
+			return outcomeError
+		}
+	}
+
+	result, err := launcher.Launch(ctx, params)
+	if err != nil {
+		// run_id is populated when the failure happened after the row was
+		// created (tool resolution, agent construction). Operators can use it
+		// to find the failed run in history, where the recorded error lives.
+		slog.Error(logPrefix+": failed to launch run", withAttrs("run_id", result.RunID, "err", err)...)
+		return outcomeError
+	}
+
+	slog.Info(logPrefix+": run launched", withAttrs("run_id", result.RunID)...)
+	return outcomeLaunched
+}

--- a/internal/trigger/poll.go
+++ b/internal/trigger/poll.go
@@ -317,52 +317,12 @@ func (p *Poller) poll(ctx context.Context, policyID string, parsed *model.Parsed
 	// Checks matched — enforce concurrency policy, then launch or queue a run.
 	payload := buildTriggerPayload(checks, results)
 
-	if err := p.launcher.CheckConcurrency(ctx, policyID, parsed.Agent.Concurrency); err != nil {
-		switch {
-		case errors.Is(err, run.ErrConcurrencySkipActive):
-			slog.Info("poller: skipping run, active run exists (concurrency: skip)", "policy_id", policyID)
-			return
-		case errors.Is(err, run.ErrConcurrencyQueueActive):
-			if enqErr := p.launcher.Enqueue(ctx, run.LaunchParams{
-				PolicyID:       policyID,
-				TriggerType:    model.TriggerTypePoll,
-				TriggerPayload: payload,
-				ParsedPolicy:   parsed,
-			}, parsed.Agent.QueueDepth); enqErr != nil {
-				if errors.Is(enqErr, run.ErrConcurrencyQueueFull) {
-					slog.Warn("poller: trigger queue is full", "policy_id", policyID)
-				} else {
-					slog.Error("poller: failed to enqueue trigger", "policy_id", policyID, "err", enqErr)
-				}
-			} else {
-				slog.Info("poller: trigger queued (active run exists)", "policy_id", policyID)
-			}
-			return
-		default:
-			slog.Error("poller: concurrency check failed", "policy_id", policyID, "err", err)
-			return
-		}
-	}
-
-	launchResult, err := p.launcher.Launch(ctx, run.LaunchParams{
+	launchOrQueueBackground(ctx, p.launcher, run.LaunchParams{
 		PolicyID:       policyID,
 		TriggerType:    model.TriggerTypePoll,
 		TriggerPayload: payload,
 		ParsedPolicy:   parsed,
-	})
-	if err != nil {
-		// run_id is populated when the failure happened after the row was
-		// created (tool resolution, agent construction). Operators can use it
-		// to find the failed run in history, where the recorded error lives.
-		slog.Error("poller: failed to launch run",
-			"policy_id", policyID,
-			"run_id", launchResult.RunID,
-			"err", err,
-		)
-		return
-	}
-
-	slog.Info("poller: run launched", "run_id", launchResult.RunID, "policy_id", policyID)
+	}, parsed.Agent.Concurrency, parsed.Agent.QueueDepth, "poller")
 }
 
 // pollResultEntry is one item in the poll_results trigger payload array.

--- a/internal/trigger/scheduled.go
+++ b/internal/trigger/scheduled.go
@@ -194,68 +194,23 @@ func (s *Scheduler) fire(ctx context.Context, policyID string, parsed *model.Par
 
 	// Enforce concurrency policy before launching, consistent with webhook and
 	// manual triggers. All non-nil errors prevent the run from firing.
-	if err := s.launcher.CheckConcurrency(ctx, policyID, parsed.Agent.Concurrency); err != nil {
-		switch {
-		case errors.Is(err, run.ErrConcurrencySkipActive):
-			slog.Info("scheduled: skipping fire, active run exists (concurrency: skip)",
-				"policy_id", policyID, "fire_at", fireTime)
-			// The fire time was consumed (skipped); it will not be retried. Pause
-			// the policy if all fire_at times are now exhausted, just like the
-			// queue and successful-launch paths — otherwise the policy stays
-			// "active" forever with no future timers and never fires again (#488).
-			s.pauseIfExhausted(ctx, policyID, parsed)
-		case errors.Is(err, run.ErrConcurrencyQueueActive):
-			if enqErr := s.launcher.Enqueue(ctx, run.LaunchParams{
-				PolicyID:       policyID,
-				TriggerType:    model.TriggerTypeScheduled,
-				TriggerPayload: string(payload),
-				ParsedPolicy:   parsed,
-			}, parsed.Agent.QueueDepth); enqErr != nil {
-				if errors.Is(enqErr, run.ErrConcurrencyQueueFull) {
-					slog.Warn("scheduled: trigger queue is full",
-						"policy_id", policyID, "fire_at", fireTime)
-				} else {
-					slog.Error("scheduled: failed to enqueue trigger",
-						"policy_id", policyID, "fire_at", fireTime, "err", enqErr)
-				}
-			} else {
-				slog.Info("scheduled: trigger queued (active run exists)",
-					"policy_id", policyID, "fire_at", fireTime)
-				// The fire time was consumed (enqueued). Pause the policy if
-				// all fire_at times are now exhausted — DrainQueue calls Launch
-				// directly and does not invoke pauseIfExhausted.
-				s.pauseIfExhausted(ctx, policyID, parsed)
-			}
-		default:
-			slog.Error("scheduled: concurrency check failed",
-				"policy_id", policyID, "err", err)
-		}
-		return
-	}
-
-	result, err := s.launcher.Launch(ctx, run.LaunchParams{
+	outcome := launchOrQueueBackground(ctx, s.launcher, run.LaunchParams{
 		PolicyID:       policyID,
 		TriggerType:    model.TriggerTypeScheduled,
 		TriggerPayload: string(payload),
 		ParsedPolicy:   parsed,
-	})
-	if err != nil {
-		// run_id is populated when the failure happened after the row was
-		// created (tool resolution, agent construction). Operators can use it
-		// to find the failed run in history, where the recorded error lives.
-		slog.Error("scheduled: failed to launch run",
-			"policy_id", policyID,
-			"run_id", result.RunID,
-			"fire_at", fireTime,
-			"err", err,
-		)
-		return
+	}, parsed.Agent.Concurrency, parsed.Agent.QueueDepth, "scheduled", "fire_at", fireTime)
+
+	// The fire time is consumed whenever the trigger was skipped, queued, or
+	// launched — only a hard error (concurrency check, enqueue, or launch
+	// failure) leaves it unconsumed. Pause the policy if all fire_at times are
+	// now exhausted; otherwise a skip would strand it "active" forever with no
+	// future timers and it would never fire again (#488). DrainQueue calls
+	// Launch directly and does not invoke pauseIfExhausted, so the queued path
+	// must pause here too.
+	if outcome != outcomeError {
+		s.pauseIfExhausted(ctx, policyID, parsed)
 	}
-
-	slog.Info("scheduled: run launched", "run_id", result.RunID, "policy_id", policyID, "fire_at", fireTime)
-
-	// Pause policy if all fire times are now in the past.
-	s.pauseIfExhausted(ctx, policyID, parsed)
 }
 
 // alreadyFired returns true if a scheduled run already exists for this policy


### PR DESCRIPTION
## Summary

Poll, cron, and scheduled each inlined the same `CheckConcurrency` → queue-or-skip → launch switch with their own log-prefix variations and subtly different log messages. Any concurrency-semantics change had to be made in four places. This funnels all three through one shared helper, mirroring how `webhook.go` and `manual.go` already share `checkConcurrencyAndLaunch`.

The HTTP helper writes to an `http.ResponseWriter`, which background triggers don't have, so this adds a non-HTTP sibling `launchOrQueueBackground` in `launch.go` that logs + returns a structured outcome instead.

Closes #143. Stepping stone that de-risks the #144 / ADR-036 dispatcher refactor by consolidating the four concurrency call sites into one beforehand.

## How each acceptance criterion is met

- **Poll, cron, and scheduled call the shared helper (no inlined `CheckConcurrency` switch):** all three `fire`/`poll` bodies now call `launchOrQueueBackground`. `grep CheckConcurrency poll.go cron.go scheduled.go` returns nothing.
- **Existing concurrency tests pass with no semantic change:** `go test ./internal/trigger/...` passes unchanged. Scheduled's `pauseIfExhausted` is now driven by the returned `launchOutcome` (consumed on skip/queue/launch, not on error) — exactly reproducing the prior per-branch pause calls, including the #488 skip-path fix.
- **Per-trigger log identification preserved:** the helper takes a `logPrefix` (`"poller"`/`"cron"`/`"scheduled"`) prepended to every log line; cron/scheduled pass `fired_at`/`fire_at` as variadic `logAttrs`.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass

## Caveats / follow-ups

- Minor, intentional log-message normalization: cron and scheduled previously logged "skipping fire", now "skipping run" (unified with poll). No test asserts on log strings, and the trigger-type prefix still identifies the source. The default concurrency-check-failure log line for cron now also carries `fired_at` (strictly more context).
- The goroutine/reconcile scheduling machinery is deliberately untouched, per the issue — this PR funnels only the launch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)