### PR TITLE
feat: one ToolResolver in front of MCP and plugin tool resolution

### DIFF
--- a/internal/execution/agent/agent.go
+++ b/internal/execution/agent/agent.go
@@ -105,51 +105,14 @@ func New(cfg Config) (*BoundAgent, error) {
 	}
 
 	// Derive dispatch-side entries and snapshot-side granted tools from plugin
-	// tool configs in a single pass (plan decision (f)).
-	pluginGrantedTools := make([]model.GrantedTool, 0, len(cfg.PluginTools))
-	for _, pt := range cfg.PluginTools {
-		dotName := pt.InstanceName + "." + pt.ToolName
-
-		schemaJSON, err := json.Marshal(pt.Schema)
-		if err != nil {
-			return nil, fmt.Errorf("marshaling schema for plugin tool %s: %w", dotName, err)
-		}
-
-		// Apply policy-level parameter scoping (ADR-017) to plugin tools, exactly
-		// as buildResolvedToolMap does for MCP tools. narrowedSchema feeds the LLM;
-		// InputSchema is the raw schema of record.
-		narrowed, err := mcp.NarrowSchema(schemaJSON, pt.Params)
-		if err != nil {
-			return nil, fmt.Errorf("narrowing schema for plugin tool %s: %w", dotName, err)
-		}
-
-		toolsByName[dotName] = resolvedToolEntry{
-			tool: mcp.ResolvedTool{
-				GrantedTool: model.GrantedTool{
-					ServerName: "", // no MCP server; plugin dispatch is via pluginSource
-					ToolName:   pt.ToolName,
-					Approval:   pt.Approval,
-					Timeout:    pt.Timeout,
-					Params:     pt.Params,
-				},
-				Client:      nil, // real dispatch wired in #198
-				Description: pt.Description,
-				InputSchema: schemaJSON,
-			},
-			narrowedSchema: narrowed,
-			pluginSource: &pluginToolSource{
-				InstanceName: pt.InstanceName,
-				Generation:   pt.Generation,
-			},
-		}
-
-		pluginGrantedTools = append(pluginGrantedTools, model.GrantedTool{
-			ServerName: "",
-			ToolName:   pt.ToolName,
-			Approval:   pt.Approval,
-			Params:     pt.Params,
-			Source:     sourceString(toolsByName[dotName]),
-		})
+	// tool configs in a single pass (plan decision (f)). buildPluginToolEntries
+	// is the single place that produces both structures so they stay in sync.
+	pluginEntries, pluginGrantedTools, err := buildPluginToolEntries(cfg.PluginTools)
+	if err != nil {
+		return nil, err
+	}
+	for dotName, entry := range pluginEntries {
+		toolsByName[dotName] = entry
 	}
 
 	var approvalOpts []ApprovalHandlerOption
@@ -493,26 +456,9 @@ func (a *BoundAgent) Run(ctx context.Context, runID string, triggerPayload strin
 		return fmt.Errorf("transitioning run to running: %w", err)
 	}
 
-	// Extract granted tools for system prompt rendering, populating the Source
-	// field so the capability snapshot identifies each tool's origin.
-	grantedTools := make([]model.GrantedTool, len(a.tools))
-	for i, rt := range a.tools {
-		gt := rt.GrantedTool // copy: GrantedTool is a value type
-		gt.Source = sourceString(resolvedToolEntry{tool: rt})
-		grantedTools[i] = gt
-	}
-	// Include the synthetic ask_operator tool in the capability snapshot when
-	// feedback is enabled, so the audit trail reflects the full set of tools
-	// available to the agent at run start. Source is intentionally empty for
-	// synthetic tools (they have no MCP server or plugin instance).
-	if a.policy.Capabilities.Feedback.Enabled {
-		grantedTools = append(grantedTools, model.GrantedTool{
-			ServerName: "gleipnir",
-			ToolName:   "ask_operator",
-		})
-	}
-	// Append plugin-source tools; their Source strings were set at New() time.
-	grantedTools = append(grantedTools, a.pluginGrantedTools...)
+	// Assemble the ordered granted-tool list for the capability snapshot and
+	// system prompt. Ordering: MCP → synthetic gleipnir.ask_operator → plugin.
+	grantedTools := buildCapabilitySnapshotTools(a.tools, a.pluginGrantedTools, a.policy.Capabilities.Feedback.Enabled)
 
 	// Render system prompt (ADR-001: only granted tools are visible to the agent).
 	systemPrompt := policy.RenderSystemPrompt(a.policy, grantedTools, time.Now().UTC())

--- a/internal/execution/agent/tools.go
+++ b/internal/execution/agent/tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/felag-engineering/gleipnir/internal/llm"
 	"github.com/felag-engineering/gleipnir/internal/mcp"
+	"github.com/felag-engineering/gleipnir/internal/model"
 )
 
 // pluginToolSource identifies the plugin instance and generation captured at run
@@ -58,6 +59,94 @@ func buildResolvedToolMap(tools []mcp.ResolvedTool) (map[string]resolvedToolEntr
 	return toolsByName, nil
 }
 
+// buildPluginToolEntries produces the dispatch-side map entries and the
+// snapshot-side granted-tool slice from a single pass over the plugin tool
+// configs. New() calls it once and merges the returned map into toolsByName,
+// keeping both structures derived from the same source (plan decision (f)).
+//
+// Panics are intentionally NOT in this helper — they live in New() as a gate
+// on PluginRegistrar/PluginDispatcher, before this function is called.
+func buildPluginToolEntries(pts []PluginToolEntry) (map[string]resolvedToolEntry, []model.GrantedTool, error) {
+	entries := make(map[string]resolvedToolEntry, len(pts))
+	granted := make([]model.GrantedTool, 0, len(pts))
+
+	for _, pt := range pts {
+		dotName := pt.InstanceName + "." + pt.ToolName
+
+		schemaJSON, err := json.Marshal(pt.Schema)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshaling schema for plugin tool %s: %w", dotName, err)
+		}
+
+		// Apply policy-level parameter scoping (ADR-017) to plugin tools, exactly
+		// as buildResolvedToolMap does for MCP tools.
+		narrowed, err := mcp.NarrowSchema(schemaJSON, pt.Params)
+		if err != nil {
+			return nil, nil, fmt.Errorf("narrowing schema for plugin tool %s: %w", dotName, err)
+		}
+
+		entry := resolvedToolEntry{
+			tool: mcp.ResolvedTool{
+				GrantedTool: model.GrantedTool{
+					ServerName: "", // no MCP server; plugin dispatch is via pluginSource
+					ToolName:   pt.ToolName,
+					Approval:   pt.Approval,
+					Timeout:    pt.Timeout,
+					Params:     pt.Params,
+				},
+				Client:      nil, // real dispatch wired in #198
+				Description: pt.Description,
+				InputSchema: schemaJSON,
+			},
+			narrowedSchema: narrowed,
+			pluginSource: &pluginToolSource{
+				InstanceName: pt.InstanceName,
+				Generation:   pt.Generation,
+			},
+		}
+		entries[dotName] = entry
+
+		granted = append(granted, model.GrantedTool{
+			ServerName: "",
+			ToolName:   pt.ToolName,
+			Approval:   pt.Approval,
+			Params:     pt.Params,
+			Source:     sourceString(entry),
+		})
+	}
+
+	return entries, granted, nil
+}
+
+// buildCapabilitySnapshotTools assembles the ordered list of granted tools for
+// the ADR-018 capability snapshot. Ordering is MCP tools → synthetic
+// gleipnir.ask_operator (when feedback is enabled) → plugin tools.
+//
+// pluginGranted carries Source strings already set at New() time (via
+// buildPluginToolEntries), so they pass through unchanged. MCP tool Source
+// strings are computed here via sourceString.
+func buildCapabilitySnapshotTools(tools []mcp.ResolvedTool, pluginGranted []model.GrantedTool, feedbackEnabled bool) []model.GrantedTool {
+	out := make([]model.GrantedTool, len(tools), len(tools)+len(pluginGranted))
+	for i, rt := range tools {
+		gt := rt.GrantedTool // copy: GrantedTool is a value type
+		gt.Source = sourceString(resolvedToolEntry{tool: rt})
+		out[i] = gt
+	}
+	// Include the synthetic ask_operator tool in the capability snapshot when
+	// feedback is enabled, so the audit trail reflects the full set of tools
+	// available to the agent at run start. Source is intentionally empty for
+	// synthetic tools (they have no MCP server or plugin instance).
+	if feedbackEnabled {
+		out = append(out, model.GrantedTool{
+			ServerName: "gleipnir",
+			ToolName:   "ask_operator",
+		})
+	}
+	// Append plugin-source tools; their Source strings were set at New() time.
+	out = append(out, pluginGranted...)
+	return out
+}
+
 // checkCapabilities verifies every capability reference in the policy resolves
 // to a tool registered at BoundAgent construction time. Called at the start of
 // Run(), before the pending→running transition, so a run with unresolvable
@@ -73,7 +162,7 @@ func (a *BoundAgent) checkCapabilities() error {
 	// check. A plugin tool that fails namespace reservation never reaches toolsByName.
 	for _, t := range a.policy.Capabilities.Tools {
 		if _, ok := a.toolsByName[t.Tool]; !ok {
-			return fmt.Errorf("capability '%s' not found in MCP registry — verify the MCP server is registered and the tool exists", t.Tool)
+			return fmt.Errorf("capability %q is not a registered tool — verify the MCP server or plugin providing it is installed and the tool exists", t.Tool)
 		}
 	}
 	return nil

--- a/internal/execution/agent/tools_test.go
+++ b/internal/execution/agent/tools_test.go
@@ -1,0 +1,210 @@
+package agent
+
+// Tests for the helper functions extracted from the plugin-tool processing loop
+// in New() and the snapshot assembly in Run(). The integration guard
+// (TestCapabilitySnapshot_IncludesPluginSourceTools) lives in agent_test.go and
+// exercises the full BoundAgent loop; these unit tests exercise the helpers in
+// isolation so the sync invariant and snapshot ordering have a focused surface.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/mcp"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// TestBuildPluginToolEntries_DispatchAndSnapshotStayInSync asserts that the
+// returned dispatch map and snapshot slice have identical dot-name coverage and
+// that every snapshot Source matches the dispatch entry's Source.
+func TestBuildPluginToolEntries_DispatchAndSnapshotStayInSync(t *testing.T) {
+	pts := []PluginToolEntry{
+		{InstanceName: "inst-a", ToolName: "read", Generation: 1,
+			Description: "reads", Schema: map[string]any{"type": "object"}},
+		{InstanceName: "inst-b", ToolName: "write", Generation: 3,
+			Description: "writes", Schema: map[string]any{"type": "object"}},
+	}
+
+	entries, granted, err := buildPluginToolEntries(pts)
+	if err != nil {
+		t.Fatalf("buildPluginToolEntries: %v", err)
+	}
+
+	// Same count in both outputs.
+	if len(entries) != len(pts) {
+		t.Errorf("dispatch map len = %d, want %d", len(entries), len(pts))
+	}
+	if len(granted) != len(pts) {
+		t.Errorf("snapshot slice len = %d, want %d", len(granted), len(pts))
+	}
+
+	// Verify dispatch entries and snapshot entries are in sync by dot-name and Source.
+	for i, pt := range pts {
+		dotName := pt.InstanceName + "." + pt.ToolName
+		wantSource := fmt.Sprintf("plugin:%s@%d", pt.InstanceName, pt.Generation)
+
+		entry, ok := entries[dotName]
+		if !ok {
+			t.Errorf("dispatch map missing key %q", dotName)
+			continue
+		}
+		gotSource := sourceString(entry)
+		if gotSource != wantSource {
+			t.Errorf("dispatch entry %q Source = %q, want %q", dotName, gotSource, wantSource)
+		}
+
+		gt := granted[i]
+		if gt.Source != wantSource {
+			t.Errorf("snapshot entry %d Source = %q, want %q", i, gt.Source, wantSource)
+		}
+		if gt.ToolName != pt.ToolName {
+			t.Errorf("snapshot entry %d ToolName = %q, want %q", i, gt.ToolName, pt.ToolName)
+		}
+	}
+}
+
+func TestBuildPluginToolEntries_EmptyInput(t *testing.T) {
+	entries, granted, err := buildPluginToolEntries(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("entries len = %d, want 0", len(entries))
+	}
+	if len(granted) != 0 {
+		t.Errorf("granted len = %d, want 0", len(granted))
+	}
+}
+
+func TestBuildPluginToolEntries_SchemaAndParamsApplied(t *testing.T) {
+	// Params narrows the schema: only the allowed property should be exposed.
+	pt := PluginToolEntry{
+		InstanceName: "inst",
+		ToolName:     "do-thing",
+		Generation:   2,
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"allowed": map[string]any{"type": "string"},
+				"denied":  map[string]any{"type": "string"},
+			},
+		},
+		Params: map[string]any{
+			"properties": map[string]any{
+				"allowed": map[string]any{"type": "string"},
+			},
+		},
+	}
+
+	entries, _, err := buildPluginToolEntries([]PluginToolEntry{pt})
+	if err != nil {
+		t.Fatalf("buildPluginToolEntries: %v", err)
+	}
+	entry, ok := entries["inst.do-thing"]
+	if !ok {
+		t.Fatal("dispatch map missing 'inst.do-thing'")
+	}
+	if entry.narrowedSchema == nil {
+		t.Error("narrowedSchema is nil; want narrowed JSON")
+	}
+}
+
+func TestBuildCapabilitySnapshotTools_Ordering(t *testing.T) {
+	// Verify MCP → synthetic ask_operator → plugin ordering.
+	mcpTools := []mcp.ResolvedTool{
+		{
+			GrantedTool: model.GrantedTool{ServerName: "srv", ToolName: "read"},
+			Description: "reads",
+		},
+	}
+	pluginGranted := []model.GrantedTool{
+		{ToolName: "do-thing", Source: "plugin:inst@1"},
+	}
+
+	got := buildCapabilitySnapshotTools(mcpTools, pluginGranted, true)
+
+	// Expected order: mcp-tool, ask_operator, plugin-tool.
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0].ToolName != "read" {
+		t.Errorf("got[0].ToolName = %q, want \"read\"", got[0].ToolName)
+	}
+	if got[0].Source != "mcp:srv" {
+		t.Errorf("got[0].Source = %q, want \"mcp:srv\"", got[0].Source)
+	}
+	if got[1].ServerName != "gleipnir" || got[1].ToolName != "ask_operator" {
+		t.Errorf("got[1] = %+v, want gleipnir.ask_operator", got[1])
+	}
+	if got[1].Source != "" {
+		t.Errorf("synthetic tool Source = %q, want empty", got[1].Source)
+	}
+	if got[2].Source != "plugin:inst@1" {
+		t.Errorf("got[2].Source = %q, want \"plugin:inst@1\"", got[2].Source)
+	}
+}
+
+func TestBuildCapabilitySnapshotTools_FeedbackDisabled(t *testing.T) {
+	// When feedbackEnabled is false, ask_operator must not appear.
+	mcpTools := []mcp.ResolvedTool{
+		{GrantedTool: model.GrantedTool{ServerName: "srv", ToolName: "read"}},
+	}
+	got := buildCapabilitySnapshotTools(mcpTools, nil, false)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (no ask_operator)", len(got))
+	}
+	for _, g := range got {
+		if g.ToolName == "ask_operator" {
+			t.Error("ask_operator found in snapshot with feedbackEnabled=false")
+		}
+	}
+}
+
+func TestBuildCapabilitySnapshotTools_MCPOnly(t *testing.T) {
+	mcpTools := []mcp.ResolvedTool{
+		{GrantedTool: model.GrantedTool{ServerName: "a", ToolName: "t1"}},
+		{GrantedTool: model.GrantedTool{ServerName: "b", ToolName: "t2"}},
+	}
+	got := buildCapabilitySnapshotTools(mcpTools, nil, false)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+}
+
+func TestBuildCapabilitySnapshotTools_PluginOnly(t *testing.T) {
+	pluginGranted := []model.GrantedTool{
+		{ToolName: "p1", Source: "plugin:inst@1"},
+	}
+	got := buildCapabilitySnapshotTools(nil, pluginGranted, false)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Source != "plugin:inst@1" {
+		t.Errorf("Source = %q, want \"plugin:inst@1\"", got[0].Source)
+	}
+}
+
+func TestBuildCapabilitySnapshotTools_ApprovalAndTimeoutPreserved(t *testing.T) {
+	// Approval mode and timeout from the GrantedTool must survive the copy.
+	mcpTools := []mcp.ResolvedTool{
+		{
+			GrantedTool: model.GrantedTool{
+				ServerName: "srv",
+				ToolName:   "gated",
+				Approval:   model.ApprovalModeRequired,
+				Timeout:    5 * time.Second,
+			},
+		},
+	}
+	got := buildCapabilitySnapshotTools(mcpTools, nil, false)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Approval != model.ApprovalModeRequired {
+		t.Errorf("Approval = %v, want required", got[0].Approval)
+	}
+	if got[0].Timeout != 5*time.Second {
+		t.Errorf("Timeout = %v, want 5s", got[0].Timeout)
+	}
+}

--- a/internal/execution/run/launcher.go
+++ b/internal/execution/run/launcher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/infra/event"
 	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
 	"github.com/felag-engineering/gleipnir/internal/llm"
-	"github.com/felag-engineering/gleipnir/internal/mcp"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/policy"
 	"github.com/felag-engineering/gleipnir/internal/settings"
@@ -76,54 +75,28 @@ type LaunchResult struct {
 // All three trigger handlers (webhook, manual, scheduled) delegate to it.
 type RunLauncher struct {
 	store                  *db.Store
-	registry               registryResolver
+	resolver               ToolResolver
 	manager                *RunManager
 	newAgent               AgentFactory
 	publisher              event.Publisher
 	defaultFeedbackTimeout time.Duration
 	modelResolver          *settings.Service
-	pluginResolver         PluginToolResolver
-	toolClassifier         ToolSourceClassifier
 	pluginRegistrar        agent.PluginGenerationLookup
 	pluginDispatcher       agent.PluginToolDispatcher
 	approvalDispatcher     agent.ApprovalChannelDispatcher
 	feedbackDispatcher     agent.FeedbackChannelDispatcher
 }
 
-// registryResolver is the subset of mcp.Registry used by RunLauncher, defined
-// as an interface so tests can supply a stub without importing internal/mcp directly.
-type registryResolver interface {
-	ResolveForPolicy(ctx context.Context, p *model.ParsedPolicy) ([]mcp.ResolvedTool, error)
-}
-
-// PluginToolResolver resolves plugin-sourced tool grants into agent-ready
-// entries. The implementation looks up the manifest, finds each tool's
-// description and schema, and reads the current generation from the registrar.
-type PluginToolResolver interface {
-	ResolvePluginTools(ctx context.Context, grants []model.ToolCapability) ([]agent.PluginToolEntry, error)
-}
-
-// ToolSourceClassifier determines whether a dot-name tool grant should be
-// resolved via MCP or the plugin path. The lookup is static — based on the
-// installed plugin instance row and its manifest snapshot, NOT on whether the
-// instance's subprocess is currently running (see #399). It does DB + manifest
-// reads, so it takes a context and can return an error.
-type ToolSourceClassifier interface {
-	IsPluginTool(ctx context.Context, dotName string) (bool, error)
-}
-
 // RunLauncherConfig holds all dependencies for a RunLauncher. Field order
 // mirrors the former positional parameters so a grep-diff is auditable.
 type RunLauncherConfig struct {
 	Store                  *db.Store
-	Registry               registryResolver
+	Resolver               ToolResolver
 	Manager                *RunManager
 	AgentFactory           AgentFactory
 	Publisher              event.Publisher // nil = no real-time events
 	DefaultFeedbackTimeout time.Duration
 	ModelResolver          *settings.Service            // nil = use launch-time snapshot only
-	PluginResolver         PluginToolResolver           // nil when plugins are disabled
-	ToolClassifier         ToolSourceClassifier         // nil when plugins are disabled; all grants go to MCP path
 	PluginRegistrar        agent.PluginGenerationLookup // nil when plugins are disabled
 	PluginDispatcher       agent.PluginToolDispatcher   // nil when plugins are disabled
 	// ApprovalDispatcher routes approvals through a plugin channel when the
@@ -143,14 +116,12 @@ type RunLauncherConfig struct {
 func NewRunLauncher(cfg RunLauncherConfig) *RunLauncher {
 	return &RunLauncher{
 		store:                  cfg.Store,
-		registry:               cfg.Registry,
+		resolver:               cfg.Resolver,
 		manager:                cfg.Manager,
 		newAgent:               cfg.AgentFactory,
 		publisher:              cfg.Publisher,
 		defaultFeedbackTimeout: cfg.DefaultFeedbackTimeout,
 		modelResolver:          cfg.ModelResolver,
-		pluginResolver:         cfg.PluginResolver,
-		toolClassifier:         cfg.ToolClassifier,
 		pluginRegistrar:        cfg.PluginRegistrar,
 		pluginDispatcher:       cfg.PluginDispatcher,
 		approvalDispatcher:     cfg.ApprovalDispatcher,
@@ -254,91 +225,22 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 		agent.WithInitialVersion(run.Version),
 	)
 
-	// Split policy tool grants by source kind so each list goes to the right
-	// resolver. When ToolClassifier is nil (plugins disabled), every grant falls
-	// through to the MCP path — preserving the pre-plugin behaviour exactly.
-	var mcpGrants, pluginGrants []model.ToolCapability
-	for _, t := range params.ParsedPolicy.Capabilities.Tools {
-		isPlugin := false
-		if l.toolClassifier != nil {
-			var classErr error
-			isPlugin, classErr = l.toolClassifier.IsPluginTool(ctx, t.Tool)
-			if classErr != nil {
-				// A classification read failed (e.g. the manifest snapshot could
-				// not be loaded). Fail the run loudly rather than silently
-				// misrouting the grant to the MCP path.
-				wrapped := fmt.Errorf("classify tool %q: %w", t.Tool, classErr)
-				if tErr := sm.Transition(context.Background(), model.RunStatusFailed, wrapped.Error()); tErr != nil {
-					if errors.Is(tErr, agent.ErrTransitionConflict) {
-						slog.Info("transition lost to concurrent writer on tool classification error", "run_id", run.ID)
-					} else {
-						slog.Error("transition to failed on tool classification error", "run_id", run.ID, "err", tErr)
-					}
-				}
-				return LaunchResult{RunID: run.ID}, wrapped
+	// Resolve all capability grants in one call. Classification (MCP vs plugin),
+	// per-source resolution, and error handling are encapsulated in the resolver.
+	// context.Background() is used for the fail-run transition because the HTTP
+	// request context that produced ctx may already be cancelled when this error
+	// surfaces, but the DB write must complete so the run does not linger in
+	// 'pending' indefinitely.
+	toolSet, resolveErr := l.resolver.ResolveCapabilities(ctx, params.ParsedPolicy.Capabilities.Tools)
+	if resolveErr != nil {
+		if tErr := sm.Transition(context.Background(), model.RunStatusFailed, resolveErr.Error()); tErr != nil {
+			if errors.Is(tErr, agent.ErrTransitionConflict) {
+				slog.Info("transition lost to concurrent writer on tool resolution error", "run_id", run.ID)
+			} else {
+				slog.Error("transition to failed on tool resolution error", "run_id", run.ID, "err", tErr)
 			}
 		}
-		if isPlugin {
-			pluginGrants = append(pluginGrants, t)
-		} else {
-			mcpGrants = append(mcpGrants, t)
-		}
-	}
-
-	// Resolve MCP tools via existing path. When mcpGrants is empty we skip the
-	// DB round-trip entirely — ResolveForPolicy with an empty list is a no-op
-	// but the shallow copy and call are still wasted work.
-	var resolvedTools []mcp.ResolvedTool
-	if len(mcpGrants) > 0 {
-		// Shallow copy avoids mutating the caller's ParsedPolicy; only Capabilities.Tools is swapped.
-		mcpPolicy := *params.ParsedPolicy
-		mcpPolicy.Capabilities.Tools = mcpGrants
-		var mcpErr error
-		resolvedTools, mcpErr = l.registry.ResolveForPolicy(ctx, &mcpPolicy)
-		if mcpErr != nil {
-			// context.Background(): the HTTP request context that produced ctx may
-			// already be cancelled, but the DB write must complete so the run does
-			// not linger in 'pending' indefinitely.
-			if tErr := sm.Transition(context.Background(), model.RunStatusFailed, mcpErr.Error()); tErr != nil {
-				if errors.Is(tErr, agent.ErrTransitionConflict) {
-					slog.Info("transition lost to concurrent writer on tool resolution error", "run_id", run.ID)
-				} else {
-					slog.Error("transition to failed on tool resolution error", "run_id", run.ID, "err", tErr)
-				}
-			}
-			return LaunchResult{RunID: run.ID}, mcpErr
-		}
-	}
-
-	// Resolve plugin tools. When no plugin grants exist this is a no-op.
-	// When grants exist but PluginResolver is nil, the policy references a
-	// plugin tool while the plugin subsystem is not enabled — fail clearly
-	// rather than silently dropping the grant.
-	var pluginToolEntries []agent.PluginToolEntry
-	if len(pluginGrants) > 0 {
-		if l.pluginResolver == nil {
-			pluginErr := fmt.Errorf("plugin tools granted but plugin subsystem is not enabled")
-			if tErr := sm.Transition(context.Background(), model.RunStatusFailed, pluginErr.Error()); tErr != nil {
-				if errors.Is(tErr, agent.ErrTransitionConflict) {
-					slog.Info("transition lost to concurrent writer on plugin tool resolution error", "run_id", run.ID)
-				} else {
-					slog.Error("transition to failed on plugin tool resolution error", "run_id", run.ID, "err", tErr)
-				}
-			}
-			return LaunchResult{RunID: run.ID}, pluginErr
-		}
-		var pluginErr error
-		pluginToolEntries, pluginErr = l.pluginResolver.ResolvePluginTools(ctx, pluginGrants)
-		if pluginErr != nil {
-			if tErr := sm.Transition(context.Background(), model.RunStatusFailed, pluginErr.Error()); tErr != nil {
-				if errors.Is(tErr, agent.ErrTransitionConflict) {
-					slog.Info("transition lost to concurrent writer on plugin tool resolution error", "run_id", run.ID)
-				} else {
-					slog.Error("transition to failed on plugin tool resolution error", "run_id", run.ID, "err", tErr)
-				}
-			}
-			return LaunchResult{RunID: run.ID}, pluginErr
-		}
+		return LaunchResult{RunID: run.ID}, resolveErr
 	}
 
 	audit := agent.NewAuditWriter(l.store.Queries(), agent.WithPublisher(l.publisher))
@@ -366,14 +268,14 @@ func (l *RunLauncher) Launch(ctx context.Context, params LaunchParams) (LaunchRe
 	// channel.
 	approvalCh := make(chan bool, 1)
 	ba, err := l.newAgent(agent.Config{
-		Tools:                  resolvedTools,
+		Tools:                  toolSet.MCPTools,
 		Policy:                 params.ParsedPolicy,
 		PolicyID:               params.PolicyID,
 		Audit:                  audit,
 		StateMachine:           sm,
 		ApprovalCh:             approvalCh,
 		DefaultFeedbackTimeout: l.defaultFeedbackTimeout,
-		PluginTools:            pluginToolEntries,
+		PluginTools:            toolSet.PluginTools,
 		PluginRegistrar:        l.pluginRegistrar,
 		PluginDispatcher:       l.pluginDispatcher,
 		ApprovalDispatcher:     l.approvalDispatcher,

--- a/internal/execution/run/launcher_test.go
+++ b/internal/execution/run/launcher_test.go
@@ -154,7 +154,7 @@ func TestCheckConcurrency(t *testing.T) {
 			// factory is nil — CheckConcurrency never calls it.
 			launcher := run.NewRunLauncher(run.RunLauncherConfig{
 				Store:                  store,
-				Registry:               registry,
+				Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 				Manager:                manager,
 				AgentFactory:           nil,
 				Publisher:              nil,
@@ -203,7 +203,7 @@ func TestCheckConcurrency_Replace(t *testing.T) {
 		registry := mcp.NewRegistry(store.Queries())
 		launcher := run.NewRunLauncher(run.RunLauncherConfig{
 			Store:                  store,
-			Registry:               registry,
+			Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 			Manager:                manager,
 			AgentFactory:           nil,
 			Publisher:              nil,
@@ -256,7 +256,7 @@ func TestCheckConcurrency_Replace(t *testing.T) {
 		registry := mcp.NewRegistry(store.Queries())
 		launcher := run.NewRunLauncher(run.RunLauncherConfig{
 			Store:                  store,
-			Registry:               registry,
+			Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 			Manager:                manager,
 			AgentFactory:           nil,
 			Publisher:              nil,
@@ -285,7 +285,7 @@ func TestLaunch_ToolResolutionFailure(t *testing.T) {
 	manager := run.NewRunManager()
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           nil,
 		Publisher:              nil,
@@ -350,7 +350,7 @@ func TestLaunch_AgentConstructionFailure(t *testing.T) {
 	agentErr := errors.New("deliberate construction failure")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           failingAgentFactory(agentErr),
 		Publisher:              nil,
@@ -414,7 +414,7 @@ func TestLaunch_Successful(t *testing.T) {
 	manager := run.NewRunManager()
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           localAgentFactory(),
 		Publisher:              nil,
@@ -537,7 +537,7 @@ agent:
 			registry := mcp.NewRegistry(store.Queries())
 			launcher := run.NewRunLauncher(run.RunLauncherConfig{
 				Store:                  store,
-				Registry:               registry,
+				Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 				Manager:                run.NewRunManager(),
 				AgentFactory:           nil,
 				Publisher:              nil,
@@ -591,7 +591,7 @@ agent:
 		manager := run.NewRunManager()
 		launcher := run.NewRunLauncher(run.RunLauncherConfig{
 			Store:                  store,
-			Registry:               registry,
+			Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 			Manager:                manager,
 			AgentFactory:           localAgentFactory(),
 			Publisher:              nil,
@@ -635,7 +635,7 @@ agent:
 		manager := run.NewRunManager()
 		launcher := run.NewRunLauncher(run.RunLauncherConfig{
 			Store:                  store,
-			Registry:               registry,
+			Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 			Manager:                manager,
 			AgentFactory:           nil,
 			Publisher:              nil,
@@ -685,7 +685,7 @@ agent:
 		manager := run.NewRunManager()
 		launcher := run.NewRunLauncher(run.RunLauncherConfig{
 			Store:                  store,
-			Registry:               registry,
+			Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 			Manager:                manager,
 			AgentFactory:           nil,
 			Publisher:              nil,
@@ -745,7 +745,7 @@ agent:
 		registry := mcp.NewRegistry(store.Queries())
 		launcher := run.NewRunLauncher(run.RunLauncherConfig{
 			Store:                  store,
-			Registry:               registry,
+			Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 			Manager:                manager,
 			AgentFactory:           nil,
 			Publisher:              nil,
@@ -773,7 +773,7 @@ func TestLaunch_ToolResolutionFailure_PublishesEvent(t *testing.T) {
 	pub := &testutil.RecordingPublisher{}
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           nil,
 		Publisher:              pub,
@@ -823,7 +823,7 @@ func TestLaunch_AgentConstructionFailure_PublishesEvent(t *testing.T) {
 	agentErr := errors.New("deliberate construction failure")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           failingAgentFactory(agentErr),
 		Publisher:              pub,
@@ -946,9 +946,12 @@ agent:
 	}
 
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
-		Store:    store,
-		Registry: registry,
-		Manager:  manager,
+		Store: store,
+		Resolver: run.NewDefaultToolResolver(registry,
+			&stubToolClassifier{pluginTools: map[string]bool{"test-plugin.do-thing": true}},
+			&stubPluginToolResolver{entries: []agent.PluginToolEntry{pluginEntry}},
+		),
+		Manager: manager,
 		AgentFactory: func(cfg agent.Config) (*agent.BoundAgent, error) {
 			cfg.LLMClient = testutil.NewMockLLMClient(
 				testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
@@ -958,14 +961,8 @@ agent:
 		Publisher:              nil,
 		DefaultFeedbackTimeout: 0,
 		ModelResolver:          nil,
-		ToolClassifier: &stubToolClassifier{
-			pluginTools: map[string]bool{"test-plugin.do-thing": true},
-		},
-		PluginResolver: &stubPluginToolResolver{
-			entries: []agent.PluginToolEntry{pluginEntry},
-		},
-		PluginRegistrar:  &stubPluginGenerationLookup{generation: 1, registered: true},
-		PluginDispatcher: &stubPluginDispatcher{},
+		PluginRegistrar:        &stubPluginGenerationLookup{generation: 1, registered: true},
+		PluginDispatcher:       &stubPluginDispatcher{},
 	})
 
 	result, launchErr := launcher.Launch(context.Background(), run.LaunchParams{
@@ -1024,17 +1021,16 @@ agent:
 	resolverErr := errors.New("instance subprocess is not running")
 
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
-		Store:                  store,
-		Registry:               registry,
+		Store: store,
+		Resolver: run.NewDefaultToolResolver(registry,
+			&stubToolClassifier{pluginTools: map[string]bool{"test-plugin.do-thing": true}},
+			&stubPluginToolResolver{err: resolverErr},
+		),
 		Manager:                manager,
 		AgentFactory:           nil,
 		Publisher:              nil,
 		DefaultFeedbackTimeout: 0,
 		ModelResolver:          nil,
-		ToolClassifier: &stubToolClassifier{
-			pluginTools: map[string]bool{"test-plugin.do-thing": true},
-		},
-		PluginResolver: &stubPluginToolResolver{err: resolverErr},
 	})
 
 	result, launchErr := launcher.Launch(context.Background(), run.LaunchParams{
@@ -1101,9 +1097,14 @@ agent:
 	}
 
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
-		Store:    store,
-		Registry: registry,
-		Manager:  manager,
+		Store: store,
+		// Only the plugin tool is classified as plugin-sourced; stub-server.read_data
+		// falls through to the MCP path inside DefaultToolResolver.
+		Resolver: run.NewDefaultToolResolver(registry,
+			&stubToolClassifier{pluginTools: map[string]bool{"test-plugin.do-thing": true}},
+			&stubPluginToolResolver{entries: []agent.PluginToolEntry{pluginEntry}},
+		),
+		Manager: manager,
 		AgentFactory: func(cfg agent.Config) (*agent.BoundAgent, error) {
 			cfg.LLMClient = testutil.NewMockLLMClient(
 				testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
@@ -1113,16 +1114,8 @@ agent:
 		Publisher:              nil,
 		DefaultFeedbackTimeout: 0,
 		ModelResolver:          nil,
-		// Only the plugin tool is classified as plugin-sourced; stub-server.read_data
-		// falls through to the MCP path.
-		ToolClassifier: &stubToolClassifier{
-			pluginTools: map[string]bool{"test-plugin.do-thing": true},
-		},
-		PluginResolver: &stubPluginToolResolver{
-			entries: []agent.PluginToolEntry{pluginEntry},
-		},
-		PluginRegistrar:  &stubPluginGenerationLookup{generation: 1, registered: true},
-		PluginDispatcher: &stubPluginDispatcher{},
+		PluginRegistrar:        &stubPluginGenerationLookup{generation: 1, registered: true},
+		PluginDispatcher:       &stubPluginDispatcher{},
 	})
 
 	result, launchErr := launcher.Launch(context.Background(), run.LaunchParams{
@@ -1168,18 +1161,18 @@ agent:
 	}
 
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
-		Store:                  store,
-		Registry:               registry,
+		Store: store,
+		// Classifier marks the tool as plugin-sourced, but pluginResolver is nil —
+		// belt-and-braces failure path exercising the "subsystem not enabled" error.
+		Resolver: run.NewDefaultToolResolver(registry,
+			&stubToolClassifier{pluginTools: map[string]bool{"test-plugin.do-thing": true}},
+			nil, // nil pluginResolver
+		),
 		Manager:                manager,
 		AgentFactory:           nil,
 		Publisher:              nil,
 		DefaultFeedbackTimeout: 0,
 		ModelResolver:          nil,
-		// Classifier marks the tool as plugin-sourced, but PluginResolver is nil.
-		ToolClassifier: &stubToolClassifier{
-			pluginTools: map[string]bool{"test-plugin.do-thing": true},
-		},
-		PluginResolver: nil, // belt-and-braces failure path
 	})
 
 	result, launchErr := launcher.Launch(context.Background(), run.LaunchParams{

--- a/internal/execution/run/resolver.go
+++ b/internal/execution/run/resolver.go
@@ -1,0 +1,35 @@
+package run
+
+import (
+	"context"
+
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/mcp"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// ResolvedToolSet holds the outputs of a single ResolveCapabilities call,
+// split by source kind. MCPTools and PluginTools are kept as separate typed
+// slices (not a pre-merged map) because the merge and schema narrowing happen
+// inside the agent package, where the unexported resolvedToolEntry and
+// pluginToolSource types live. The resolver's job is classify + per-source
+// resolve; the merge stays in agent.New.
+type ResolvedToolSet struct {
+	MCPTools    []mcp.ResolvedTool
+	PluginTools []agent.PluginToolEntry
+}
+
+// ToolResolver is the single entry point for tool resolution. Callers pass
+// the policy's raw capability grants and receive back the fully-resolved tool
+// sets for each source. Classification, per-source resolution, and the merge
+// inputs are all encapsulated here — callers have no knowledge of the routing.
+type ToolResolver interface {
+	ResolveCapabilities(ctx context.Context, grants []model.ToolCapability) (ResolvedToolSet, error)
+}
+
+// registryResolver is the subset of mcp.Registry used by DefaultToolResolver.
+// Defined here as an interface so tests can supply a stub without importing
+// internal/mcp directly.
+type registryResolver interface {
+	ResolveForPolicy(ctx context.Context, p *model.ParsedPolicy) ([]mcp.ResolvedTool, error)
+}

--- a/internal/execution/run/resolver_default.go
+++ b/internal/execution/run/resolver_default.go
@@ -1,0 +1,110 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/mcp"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// PluginToolResolver resolves plugin-sourced tool grants into agent-ready
+// entries. The implementation looks up the manifest, finds each tool's
+// description and schema, and reads the current generation from the registrar.
+type PluginToolResolver interface {
+	ResolvePluginTools(ctx context.Context, grants []model.ToolCapability) ([]agent.PluginToolEntry, error)
+}
+
+// ToolSourceClassifier determines whether a dot-name tool grant should be
+// resolved via MCP or the plugin path. The lookup is static — based on the
+// installed plugin instance row and its manifest snapshot, NOT on whether the
+// instance's subprocess is currently running (see #399). It does DB + manifest
+// reads, so it takes a context and can return an error.
+type ToolSourceClassifier interface {
+	IsPluginTool(ctx context.Context, dotName string) (bool, error)
+}
+
+// DefaultToolResolver is the standard ToolResolver implementation. It
+// classifies each grant as MCP or plugin-sourced, dispatches to the
+// appropriate resolver, and returns the combined results. When classifier or
+// pluginResolver is nil (plugins disabled), all grants route to the MCP path.
+type DefaultToolResolver struct {
+	registry       registryResolver
+	classifier     ToolSourceClassifier
+	pluginResolver PluginToolResolver
+}
+
+// NewDefaultToolResolver constructs a DefaultToolResolver. classifier and
+// pluginResolver may both be nil when plugins are disabled; all grants then
+// route to the MCP path, preserving the pre-plugin behaviour exactly.
+func NewDefaultToolResolver(registry registryResolver, classifier ToolSourceClassifier, pluginResolver PluginToolResolver) *DefaultToolResolver {
+	return &DefaultToolResolver{
+		registry:       registry,
+		classifier:     classifier,
+		pluginResolver: pluginResolver,
+	}
+}
+
+// ResolveCapabilities implements ToolResolver. It splits the grants by source
+// (via classifier), resolves each group, and returns the combined result. All
+// four error paths (classify error, MCP-resolve error, nil-resolver with plugin
+// grants, plugin-resolve error) return the error unwrapped — the launcher
+// applies a single fail-run transition on any non-nil error.
+func (r *DefaultToolResolver) ResolveCapabilities(ctx context.Context, grants []model.ToolCapability) (ResolvedToolSet, error) {
+	var mcpGrants, pluginGrants []model.ToolCapability
+	for _, t := range grants {
+		isPlugin := false
+		if r.classifier != nil {
+			var classErr error
+			isPlugin, classErr = r.classifier.IsPluginTool(ctx, t.Tool)
+			if classErr != nil {
+				// A classification read failed (e.g. the manifest snapshot could not
+				// be loaded). Return loudly rather than silently misrouting the grant
+				// to the MCP path.
+				return ResolvedToolSet{}, fmt.Errorf("classify tool %q: %w", t.Tool, classErr)
+			}
+		}
+		if isPlugin {
+			pluginGrants = append(pluginGrants, t)
+		} else {
+			mcpGrants = append(mcpGrants, t)
+		}
+	}
+
+	// Resolve MCP tools. When mcpGrants is empty we skip the DB round-trip
+	// entirely — ResolveForPolicy with an empty list is a no-op but the shallow
+	// copy and call are still wasted work.
+	var resolvedTools []mcp.ResolvedTool
+	if len(mcpGrants) > 0 {
+		// Construct a minimal ParsedPolicy carrying only the grants for this
+		// resolution call; ResolveForPolicy reads only Capabilities.Tools.
+		// Shallow copy avoids mutating the caller's policy if they passed one in.
+		mcpPolicy := &model.ParsedPolicy{}
+		mcpPolicy.Capabilities.Tools = mcpGrants
+		var mcpErr error
+		resolvedTools, mcpErr = r.registry.ResolveForPolicy(ctx, mcpPolicy)
+		if mcpErr != nil {
+			return ResolvedToolSet{}, mcpErr
+		}
+	}
+
+	// Resolve plugin tools. When no plugin grants exist this is a no-op. When
+	// grants exist but pluginResolver is nil, the policy references a plugin
+	// tool while the plugin subsystem is not enabled — fail clearly rather than
+	// silently dropping the grant.
+	var pluginToolEntries []agent.PluginToolEntry
+	if len(pluginGrants) > 0 {
+		if r.pluginResolver == nil {
+			return ResolvedToolSet{}, errors.New("plugin tools granted but plugin subsystem is not enabled")
+		}
+		var pluginErr error
+		pluginToolEntries, pluginErr = r.pluginResolver.ResolvePluginTools(ctx, pluginGrants)
+		if pluginErr != nil {
+			return ResolvedToolSet{}, pluginErr
+		}
+	}
+
+	return ResolvedToolSet{MCPTools: resolvedTools, PluginTools: pluginToolEntries}, nil
+}

--- a/internal/execution/run/resolver_default_test.go
+++ b/internal/execution/run/resolver_default_test.go
@@ -1,0 +1,207 @@
+package run
+
+// Tests for DefaultToolResolver.ResolveCapabilities. This file uses package run
+// (internal) so it can access NewDefaultToolResolver and the stub interfaces
+// directly, without going through the public API surface.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/mcp"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// stubRegistry is a test double for registryResolver. It records the grants
+// it was called with and returns pre-canned results or errors.
+type stubRegistry struct {
+	called bool
+	gotTools []model.ToolCapability
+	tools  []mcp.ResolvedTool
+	err    error
+}
+
+func (s *stubRegistry) ResolveForPolicy(_ context.Context, p *model.ParsedPolicy) ([]mcp.ResolvedTool, error) {
+	s.called = true
+	s.gotTools = p.Capabilities.Tools
+	return s.tools, s.err
+}
+
+// stubClassifier classifies tools whose dot-name is in pluginTools as plugin-sourced.
+// When err is non-nil it is returned for every call.
+type stubClassifier struct {
+	pluginTools map[string]bool
+	err         error
+}
+
+func (s *stubClassifier) IsPluginTool(_ context.Context, dotName string) (bool, error) {
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.pluginTools[dotName], nil
+}
+
+// stubPluginResolver returns pre-canned PluginToolEntry values or an error.
+type stubPluginResolver struct {
+	entries []agent.PluginToolEntry
+	err     error
+}
+
+func (s *stubPluginResolver) ResolvePluginTools(_ context.Context, _ []model.ToolCapability) ([]agent.PluginToolEntry, error) {
+	return s.entries, s.err
+}
+
+func TestDefaultToolResolver_AllMCP_NilClassifier(t *testing.T) {
+	// When classifier is nil, all grants go to the registry; PluginTools is empty.
+	grant := model.ToolCapability{Tool: "srv.read"}
+	reg := &stubRegistry{tools: []mcp.ResolvedTool{{GrantedTool: model.GrantedTool{ToolName: "read"}}}}
+	r := NewDefaultToolResolver(reg, nil, nil)
+
+	got, err := r.ResolveCapabilities(context.Background(), []model.ToolCapability{grant})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reg.called {
+		t.Error("registry was not called")
+	}
+	if len(reg.gotTools) != 1 || reg.gotTools[0].Tool != "srv.read" {
+		t.Errorf("registry received wrong grants: %v", reg.gotTools)
+	}
+	if len(got.MCPTools) != 1 {
+		t.Errorf("MCPTools len = %d, want 1", len(got.MCPTools))
+	}
+	if len(got.PluginTools) != 0 {
+		t.Errorf("PluginTools len = %d, want 0", len(got.PluginTools))
+	}
+}
+
+func TestDefaultToolResolver_EmptyGrants_SkipsRegistry(t *testing.T) {
+	// With no grants, the registry should never be called (DB round-trip skip).
+	reg := &stubRegistry{}
+	r := NewDefaultToolResolver(reg, nil, nil)
+
+	got, err := r.ResolveCapabilities(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reg.called {
+		t.Error("registry was called with empty grants — expected skip")
+	}
+	if len(got.MCPTools) != 0 || len(got.PluginTools) != 0 {
+		t.Errorf("expected empty slices, got MCPTools=%d PluginTools=%d", len(got.MCPTools), len(got.PluginTools))
+	}
+}
+
+func TestDefaultToolResolver_MixedGrants(t *testing.T) {
+	// Mixed grants: one MCP tool, one plugin tool. Each goes to the right resolver.
+	mcpGrant := model.ToolCapability{Tool: "mcp-srv.read"}
+	plugGrant := model.ToolCapability{Tool: "plug.do-thing"}
+
+	mcpTool := mcp.ResolvedTool{GrantedTool: model.GrantedTool{ToolName: "read"}}
+	plugEntry := agent.PluginToolEntry{InstanceName: "plug", ToolName: "do-thing"}
+
+	reg := &stubRegistry{tools: []mcp.ResolvedTool{mcpTool}}
+	cls := &stubClassifier{pluginTools: map[string]bool{"plug.do-thing": true}}
+	plugRes := &stubPluginResolver{entries: []agent.PluginToolEntry{plugEntry}}
+
+	r := NewDefaultToolResolver(reg, cls, plugRes)
+	got, err := r.ResolveCapabilities(context.Background(), []model.ToolCapability{mcpGrant, plugGrant})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Registry should have received only the MCP grant.
+	if len(reg.gotTools) != 1 || reg.gotTools[0].Tool != "mcp-srv.read" {
+		t.Errorf("registry grants = %v, want only mcp-srv.read", reg.gotTools)
+	}
+	if len(got.MCPTools) != 1 {
+		t.Errorf("MCPTools len = %d, want 1", len(got.MCPTools))
+	}
+	if len(got.PluginTools) != 1 {
+		t.Errorf("PluginTools len = %d, want 1", len(got.PluginTools))
+	}
+}
+
+func TestDefaultToolResolver_ClassifyError(t *testing.T) {
+	// A classifier error should return an empty ResolvedToolSet and an error
+	// wrapping "classify tool %q".
+	classErr := errors.New("manifest load failed")
+	cls := &stubClassifier{err: classErr}
+	reg := &stubRegistry{}
+	r := NewDefaultToolResolver(reg, cls, nil)
+
+	grant := model.ToolCapability{Tool: "some.tool"}
+	got, err := r.ResolveCapabilities(context.Background(), []model.ToolCapability{grant})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, classErr) {
+		t.Errorf("error chain does not wrap classErr: %v", err)
+	}
+	// Should contain the tool name in the message.
+	if err.Error() == "" {
+		t.Error("error message is empty")
+	}
+	// Registry must not be called — no partial resolution on classify error.
+	if reg.called {
+		t.Error("registry was called despite classify error")
+	}
+	// ResolvedToolSet must be empty (zero value).
+	if len(got.MCPTools) != 0 || len(got.PluginTools) != 0 {
+		t.Errorf("expected empty ResolvedToolSet, got MCPTools=%d PluginTools=%d", len(got.MCPTools), len(got.PluginTools))
+	}
+}
+
+func TestDefaultToolResolver_PluginGrantNilResolver(t *testing.T) {
+	// A plugin-classified grant with a nil pluginResolver must fail with a
+	// clear "subsystem not enabled" error.
+	cls := &stubClassifier{pluginTools: map[string]bool{"plug.thing": true}}
+	reg := &stubRegistry{}
+	r := NewDefaultToolResolver(reg, cls, nil) // nil pluginResolver
+
+	grant := model.ToolCapability{Tool: "plug.thing"}
+	_, err := r.ResolveCapabilities(context.Background(), []model.ToolCapability{grant})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	wantSub := "plugin subsystem is not enabled"
+	if !strings.Contains(err.Error(), wantSub) {
+		t.Errorf("error %q does not contain %q", err.Error(), wantSub)
+	}
+}
+
+func TestDefaultToolResolver_MCPResolveError(t *testing.T) {
+	// When the registry returns an error, it must propagate unwrapped.
+	regErr := errors.New("mcp server offline")
+	reg := &stubRegistry{err: regErr}
+	r := NewDefaultToolResolver(reg, nil, nil)
+
+	grant := model.ToolCapability{Tool: "srv.read"}
+	_, err := r.ResolveCapabilities(context.Background(), []model.ToolCapability{grant})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, regErr) {
+		t.Errorf("error chain does not wrap regErr: %v", err)
+	}
+}
+
+func TestDefaultToolResolver_PluginResolveError(t *testing.T) {
+	// When the plugin resolver returns an error, it must propagate unwrapped.
+	plugErr := errors.New("instance not running")
+	cls := &stubClassifier{pluginTools: map[string]bool{"plug.thing": true}}
+	plugRes := &stubPluginResolver{err: plugErr}
+	r := NewDefaultToolResolver(&stubRegistry{}, cls, plugRes)
+
+	grant := model.ToolCapability{Tool: "plug.thing"}
+	_, err := r.ResolveCapabilities(context.Background(), []model.ToolCapability{grant})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, plugErr) {
+		t.Errorf("error chain does not wrap plugErr: %v", err)
+	}
+}
+

--- a/internal/execution/run/resolver_default_test.go
+++ b/internal/execution/run/resolver_default_test.go
@@ -18,10 +18,10 @@ import (
 // stubRegistry is a test double for registryResolver. It records the grants
 // it was called with and returns pre-canned results or errors.
 type stubRegistry struct {
-	called bool
+	called   bool
 	gotTools []model.ToolCapability
-	tools  []mcp.ResolvedTool
-	err    error
+	tools    []mcp.ResolvedTool
+	err      error
 }
 
 func (s *stubRegistry) ResolveForPolicy(_ context.Context, p *model.ParsedPolicy) ([]mcp.ResolvedTool, error) {
@@ -204,4 +204,3 @@ func TestDefaultToolResolver_PluginResolveError(t *testing.T) {
 		t.Errorf("error chain does not wrap plugErr: %v", err)
 	}
 }
-

--- a/internal/execution/run/run_and_drain_test.go
+++ b/internal/execution/run/run_and_drain_test.go
@@ -158,7 +158,7 @@ func TestRunAndDrain_NonQueuePolicy(t *testing.T) {
 
 	launcher := NewRunLauncher(RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               NewDefaultToolResolver(registry, nil, nil),
 		Manager:                NewRunManager(),
 		AgentFactory:           nil,
 		Publisher:              nil,
@@ -218,7 +218,7 @@ func TestRunAndDrain_QueuePolicy(t *testing.T) {
 	manager := NewRunManager()
 	launcher := NewRunLauncher(RunLauncherConfig{
 		Store:    store,
-		Registry: registry,
+		Resolver: NewDefaultToolResolver(registry, nil, nil),
 		Manager:  manager,
 		AgentFactory: func(cfg agent.Config) (*agent.BoundAgent, error) {
 			cfg.LLMClient = testutil.NewMockLLMClient(

--- a/internal/http/api/health_test.go
+++ b/internal/http/api/health_test.go
@@ -41,7 +41,7 @@ func buildHealthTestRouter(t *testing.T, sigDisabled bool) http.Handler {
 	systemSettings := settings.NewService(store.Queries())
 	adminHandler := admin.NewHandler(adminQuerier, systemSettings, nil, []string{"anthropic"}, nil, nil, nil)
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
-		Store: store, Registry: registry, Manager: runManager,
+		Store: store, Resolver: run.NewDefaultToolResolver(registry, nil, nil), Manager: runManager,
 		AgentFactory: run.NewAgentFactory(providerRegistry), Publisher: broadcaster,
 		DefaultFeedbackTimeout: 30 * time.Minute, ModelResolver: systemSettings,
 	})

--- a/internal/http/api/router_test.go
+++ b/internal/http/api/router_test.go
@@ -43,7 +43,7 @@ func buildTestRouterWithStore(t *testing.T, store *db.Store) http.Handler {
 
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                runManager,
 		AgentFactory:           run.NewAgentFactory(providerRegistry),
 		Publisher:              broadcaster,

--- a/internal/trigger/cron_test.go
+++ b/internal/trigger/cron_test.go
@@ -40,7 +40,7 @@ func setupCronFixture(t *testing.T) (*db.Store, *CronRunner) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           cronAgentFactory(),
 		Publisher:              nil,
@@ -221,7 +221,7 @@ func TestCronRunner_Start_LoadsActivePolicies(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           cronAgentFactory(),
 		Publisher:              nil,
@@ -472,7 +472,7 @@ func TestCronRunner_Stop_DoesNotDeadlock(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           cronAgentFactory(),
 		Publisher:              nil,

--- a/internal/trigger/integration_test.go
+++ b/internal/trigger/integration_test.go
@@ -46,7 +46,7 @@ func buildIntegrationRouter(store *db.Store, registry *mcp.Registry, llmClient l
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           factory,
 		Publisher:              nil,

--- a/internal/trigger/manual_test.go
+++ b/internal/trigger/manual_test.go
@@ -212,7 +212,7 @@ func TestManualTriggerHandler(t *testing.T) {
 			resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 			launcher := run.NewRunLauncher(run.RunLauncherConfig{
 				Store:                  store,
-				Registry:               registry,
+				Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 				Manager:                run.NewRunManager(),
 				AgentFactory:           run.NewAgentFactory(providerReg),
 				Publisher:              nil,
@@ -240,7 +240,7 @@ func TestManualTriggerHandler_RunCreatedInDB(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           run.NewAgentFactory(providerReg),
 		Publisher:              nil,
@@ -304,7 +304,7 @@ func TestManualTriggerHandler_LaunchFailureSurfacesDetailAndRunID(t *testing.T) 
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           run.NewAgentFactory(providerReg),
 		Publisher:              nil,
@@ -371,7 +371,7 @@ func TestManualTriggerHandler_EmptyBody(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           run.NewAgentFactory(providerReg),
 		Publisher:              nil,

--- a/internal/trigger/notify_test.go
+++ b/internal/trigger/notify_test.go
@@ -39,7 +39,7 @@ func setupNotifyPollerFixture(t *testing.T) (*db.Store, *Poller) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           notifyPollerFactory(),
 		Publisher:              nil,
@@ -185,7 +185,7 @@ func setupNotifySchedulerFixture(t *testing.T) (*db.Store, *Scheduler) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           notifyPollerFactory(),
 		Publisher:              nil,

--- a/internal/trigger/poll_test.go
+++ b/internal/trigger/poll_test.go
@@ -241,7 +241,7 @@ func TestPoller_CheckMatchFires(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -278,7 +278,7 @@ func TestPoller_CheckNoMatchNoRun(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -323,7 +323,7 @@ func TestPoller_MatchAny_OnePassFires(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -382,7 +382,7 @@ agent:
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -426,7 +426,7 @@ func TestPoller_ToolErrorTreatedAsNotPassed(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -472,7 +472,7 @@ func TestPoller_ConcurrencySkip(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -515,7 +515,7 @@ func TestPoller_GracefulShutdown(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -563,7 +563,7 @@ func TestPoller_Stop_DoesNotDeadlock(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -679,7 +679,7 @@ func TestPoller_CheckTimeout_CancelsCallTool(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,
@@ -743,7 +743,7 @@ func TestPoller_SkipsLoop_WhenNoSystemDefaultAndNoModelInYAML(t *testing.T) {
 	noDefault := newTestSettings("", "")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           pollerFactory(),
 		Publisher:              nil,

--- a/internal/trigger/scheduled_test.go
+++ b/internal/trigger/scheduled_test.go
@@ -123,7 +123,7 @@ func TestScheduler_SkipsPastTimestampsOnStartup(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -166,7 +166,7 @@ func TestScheduler_FiresFutureTimestamp(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -210,7 +210,7 @@ func TestScheduler_AutoPausesAfterAllTimesConsumed(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -264,7 +264,7 @@ func TestScheduler_DeduplicatesAlreadyFiredTime(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -310,7 +310,7 @@ func TestScheduler_ConcurrencySkip_BlocksWhenActive(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -358,7 +358,7 @@ func TestScheduler_ConcurrencySkip_AutoPausesWhenExhausted(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -409,7 +409,7 @@ func TestScheduler_ConcurrencySkip_ProceedsWhenIdle(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -456,7 +456,7 @@ func TestScheduler_ConcurrencyQueue_EnqueuesWhenActive(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -508,7 +508,7 @@ func TestScheduler_ConcurrencyQueue_LaunchesWhenIdle(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -582,7 +582,7 @@ func TestScheduler_SkipsPolicy_WhenNoSystemDefaultAndNoModelInYAML(t *testing.T)
 	noDefault := newTestSettings("", "")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           schedulerFactory(),
 		Publisher:              nil,
@@ -642,7 +642,7 @@ func TestScheduler_Wait_DrainsInFlightFire(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           gatedSchedulerFactory(entered, release),
 		Publisher:              nil,

--- a/internal/trigger/sse_integration_test.go
+++ b/internal/trigger/sse_integration_test.go
@@ -40,7 +40,7 @@ func buildSSERouter(t *testing.T, policyID string, llmClient llm.LLMClient, broa
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                manager,
 		AgentFactory:           factory,
 		Publisher:              broadcaster,

--- a/internal/trigger/webhook_test.go
+++ b/internal/trigger/webhook_test.go
@@ -164,7 +164,7 @@ func newHandler(t *testing.T, store *db.Store, loader trigger.SecretLoaderInterf
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           run.NewAgentFactory(providerReg),
 		Publisher:              nil,
@@ -536,7 +536,7 @@ func TestWebhookHandler_RunCreatedInDB(t *testing.T) {
 	resolver := newTestSettings("anthropic", "claude-sonnet-4-6")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           run.NewAgentFactory(providerReg),
 		Publisher:              nil,
@@ -614,7 +614,7 @@ func TestWebhookHandler_Returns500_WhenNoDefaultModelAndPolicyOmitsModel(t *test
 	noDefault := newTestSettings("", "")
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               run.NewDefaultToolResolver(registry, nil, nil),
 		Manager:                run.NewRunManager(),
 		AgentFactory:           run.NewAgentFactory(providerReg),
 		Publisher:              nil,

--- a/main.go
+++ b/main.go
@@ -253,14 +253,12 @@ func run(cfg config.Config) error {
 
 	launcher := runpkg.NewRunLauncher(runpkg.RunLauncherConfig{
 		Store:                  store,
-		Registry:               registry,
+		Resolver:               runpkg.NewDefaultToolResolver(registry, toolClassifier, pluginResolver),
 		Manager:                runManager,
 		AgentFactory:           runpkg.NewAgentFactory(providerRegistry),
 		Publisher:              broadcaster,
 		DefaultFeedbackTimeout: cfg.DefaultFeedbackTimeout,
 		ModelResolver:          systemSettings,
-		PluginResolver:         pluginResolver,
-		ToolClassifier:         toolClassifier,
 		PluginRegistrar:        pluginRegistrar,
 		PluginDispatcher:       dispatchAdapter,
 		ApprovalDispatcher:     approvalAdapter,


### PR DESCRIPTION
Closes #507

## Summary

Replaces the ~80 lines of caller-side classify/route/merge choreography in `RunLauncher.Launch` with a single deep `ToolResolver` interface:

```go
ResolveCapabilities(ctx context.Context, grants []model.ToolCapability) (ResolvedToolSet, error)
```

The launcher now makes one resolution call. MCP-vs-plugin classification, per-source resolution, the "plugin subsystem not enabled" guard, and the merge all become implementation detail of `DefaultToolResolver`. Four of the five fail-run transitions collapse into one CAS-guarded transition (the fifth — agent-construction failure — stays put).

Downstream, the `BoundAgent` two-structure sync invariant (`toolsByName` dispatch map + `pluginGrantedTools` snapshot slice) that nothing previously checked is now produced from a single pass in `buildPluginToolEntries`, and the ADR-018 capability-snapshot assembly is extracted into `buildCapabilitySnapshotTools` (preserving the MCP → synthetic `gleipnir.ask_operator` → plugin ordering). Both gain direct unit-test surfaces — the headline win called out in the issue.

## What changed

- **New** `internal/execution/run/resolver.go` — `ToolResolver` interface, `ResolvedToolSet`, `registryResolver` (moved from launcher).
- **New** `internal/execution/run/resolver_default.go` — `DefaultToolResolver` + `NewDefaultToolResolver`; `PluginToolResolver` / `ToolSourceClassifier` kept exported (referenced by `main.go` / `pluginruntime.go`).
- `launcher.go` — `RunLauncher` loses three resolution fields for a single `resolver ToolResolver`; the classify/resolve/merge block becomes one call + one fail-run transition.
- `agent/tools.go`, `agent/agent.go` — extracted `buildPluginToolEntries` and `buildCapabilitySnapshotTools`; `checkCapabilities` error message made source-agnostic (plugin tools now flow through the same `toolsByName` map).
- `main.go` — wiring: three config fields collapse to one `Resolver:` constructed via `NewDefaultToolResolver`.
- New unit tests: `resolver_default_test.go` (classify/route/merge + error paths) and `agent/tools_test.go` (dispatch/snapshot sync invariant + snapshot ordering).
- 56 `RunLauncherConfig` test sites across 13 files migrated from `Registry:` to `Resolver:`.

`internal/mcp` is untouched (the `internal/mcp` → `internal/execution/agent` boundary is preserved); this is a behavior-preserving refactor.

## Architecture plan

<details>
<summary>Implementation plan (architect, 1 revision)</summary>

See `.dev-loop/plan.md` on the branch history. The plan introduced the `ToolResolver` interface in `internal/execution/run` (the sole caller, already importing both `internal/mcp` and `internal/execution/agent`), kept `ResolvedToolSet` as two typed slices to avoid exposing unexported agent internals or relocating fallible `mcp.NarrowSchema`, and collapsed four of five fail-run transitions. The plan-reviewer's REVISE pass corrected the full 57-site blast radius, mandated keeping the two interfaces exported, and flagged the stale "MCP registry" error message.

</details>

## Review cycles

- **Plan review:** 1 architect revision (REVISE → addressed → implemented).
- **Code review:** 2 cycles. Cycle 1 was APPROVE-on-compliance with one blocking test-readability issue (dead `errors.Is(err, errors.New(""))` code + a needless hand-rolled `contains` helper); cycle 2 APPROVE after the fix.

CLAUDE.md: no updates needed (no new package, env var, route, trigger type, or ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.
