### PR TITLE
refactor: extract crypto helpers to internal/infra/crypto (#141)

### DIFF
--- a/cmd/gleipnirctl/rotate.go
+++ b/cmd/gleipnirctl/rotate.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 )
 
 // Rotate re-encrypts all secrets under newKey. oldKey and newKey are already
@@ -122,11 +122,11 @@ func rotateWithDryRun(ctx context.Context, store *db.Store, oldKey, newKey []byt
 	}
 	for _, row := range apiKeyRows {
 		// plaintext cannot be zeroed (Go string is immutable); key bytes are zeroed by the caller
-		plaintext, err := admin.Decrypt(oldKey, row.Value)
+		plaintext, err := crypto.Decrypt(oldKey, row.Value)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("decrypt system_settings[%s]: %w", row.Key, err)
 		}
-		newCiphertext, err := admin.Encrypt(newKey, plaintext)
+		newCiphertext, err := crypto.Encrypt(newKey, plaintext)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("re-encrypt system_settings[%s]: %w", row.Key, err)
 		}
@@ -146,11 +146,11 @@ func rotateWithDryRun(ctx context.Context, store *db.Store, oldKey, newKey []byt
 		return 0, 0, 0, 0, fmt.Errorf("list openai-compat providers: %w", err)
 	}
 	for _, row := range compatRows {
-		plaintext, err := admin.Decrypt(oldKey, row.ApiKeyEncrypted)
+		plaintext, err := crypto.Decrypt(oldKey, row.ApiKeyEncrypted)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("decrypt openai_compat_providers id=%d name=%q: %w", row.ID, row.Name, err)
 		}
-		newCiphertext, err := admin.Encrypt(newKey, plaintext)
+		newCiphertext, err := crypto.Encrypt(newKey, plaintext)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("re-encrypt openai_compat_providers id=%d name=%q: %w", row.ID, row.Name, err)
 		}
@@ -175,11 +175,11 @@ func rotateWithDryRun(ctx context.Context, store *db.Store, oldKey, newKey []byt
 		if row.WebhookSecretEncrypted == nil {
 			continue
 		}
-		plaintext, err := admin.Decrypt(oldKey, *row.WebhookSecretEncrypted)
+		plaintext, err := crypto.Decrypt(oldKey, *row.WebhookSecretEncrypted)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("decrypt policies.webhook_secret_encrypted id=%s: %w", row.ID, err)
 		}
-		newCiphertext, err := admin.Encrypt(newKey, plaintext)
+		newCiphertext, err := crypto.Encrypt(newKey, plaintext)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("re-encrypt policies.webhook_secret_encrypted id=%s: %w", row.ID, err)
 		}
@@ -202,11 +202,11 @@ func rotateWithDryRun(ctx context.Context, store *db.Store, oldKey, newKey []byt
 		if row.AuthHeadersEncrypted == nil {
 			continue
 		}
-		plaintext, err := admin.Decrypt(oldKey, *row.AuthHeadersEncrypted)
+		plaintext, err := crypto.Decrypt(oldKey, *row.AuthHeadersEncrypted)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("decrypt mcp_servers.auth_headers_encrypted id=%s: %w", row.ID, err)
 		}
-		newCiphertext, err := admin.Encrypt(newKey, plaintext)
+		newCiphertext, err := crypto.Encrypt(newKey, plaintext)
 		if err != nil {
 			return 0, 0, 0, 0, fmt.Errorf("re-encrypt mcp_servers.auth_headers_encrypted id=%s: %w", row.ID, err)
 		}

--- a/cmd/gleipnirctl/rotate_test.go
+++ b/cmd/gleipnirctl/rotate_test.go
@@ -11,14 +11,14 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/testutil"
 )
 
 // mustKey parses a hex key or panics. Used only for test key constants.
 func mustKey(hex string) []byte {
-	k, err := admin.ParseEncryptionKey(hex)
+	k, err := crypto.ParseEncryptionKey(hex)
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +58,7 @@ func seedDB(t *testing.T, s *db.Store, encKey []byte) {
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	encryptWith := func(plaintext string) string {
-		c, err := admin.Encrypt(encKey, plaintext)
+		c, err := crypto.Encrypt(encKey, plaintext)
 		if err != nil {
 			t.Fatalf("encrypt %q: %v", plaintext, err)
 		}
@@ -205,10 +205,10 @@ func TestRotate_RoundTripsAllThreeSecretTypes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("get %s: %v", key, err)
 		}
-		if _, err := admin.Decrypt(newKey, row.Value); err != nil {
+		if _, err := crypto.Decrypt(newKey, row.Value); err != nil {
 			t.Errorf("%s: decrypt with new key failed: %v", key, err)
 		}
-		if _, err := admin.Decrypt(oldKey, row.Value); err == nil {
+		if _, err := crypto.Decrypt(oldKey, row.Value); err == nil {
 			t.Errorf("%s: old key should no longer decrypt ciphertext", key)
 		}
 	}
@@ -231,10 +231,10 @@ func TestRotate_RoundTripsAllThreeSecretTypes(t *testing.T) {
 		t.Fatalf("expected 2 compat rows, got %d", len(compatRows))
 	}
 	for _, row := range compatRows {
-		if _, err := admin.Decrypt(newKey, row.ApiKeyEncrypted); err != nil {
+		if _, err := crypto.Decrypt(newKey, row.ApiKeyEncrypted); err != nil {
 			t.Errorf("compat provider %q: decrypt with new key failed: %v", row.Name, err)
 		}
-		if _, err := admin.Decrypt(oldKey, row.ApiKeyEncrypted); err == nil {
+		if _, err := crypto.Decrypt(oldKey, row.ApiKeyEncrypted); err == nil {
 			t.Errorf("compat provider %q: old key should no longer decrypt ciphertext", row.Name)
 		}
 	}
@@ -251,10 +251,10 @@ func TestRotate_RoundTripsAllThreeSecretTypes(t *testing.T) {
 		if row.WebhookSecretEncrypted == nil {
 			t.Fatal("webhook_secret_encrypted is nil")
 		}
-		if _, err := admin.Decrypt(newKey, *row.WebhookSecretEncrypted); err != nil {
+		if _, err := crypto.Decrypt(newKey, *row.WebhookSecretEncrypted); err != nil {
 			t.Errorf("policy %s: decrypt webhook secret with new key failed: %v", row.ID, err)
 		}
-		if _, err := admin.Decrypt(oldKey, *row.WebhookSecretEncrypted); err == nil {
+		if _, err := crypto.Decrypt(oldKey, *row.WebhookSecretEncrypted); err == nil {
 			t.Errorf("policy %s: old key should no longer decrypt webhook secret", row.ID)
 		}
 	}
@@ -271,10 +271,10 @@ func TestRotate_RoundTripsAllThreeSecretTypes(t *testing.T) {
 		if row.AuthHeadersEncrypted == nil {
 			t.Fatal("auth_headers_encrypted is nil")
 		}
-		if _, err := admin.Decrypt(newKey, *row.AuthHeadersEncrypted); err != nil {
+		if _, err := crypto.Decrypt(newKey, *row.AuthHeadersEncrypted); err != nil {
 			t.Errorf("mcp server %s: decrypt auth headers with new key failed: %v", row.ID, err)
 		}
-		if _, err := admin.Decrypt(oldKey, *row.AuthHeadersEncrypted); err == nil {
+		if _, err := crypto.Decrypt(oldKey, *row.AuthHeadersEncrypted); err == nil {
 			t.Errorf("mcp server %s: old key should no longer decrypt auth headers", row.ID)
 		}
 	}
@@ -321,7 +321,7 @@ func TestRotate_DryRunRollsBack(t *testing.T) {
 		t.Fatalf("list api key settings after dry-run: %v", err)
 	}
 	for _, row := range afterRows {
-		if _, err := admin.Decrypt(oldKey, row.Value); err != nil {
+		if _, err := crypto.Decrypt(oldKey, row.Value); err != nil {
 			t.Errorf("%s: ciphertext changed after dry-run (should still decrypt with old key): %v", row.Key, err)
 		}
 		if origByKey[row.Key] != row.Value {
@@ -339,11 +339,11 @@ func TestRotate_WrongOldKeyFailsWithoutPartialWrites(t *testing.T) {
 
 	// Encrypt anthropic with keyA, openai with keyB — mixing keys so keyA alone
 	// cannot decrypt the openai row.
-	antCipher, err := admin.Encrypt(mustKey(keyA), "sk-ant-test")
+	antCipher, err := crypto.Encrypt(mustKey(keyA), "sk-ant-test")
 	if err != nil {
 		t.Fatalf("encrypt anthropic: %v", err)
 	}
-	openaiCipher, err := admin.Encrypt(mustKey(keyB), "sk-openai-test")
+	openaiCipher, err := crypto.Encrypt(mustKey(keyB), "sk-openai-test")
 	if err != nil {
 		t.Fatalf("encrypt openai: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestRotate_WrongOldKeyFailsWithoutPartialWrites(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get anthropic_api_key: %v", err)
 	}
-	if _, err := admin.Decrypt(mustKey(keyA), row.Value); err != nil {
+	if _, err := crypto.Decrypt(mustKey(keyA), row.Value); err != nil {
 		t.Errorf("anthropic_api_key should still decrypt with keyA after rollback: %v", err)
 	}
 }

--- a/cmd/gleipnirctl/rotatekey.go
+++ b/cmd/gleipnirctl/rotatekey.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 )
 
 const defaultDBPath = "/data/gleipnir.db"
@@ -83,13 +83,13 @@ func runRotateKey(cmd *cobra.Command, oldKeyFlag, newKeyFlag, dbPath string, dry
 		newKeyFlag = strings.TrimSpace(line)
 	}
 
-	oldKey, err := admin.ParseEncryptionKey(oldKeyFlag)
+	oldKey, err := crypto.ParseEncryptionKey(oldKeyFlag)
 	if err != nil {
 		return fmt.Errorf("parse --old key: %w", err)
 	}
 	defer zeroKey(oldKey)
 
-	newKey, err := admin.ParseEncryptionKey(newKeyFlag)
+	newKey, err := crypto.ParseEncryptionKey(newKeyFlag)
 	if err != nil {
 		return fmt.Errorf("parse --new key: %w", err)
 	}

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	"github.com/felag-engineering/gleipnir/internal/settings"
 )
@@ -84,10 +85,10 @@ func (h *Handler) ListProviders(w http.ResponseWriter, r *http.Request) {
 		ps := ProviderStatus{Name: name}
 		row, err := h.q.GetSystemSetting(ctx, name+"_api_key")
 		if err == nil {
-			decrypted, derr := Decrypt(h.encryptionKey, row.Value)
+			decrypted, derr := crypto.Decrypt(h.encryptionKey, row.Value)
 			if derr == nil {
 				ps.HasKey = true
-				ps.MaskedKey = MaskKey(decrypted)
+				ps.MaskedKey = crypto.MaskKey(decrypted)
 			}
 		}
 		statuses = append(statuses, ps)
@@ -123,7 +124,7 @@ func (h *Handler) SetProviderKey(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	encrypted, err := Encrypt(h.encryptionKey, body.Key)
+	encrypted, err := crypto.Encrypt(h.encryptionKey, body.Key)
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "encryption failed", "")
 		return

--- a/internal/admin/openai_compat_handler.go
+++ b/internal/admin/openai_compat_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	"github.com/felag-engineering/gleipnir/internal/llm/openaicompat"
 )
@@ -107,14 +108,14 @@ type providerResponse struct {
 
 func (h *OpenAICompatHandler) rowToResponse(row OpenAICompatRow) providerResponse {
 	// Decrypt error is intentionally swallowed: if the key is unreadable we
-	// still want to return a response — MaskKey("") produces an empty string,
+	// still want to return a response — crypto.MaskKey("") produces an empty string,
 	// which is a safe degraded value the UI can handle without crashing.
-	plain, _ := Decrypt(h.encKey, row.APIKeyEncrypted)
+	plain, _ := crypto.Decrypt(h.encKey, row.APIKeyEncrypted)
 	return providerResponse{
 		ID:                      row.ID,
 		Name:                    row.Name,
 		BaseURL:                 row.BaseURL,
-		MaskedKey:               MaskKey(plain),
+		MaskedKey:               crypto.MaskKey(plain),
 		ModelsEndpointAvailable: h.modelsAvail[row.Name],
 		CreatedAt:               row.CreatedAt,
 		UpdatedAt:               row.UpdatedAt,
@@ -238,7 +239,7 @@ func (h *OpenAICompatHandler) CreateProvider(w http.ResponseWriter, r *http.Requ
 			fmt.Sprintf("connection test failed: %v", err), "")
 		return
 	}
-	enc, err := Encrypt(h.encKey, body.APIKey)
+	enc, err := crypto.Encrypt(h.encKey, body.APIKey)
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "encryption failed", "")
 		return
@@ -308,7 +309,7 @@ func (h *OpenAICompatHandler) UpdateProvider(w http.ResponseWriter, r *http.Requ
 	var effectiveKey string
 	var newCiphertext string
 	if isMaskedKey(body.APIKey) || body.APIKey == "" {
-		plain, err := Decrypt(h.encKey, existing.APIKeyEncrypted)
+		plain, err := crypto.Decrypt(h.encKey, existing.APIKeyEncrypted)
 		if err != nil {
 			httputil.WriteError(w, http.StatusInternalServerError, "could not decrypt existing key", "")
 			return
@@ -317,7 +318,7 @@ func (h *OpenAICompatHandler) UpdateProvider(w http.ResponseWriter, r *http.Requ
 		newCiphertext = existing.APIKeyEncrypted
 	} else {
 		effectiveKey = body.APIKey
-		enc, err := Encrypt(h.encKey, body.APIKey)
+		enc, err := crypto.Encrypt(h.encKey, body.APIKey)
 		if err != nil {
 			httputil.WriteError(w, http.StatusInternalServerError, "encryption failed", "")
 			return
@@ -392,7 +393,7 @@ func (h *OpenAICompatHandler) TestProvider(w http.ResponseWriter, r *http.Reques
 		httputil.WriteError(w, http.StatusNotFound, "provider not found", "")
 		return
 	}
-	plain, err := Decrypt(h.encKey, existing.APIKeyEncrypted)
+	plain, err := crypto.Decrypt(h.encKey, existing.APIKeyEncrypted)
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "could not decrypt key", "")
 		return

--- a/internal/admin/openai_compat_handler_test.go
+++ b/internal/admin/openai_compat_handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 
@@ -294,7 +295,7 @@ func TestUpdate_NewKeyReencrypts(t *testing.T) {
 	if q.rows[1].APIKeyEncrypted == originalCiphertext {
 		t.Errorf("ciphertext should have changed")
 	}
-	plain, _ := Decrypt(testKey, q.rows[1].APIKeyEncrypted)
+	plain, _ := crypto.Decrypt(testKey, q.rows[1].APIKeyEncrypted)
 	if plain != "sk-new-key-xyz" {
 		t.Errorf("plaintext after decrypt: %q", plain)
 	}

--- a/internal/http/api/arcade_handler.go
+++ b/internal/http/api/arcade_handler.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/arcade"
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 )
 
@@ -260,7 +260,7 @@ func (h *ArcadeHandler) loadArcadeServer(ctx context.Context, id string) (db.Mcp
 		return db.McpServer{}, "", "", http.StatusInternalServerError, "missing required Arcade headers"
 	}
 
-	plaintext, err := admin.Decrypt(h.encKey, *server.AuthHeadersEncrypted)
+	plaintext, err := crypto.Decrypt(h.encKey, *server.AuthHeadersEncrypted)
 	if err != nil {
 		slog.Warn("failed to decrypt MCP server auth headers for Arcade handler",
 			"server_id", server.ID, "err", err)

--- a/internal/http/api/arcade_handler_test.go
+++ b/internal/http/api/arcade_handler_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/arcade"
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/api"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/testutil"
@@ -42,7 +42,7 @@ func encryptArcadeHeaders(t *testing.T, encKey []byte, headers []mcp.AuthHeader)
 	if err != nil {
 		t.Fatalf("MarshalAuthHeaders: %v", err)
 	}
-	ct, err := admin.Encrypt(encKey, string(raw))
+	ct, err := crypto.Encrypt(encKey, string(raw))
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}

--- a/internal/http/api/mcp_handler.go
+++ b/internal/http/api/mcp_handler.go
@@ -19,10 +19,10 @@ import (
 	"github.com/go-chi/chi/v5"
 	"gopkg.in/yaml.v3"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/arcade"
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/toolregistry"
@@ -104,7 +104,7 @@ func (h *MCPHandler) serverToResponse(s db.McpServer) mcpServerResponse {
 	keys := make([]string, 0)
 
 	if s.AuthHeadersEncrypted != nil && h.encKey != nil {
-		plaintext, err := admin.Decrypt(h.encKey, *s.AuthHeadersEncrypted)
+		plaintext, err := crypto.Decrypt(h.encKey, *s.AuthHeadersEncrypted)
 		if err != nil {
 			slog.Warn("failed to decrypt mcp server auth headers for response",
 				"server_id", s.ID, "err", err)
@@ -667,7 +667,7 @@ func (h *MCPHandler) decryptHeaders(server db.McpServer) ([]mcp.AuthHeader, erro
 	if h.encKey == nil {
 		return nil, fmt.Errorf("encryption key not configured")
 	}
-	plaintext, err := admin.Decrypt(h.encKey, *server.AuthHeadersEncrypted)
+	plaintext, err := crypto.Decrypt(h.encKey, *server.AuthHeadersEncrypted)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt: %w", err)
 	}
@@ -692,7 +692,7 @@ func (h *MCPHandler) encryptHeaders(headers []mcp.AuthHeader) (*string, int) {
 	if raw == nil {
 		return nil, 0
 	}
-	ct, err := admin.Encrypt(h.encKey, string(raw))
+	ct, err := crypto.Encrypt(h.encKey, string(raw))
 	if err != nil {
 		return nil, http.StatusInternalServerError
 	}

--- a/internal/http/api/mcp_handler_test.go
+++ b/internal/http/api/mcp_handler_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/api"
 	"github.com/felag-engineering/gleipnir/internal/http/auth"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/testutil"
@@ -1179,7 +1179,7 @@ func TestMCPSetToolEnabledHandler(t *testing.T) {
 // testEncKey returns a deterministic 32-byte key for handler tests.
 func testEncKey(t *testing.T) []byte {
 	t.Helper()
-	k, err := admin.ParseEncryptionKey("aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd")
+	k, err := crypto.ParseEncryptionKey("aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd")
 	if err != nil {
 		t.Fatalf("parse test key: %v", err)
 	}
@@ -1201,7 +1201,7 @@ func insertTestMCPServerWithHeaders(t *testing.T, s *db.Store, name, url string,
 		if err != nil {
 			t.Fatalf("marshal auth headers: %v", err)
 		}
-		ct, err := admin.Encrypt(encKey, string(raw))
+		ct, err := crypto.Encrypt(encKey, string(raw))
 		if err != nil {
 			t.Fatalf("encrypt auth headers: %v", err)
 		}
@@ -1259,7 +1259,7 @@ func TestMCPAuthHeaders_Create(t *testing.T) {
 			t.Fatal("auth_headers_encrypted is nil, want non-nil")
 		}
 		// Decrypt and verify value.
-		plaintext, err := admin.Decrypt(encKey, *rows[0].AuthHeadersEncrypted)
+		plaintext, err := crypto.Decrypt(encKey, *rows[0].AuthHeadersEncrypted)
 		if err != nil {
 			t.Fatalf("decrypt: %v", err)
 		}
@@ -1448,7 +1448,7 @@ func TestMCPAuthHeaders_Update(t *testing.T) {
 		if row.AuthHeadersEncrypted == nil {
 			t.Fatal("auth_headers_encrypted is nil after update — should have been preserved")
 		}
-		plaintext, err := admin.Decrypt(encKey, *row.AuthHeadersEncrypted)
+		plaintext, err := crypto.Decrypt(encKey, *row.AuthHeadersEncrypted)
 		if err != nil {
 			t.Fatalf("decrypt: %v", err)
 		}
@@ -1491,7 +1491,7 @@ func TestSetAuthHeader(t *testing.T) {
 		if row.AuthHeadersEncrypted == nil {
 			t.Fatal("auth_headers_encrypted is nil after set")
 		}
-		plaintext, _ := admin.Decrypt(encKey, *row.AuthHeadersEncrypted)
+		plaintext, _ := crypto.Decrypt(encKey, *row.AuthHeadersEncrypted)
 		headers, _ := mcp.UnmarshalAuthHeaders([]byte(plaintext))
 		if len(headers) != 1 || headers[0].Name != "x-api-key" || headers[0].Value != "sk-new" {
 			t.Errorf("headers = %+v, want [{x-api-key sk-new}]", headers)
@@ -1527,7 +1527,7 @@ func TestSetAuthHeader(t *testing.T) {
 		if err != nil {
 			t.Fatalf("get server: %v", err)
 		}
-		plaintext, _ := admin.Decrypt(encKey, *row.AuthHeadersEncrypted)
+		plaintext, _ := crypto.Decrypt(encKey, *row.AuthHeadersEncrypted)
 		headers, _ := mcp.UnmarshalAuthHeaders([]byte(plaintext))
 		// Must have exactly one header — no duplicates.
 		if len(headers) != 1 {
@@ -1642,7 +1642,7 @@ func TestDeleteAuthHeader(t *testing.T) {
 		if row.AuthHeadersEncrypted == nil {
 			t.Fatal("auth_headers_encrypted is nil — x-keep should still be stored")
 		}
-		plaintext, _ := admin.Decrypt(encKey, *row.AuthHeadersEncrypted)
+		plaintext, _ := crypto.Decrypt(encKey, *row.AuthHeadersEncrypted)
 		headers, _ := mcp.UnmarshalAuthHeaders([]byte(plaintext))
 		if len(headers) != 1 || headers[0].Name != "x-keep" {
 			t.Errorf("headers = %+v, want [{x-keep KEEP}]", headers)

--- a/internal/infra/crypto/crypto.go
+++ b/internal/infra/crypto/crypto.go
@@ -1,4 +1,11 @@
-package admin
+// Package crypto provides AES-256-GCM encryption helpers and encryption-key
+// parsing/masking utilities shared across packages that store secrets at rest
+// (provider API keys, webhook secrets, MCP auth headers, plugin credentials).
+//
+// These helpers are algorithm-agnostic and carry no admin-handler concerns;
+// they live in internal/infra so leaf packages (e.g. internal/mcp) can reuse
+// them without importing the higher-level internal/admin package (issue #141).
+package crypto
 
 import (
 	"crypto/aes"

--- a/internal/infra/crypto/crypto_test.go
+++ b/internal/infra/crypto/crypto_test.go
@@ -1,4 +1,4 @@
-package admin
+package crypto
 
 import (
 	"crypto/rand"

--- a/internal/llm/openaicompat/loader.go
+++ b/internal/llm/openaicompat/loader.go
@@ -23,9 +23,9 @@ type LoaderQuerier interface {
 }
 
 // DecryptFunc decrypts a ciphertext using the provided key. In production
-// main.go passes admin.Decrypt; in tests the loader_test file can pass its
-// own helper. Accepting it as a parameter avoids an import cycle between
-// internal/llm/openai and internal/admin.
+// main.go passes crypto.Decrypt; in tests the loader_test file can pass its
+// own helper. Accepting it as a parameter keeps the decryption strategy
+// injectable for tests without binding the loader to a concrete crypto helper.
 type DecryptFunc func(key []byte, encoded string) (string, error)
 
 // LoadAndRegister reads all rows from the querier, decrypts each API key

--- a/internal/llm/openaicompat/loader_test.go
+++ b/internal/llm/openaicompat/loader_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	"github.com/felag-engineering/gleipnir/internal/llm/openaicompat"
 )
@@ -22,7 +22,7 @@ func (f *fakeLoaderQuerier) ListOpenAICompatProvidersForLoader(ctx context.Conte
 func TestLoadAndRegister_NoRows(t *testing.T) {
 	reg := llm.NewProviderRegistry()
 	q := &fakeLoaderQuerier{}
-	if err := openaicompat.LoadAndRegister(context.Background(), q, []byte("01234567890123456789012345678901"), reg, admin.Decrypt); err != nil {
+	if err := openaicompat.LoadAndRegister(context.Background(), q, []byte("01234567890123456789012345678901"), reg, crypto.Decrypt); err != nil {
 		t.Fatalf("LoadAndRegister: %v", err)
 	}
 	if len(reg.Providers()) != 0 {
@@ -32,15 +32,15 @@ func TestLoadAndRegister_NoRows(t *testing.T) {
 
 func TestLoadAndRegister_MultipleRows(t *testing.T) {
 	key := []byte("01234567890123456789012345678901")
-	enc1, _ := admin.Encrypt(key, "sk-one")
-	enc2, _ := admin.Encrypt(key, "sk-two")
+	enc1, _ := crypto.Encrypt(key, "sk-one")
+	enc2, _ := crypto.Encrypt(key, "sk-two")
 
 	reg := llm.NewProviderRegistry()
 	q := &fakeLoaderQuerier{rows: []openaicompat.LoaderRow{
 		{Name: "openai", BaseURL: "https://api.openai.com/v1", APIKeyEncrypted: enc1},
 		{Name: "ollama-local", BaseURL: "http://ollama:11434/v1", APIKeyEncrypted: enc2},
 	}}
-	if err := openaicompat.LoadAndRegister(context.Background(), q, key, reg, admin.Decrypt); err != nil {
+	if err := openaicompat.LoadAndRegister(context.Background(), q, key, reg, crypto.Decrypt); err != nil {
 		t.Fatalf("LoadAndRegister: %v", err)
 	}
 	names := reg.Providers()
@@ -57,13 +57,13 @@ func TestLoadAndRegister_MultipleRows(t *testing.T) {
 
 func TestLoadAndRegister_CorruptCiphertextRowIsSkipped(t *testing.T) {
 	key := []byte("01234567890123456789012345678901")
-	enc, _ := admin.Encrypt(key, "sk-good")
+	enc, _ := crypto.Encrypt(key, "sk-good")
 	reg := llm.NewProviderRegistry()
 	q := &fakeLoaderQuerier{rows: []openaicompat.LoaderRow{
 		{Name: "corrupt", BaseURL: "https://api.openai.com/v1", APIKeyEncrypted: "not-valid-ciphertext"},
 		{Name: "good", BaseURL: "https://api.openai.com/v1", APIKeyEncrypted: enc},
 	}}
-	if err := openaicompat.LoadAndRegister(context.Background(), q, key, reg, admin.Decrypt); err != nil {
+	if err := openaicompat.LoadAndRegister(context.Background(), q, key, reg, crypto.Decrypt); err != nil {
 		t.Fatalf("LoadAndRegister should not abort on corrupt row: %v", err)
 	}
 	if _, err := reg.Get("good"); err != nil {

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 )
@@ -105,7 +105,7 @@ func (r *Registry) newClientForServer(srv db.McpServer) *Client {
 			slog.Warn("encryption key unset; mcp server has stored auth headers but they will not be sent",
 				"server_id", srv.ID, "server_name", srv.Name)
 		} else {
-			plaintext, err := admin.Decrypt(r.encKey, *srv.AuthHeadersEncrypted)
+			plaintext, err := crypto.Decrypt(r.encKey, *srv.AuthHeadersEncrypted)
 			if err != nil {
 				slog.Warn("failed to decrypt mcp server auth headers; headers will not be sent",
 					"server_id", srv.ID, "server_name", srv.Name, "err", err)

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/toolregistry"
 )
 
@@ -685,7 +685,7 @@ func mustEncryptHeaders(t *testing.T, key []byte, headers []AuthHeader) *string 
 	if raw == nil {
 		return nil
 	}
-	ciphertext, err := admin.Encrypt(key, string(raw))
+	ciphertext, err := crypto.Encrypt(key, string(raw))
 	if err != nil {
 		t.Fatalf("encrypt auth headers: %v", err)
 	}
@@ -790,7 +790,7 @@ func TestRegistry_WarnAndFailOpenWhenNoEncKey(t *testing.T) {
 // mustTestKey generates a deterministic 32-byte test key.
 func mustTestKey(t *testing.T) []byte {
 	t.Helper()
-	k, err := admin.ParseEncryptionKey("aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd")
+	k, err := crypto.ParseEncryptionKey("aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd")
 	if err != nil {
 		t.Fatalf("parse test key: %v", err)
 	}

--- a/internal/plugin/hostsvc/handlers_tier1.go
+++ b/internal/plugin/hostsvc/handlers_tier1.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
 	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/model"
@@ -69,7 +69,7 @@ func (s *Server) GetCredentials(ctx context.Context, _ *hostv1.GetCredentialsReq
 		return &hostv1.GetCredentialsResponse{}, nil
 	}
 
-	plaintext, decryptErr := admin.Decrypt(s.encryptionKey, *inst.CredentialsEncrypted)
+	plaintext, decryptErr := crypto.Decrypt(s.encryptionKey, *inst.CredentialsEncrypted)
 	if decryptErr != nil {
 		return nil, status.Errorf(codes.Internal, "decrypt credentials: %v", decryptErr)
 	}

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -17,8 +17,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	inframetrics "github.com/felag-engineering/gleipnir/internal/infra/metrics"
 	"github.com/felag-engineering/gleipnir/internal/plugin/dispatch"
 	"github.com/felag-engineering/gleipnir/internal/plugin/hostsvc"
@@ -312,7 +312,7 @@ func TestGetCredentials_DecryptsAndReturns(t *testing.T) {
 	t.Parallel()
 
 	creds := `{"token":"secret-value"}`
-	encrypted, err := admin.Encrypt(testEncryptionKey, creds)
+	encrypted, err := crypto.Encrypt(testEncryptionKey, creds)
 	if err != nil {
 		t.Fatalf("encrypt: %v", err)
 	}
@@ -335,7 +335,7 @@ func TestGetCredentials_NoCaching(t *testing.T) {
 	t.Parallel()
 
 	creds := `{"key":"no-cache"}`
-	encrypted, _ := admin.Encrypt(testEncryptionKey, creds)
+	encrypted, _ := crypto.Encrypt(testEncryptionKey, creds)
 
 	q := &fakeQuerier{
 		instance: db.PluginInstance{ID: "iid-1", PluginID: "plug-1", CredentialsEncrypted: &encrypted},
@@ -367,7 +367,7 @@ func TestGetCredentials_NoAuditEventOnRead(t *testing.T) {
 	t.Run("configured credentials", func(t *testing.T) {
 		t.Parallel()
 		creds := `{"strategy":"static_api_key"}`
-		encrypted, err := admin.Encrypt(testEncryptionKey, creds)
+		encrypted, err := crypto.Encrypt(testEncryptionKey, creds)
 		if err != nil {
 			t.Fatalf("encrypt: %v", err)
 		}

--- a/internal/plugin/oauth/store.go
+++ b/internal/plugin/oauth/store.go
@@ -42,13 +42,13 @@ const RefreshFailureDetailPrefix = "oauth refresh failed"
 var ErrWrongStrategy = errors.New("oauth store: instance strategy does not match operation")
 
 // EncryptFunc encrypts a plaintext string to a base64-encoded ciphertext blob.
-// The concrete implementation is admin.Encrypt bound to the host's
+// The concrete implementation is crypto.Encrypt bound to the host's
 // GLEIPNIR_ENCRYPTION_KEY — passed as a function to avoid importing
 // internal/admin (which imports internal/plugin/oauth, causing a cycle).
 type EncryptFunc func(plaintext string) (string, error)
 
 // DecryptFunc decrypts a base64-encoded ciphertext blob produced by EncryptFunc.
-// The concrete implementation is admin.Decrypt bound to the same key.
+// The concrete implementation is crypto.Decrypt bound to the same key.
 type DecryptFunc func(encoded string) (string, error)
 
 // OAuthQuerier is the narrow DB interface required by DBStore and Manager.

--- a/internal/policy/service.go
+++ b/internal/policy/service.go
@@ -33,8 +33,8 @@ var (
 	ErrNoSecret = errors.New("no webhook secret stored")
 )
 
-// SecretCipher is satisfied by an adapter that wraps admin.Encrypt and
-// admin.Decrypt. Defined as an interface so the policy package does not import
+// SecretCipher is satisfied by an adapter that wraps crypto.Encrypt and
+// crypto.Decrypt. Defined as an interface so the policy package does not import
 // internal/admin directly.
 type SecretCipher interface {
 	EncryptWebhookSecret(plaintext string) (ciphertext string, err error)

--- a/internal/trigger/webhook_secret.go
+++ b/internal/trigger/webhook_secret.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/felag-engineering/gleipnir/internal/admin"
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 )
 
 // ErrNoSecret is returned by LoadWebhookSecret when the policy has no stored secret.
@@ -43,7 +43,7 @@ func (l *SecretLoader) LoadWebhookSecret(ctx context.Context, policyID string) (
 	if l.key == nil {
 		return "", ErrEncryptionKeyMissing
 	}
-	plaintext, err := admin.Decrypt(l.key, *ciphertext)
+	plaintext, err := crypto.Decrypt(l.key, *ciphertext)
 	if err != nil {
 		return "", fmt.Errorf("decrypt webhook secret: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/http/auth"
 	"github.com/felag-engineering/gleipnir/internal/http/sse"
 	"github.com/felag-engineering/gleipnir/internal/infra/config"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/infra/version"
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	llmfactory "github.com/felag-engineering/gleipnir/internal/llm/factory"
@@ -124,7 +125,7 @@ func run(cfg config.Config) error {
 	var encryptionKey []byte
 	if raw := cfg.EncryptionKey; raw != "" {
 		var err error
-		encryptionKey, err = admin.ParseEncryptionKey(raw)
+		encryptionKey, err = crypto.ParseEncryptionKey(raw)
 		if err != nil {
 			return fmt.Errorf("parse GLEIPNIR_ENCRYPTION_KEY: %w", err)
 		}
@@ -187,7 +188,7 @@ func run(cfg config.Config) error {
 		if err != nil {
 			continue
 		}
-		apiKey, err := admin.Decrypt(encryptionKey, row.Value)
+		apiKey, err := crypto.Decrypt(encryptionKey, row.Value)
 		if err != nil {
 			slog.Error("failed to decrypt stored API key", "provider", provName, "err", err)
 			continue
@@ -218,7 +219,7 @@ func run(cfg config.Config) error {
 	// Load any previously-saved OpenAI-compat providers from the DB into the
 	// registry at startup. Failure is non-fatal (mirrors bootstrap-providers
 	// loop above) — a log entry is sufficient.
-	if err := openaicompatllm.LoadAndRegister(ctx, openaiAdapter, encryptionKey, providerRegistry, admin.Decrypt); err != nil {
+	if err := openaicompatllm.LoadAndRegister(ctx, openaiAdapter, encryptionKey, providerRegistry, crypto.Decrypt); err != nil {
 		slog.Error("failed to load openai-compat providers at startup", "err", err)
 	}
 
@@ -667,8 +668,9 @@ func (a *modelFilterAdapter) ListEnabledModels(ctx context.Context) ([]api.Enabl
 	return result, nil
 }
 
-// webhookSecretEncrypterAdapter wraps admin.Encrypt and admin.Decrypt so the
-// policy package can encrypt/decrypt webhook secrets without importing admin.
+// webhookSecretEncrypterAdapter wraps crypto.Encrypt and crypto.Decrypt so the
+// policy package can encrypt/decrypt webhook secrets through the SecretCipher
+// interface without binding to a concrete crypto helper.
 // It satisfies both the policy.secretEncrypter interface and the decrypter
 // extension interface checked via type assertion in service.go.
 type webhookSecretEncrypterAdapter struct {
@@ -676,11 +678,11 @@ type webhookSecretEncrypterAdapter struct {
 }
 
 func (a *webhookSecretEncrypterAdapter) EncryptWebhookSecret(plaintext string) (string, error) {
-	return admin.Encrypt(a.key, plaintext)
+	return crypto.Encrypt(a.key, plaintext)
 }
 
 func (a *webhookSecretEncrypterAdapter) DecryptWebhookSecret(ciphertext string) (string, error) {
-	return admin.Decrypt(a.key, ciphertext)
+	return crypto.Decrypt(a.key, ciphertext)
 }
 
 // countEncryptedWebhookSecrets returns the number of policies with a non-NULL

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -18,6 +18,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/execution/agent"
 	runpkg "github.com/felag-engineering/gleipnir/internal/execution/run"
 	"github.com/felag-engineering/gleipnir/internal/infra/config"
+	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/infra/event"
 	pluginpkg "github.com/felag-engineering/gleipnir/internal/plugin"
 	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
@@ -234,8 +235,8 @@ func startPluginRuntime(
 	// (OnPublicURLChanged) is returned as a field so run() can attach it to
 	// adminHandler without this file importing admin.Handler directly.
 	if encryptionKey != nil {
-		enc := func(p string) (string, error) { return admin.Encrypt(encryptionKey, p) }
-		dec := func(c string) (string, error) { return admin.Decrypt(encryptionKey, c) }
+		enc := func(p string) (string, error) { return crypto.Encrypt(encryptionKey, p) }
+		dec := func(c string) (string, error) { return crypto.Decrypt(encryptionKey, c) }
 		oauthStore := pluginoauth.NewDBStore(store.Queries(), enc, dec, store.Queries(), time.Now)
 		oauthNonces := pluginoauth.NewDBNonceStore(store.Queries(), time.Now)
 		// Own the janitor goroutine under bgWG so shutdown() can join it rather


### PR DESCRIPTION
## Summary

Moves the AES-256-GCM crypto helpers — `Encrypt`, `Decrypt`, `MaskKey`, `ParseEncryptionKey` — out of `internal/admin` into a new leaf package `internal/infra/crypto` (sibling of `config`, `version`, `metrics`).

These helpers are algorithm-agnostic and have no admin-handler concerns; they only lived in `internal/admin` because that's where the first caller was. Keeping them there forced low-level packages (notably `internal/mcp`) to depend on the high-level admin handler package just to decrypt secrets at rest.

The crypto file is moved with `git mv` (rename preserved in history); only the package clause and a package doc comment change. The algorithm and key-parsing logic are byte-for-byte identical — no behavior change.

## How each acceptance criterion is met

- **`internal/infra/crypto/` package exists and exports the four functions** — `internal/infra/crypto/crypto.go` defines exported `Encrypt`, `Decrypt`, `MaskKey`, `ParseEncryptionKey`. The helper tests moved alongside into `internal/infra/crypto/crypto_test.go`.
- **`internal/mcp/registry.go` no longer imports `internal/admin`** — its `import` block now references `internal/infra/crypto`; `grep -c "internal/admin" internal/mcp/registry.go` returns `0`.
- **`grep -r "admin.Encrypt\|admin.Decrypt\|admin.MaskKey\|admin.ParseEncryptionKey"` returns nothing outside the admin package** — verified; all call sites (and stale comments) updated. The admin package itself now calls `crypto.Encrypt` / `crypto.Decrypt` / `crypto.MaskKey` via the new import.
- **All existing tests pass with no behavior change** — `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- **`gleipnirctl rotate-key` continues to work** — `cmd/gleipnirctl/rotate.go` / `rotatekey.go` now use `crypto.*`; `cmd/gleipnirctl` package tests pass.

## Callers updated

`internal/admin` (handler.go, openai_compat_handler.go + tests), `internal/mcp/registry.go`, `internal/policy/service.go`, `internal/trigger/webhook_secret.go`, `internal/http/api` (mcp + arcade handlers and tests), `internal/plugin/hostsvc` (handlers_tier1.go + tests), `internal/plugin/oauth/store.go` (doc comments), `internal/llm/openaicompat` (loader.go + tests), `main.go`, `pluginruntime.go`, `cmd/gleipnirctl`.

## Out of scope

No KMS/keyring abstraction — that's a follow-up this refactor unblocks (per the issue).

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)