### PR TITLE
fix: drain scheduler and timeout scanners on shutdown and fix Poller.Stop() deadlock (#487)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ npm run storybook        # Storybook on port 6006
 | `GLEIPNIR_APPROVAL_SCAN_INTERVAL` | `30s` | How often to check for timed-out approvals |
 | `GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT` | `30m` | Default timeout for feedback requests |
 | `GLEIPNIR_FEEDBACK_SCAN_INTERVAL` | `30s` | How often to check for timed-out feedback |
-| `GLEIPNIR_DRAIN_TIMEOUT` | `5m` | Graceful-shutdown drain timeout for in-flight runs and background loops |
+| `GLEIPNIR_DRAIN_TIMEOUT` | `5m` | Graceful-shutdown drain timeout for in-flight runs and background loops. Bounds the concurrent drain of the poller, cron runner, scheduler (in-flight `fire()`), and the approval/feedback timeout scanners (in-flight `resolveTimeout()`), plus the run manager — all joined in one timeout-raced goroutine (#487). |
 | `GLEIPNIR_PID_FILE` | `/var/run/gleipnir.pid` | Path the server writes its PID to on startup |
 | `GLEIPNIR_PLUGINS_ENABLED` | `true` | Enable the host-side plugin loader (on by default; set to `false` to opt out for one more release before flag removal; see docs/developer/plugin-system-spec.md §15.2). |
 | `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS` | `false` | When `true`, the loader accepts plugins lacking a Minisign `.minisig`/`signing.pub` pair (instance health = `unsigned_permissive`). Every load emits a high-severity audit event; admin UI shows a non-dismissible red banner; `/api/v1/health` reports `signature_verification: disabled`. **Signed plugins are still fully verified even in permissive mode.** Scope is global, not per-plugin. Read once at startup. See ADR-045 §6. |

--- a/internal/timeout/scanner.go
+++ b/internal/timeout/scanner.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
@@ -209,6 +210,7 @@ type Scanner struct {
 	interval  time.Duration
 	publisher event.Publisher
 	cfg       Config
+	wg        sync.WaitGroup // tracks the background scan goroutine for graceful drain
 }
 
 // ScannerOption is a functional option for Scanner.
@@ -237,9 +239,14 @@ func NewScanner(store *db.Store, interval time.Duration, cfg Config, opts ...Sca
 }
 
 // Start launches the background scan goroutine. It returns immediately; the
-// goroutine exits when ctx is cancelled.
+// goroutine exits when ctx is cancelled. The goroutine is tracked by a
+// WaitGroup so Wait() can drain an in-flight scan during shutdown rather than
+// cutting off a resolveTimeout mid-flight (which writes run steps and
+// transitions run state).
 func (s *Scanner) Start(ctx context.Context) {
+	s.wg.Add(1)
 	go func() {
+		defer s.wg.Done()
 		ticker := time.NewTicker(s.interval)
 		defer ticker.Stop()
 		for {
@@ -253,6 +260,14 @@ func (s *Scanner) Start(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// Wait blocks until the background scan goroutine has exited. Call after
+// cancelling the context passed to Start to drain an in-flight scan cleanly
+// during shutdown. Wait is safe to call when Start was never called (the
+// WaitGroup counter is zero) and may be called more than once.
+func (s *Scanner) Wait() {
+	s.wg.Wait()
 }
 
 // Scan finds all pending requests whose deadline has passed and resolves each

--- a/internal/timeout/scanner_test.go
+++ b/internal/timeout/scanner_test.go
@@ -378,6 +378,105 @@ func TestScanner_StartStop(t *testing.T) {
 	}
 }
 
+// TestScanner_Wait_DrainsInFlightScan verifies that Scanner.Wait() (called after
+// the context is cancelled) blocks until an in-flight scan finishes instead of
+// returning while the scan goroutine is mid-flight. Previously Start() was
+// fire-and-forget with no WaitGroup, so a scan in progress at shutdown (which
+// writes run steps and transitions run state in resolveTimeout) could be cut off
+// mid-flight (#487).
+//
+// The scan is held in-flight by gating ListExpired: it signals `entered` on the
+// first call and then blocks until `release` is closed.
+func TestScanner_Wait_DrainsInFlightScan(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusWaitingForApproval)
+	insertApprovalRequest(t, s, "a1", "r1", "tool_z", pastTimestamp())
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	var scanFinished atomic.Bool
+
+	cfg := approvalConfig(s)
+	inner := cfg.ListExpired
+	cfg.ListExpired = func(ctx context.Context, cutoff string) ([]timeout.ExpiredItem, error) {
+		// Perform the real read first under the live context so the scan does
+		// real work, then hold the goroutine in-flight at the gate.
+		items, err := inner(ctx, cutoff)
+		once.Do(func() { close(entered) })
+		<-release
+		// scanFinished flips only after the gate releases — if Wait() returned
+		// before this, the goroutine was not tracked by the WaitGroup.
+		scanFinished.Store(true)
+		return items, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	scanner := timeout.NewScanner(s, 20*time.Millisecond, cfg)
+	scanner.Start(ctx)
+
+	// Wait until the scan goroutine is inside ListExpired (in-flight).
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		cancel()
+		close(release)
+		t.Fatal("scan never reached the in-flight gate")
+	}
+
+	// Cancel the context while the scan is held in-flight. The in-flight scan
+	// must still be drained by Wait() even though the loop has been signalled
+	// to stop.
+	cancel()
+
+	waitReturned := make(chan struct{})
+	go func() { scanner.Wait(); close(waitReturned) }()
+
+	// Wait() must NOT return while the scan is still blocked at the gate.
+	select {
+	case <-waitReturned:
+		t.Fatal("Wait() returned while a scan was still in-flight — goroutine not tracked by wg")
+	case <-time.After(200 * time.Millisecond):
+		// Good: still draining.
+	}
+	if scanFinished.Load() {
+		t.Fatal("scan finished before the gate was released — test gate is ineffective")
+	}
+
+	// Release the gate; the scan completes, the goroutine returns, Wait() unblocks.
+	close(release)
+
+	select {
+	case <-waitReturned:
+		// Drained cleanly.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait() did not return after the in-flight scan completed")
+	}
+
+	// Wait() returning guarantees the goroutine reached the end of the gated
+	// function — the in-flight scan was drained rather than abandoned.
+	if !scanFinished.Load() {
+		t.Error("Wait() returned but the in-flight scan goroutine had not finished")
+	}
+}
+
+// TestScanner_Wait_SafeWithoutStart verifies that Wait() is a no-op (no panic,
+// no hang) when Start was never called — the WaitGroup counter is zero (#487).
+func TestScanner_Wait_SafeWithoutStart(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	scanner := timeout.NewScanner(s, time.Minute, approvalConfig(s))
+
+	done := make(chan struct{})
+	go func() { scanner.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait() hung when Start was never called")
+	}
+}
+
 func TestScanner_StepNumberContinuesExistingSteps(t *testing.T) {
 	s := testutil.NewTestStore(t)
 	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")

--- a/internal/trigger/poll.go
+++ b/internal/trigger/poll.go
@@ -48,10 +48,11 @@ type Poller struct {
 	launcher      *run.RunLauncher
 	toolResolver  toolResolver
 	modelResolver *settings.Service
-	mu            sync.Mutex                 // protects loops and rootCtx
+	mu            sync.Mutex                 // protects loops, rootCtx, and rootCancel
 	loops         map[string]*pollLoopHandle // policyID -> handle for that goroutine
 	wg            sync.WaitGroup             // tracks all poll loop goroutines
 	rootCtx       context.Context            // set in Start; used by Notify to outlive the HTTP request
+	rootCancel    context.CancelFunc         // cancels rootCtx; set in Start
 }
 
 // NewPoller returns a Poller ready to be started. resolver is used to call
@@ -73,24 +74,31 @@ func NewPoller(store *db.Store, launcher *run.RunLauncher, resolver toolResolver
 // created, paused, or deleted after startup.
 // Start returns immediately; goroutines run in the background.
 func (p *Poller) Start(ctx context.Context) error {
+	// Derive a cancellable root context with a stored cancel so Stop() can
+	// terminate the reconcile loop (and every per-policy loop, which derive
+	// from rootCtx) even when the caller does not own the context passed here.
+	// Mirrors CronRunner.Start.
+	rootCtx, rootCancel := context.WithCancel(ctx)
 	p.mu.Lock()
-	p.rootCtx = ctx
+	p.rootCtx = rootCtx
+	p.rootCancel = rootCancel
 	p.mu.Unlock()
 
-	policies, err := p.store.GetPollActivePolicies(ctx)
+	policies, err := p.store.GetPollActivePolicies(rootCtx)
 	if err != nil {
+		rootCancel()
 		return fmt.Errorf("load poll policies: %w", err)
 	}
 
 	for _, pol := range policies {
-		p.startPollLoop(ctx, pol)
+		p.startPollLoop(rootCtx, pol)
 	}
 
 	// The reconciliation goroutine is tracked by wg so Wait() waits for it too.
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
-		p.reconcileLoop(ctx)
+		p.reconcileLoop(rootCtx)
 	}()
 
 	return nil
@@ -358,14 +366,24 @@ func (p *Poller) Wait() {
 	p.wg.Wait()
 }
 
-// Stop cancels all active poll goroutines and waits for them to exit.
-// It is equivalent to cancelling the context passed to Start, but is
-// provided as an explicit method for callers that do not own the context.
+// Stop cancels all active poll goroutines (including the reconcile loop) and
+// waits for them to exit. It is equivalent to cancelling the context passed to
+// Start, but is provided as an explicit method for callers that do not own the
+// context.
+//
+// Cancelling rootCtx propagates to every per-policy loop context (derived from
+// rootCtx) and to the reconcile loop, so a single cancel drains all goroutines.
+// Previously Stop() only cancelled the per-policy loops and never the reconcile
+// loop, so wg.Wait() blocked forever (the reconcile goroutine only exits on
+// rootCtx cancellation). Stop() is safe to call when Start was never called
+// (rootCancel is nil → no-op) and is idempotent (context.CancelFunc tolerates
+// repeated calls).
 func (p *Poller) Stop() {
 	p.mu.Lock()
-	for _, h := range p.loops {
-		h.cancel()
-	}
+	cancel := p.rootCancel
 	p.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	p.wg.Wait()
 }

--- a/internal/trigger/poll_test.go
+++ b/internal/trigger/poll_test.go
@@ -546,6 +546,62 @@ func TestPoller_GracefulShutdown(t *testing.T) {
 	}
 }
 
+// TestPoller_Stop_DoesNotDeadlock verifies that Stop() exits cleanly without
+// cancelling the context passed to Start. Previously Stop() only cancelled the
+// per-policy loops and never the reconcile goroutine, so wg.Wait() blocked
+// forever (the reconcile loop only exits on root-context cancellation, and
+// Stop() had no stored cancel for it). The fix wires a stored rootCancel into
+// Stop() (#487). Note we pass context.Background() (never cancelled) so the only
+// thing that can drain the goroutines is Stop()'s own cancel.
+func TestPoller_Stop_DoesNotDeadlock(t *testing.T) {
+	mcpSrv, _ := pollResultServer(t, textContent(`{"status":"healthy"}`))
+	store, registry := setupPollerFixture(t, mcpSrv)
+
+	yamlStr := pollPolicyYAML("poll-stop", "100ms")
+	insertTestPollPolicy(t, store, "pol-poll-stop", "poll-stop", yamlStr)
+
+	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           pollerFactory(),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
+	poller := trigger.NewPoller(store, launcher, registry, resolver)
+
+	if err := poller.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() { poller.Stop(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() deadlocked — reconcile goroutine was not cancelled")
+	}
+}
+
+// TestPoller_Stop_SafeWithoutStart verifies that Stop() is a no-op (no panic, no
+// hang) when Start was never called — rootCancel is nil and the WaitGroup is
+// empty (#487).
+func TestPoller_Stop_SafeWithoutStart(t *testing.T) {
+	poller := trigger.NewPoller(nil, nil, nil, nil)
+
+	done := make(chan struct{})
+	go func() { poller.Stop(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() hung when Start was never called")
+	}
+}
+
 // pollPolicyYAMLNoModel builds a poll policy with no model block in the agent
 // section. Used to test the empty-system-default code path.
 func pollPolicyYAMLNoModel(name, intervalStr string) string {

--- a/internal/trigger/scheduled.go
+++ b/internal/trigger/scheduled.go
@@ -26,9 +26,11 @@ type Scheduler struct {
 	store         *db.Store
 	launcher      *run.RunLauncher
 	modelResolver *settings.Service
-	mu            sync.Mutex                      // protects timers and rootCtx
+	mu            sync.Mutex                      // protects timers, rootCtx, and rootCancel
 	timers        map[string][]context.CancelFunc // policyID -> per-fire-time cancel funcs
+	wg            sync.WaitGroup                  // tracks all timer goroutines
 	rootCtx       context.Context                 // set in Start; used by Notify to outlive the HTTP request
+	rootCancel    context.CancelFunc              // cancels rootCtx; set in Start
 }
 
 // NewScheduler returns a Scheduler ready to be started.
@@ -45,17 +47,24 @@ func NewScheduler(store *db.Store, launcher *run.RunLauncher, modelResolver *set
 // It returns immediately after scheduling; timers fire in background goroutines.
 // Cancelling ctx stops any pending timers before they fire.
 func (s *Scheduler) Start(ctx context.Context) error {
+	// Derive a cancellable root context with a stored cancel so Stop()/Wait()
+	// can drain in-flight timer goroutines (and the fire() calls they make)
+	// during shutdown, even when the caller does not own the context passed
+	// here. Mirrors CronRunner.Start.
+	rootCtx, rootCancel := context.WithCancel(ctx)
 	s.mu.Lock()
-	s.rootCtx = ctx
+	s.rootCtx = rootCtx
+	s.rootCancel = rootCancel
 	s.mu.Unlock()
 
-	policies, err := s.store.GetScheduledActivePolicies(ctx)
+	policies, err := s.store.GetScheduledActivePolicies(rootCtx)
 	if err != nil {
+		rootCancel()
 		return fmt.Errorf("load scheduled policies: %w", err)
 	}
 
 	for _, p := range policies {
-		provider, modelName := s.resolveDefaults(ctx)
+		provider, modelName := s.resolveDefaults(rootCtx)
 		parsed, err := policy.Parse(p.Yaml, provider, modelName)
 		if err != nil {
 			slog.Error("scheduled: failed to parse policy yaml", "policy_id", p.ID, "err", err)
@@ -66,7 +75,7 @@ func (s *Scheduler) Start(ctx context.Context) error {
 				"policy_id", p.ID)
 			continue
 		}
-		s.schedulePolicy(ctx, p.ID, parsed)
+		s.schedulePolicy(rootCtx, p.ID, parsed)
 	}
 	return nil
 }
@@ -114,11 +123,18 @@ func (s *Scheduler) schedulePolicy(ctx context.Context, policyID string, parsed 
 		// without cancelling unrelated ones.
 		timerCtx, timerCancel := context.WithCancel(ctx)
 
+		// Add to the WaitGroup under the same lock that records the timer cancel
+		// so Wait() (which is called only after the root context is cancelled)
+		// cannot observe a zero counter between the append and the goroutine
+		// launch. Each goroutine is tracked so Wait() can drain an in-flight
+		// fire() during shutdown rather than cutting it off mid-launch.
 		s.mu.Lock()
 		s.timers[policyID] = append(s.timers[policyID], timerCancel)
+		s.wg.Add(1)
 		s.mu.Unlock()
 
 		go func() {
+			defer s.wg.Done()
 			timer := time.NewTimer(delay)
 			defer timer.Stop()
 
@@ -247,4 +263,26 @@ func (s *Scheduler) pauseIfExhausted(ctx context.Context, policyID string, parse
 	} else {
 		slog.Info("scheduled: policy paused after all fire times consumed", "policy_id", policyID)
 	}
+}
+
+// Wait blocks until all timer goroutines have exited. Call after cancelling the
+// root context to drain an in-flight fire() cleanly during shutdown. Wait is
+// safe to call when Start was never called (the WaitGroup counter is zero).
+func (s *Scheduler) Wait() {
+	s.wg.Wait()
+}
+
+// Stop cancels all pending timers (including the reconcile-less fire goroutines)
+// and waits for them to exit. It is equivalent to cancelling the context passed
+// to Start, but is provided as an explicit method for callers that do not own
+// the context. Stop is safe to call when Start was never called (rootCancel is
+// nil → no-op) and is idempotent (context.CancelFunc tolerates repeated calls).
+func (s *Scheduler) Stop() {
+	s.mu.Lock()
+	cancel := s.rootCancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	s.wg.Wait()
 }

--- a/internal/trigger/scheduled_test.go
+++ b/internal/trigger/scheduled_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -603,5 +604,119 @@ func TestScheduler_SkipsPolicy_WhenNoSystemDefaultAndNoModelInYAML(t *testing.T)
 	}
 	if len(runs) != 0 {
 		t.Errorf("expected 0 runs when system default is unset and policy omits model, got %d", len(runs))
+	}
+}
+
+// gatedSchedulerFactory returns an AgentFactory that signals on `entered` when a
+// fire() reaches agent construction (the run row already exists at this point),
+// then blocks until `release` is closed. Used to hold a fire() in-flight so a
+// test can assert Scheduler.Wait() drains it rather than cutting it off.
+func gatedSchedulerFactory(entered chan<- struct{}, release <-chan struct{}) run.AgentFactory {
+	var once sync.Once
+	return func(cfg agent.Config) (*agent.BoundAgent, error) {
+		once.Do(func() { close(entered) })
+		<-release
+		cfg.LLMClient = testutil.NewMockLLMClient(
+			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
+		)
+		return agent.New(cfg)
+	}
+}
+
+// TestScheduler_Wait_DrainsInFlightFire verifies that Scheduler.Wait() (called
+// after the root context is cancelled) blocks until an in-flight fire() finishes
+// instead of returning while the fire goroutine is mid-launch. Previously the
+// Scheduler had no WaitGroup, so a fire() in progress at shutdown was undrained
+// and could be cut off after writing partial state (#487).
+func TestScheduler_Wait_DrainsInFlightFire(t *testing.T) {
+	store, registry := setupSchedulerFixture(t)
+
+	// Near-immediate fire so the timer fires almost at once.
+	future := time.Now().Add(1 * time.Second)
+	yaml := scheduledPolicyYAML("drain-policy", []time.Time{future})
+	insertTestScheduledPolicy(t, store, "pol-drain", "drain-policy", yaml)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
+	launcher := run.NewRunLauncher(run.RunLauncherConfig{
+		Store:                  store,
+		Registry:               registry,
+		Manager:                run.NewRunManager(),
+		AgentFactory:           gatedSchedulerFactory(entered, release),
+		Publisher:              nil,
+		DefaultFeedbackTimeout: 0,
+		ModelResolver:          resolver,
+	})
+	scheduler := trigger.NewScheduler(store, launcher, resolver)
+
+	// Pass a cancellable context we will cancel while fire() is held in-flight.
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := scheduler.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait until fire() has reached agent construction (it is now in-flight,
+	// holding the wg counter above zero).
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("fire() never reached the agent factory")
+	}
+
+	// Cancel the root context now — the fire goroutine is past its ctx check and
+	// must run to completion regardless.
+	cancel()
+
+	waitReturned := make(chan struct{})
+	go func() { scheduler.Wait(); close(waitReturned) }()
+
+	// Wait() must NOT return while fire() is still blocked in the factory.
+	select {
+	case <-waitReturned:
+		t.Fatal("Wait() returned while fire() was still in-flight — goroutine not tracked by wg")
+	case <-time.After(200 * time.Millisecond):
+		// Good: still draining.
+	}
+
+	// Release the gate; fire() completes, the goroutine returns, Wait() unblocks.
+	close(release)
+
+	select {
+	case <-waitReturned:
+		// Drained cleanly.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait() did not return after the in-flight fire() completed")
+	}
+
+	// The run row created by the drained fire() must exist (proof fire() finished).
+	runs, err := store.ListRuns(context.Background(), db.ListRunsParams{PolicyID: "pol-drain", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Error("expected the drained fire() to have created a run row")
+	}
+}
+
+// TestScheduler_Stop_SafeWithoutStart verifies that Stop() and Wait() are no-ops
+// (no panic, no hang) when Start was never called — rootCancel is nil and the
+// WaitGroup counter is zero (#487).
+func TestScheduler_Stop_SafeWithoutStart(t *testing.T) {
+	scheduler := trigger.NewScheduler(nil, nil, nil)
+
+	done := make(chan struct{})
+	go func() {
+		scheduler.Stop()
+		scheduler.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop()/Wait() hung when Start was never called")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -491,13 +491,20 @@ func run(cfg config.Config) error {
 	// Signal all in-flight agent runs to stop.
 	runManager.CancelAll()
 
-	// Wait for poll loops, cron loops, and agent runs to drain, with a timeout.
-	// Poll and cron loops should exit quickly (they are just sleeping timers).
-	// Agent runs may take longer, so all are waited concurrently.
+	// Wait for poll loops, cron loops, scheduled timers, timeout scanners, and
+	// agent runs to drain, with a timeout. The trigger loops/timers and scanner
+	// loops should exit quickly once their root context is cancelled (cancel()
+	// above), but an in-flight scheduled fire() or scanner resolveTimeout() — the
+	// latter writes run steps and transitions run state — must be allowed to
+	// finish rather than be cut off mid-flight. Agent runs may take longer, so
+	// all are waited concurrently and bounded by cfg.DrainTimeout below (#487).
 	runsDrained := make(chan struct{})
 	go func() {
 		poller.Wait()
 		cronRunner.Wait()
+		scheduler.Wait()
+		approvalScanner.Wait()
+		feedbackScanner.Wait()
 		runManager.Wait()
 		close(runsDrained)
 	}()


### PR DESCRIPTION
Closes #487

## Summary

Three related graceful-shutdown lifecycle gaps, all fixed by mirroring the existing **CronRunner** pattern (`internal/trigger/cron.go`): a derived root context with a stored `cancel`, a `sync.WaitGroup` tracking every spawned goroutine, and a `Wait()` (plus `Stop()`) method.

### 1. `Poller.Stop()` latent deadlock — `internal/trigger/poll.go`
`Stop()` cancelled the per-policy loop handles but never the `reconcileLoop` goroutine, which only exits when the context passed to `Start` is cancelled. `Stop()` had no stored cancel for that context, so `p.wg.Wait()` (which includes the reconcile goroutine) blocked forever. The doc comment claiming `Stop()` is "equivalent to cancelling the context passed to Start" was false.

**Fix:** `Start` now derives a cancellable `rootCtx` and stores `rootCancel`; `Stop()` cancels it — propagating to the reconcile loop **and** every per-policy loop (which derive from `rootCtx`) — before `wg.Wait()`. Latent today only because `main.go` used `cancel()` + `Wait()`, never `Stop()`.

### 2. `Scheduler` unwaitable — `internal/trigger/scheduled.go`
No `WaitGroup`, no `Wait()`, no stored cancel — so an in-flight `fire()`/`Launch` was cut off on shutdown.

**Fix:** added a `WaitGroup` tracking every timer goroutine (`Add` under the same lock that records the timer cancel, to avoid a Wait-before-Add race), a derived `rootCtx` + `rootCancel`, and `Wait()`/`Stop()`.

### 3. Timeout scanners never drained — `internal/timeout/scanner.go`
`Scanner.Start()` fire-and-forgot its goroutine, so an in-flight `resolveTimeout()` (which writes run steps and transitions run state) could be cut off mid-flight, corrupting the audit trail / leaving runs in a bad state.

**Fix:** added a `WaitGroup` and `Wait()` so an in-flight scan drains.

### `main.go` drain wiring
The new `scheduler.Wait()`, `approvalScanner.Wait()`, and `feedbackScanner.Wait()` are slotted into the **existing** `runsDrained` goroutine alongside `poller.Wait()`/`cronRunner.Wait()`/`runManager.Wait()`, so they are all bounded by `cfg.DrainTimeout`.

**#500 preserved:** the `cancel()` → `quiesceTriggers()` → `CancelAll()` → drain ordering is unchanged — the new `Wait()`s only join the existing drain goroutine. The plugin OAuth refresh scanner is already joined under pluginruntime's `bgWG` (#500) and needed no change; `NewPluginRequestScanner` has no production caller.

## Adversarial review notes
- **No new deadlock / no blocking past DrainTimeout:** all new `Wait()`s live inside the `runsDrained` goroutine, raced against `time.After(cfg.DrainTimeout)`.
- **`main.go`'s existing `cancel()`+`Wait()` path still works:** `cancel()` cancels the parent ctx → the derived `rootCtx` is cancelled too → all loops exit.
- **No double-cancel hazard:** `context.CancelFunc` is idempotent; the `Start` error path that calls `rootCancel()` is safe even if `Stop()` later cancels again.
- **`Wait()`/`Stop()` safe when `Start` was never called or errored:** `rootCancel` is nil → no-op; WaitGroup counter is zero. Covered by tests.

<details>
<summary>Plan</summary>

1. Read `cron.go` (reference), `poll.go`, `scheduled.go`, `timeout/scanner.go`, `main.go` shutdown (~L470-525), and `pluginruntime.go` shutdown.
2. Poller: store derived `rootCancel`; `Stop()` cancels it before `wg.Wait()`.
3. Scheduler: add `wg` + `rootCancel`, derive `rootCtx`, wrap timer goroutines in `wg`, add `Wait()`/`Stop()`.
4. Scanner: add `wg` + `Wait()`; track the `Start` goroutine.
5. main.go: add the three `Wait()`s into the existing timeout-raced drain goroutine; preserve #500 ordering.
6. Tests + full `-race` gate on every consumer.
</details>

## Review cycles
Self-reviewed the diff for shutdown ordering, double-cancel, Wait-before-Add races, and #500-regression. One test bug found and fixed during the gate: `scheduledPolicyYAML` formats fire times with second-precision `time.RFC3339`, so a sub-second "near future" truncated into the past and was skipped — bumped the drain test's fire time to a whole-second future.

## What's tested
- `TestPoller_Stop_DoesNotDeadlock` — `Stop()` returns after `Start` without cancelling the Start context (mirrors `TestCronRunner_Stop_DoesNotDeadlock`).
- `TestPoller_Stop_SafeWithoutStart` — `Stop()` is a no-op without `Start`.
- `TestScheduler_Wait_DrainsInFlightFire` — gated agent factory holds a `fire()` in-flight; asserts `Wait()` blocks until released, then returns, and the run row exists.
- `TestScheduler_Stop_SafeWithoutStart` — `Stop()`/`Wait()` no-op without `Start`.
- `TestScanner_Wait_DrainsInFlightScan` — gated `ListExpired` holds a scan in-flight after ctx cancel; asserts `Wait()` blocks then drains.
- `TestScanner_Wait_SafeWithoutStart` — `Wait()` no-op without `Start`.

**Gate:** `go build ./...`, `go vet ./...`, `go test -race ./internal/trigger/... ./internal/timeout/...`, and `go test -race .` all pass. Full `go test -race ./...` is green except two pre-existing load-sensitive flakes in `internal/execution/agent` (`TestAuditWriter_PerformanceBaseline` — a wall-clock perf baseline; `TestApprovalHandler_Wait_ContextCancelled` — a deadline-vs-cancel race), both unrelated to this change (that package is untouched) and both pass without `-race`/concurrent load.

## CLAUDE.md
Updated the `GLEIPNIR_DRAIN_TIMEOUT` row to note the drain now also bounds the scheduler's in-flight `fire()` and the approval/feedback scanners' in-flight `resolveTimeout()`. No ADR — this is a bug fix mirroring an existing pattern, not a new architectural decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)