### PR TITLE
feat(frontend): add in-app Contact tray with maintainer contact info (#153)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -241,7 +241,8 @@ Response envelope: `{ data: T }` for success, `{ error: string, detail?: string 
 
 Organized by feature area:
 
-- **Layout** — sidebar navigation, content area, theme toggle, connection status banner
+- **Layout** — sidebar navigation, content area, theme toggle, connection status banner; a Contact nav item is pinned to the bottom of the sidebar nav (below the main/admin items) and opens the `ContactTray` (#153)
+- **ContactTray** — maintainer contact tray (email mailto + GitHub repo link). Reuses the shared `Modal` primitive for focus-trap / Esc / outside-click / focus-restore. Triggered from the Layout sidebar bottom; available to all authenticated roles (#153)
 - **dashboard/** — StatsBar, StatusBadge, StatusBoard, TriggerChip, ActivityFeed, SetupChecklist (context-aware onboarding checklist that renders until all setup steps are complete)
 - **AgentEditor/** — the agent editor (EditorTopBar, FormMode with 8 form sections)
 - **AgentList/** — agent list with folder grouping
@@ -249,7 +250,7 @@ Organized by feature area:
 - **MCPPage/** — ServerCard, ToolList, ToolRow, MCPStatsBar, HealthIndicator, AddServerModal, DeleteServerModal, ServerDetailModal (per-header auth editor: existing name fields are read-only, value field is empty with placeholder; save fans out via `useSetMcpServerHeader`/`useDeleteMcpServerHeader`; no sentinel; see ADR-039), ArcadeAuthSection (toolkit-level OAuth pre-authorization for Arcade gateways; renders only when `server.is_arcade_gateway && canManage`; see ADR-040)
 - **admin/** — EncryptionKeyNotice (persistent warning banner on the Models page about encryption key backup requirements), PluginHealthChip (colored chip — green/yellow/red/gray — for the 11 plugin-instance health states including `inactive`; pairs with `utils/pluginHealth.ts` for the worst-across-instances aggregate), PluginCard (clickable card for the `/admin/plugins` two-pane list: name, version, service badges Tool/Trigger/Channel, instance count, aggregate health chip; `isSelected` prop for visual selection state), PluginMemoryBar (aggregate plugin RSS display in the plugins page header; shows total bytes + instance count; click-to-expand per-instance breakdown table sorted by RSS descending; 30s polling via `usePluginRSS`), PluginReviewCard (consent surface for pending-review plugins: services, tier-2 capabilities, auth strategy, pubkey fingerprint, SBOM badge, author/license; Approve/Reject buttons), RejectPluginModal (confirmation modal before rejecting a pending-review plugin; follows UninstallPluginModal pattern), InstallPluginButton (file-picker upload of a plugin tarball; persistent success card with "Review & approve" link for `pending_review` status or "Add instance" CTA for `active` status), AddInstanceModal (form to instantiate an installed plugin by name; reused as a standalone modal on the plugins page AND inline from the install-success card; client-side validation + per-status error mapping)
 - **form/** — FieldError (inline message under a field), ErrorBanner (top-of-form bulleted summary with scroll-to-field). Shared primitives for surfacing validation/save errors.
-- **Shared** — Button, Modal, ModalFooter, EmptyState, ErrorBoundary, QueryBoundary, CopyBlock, CollapsibleJSON, SkeletonBlock, PageHeader, ApprovalBanner, ConnectionBanner, TriggerRunModal
+- **Shared** — Button, Modal, ModalFooter, ContactTray, EmptyState, ErrorBoundary, QueryBoundary, CopyBlock, CollapsibleJSON, SkeletonBlock, PageHeader, ApprovalBanner, ConnectionBanner, TriggerRunModal
 
 ### Hooks (`src/hooks/`)
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -242,7 +242,7 @@ Response envelope: `{ data: T }` for success, `{ error: string, detail?: string 
 Organized by feature area:
 
 - **Layout** — sidebar navigation, content area, theme toggle, connection status banner; a Contact nav item is pinned to the bottom of the sidebar nav (below the main/admin items) and opens the `ContactTray` (#153)
-- **ContactTray** — maintainer contact tray (email mailto + GitHub repo link). Reuses the shared `Modal` primitive for focus-trap / Esc / outside-click / focus-restore. Triggered from the Layout sidebar bottom; available to all authenticated roles (#153)
+- **ContactTray** — maintainer contact tray (email mailto + intent-routed GitHub links: "Report a bug" → Issues, "Ask a question" → Discussions). Reuses the shared `Modal` primitive for focus-trap / Esc / outside-click / focus-restore. Triggered from the Layout sidebar bottom; available to all authenticated roles (#153)
 - **dashboard/** — StatsBar, StatusBadge, StatusBoard, TriggerChip, ActivityFeed, SetupChecklist (context-aware onboarding checklist that renders until all setup steps are complete)
 - **AgentEditor/** — the agent editor (EditorTopBar, FormMode with 8 form sections)
 - **AgentList/** — agent list with folder grouping

--- a/frontend/src/components/ContactTray/ContactTray.module.css
+++ b/frontend/src/components/ContactTray/ContactTray.module.css
@@ -1,0 +1,70 @@
+.intro {
+  margin: 0 0 var(--space-4) 0;
+  color: var(--text-second);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.channelList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.channel {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-section);
+  text-decoration: none;
+  color: var(--text-primary);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+
+.channel:hover {
+  border-color: var(--border-mid);
+  background: var(--bg-elevated);
+}
+
+.channelIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: var(--radius-section);
+  background: var(--accent-muted);
+  color: var(--color-blue);
+}
+
+.channelText {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.channelLabel {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.channelValue {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/components/ContactTray/ContactTray.stories.tsx
+++ b/frontend/src/components/ContactTray/ContactTray.stories.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { fn } from 'storybook/test'
+import '@/tokens.css'
+import { ContactTray } from './ContactTray'
+
+const meta: Meta<typeof ContactTray> = {
+  title: 'Components/ContactTray',
+  component: ContactTray,
+  args: {
+    onClose: fn(),
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ContactTray>
+
+/** The tray is closed — renders nothing over the shell. */
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+}
+
+/** The tray is open, showing the email and GitHub contact channels. */
+export const Open: Story = {
+  args: {
+    open: true,
+  },
+}
+
+/** Interactive demo: a trigger button opens and closes the tray, mirroring the sidebar usage. */
+export const Interactive: Story = {
+  render: (args) => {
+    function Demo() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open contact tray
+          </button>
+          <ContactTray open={open} onClose={() => { args.onClose(); setOpen(false) }} />
+        </>
+      )
+    }
+    return <Demo />
+  },
+}

--- a/frontend/src/components/ContactTray/ContactTray.stories.tsx
+++ b/frontend/src/components/ContactTray/ContactTray.stories.tsx
@@ -25,7 +25,7 @@ export const Closed: Story = {
   },
 }
 
-/** The tray is open, showing the email and GitHub contact channels. */
+/** The tray is open, showing the email, bug-report, and ask-a-question channels. */
 export const Open: Story = {
   args: {
     open: true,

--- a/frontend/src/components/ContactTray/ContactTray.test.tsx
+++ b/frontend/src/components/ContactTray/ContactTray.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ContactTray } from './ContactTray'
+
+describe('ContactTray — visibility', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(<ContactTray open={false} onClose={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the dialog with heading when open', () => {
+    render(<ContactTray open onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Get in touch')).toBeInTheDocument()
+  })
+})
+
+describe('ContactTray — contact links', () => {
+  it('renders the email as a mailto link', () => {
+    render(<ContactTray open onClose={vi.fn()} />)
+    const email = screen.getByRole('link', { name: /email/i })
+    expect(email).toHaveAttribute('href', 'mailto:support@gleipnir.dev')
+  })
+
+  it('renders the GitHub link opening in a new tab with safe rel', () => {
+    render(<ContactTray open onClose={vi.fn()} />)
+    const gh = screen.getByRole('link', { name: /github/i })
+    expect(gh).toHaveAttribute('href', 'https://github.com/Felag-Engineering/gleipnir')
+    expect(gh).toHaveAttribute('target', '_blank')
+    expect(gh).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})
+
+describe('ContactTray — close interactions', () => {
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<ContactTray open onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(<ContactTray open onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/ContactTray/ContactTray.test.tsx
+++ b/frontend/src/components/ContactTray/ContactTray.test.tsx
@@ -22,12 +22,20 @@ describe('ContactTray — contact links', () => {
     expect(email).toHaveAttribute('href', 'mailto:support@gleipnir.dev')
   })
 
-  it('renders the GitHub link opening in a new tab with safe rel', () => {
+  it('renders the bug report link to GitHub Issues, opening in a new tab with safe rel', () => {
     render(<ContactTray open onClose={vi.fn()} />)
-    const gh = screen.getByRole('link', { name: /github/i })
-    expect(gh).toHaveAttribute('href', 'https://github.com/Felag-Engineering/gleipnir')
-    expect(gh).toHaveAttribute('target', '_blank')
-    expect(gh).toHaveAttribute('rel', 'noopener noreferrer')
+    const bug = screen.getByRole('link', { name: /report a bug/i })
+    expect(bug).toHaveAttribute('href', 'https://github.com/Felag-Engineering/gleipnir/issues/new')
+    expect(bug).toHaveAttribute('target', '_blank')
+    expect(bug).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders the question link to GitHub Discussions, opening in a new tab with safe rel', () => {
+    render(<ContactTray open onClose={vi.fn()} />)
+    const question = screen.getByRole('link', { name: /ask a question/i })
+    expect(question).toHaveAttribute('href', 'https://github.com/Felag-Engineering/gleipnir/discussions')
+    expect(question).toHaveAttribute('target', '_blank')
+    expect(question).toHaveAttribute('rel', 'noopener noreferrer')
   })
 })
 

--- a/frontend/src/components/ContactTray/ContactTray.tsx
+++ b/frontend/src/components/ContactTray/ContactTray.tsx
@@ -1,9 +1,11 @@
-import { ExternalLink, Mail } from 'lucide-react'
+import { Bug, Mail, MessagesSquare } from 'lucide-react'
 import { Modal } from '@/components/Modal'
 import styles from './ContactTray.module.css'
 
 const SUPPORT_EMAIL = 'support@gleipnir.dev'
 const GITHUB_REPO_URL = 'https://github.com/Felag-Engineering/gleipnir'
+const GITHUB_NEW_ISSUE_URL = `${GITHUB_REPO_URL}/issues/new`
+const GITHUB_DISCUSSIONS_URL = `${GITHUB_REPO_URL}/discussions`
 
 interface Props {
   open: boolean
@@ -23,7 +25,7 @@ export function ContactTray({ open, onClose }: Props) {
     <Modal title="Get in touch" onClose={onClose}>
       <p className={styles.intro}>
         Questions, feedback, or a bug to report? Reach the Gleipnir maintainers
-        through either channel below.
+        through whichever channel fits.
       </p>
       <ul className={styles.channelList}>
         <li>
@@ -40,16 +42,32 @@ export function ContactTray({ open, onClose }: Props) {
         <li>
           <a
             className={styles.channel}
-            href={GITHUB_REPO_URL}
+            href={GITHUB_NEW_ISSUE_URL}
             target="_blank"
             rel="noopener noreferrer"
           >
             <span className={styles.channelIcon}>
-              <ExternalLink size={18} aria-hidden strokeWidth={1.5} />
+              <Bug size={18} aria-hidden strokeWidth={1.5} />
             </span>
             <span className={styles.channelText}>
-              <span className={styles.channelLabel}>GitHub</span>
-              <span className={styles.channelValue}>Felag-Engineering/gleipnir</span>
+              <span className={styles.channelLabel}>Report a bug</span>
+              <span className={styles.channelValue}>GitHub Issues</span>
+            </span>
+          </a>
+        </li>
+        <li>
+          <a
+            className={styles.channel}
+            href={GITHUB_DISCUSSIONS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className={styles.channelIcon}>
+              <MessagesSquare size={18} aria-hidden strokeWidth={1.5} />
+            </span>
+            <span className={styles.channelText}>
+              <span className={styles.channelLabel}>Ask a question</span>
+              <span className={styles.channelValue}>GitHub Discussions</span>
             </span>
           </a>
         </li>

--- a/frontend/src/components/ContactTray/ContactTray.tsx
+++ b/frontend/src/components/ContactTray/ContactTray.tsx
@@ -1,0 +1,59 @@
+import { ExternalLink, Mail } from 'lucide-react'
+import { Modal } from '@/components/Modal'
+import styles from './ContactTray.module.css'
+
+const SUPPORT_EMAIL = 'support@gleipnir.dev'
+const GITHUB_REPO_URL = 'https://github.com/Felag-Engineering/gleipnir'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+/**
+ * ContactTray surfaces the maintainer's contact info in a tray that pops out
+ * over the app shell. It reuses the shared Modal primitive, which already
+ * provides focus-trap, Escape-to-close, outside-click dismissal, and focus
+ * restoration to the trigger — no need to reimplement that behavior here.
+ */
+export function ContactTray({ open, onClose }: Props) {
+  if (!open) return null
+
+  return (
+    <Modal title="Get in touch" onClose={onClose}>
+      <p className={styles.intro}>
+        Questions, feedback, or a bug to report? Reach the Gleipnir maintainers
+        through either channel below.
+      </p>
+      <ul className={styles.channelList}>
+        <li>
+          <a className={styles.channel} href={`mailto:${SUPPORT_EMAIL}`}>
+            <span className={styles.channelIcon}>
+              <Mail size={18} aria-hidden strokeWidth={1.5} />
+            </span>
+            <span className={styles.channelText}>
+              <span className={styles.channelLabel}>Email</span>
+              <span className={styles.channelValue}>{SUPPORT_EMAIL}</span>
+            </span>
+          </a>
+        </li>
+        <li>
+          <a
+            className={styles.channel}
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className={styles.channelIcon}>
+              <ExternalLink size={18} aria-hidden strokeWidth={1.5} />
+            </span>
+            <span className={styles.channelText}>
+              <span className={styles.channelLabel}>GitHub</span>
+              <span className={styles.channelValue}>Felag-Engineering/gleipnir</span>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </Modal>
+  )
+}

--- a/frontend/src/components/ContactTray/index.ts
+++ b/frontend/src/components/ContactTray/index.ts
@@ -1,0 +1,1 @@
+export { ContactTray } from './ContactTray'

--- a/frontend/src/components/Layout/Layout.module.css
+++ b/frontend/src/components/Layout/Layout.module.css
@@ -106,6 +106,28 @@
   overflow: hidden;
 }
 
+/* Contact — pinned to the bottom of the nav, set visually apart from the
+   main items by a top border. margin-top:auto works because .nav is a flex
+   column with flex:1. Reset button defaults since .navLink targets links. */
+.navContact {
+  margin-top: auto;
+  margin-bottom: var(--space-1);
+  padding-top: var(--space-3);
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: transparent;
+  width: auto;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.navContact:hover {
+  color: var(--text-second);
+  background: var(--bg-elevated);
+}
+
 /* ---- Sidebar footer ---- */
 
 .sidebarFooterWrapper {

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
-import { Activity, Bot, ChevronUp, Cpu, History, Megaphone, Puzzle, Settings2, Users, Wrench } from 'lucide-react'
+import { Activity, Bot, ChevronUp, Cpu, History, Mail, Megaphone, Puzzle, Settings2, Users, Wrench } from 'lucide-react'
 import { Logo } from '@/components/Logo/Logo'
+import { ContactTray } from '@/components/ContactTray'
 import { NavLink, Outlet, useLocation } from 'react-router-dom'
 import { useSSE } from '@/hooks/useSSE'
 import { useCurrentUser } from '@/hooks/queries/users'
@@ -30,6 +31,8 @@ export default function Layout() {
   const { data: currentUser } = useCurrentUser()
   const [menuOpen, setMenuOpen] = useState(false)
   const handleMenuClose = useCallback(() => setMenuOpen(false), [])
+  const [contactOpen, setContactOpen] = useState(false)
+  const handleContactClose = useCallback(() => setContactOpen(false), [])
   const { items: attentionItems } = useAttentionItems()
   const { data: mcpServers } = useMcpServers()
 
@@ -95,7 +98,20 @@ export default function Layout() {
               ))}
             </>
           )}
+
+          <button
+            type="button"
+            className={`${styles.navLink} ${styles.navContact}`}
+            onClick={() => setContactOpen(true)}
+          >
+            <span className={styles.navIcon}>
+              <Mail size={20} aria-hidden strokeWidth={1.5} />
+            </span>
+            <span className={styles.navLabel}>Contact</span>
+          </button>
         </nav>
+
+        <ContactTray open={contactOpen} onClose={handleContactClose} />
 
         <div className={styles.sidebarFooterWrapper}>
           <UserMenu


### PR DESCRIPTION
## Summary

Adds an in-app **Contact** affordance so any authenticated user can reach the maintainers. This is the **app feature** (lives in `frontend/src/`, the React app shell) — **not** the marketing-site contact form. The earlier confusion about `gleipnir_website` is resolved: this belongs in the app's `Layout`.

- A **Contact** nav item is pinned to the **bottom of the left sidebar** nav, set visually apart from the main/admin items by a top-border separator. It uses `margin-top: auto` inside the existing `flex:1` flex-column `<nav>`, so it sinks to the bottom above the user menu.
- Activating it **pops out a tray** with the maintainer's contact info:
  - **Email** — `support@gleipnir.dev` as a clickable `mailto:` link
  - **GitHub** — `https://github.com/Felag-Engineering/gleipnir`, opening in a new tab with `rel="noopener noreferrer"`
- Available to **all authenticated roles** (in the shell — no role gating).

### Reuse Modal vs. build a drawer
**Reused the shared `Modal` primitive.** It already provides focus-trap, Escape-to-close, outside-click dismissal, `role="dialog"`/`aria-modal`, and focus restoration to the trigger. Building a bespoke drawer would have reimplemented all of that a11y machinery for no UX gain — the modal overlay satisfies the "tray that pops out" requirement and matches the design system.

## Files added
- `frontend/src/components/ContactTray/ContactTray.tsx`
- `frontend/src/components/ContactTray/ContactTray.module.css`
- `frontend/src/components/ContactTray/ContactTray.stories.tsx` — **Storybook story** (Closed / Open / Interactive)
- `frontend/src/components/ContactTray/ContactTray.test.tsx` — **Vitest test** (visibility, link hrefs/rel, close interactions)
- `frontend/src/components/ContactTray/index.ts`

## Files changed
- `frontend/src/components/Layout/Layout.tsx` — Contact trigger button + tray wiring
- `frontend/src/components/Layout/Layout.module.css` — `.navContact` bottom-pinned style
- `frontend/CLAUDE.md` — component list updated (Layout note + ContactTray + Shared list)

## Plan
<details>
<summary>Architecture &amp; review</summary>

**Decision:** reuse `Modal` (a11y already handled), folder-per-component idiom matching neighbors, barrel `index.ts`, matching `Modal.stories.tsx` / `Modal.test.tsx` shapes.

**Adversarial plan review against real code:**
- Layout's `<nav>` is `display:flex; flex-direction:column; flex:1` → `margin-top:auto` on the Contact button reliably pins it to the bottom. ✓
- `Modal` confirmed to provide focus-trap (`focus-trap-react`), Esc, outside-click, and `returnFocusOnDeactivate` — no reinvention needed. ✓
- Existing bottom-of-sidebar pattern (the user-menu footer) is a separate `sidebarFooterWrapper` below `<nav>`; the Contact item sits at the bottom of `<nav>` itself, above it, separated by a border — mirrors the admin section-header separator idiom. ✓
- Design tokens exist for all needed colors/spacing (`--accent-muted`, `--color-blue`, `--border-subtle`, `--space-*`, `--radius-section`). ✓

**Minor decision:** the brand `Github` icon was removed from the pinned `lucide-react` version (brand icons deprecated), so the GitHub channel uses the neutral `ExternalLink` icon instead.
</details>

## Review cycles
Self code-review pass against design-system rules: **no inline `style={}`** (CSS Modules only), **4px spacing scale** throughout, real focusable `<button type="button">` trigger, story + test present. No issues required a second cycle.

## Test gate
- `npm run build` (tsc + vite) — **green**
- `npx vitest run` for ContactTray + Layout — **34/34 green**
- Full `npx vitest run` has 12 pre-existing failures in 3 unrelated storybook-chromium files (`AddInstanceModal`, `InstallPluginButton`, `ArcadeAuthSection` — plugin/Arcade MSW flakes); reproduced on pristine `origin/main`, untouched by this PR.

## CLAUDE.md status
Updated `frontend/CLAUDE.md` (Layout description, new ContactTray entry, Shared primitives list) per its conventions.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)