### PR TITLE
fix(plugin-sdk): sign the canonical manifest bytes so signatures verify (#489)

### DIFF
--- a/plugin-sdk/cmd/gleipnir-plugin/cmd/sign.go
+++ b/plugin-sdk/cmd/gleipnir-plugin/cmd/sign.go
@@ -64,9 +64,17 @@ func runSign(cmd *cobra.Command, flagKey string, flagKeyStdin bool, binary, mani
 		return fmt.Errorf("sign: read binary %s: %w", binary, err)
 	}
 
-	manifestData, err := os.ReadFile(manifestPath)
+	// Sign the CANONICAL manifest bytes, not the raw on-disk bytes. `package`
+	// canonicalises (sorted keys, 2-space indent) the manifest before both
+	// hashing it AND writing it into the bundle, and the host loader verifies the
+	// signature against the bundle's manifest.yaml as-is. So if `sign` hashed the
+	// raw bytes, its signature would not verify whenever the on-disk manifest is
+	// not already canonical (#489) — `sign` and `package` would sign different
+	// bytes. loadCanonicalManifest is the same helper package.go and validate.go
+	// use, guaranteeing all three paths hash identical bytes.
+	manifestData, err := loadCanonicalManifest(manifestPath)
 	if err != nil {
-		return fmt.Errorf("sign: read manifest %s: %w", manifestPath, err)
+		return fmt.Errorf("sign: %w", err)
 	}
 
 	if trustedComment == "" {

--- a/plugin-sdk/cmd/gleipnir-plugin/cmd/sign_test.go
+++ b/plugin-sdk/cmd/gleipnir-plugin/cmd/sign_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
 
@@ -72,6 +73,83 @@ func TestRunSignProducesVerifiableSignature(t *testing.T) {
 	payload := signing.PluginPayload(binaryData, manifestData)
 	if err := signing.Verify(pk, payload, sig, "timestamp:999"); err != nil {
 		t.Errorf("verify: %v", err)
+	}
+}
+
+// nonCanonicalManifestYAML is the same manifest as canonicalManifestYAML but
+// with keys out of sorted order and 4-space indentation. Canonicalising it
+// (sorted keys, 2-space indent) yields exactly canonicalManifestYAML, so it
+// proves sign canonicalises before hashing rather than signing raw bytes.
+const nonCanonicalManifestYAML = `version: 1.0.0
+name: testplugin
+schema_version: v1
+auth:
+    strategy: none
+    mode: instance_credentials
+services:
+    tool: v1
+tools:
+    - name: my_tool
+      description: Does things
+`
+
+// TestRunSignCanonicalisesManifest is the regression test for #489: sign must
+// hash the CANONICAL manifest bytes (matching package.go and the host loader),
+// not the raw on-disk bytes. Against the pre-fix code (os.ReadFile) the produced
+// signature covers the raw, non-canonical bytes and FAILS to verify against the
+// canonical form below. After the fix both sides agree.
+func TestRunSignCanonicalisesManifest(t *testing.T) {
+	dir := t.TempDir()
+	pk := writeTestKey(t, dir)
+
+	binaryPath := filepath.Join(dir, "myplugin")
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	outPath := filepath.Join(dir, "myplugin.minisig")
+
+	binaryData := []byte("fake binary content")
+
+	if err := os.WriteFile(binaryPath, binaryData, 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	// Write the deliberately NON-canonical manifest to disk.
+	if err := os.WriteFile(manifestPath, []byte(nonCanonicalManifestYAML), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	// Sanity check the test is not a tautology: the on-disk bytes must differ
+	// from the canonical bytes, otherwise raw-vs-canonical signing is identical.
+	canonicalManifest, err := manifest.Canonicalize([]byte(nonCanonicalManifestYAML))
+	if err != nil {
+		t.Fatalf("canonicalise: %v", err)
+	}
+	if bytes.Equal([]byte(nonCanonicalManifestYAML), canonicalManifest) {
+		t.Fatal("non-canonical fixture canonicalises to itself — test would be a tautology")
+	}
+
+	fakeCmd := &cobra.Command{}
+	fakeCmd.SetOut(&bytes.Buffer{})
+	fakeCmd.SetErr(&bytes.Buffer{})
+	fakeCmd.SetIn(strings.NewReader(""))
+
+	keyPath := filepath.Join(dir, "signing.key")
+	if err := runSign(fakeCmd, keyPath, false, binaryPath, manifestPath, outPath, "timestamp:489"); err != nil {
+		t.Fatalf("runSign: %v", err)
+	}
+
+	sigData, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read .minisig: %v", err)
+	}
+	sig, _, err := signing.ParseSignature(sigData)
+	if err != nil {
+		t.Fatalf("parse signature: %v", err)
+	}
+
+	// Verify against the CANONICAL bytes — the bytes package and the host loader
+	// hash. Pre-fix this fails (signature covered the raw bytes); post-fix it passes.
+	payload := signing.PluginPayload(binaryData, canonicalManifest)
+	if err := signing.Verify(pk, payload, sig, "timestamp:489"); err != nil {
+		t.Errorf("verify against canonical manifest: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #489

## Summary

`gleipnir-plugin sign` and `gleipnir-plugin package` signed **different bytes** for the same plugin, so a `sign`-produced signature could fail to verify against the form `package`/the host actually use.

- `runSign` hashed the **raw on-disk** manifest bytes (`os.ReadFile`).
- `runPackage` hashed the **canonical** manifest (`loadCanonicalManifest` → `manifest.Canonicalize`, which sorts keys and normalizes indentation) — and writes those same canonical bytes into the bundle that the host loader (`internal/plugin/verify.go`) hashes as-is.

For any non-canonical manifest (keys out of sorted order, non-2-space indent) the two paths signed different bytes, producing mutually incompatible signatures. All existing tests fed already-canonical YAML, so CI never saw it.

**Fix:** `runSign` now calls `loadCanonicalManifest` — the exact helper `package.go` and `validate.go` already use — and surfaces its error with the same `sign: %w` wrapping. All three paths now hash identical bytes. (`os` is still used for the binary read + signature write, so no import change.)

## Test

`TestRunSignCanonicalisesManifest` signs a deliberately non-canonical manifest and verifies the signature against the canonical form (the bytes the host loader hashes). It includes an explicit guard asserting the fixture is non-canonical so the test cannot degrade into a tautology.

Proven failing against pre-fix code:
```
sign_test.go: verify against canonical manifest: signing: signature verification failed
--- FAIL: TestRunSignCanonicalisesManifest
```
Passing after the fix.

<details>
<summary>Plan</summary>

1. Read `sign.go`, `package.go`, `manifest_helpers.go`, `signing.PluginPayload`, `manifest.Canonicalize`, and the host verify path (`internal/plugin/verify.go`). Confirmed `PluginPayload = sha256(binary) || sha256(manifest)` — manifest bytes are hashed directly, so canonical vs raw bytes differ.
2. Swap the one call in `runSign`: `os.ReadFile` → `loadCanonicalManifest`, with `fmt.Errorf("sign: %w", err)` matching `package`'s error shape.
3. Add a non-tautological regression test: non-canonical input (keys reordered, 4-space indent) canonicalizes to different bytes (verified: 188 → 178 bytes, and the canonical output exactly matches the existing `canonicalManifestYAML` constant). Verify against the canonical form using the same `signing.Verify` path the host loader uses.
4. Adversarial check: confirmed the chosen input actually changes under `Canonicalize` (not a tautology), the verify path matches the host's, and `package`/`validate` share the same `loadCanonicalManifest` helper.
</details>

## Test gate
- `go build ./...` — both root and `plugin-sdk` modules: pass
- `go vet ./plugin-sdk/...`: pass
- `go test -race ./...` (whole `plugin-sdk` module): pass
- Root-module consumer check: `go test -race ./internal/plugin/...` (host loader verify + install paths that call `signing.PluginPayload`): pass
- New test confirmed to fail against pre-fix code, pass after.

## Review cycles
One self-review cycle: tightened the WHY comment to accurately describe the `package`/host-loader invariant (the host loader hashes the bundle manifest as-is rather than re-canonicalizing) instead of overclaiming.

## CLAUDE.md
No update needed — internal SDK CLI byte-consistency fix, no architectural/structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)