### PR TITLE
feat: ProviderWire seam — shared LLM choreography behind a common adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,9 @@ internal/
     logctx/           — context-based structured log correlation (run_id + policy_id)
     metrics/          — custom Prometheus registry, histogram bucket presets (BucketsFast/BucketsSlow), shared label constants, Handler()/Registry() accessors (ADR-037)
     version/          — single-source-of-truth release version constant; bump in the commit immediately preceding a release tag
-  llm/                — LLM provider abstraction (ADR-026)
+  llm/                — LLM provider abstraction (ADR-026). The shallow `ProviderWire` seam (wire.go) splits each provider into wire-level translation behind a single shared `ProviderAdapter` (adapter.go) that owns the common choreography (request-duration/token/error metrics defer); each provider's exported Client embeds the adapter and promotes only CreateMessage/StreamMessage, keeping thin forwarders for the model/option methods so a zero-value client stays panic-free. `FakeWire` (fake_wire.go, exposed via testutil.NewFakeClient) is the fifth wire used to drive agent/trigger tests through the real adapter (ADR-022, undeferred). Streaming state machines stay per-provider (#506).
     anthropic/        — Anthropic API client
+    contract/         — cross-wire contract test suite (external test package); table-driven over all four real wires, asserting continuity-state round-trip, tool-name round-trip, stop-reason normalization, and usage extraction uniformly. Sits outside internal/llm to avoid the provider-import cycle (same reason as factory/). #506
     factory/          — NewClientForProvider: maps a provider name string to a concrete LLMClient; lives in its own sub-package to avoid the cycle caused by provider packages importing internal/llm
     google/           — Google AI client
     openai/           — OpenAI API client

--- a/docs/developer/ADR_Tracker.md
+++ b/docs/developer/ADR_Tracker.md
@@ -38,7 +38,7 @@ Running index of all Architecture Decision Records. Promote items from the Roadm
 | ADR-019 | Dual-mode policy editor (form + YAML)             | 🟢 Decided    | v0.1   | Frontend, policy YAML schema                         |
 | ADR-020 | Policy folders for UI grouping                    | 🟢 Decided    | v0.1   | Policy YAML schema, frontend dashboard               |
 | ADR-021 | MCP discovery diffs                               | 🟢 Decided    | v0.1   | MCP discovery endpoint, frontend                     |
-| ADR-022 | Transport-level fake for Anthropic API in tests   | ⬜ Deferred   | v0.1   | agent package, integration tests                     |
+| ADR-022 | ProviderWire seam + cross-wire contract suite      | 🟢 Decided    | v1.1   | internal/llm, all four provider packages, contract suite |
 | ADR-023 | Per-policy model selection                         | 🟢 Decided    | v0.1   | Policy schema, agent runtime, capability snapshot    |
 | ADR-024 | Webhook HMAC-SHA256 signature verification         | 🟢 Decided    | v0.1   | Webhook handler, policy schema, trigger package      |
 | ADR-026 | Model-agnostic design (multi-provider) — revised   | 🟢 Decided    | v1.0   | LLM client interface, agent runtime, policy schema   |
@@ -1749,23 +1749,58 @@ used in policies.
 
 ---
 
-## ADR-022: Transport-level fake for Anthropic API in tests
+## ADR-022: ProviderWire seam + cross-wire contract suite
 
-**Status:** Deferred (tracked: #78)
-**Date:** 2026-03
+**Status:** Decided (undeferred 2026-06, issue #506)
+**Date:** 2026-03 (original deferral); revised 2026-06
 
-**Decision:** Test infrastructure that needs to avoid real Anthropic API calls should inject
-a fake `http.RoundTripper` into the `anthropic.Client` rather than bypassing the SDK via an
-interface seam in production types.
+**Original decision (deferred):** Test infrastructure should inject a fake `http.RoundTripper`
+rather than adding interface seams to production types. Deferred because `agent.Config.MessagesOverride`
+was the blocking prerequisite.
 
-**Rejected alternative:** `MessagesOverride MessagesAPI` field on `agent.Config`. This is a
-test concern embedded in a production struct — production code should not be modified to
-accommodate tests. Superseded by the `AgentFactory` pattern which already removed the seam
-from `WebhookHandler`; `agent.Config.MessagesOverride` is the remaining field to eliminate.
+**Revised decision:** A `ProviderWire` interface is introduced in `internal/llm` as a shallow
+provider-level seam. Each provider adapter (anthropic, openai, google, openaicompat) implements
+`ProviderWire` with methods `Call`, `Stream`, `ListModels`, `ValidateModelName`, `ValidateOptions`,
+`InvalidateModelCache`, `ClassifyError`, and `ProviderName`. A shared `ProviderAdapter` wraps any
+`ProviderWire` and owns the metrics-defer choreography in `CreateMessage` (timer, `ObserveRequestDuration`,
+`RecordError`, `RecordTokens`). `StreamMessage` delegates directly.
 
-**Consequence:** `agent.Config.MessagesOverride` and `integrationFakeMessages` to be removed
-when the transport fake is implemented. `agent_test.go` and `integration_test.go` both move
-to the transport fake.
+**Test infrastructure:** `FakeWire` is a fifth `ProviderWire` implementation that returns scripted
+responses and captures requests. `testutil.NewFakeClient` wraps a `FakeWire` in a `ProviderAdapter`
+so tests get a real client that exercises the metrics path. `testutil.NewFakeClientOnly` discards
+the wire handle for inline use. `MockLLMClient` is retained for the `hookOnceLLMClient` pattern
+in `agent_test.go` which requires the concrete type; all other test call sites migrated to
+`NewFakeClient` / `NewFakeClientOnly`.
+
+**Cross-wire contract suite:** `internal/llm/contract` contains a table-driven test suite
+(`package contract_test`) parameterized over all four real wires. It asserts the
+provider-agnostic invariants uniformly: stop-reason normalization (end_turn / tool_use /
+max_tokens), usage extraction (InputTokens / OutputTokens / ThinkingTokens), tool-name
+round-trip (sanitization + reverse-mapping), and continuity-state carriers (per-provider,
+explicitly non-uniform per BLOCKING-3):
+- anthropic / openai: `ThinkingBlock.ProviderState` JSON round-trip
+- google: `ToolCallBlock.ProviderMetadata["google.thought_signature"]` (no ProviderState)
+- openaicompat: ThinkingBlocks are DROPPED (Chat Completions has no reasoning round-trip;
+  the contract test asserts they do not appear in the outbound request)
+
+**Boundary preserved:** `LLMClient` interface and agent runtime are unchanged (ADR-026). The
+`ProviderWire` seam is entirely inside `internal/llm`; `internal/execution/agent` imports
+`internal/llm` only, never provider packages.
+
+**Zero-value safety (BLOCKING-1):** The four model/option methods (`ValidateOptions`,
+`ValidateModelName`, `ListModels`, `InvalidateModelCache`) are kept as thin explicit forwarders
+on each concrete Client type, never promoted from the embedded `*ProviderAdapter`. A zero-value
+`&AnthropicClient{}` / `&Client{}` / `&GeminiClient{}` is still safe to call model methods on.
+
+**Consequences:**
+- `internal/llm/wire.go` — `ProviderWire` interface definition
+- `internal/llm/adapter.go` — `ProviderAdapter` + metrics-defer
+- `internal/llm/fake_wire.go` — `FakeWire` + `NewFakeWire`
+- All four provider `client.go` files restructured with an inner `wire` / `compatWire` type
+- `internal/testutil/mock_llm.go` — `NewFakeClient`, `NewFakeClientOnly` added
+- `internal/llm/contract/` — new package with cross-wire contract suite
+- All test call sites in execution, trigger, run, admin, http packages migrated from
+  `NewMockLLMClient` to `NewFakeClient` / `NewFakeClientOnly`
 
 ---
 
@@ -1979,6 +2014,12 @@ and the agent fails the run with a wrapped message — do not silently drop cont
 Destructive migration: no DB schema change (`ThinkingBlock` provider-specific fields were never
 persisted — the audit writer records only `{text, redacted}`). Fresh installs only for in-flight
 conversations.
+
+**Amendment (2026-06, issue #506):** The `LLMClient` interface and `internal/execution/agent`
+runtime are confirmed unchanged by the ProviderWire refactor (ADR-022). The seam is internal to
+`internal/llm`; the agent boundary remains `LLMClient`. Adding a new provider requires implementing
+`ProviderWire` (not `LLMClient`) and registering in `internal/llm/factory`. The `ProviderAdapter`
+handles metrics uniformly so new providers inherit observability without per-provider boilerplate.
 
 ---
 

--- a/internal/execution/agent/agent_test.go
+++ b/internal/execution/agent/agent_test.go
@@ -381,7 +381,7 @@ func TestRun_SingleTurnEndTurn(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient:    testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("I completed the task.", llm.StopReasonEndTurn, 10, 20)),
+		LLMClient:    testutil.NewFakeClientOnly(testutil.MakeLLMTextResponse("I completed the task.", llm.StopReasonEndTurn, 10, 20)),
 		Tools:        nil,
 		Policy:       minimalPolicy(),
 		Audit:        w,
@@ -523,7 +523,7 @@ func TestRun_ToolCallLoop(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "my-server.read_data", map[string]any{"arg": "x"}, 10, 5),
 			testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 3),
 		),
@@ -678,7 +678,7 @@ func TestRun_ToolNotFound(t *testing.T) {
 	// No tools registered, but response asks for one.
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "missing-server.nonexistent", map[string]any{}, 10, 5),
 		),
 		Tools:        nil,
@@ -745,7 +745,7 @@ func TestRun_TokenBudgetExceeded(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "my-server.read_data", map[string]any{}, 600, 400),
 			// This second response should never be reached.
 			testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 5),
@@ -801,7 +801,7 @@ func TestRun_CapabilitySnapshotFirst(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient:    testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 5)),
+		LLMClient:    testutil.NewFakeClientOnly(testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 5)),
 		Tools:        []mcp.ResolvedTool{mcpTool},
 		Policy:       pol,
 		Audit:        w,
@@ -874,7 +874,7 @@ func TestHandleToolCall_SchemaValidation(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "my-server.read_data", map[string]any{"badkey": "val"}, 10, 5),
 		),
 		Tools:        tools,
@@ -942,7 +942,7 @@ func TestHandleToolCall_ApprovalRejected(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "my-server.do_thing", map[string]any{"arg": "v"}, 10, 5),
 		),
 		Tools:        []mcp.ResolvedTool{approvalTool},
@@ -1032,7 +1032,7 @@ func TestRun_ToolCallCapExceeded(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "my-server.read_data", map[string]any{}, 10, 5),
 			testutil.MakeLLMToolCallResponse("tu-2", "my-server.read_data", map[string]any{}, 10, 5),
 			// Third response should never be reached.
@@ -1103,7 +1103,7 @@ func TestRun_LimitsNotExceeded(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "my-server.read_data", map[string]any{}, 10, 5),
 			testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 3),
 		),
@@ -1286,7 +1286,7 @@ func TestRun_Cancellation(t *testing.T) {
 
 		w := NewAuditWriter(s.Queries())
 		ba, err := New(Config{
-			LLMClient: testutil.NewMockLLMClient(
+			LLMClient: testutil.NewFakeClientOnly(
 				testutil.MakeLLMToolCallResponse("tu-1", "slow-server.slow_tool", map[string]any{}, 10, 5),
 			),
 			Tools:        tools,
@@ -1352,14 +1352,14 @@ func TestRun_ToolResultTimestamp(t *testing.T) {
 
 	tools := []mcp.ResolvedTool{toolForRun(mcpSrv.URL, "my-server", "read_data")}
 
-	mockClient := testutil.NewMockLLMClient(
+	fakeClient, fakeWire := testutil.NewFakeClient(
 		testutil.MakeLLMToolCallResponse("tu-1", "my-server.read_data", map[string]any{"arg": "x"}, 10, 5),
 		testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 3),
 	)
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient:    mockClient,
+		LLMClient:    fakeClient,
 		Tools:        tools,
 		Policy:       minimalPolicy(),
 		Audit:        w,
@@ -1378,7 +1378,7 @@ func TestRun_ToolResultTimestamp(t *testing.T) {
 	//   [0] user (trigger payload)
 	//   [1] assistant (tool_use response)
 	//   [2] user (tool results with prepended timestamp)
-	requests := mockClient.Requests()
+	requests := fakeWire.Requests()
 	if len(requests) != 2 {
 		t.Fatalf("expected 2 API calls, got %d", len(requests))
 	}
@@ -1729,7 +1729,7 @@ func TestRunAPILoop_EndTurn(t *testing.T) {
 	ba, err := New(Config{
 		Policy:       minimalPolicy(),
 		Tools:        nil,
-		LLMClient:    testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("all done", llm.StopReasonEndTurn, 10, 5)),
+		LLMClient:    testutil.NewFakeClientOnly(testutil.MakeLLMTextResponse("all done", llm.StopReasonEndTurn, 10, 5)),
 		Audit:        w,
 		StateMachine: NewRunStateMachine("r1", model.RunStatusRunning, s.DB(), s.Queries()),
 	})
@@ -1839,7 +1839,7 @@ func TestHandleToolCall_AskOperator_Success(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tc-1", AskOperatorToolName,
 				map[string]any{"reason": "Need clarification", "context": "Some details"}, 10, 5),
 			testutil.MakeLLMTextResponse("All done.", llm.StopReasonEndTurn, 5, 3),
@@ -1967,7 +1967,7 @@ func TestHandleToolCall_AskOperator_NotAvailableWhenDisabled(t *testing.T) {
 	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusPending)
 
 	// Policy has feedback disabled — gleipnir.ask_operator must not be offered to the LLM.
-	mockClient := testutil.NewMockLLMClient(
+	fakeClient, fakeWire := testutil.NewFakeClient(
 		// LLM hallucinates a call to gleipnir.ask_operator even though it was never registered.
 		testutil.MakeLLMToolCallResponse("tc-1", AskOperatorToolName,
 			map[string]any{"reason": "something"}, 10, 5),
@@ -1975,7 +1975,7 @@ func TestHandleToolCall_AskOperator_NotAvailableWhenDisabled(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient:    mockClient,
+		LLMClient:    fakeClient,
 		Tools:        nil,
 		Policy:       minimalPolicy(), // feedback disabled
 		Audit:        w,
@@ -2018,7 +2018,7 @@ func TestHandleToolCall_AskOperator_NotAvailableWhenDisabled(t *testing.T) {
 	}
 
 	// Verify gleipnir.ask_operator was not in the tools sent to the LLM.
-	requests := mockClient.Requests()
+	requests := fakeWire.Requests()
 	if len(requests) == 0 {
 		t.Fatal("expected at least one API request")
 	}
@@ -2036,7 +2036,7 @@ func TestHandleToolCall_AskOperator_ReasonRequired(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			// Missing required "reason" field — only "context" provided.
 			testutil.MakeLLMToolCallResponse("tc-1", AskOperatorToolName,
 				map[string]any{"context": "only context, no reason"}, 10, 5),
@@ -2181,7 +2181,7 @@ func TestRun_feedback_timeout(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tc-1", AskOperatorToolName,
 				map[string]any{"reason": "Need your input"}, 10, 5),
 		),
@@ -2243,7 +2243,7 @@ func TestCapabilitySnapshot_IncludesAskOperator(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient:    testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 5, 3)),
+		LLMClient:    testutil.NewFakeClientOnly(testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 5, 3)),
 		Tools:        nil,
 		Policy:       feedbackPolicy(),
 		Audit:        w,
@@ -2721,14 +2721,14 @@ func TestRun_ThinkingBlocksIncludedInHistory(t *testing.T) {
 		Usage:      llm.TokenUsage{InputTokens: 10, OutputTokens: 5},
 	}
 
-	mock := testutil.NewMockLLMClient(
+	fakeClient, fakeWire := testutil.NewFakeClient(
 		firstResp,
 		testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 5, 3),
 	)
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient:    mock,
+		LLMClient:    fakeClient,
 		Tools:        tools,
 		Policy:       minimalPolicy(),
 		Audit:        w,
@@ -2742,13 +2742,13 @@ func TestRun_ThinkingBlocksIncludedInHistory(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if mock.Calls() != 2 {
-		t.Fatalf("expected 2 API calls, got %d", mock.Calls())
+	if fakeWire.Calls() != 2 {
+		t.Fatalf("expected 2 API calls, got %d", fakeWire.Calls())
 	}
 
 	// The second request's history should include the assistant turn from the
 	// first response. That turn must contain the ThinkingBlock before the tool call.
-	reqs := mock.Requests()
+	reqs := fakeWire.Requests()
 	secondReq := reqs[1]
 
 	// Find the assistant turn in history.
@@ -2810,7 +2810,7 @@ func TestRun_ThinkingTokensIncludedInCost(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient:    testutil.NewMockLLMClient(resp),
+		LLMClient:    testutil.NewFakeClientOnly(resp),
 		Tools:        nil,
 		Policy:       minimalPolicy(),
 		Audit:        w,
@@ -2904,7 +2904,7 @@ func TestRun_MCPTransportError_BecomesToolResult(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			// LLM issues a tool call.
 			testutil.MakeLLMToolCallResponse("tu-1", "failing-server.do_thing", map[string]any{}, 10, 5),
 			// After receiving the is_error tool result, LLM completes.
@@ -3006,7 +3006,7 @@ func TestCapabilitySnapshot_IncludesPluginSourceTools(t *testing.T) {
 
 	w := NewAuditWriter(s.Queries())
 	ba, err := New(Config{
-		LLMClient: testutil.NewMockLLMClient(testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 5, 5)),
+		LLMClient: testutil.NewFakeClientOnly(testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 5, 5)),
 		Tools:     []mcp.ResolvedTool{mcpTool},
 		PluginTools: []PluginToolEntry{
 			{InstanceName: "my-plugin", ToolName: "do-thing", Generation: 1, Description: "a plugin tool"},

--- a/internal/execution/agent/cross_provider_test.go
+++ b/internal/execution/agent/cross_provider_test.go
@@ -21,7 +21,7 @@ import (
 // trail step type sequence. Both entries use MockLLMClient — provider name is
 // recorded in the capability_snapshot step but does not affect routing here.
 func TestCrossProvider_StructuralParity(t *testing.T) {
-	t.Log("Both sub-tests use MockLLMClient which returns scripted IDs. These tests validate the provider-agnostic architecture path, not provider-specific behaviors like Gemini's synthetic UUID generation (which occurs in the real GeminiClient.translateResponse, not exercised here).")
+	t.Log("Both sub-tests run through the real ProviderAdapter (FakeWire). Provider-specific continuity-state round-trip, stop-reason normalization, and tool-name round-trip are covered by the contract suite in internal/llm/contract.")
 
 	mcpSrv := makeToolCallServer(t, json.RawMessage(`[{"type":"text","text":"result data"}]`), false)
 
@@ -46,15 +46,16 @@ func TestCrossProvider_StructuralParity(t *testing.T) {
 			pol.Agent.ModelConfig.Provider = tc.provider
 			pol.Agent.ModelConfig.Name = tc.modelName
 
-			mockClient := testutil.NewMockLLMClient(
+			fakeClient, fakeWire := testutil.NewFakeClient(
 				testutil.MakeToolCallResponse("my-server.read_data", "call-1", nil),
 				testutil.MakeTextResponse("Done."),
 			)
+			_ = fakeWire // requests not inspected in this sub-test
 
 			tools := []mcp.ResolvedTool{toolForRun(mcpSrv.URL, "my-server", "read_data")}
 
 			ba, err := New(Config{
-				LLMClient:    mockClient,
+				LLMClient:    fakeClient,
 				Tools:        tools,
 				Policy:       pol,
 				Audit:        NewAuditWriter(s.Queries()),
@@ -210,7 +211,7 @@ func TestCrossProvider_OptionsValidation(t *testing.T) {
 // multiple tool calls in a single response, the agent dispatches each one and
 // records interleaved tool_call/tool_result pairs in the audit trail.
 func TestCrossProvider_MultiToolCallBatching(t *testing.T) {
-	t.Log("Both sub-tests use MockLLMClient. Gemini synthetic UUID generation is not exercised here — these tests validate provider-agnostic batching behavior.")
+	t.Log("Both sub-tests run through the real ProviderAdapter (FakeWire). Provider-specific behaviors (Gemini synthetic UUID generation, etc.) are covered by the contract suite in internal/llm/contract.")
 
 	// makeToolCallServer handles any tools/call request with a fixed response,
 	// so a single server can back all three registered tools.
@@ -243,7 +244,7 @@ func TestCrossProvider_MultiToolCallBatching(t *testing.T) {
 				toolForRun(mcpSrv.URL, "srv", "tool_c"),
 			}
 
-			mockClient := testutil.NewMockLLMClient(
+			fakeClient2, _ := testutil.NewFakeClient(
 				testutil.MakeMultiToolCallResponse([]testutil.MockToolCall{
 					{ID: "call-a", Name: "srv.tool_a", Input: nil},
 					{ID: "call-b", Name: "srv.tool_b", Input: nil},
@@ -253,7 +254,7 @@ func TestCrossProvider_MultiToolCallBatching(t *testing.T) {
 			)
 
 			ba, err := New(Config{
-				LLMClient:    mockClient,
+				LLMClient:    fakeClient2,
 				Tools:        tools,
 				Policy:       pol,
 				Audit:        NewAuditWriter(s.Queries()),
@@ -329,7 +330,7 @@ func TestToolResultBlocksBeforeTextInUserTurn(t *testing.T) {
 		toolForRun(mcpSrv.URL, "srv", "tool_b"),
 	}
 
-	mockClient := testutil.NewMockLLMClient(
+	fakeClient3, fakeWire3 := testutil.NewFakeClient(
 		testutil.MakeMultiToolCallResponse([]testutil.MockToolCall{
 			{ID: "call-a", Name: "srv.tool_a", Input: nil},
 			{ID: "call-b", Name: "srv.tool_b", Input: nil},
@@ -338,7 +339,7 @@ func TestToolResultBlocksBeforeTextInUserTurn(t *testing.T) {
 	)
 
 	ba, err := New(Config{
-		LLMClient:    mockClient,
+		LLMClient:    fakeClient3,
 		Tools:        tools,
 		Policy:       pol,
 		Audit:        NewAuditWriter(s.Queries()),
@@ -353,7 +354,7 @@ func TestToolResultBlocksBeforeTextInUserTurn(t *testing.T) {
 	}
 
 	// The second CreateMessage call should have the tool results turn in its history.
-	reqs := mockClient.Requests()
+	reqs := fakeWire3.Requests()
 	if len(reqs) < 2 {
 		t.Fatalf("expected at least 2 API calls, got %d", len(reqs))
 	}

--- a/internal/execution/run/launcher_test.go
+++ b/internal/execution/run/launcher_test.go
@@ -82,7 +82,7 @@ func setupIntegrationFixture(t *testing.T) (*db.Store, *mcp.Registry) {
 // no real API calls are made during launcher tests.
 func localAgentFactory() run.AgentFactory {
 	return func(cfg agent.Config) (*agent.BoundAgent, error) {
-		cfg.LLMClient = testutil.NewMockLLMClient(
+		cfg.LLMClient = testutil.NewFakeClientOnly(
 			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 		)
 		return agent.New(cfg)
@@ -953,7 +953,7 @@ agent:
 		),
 		Manager: manager,
 		AgentFactory: func(cfg agent.Config) (*agent.BoundAgent, error) {
-			cfg.LLMClient = testutil.NewMockLLMClient(
+			cfg.LLMClient = testutil.NewFakeClientOnly(
 				testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 			)
 			return agent.New(cfg)
@@ -1106,7 +1106,7 @@ agent:
 		),
 		Manager: manager,
 		AgentFactory: func(cfg agent.Config) (*agent.BoundAgent, error) {
-			cfg.LLMClient = testutil.NewMockLLMClient(
+			cfg.LLMClient = testutil.NewFakeClientOnly(
 				testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 			)
 			return agent.New(cfg)

--- a/internal/execution/run/run_and_drain_test.go
+++ b/internal/execution/run/run_and_drain_test.go
@@ -74,7 +74,7 @@ func buildBoundAgent(t *testing.T, store *db.Store, runRow db.Run, resolvedTools
 		Audit:        audit,
 		StateMachine: sm,
 		ApprovalCh:   make(chan bool, 1),
-		LLMClient: testutil.NewMockLLMClient(
+		LLMClient: testutil.NewFakeClientOnly(
 			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 		),
 	})
@@ -221,7 +221,7 @@ func TestRunAndDrain_QueuePolicy(t *testing.T) {
 		Resolver: NewDefaultToolResolver(registry, nil, nil),
 		Manager:  manager,
 		AgentFactory: func(cfg agent.Config) (*agent.BoundAgent, error) {
-			cfg.LLMClient = testutil.NewMockLLMClient(
+			cfg.LLMClient = testutil.NewFakeClientOnly(
 				testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 			)
 			return agent.New(cfg)

--- a/internal/llm/adapter.go
+++ b/internal/llm/adapter.go
@@ -1,0 +1,84 @@
+package llm
+
+import (
+	"context"
+	"time"
+)
+
+// ProviderAdapter satisfies LLMClient by wrapping a ProviderWire. It owns the
+// choreography that is genuinely identical across all providers:
+//   - the CreateMessage metrics-defer (timer, error classification, token recording)
+//   - delegation of StreamMessage, ValidateOptions, ValidateModelName, ListModels,
+//     and InvalidateModelCache to the wire
+//
+// The streaming state machine, error-classification errors.As ladders, and all
+// wire-format translation stay inside each provider's ProviderWire implementation.
+//
+// Concrete provider Client types embed *ProviderAdapter and promote only
+// CreateMessage and StreamMessage from it. The four model/option methods
+// (ValidateOptions, ValidateModelName, ListModels, InvalidateModelCache) stay as
+// thin explicit forwarders on each concrete Client so zero-value clients remain
+// safe — see BLOCKING-1 in the plan for issue #506.
+//
+// The adapter itself implements the full LLMClient interface so FakeWire can be
+// wrapped directly (without a concrete provider type in front).
+type ProviderAdapter struct {
+	wire ProviderWire
+}
+
+// NewAdapter wraps w in a ProviderAdapter that satisfies LLMClient.
+func NewAdapter(w ProviderWire) *ProviderAdapter {
+	return &ProviderAdapter{wire: w}
+}
+
+// Compile-time check: ProviderAdapter satisfies the full LLMClient interface.
+// This matters for the FakeWire path where no concrete provider type is present.
+var _ LLMClient = (*ProviderAdapter)(nil)
+
+// CreateMessage owns the metrics-defer choreography lifted verbatim from all
+// four provider CreateMessage implementations. The metrics-defer block is the
+// only genuinely identical code across providers; everything else stays in wire.Call.
+func (a *ProviderAdapter) CreateMessage(ctx context.Context, req MessageRequest) (resp *MessageResponse, err error) {
+	start := time.Now()
+	provider := a.wire.ProviderName()
+	defer func() {
+		ObserveRequestDuration(provider, req.Model, time.Since(start))
+		if err != nil {
+			RecordError(provider, a.wire.ClassifyError(err))
+			return
+		}
+		if resp != nil {
+			RecordTokens(provider, req.Model, resp.Usage)
+		}
+	}()
+	resp, err = a.wire.Call(ctx, req)
+	return
+}
+
+// StreamMessage delegates directly to the wire. No metrics-defer is added here
+// because none of the four original providers wrap StreamMessage in a defer.
+func (a *ProviderAdapter) StreamMessage(ctx context.Context, req MessageRequest) (<-chan MessageChunk, error) {
+	return a.wire.Stream(ctx, req)
+}
+
+// ValidateOptions delegates to the wire. Concrete provider Clients shadow this
+// with a thin forwarder that calls the same logic without going through the
+// embedded adapter — this ensures zero-value clients remain safe.
+func (a *ProviderAdapter) ValidateOptions(options map[string]any) error {
+	return a.wire.ValidateOptions(options)
+}
+
+// ValidateModelName delegates to the wire.
+func (a *ProviderAdapter) ValidateModelName(ctx context.Context, modelName string) error {
+	return a.wire.ValidateModelName(ctx, modelName)
+}
+
+// ListModels delegates to the wire.
+func (a *ProviderAdapter) ListModels(ctx context.Context) ([]ModelInfo, error) {
+	return a.wire.ListModels(ctx)
+}
+
+// InvalidateModelCache delegates to the wire.
+func (a *ProviderAdapter) InvalidateModelCache() {
+	a.wire.InvalidateModelCache()
+}

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -37,7 +36,19 @@ var validOptions = map[string]bool{
 var _ llm.LLMClient = (*AnthropicClient)(nil)
 
 // AnthropicClient implements llm.LLMClient using the Anthropic Claude API.
+// It embeds *llm.ProviderAdapter which promotes CreateMessage and StreamMessage;
+// the four model/option methods are kept as thin explicit forwarders so that a
+// zero-value &AnthropicClient{} is safe (BLOCKING-1, issue #506).
 type AnthropicClient struct {
+	*llm.ProviderAdapter
+	w *wire
+}
+
+// wire implements llm.ProviderWire for the Anthropic provider. It owns all
+// wire-specific work: param building, SDK call, response translation, and error
+// classification. The streaming state machine lives in consumeStream (stream.go),
+// called by Stream.
+type wire struct {
 	client *anthropic.Client
 }
 
@@ -48,7 +59,8 @@ type AnthropicClient struct {
 func NewClient(apiKey string, opts ...option.RequestOption) *AnthropicClient {
 	allOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, opts...)
 	c := anthropic.NewClient(allOpts...)
-	return &AnthropicClient{client: &c}
+	w := &wire{client: &c}
+	return &AnthropicClient{ProviderAdapter: llm.NewAdapter(w), w: w}
 }
 
 // NewClientFromEnv constructs an AnthropicClient using only the default SDK
@@ -56,71 +68,17 @@ func NewClient(apiKey string, opts ...option.RequestOption) *AnthropicClient {
 // is read from the environment without an empty string override.
 func NewClientFromEnv(opts ...option.RequestOption) *AnthropicClient {
 	c := anthropic.NewClient(opts...)
-	return &AnthropicClient{client: &c}
+	w := &wire{client: &c}
+	return &AnthropicClient{ProviderAdapter: llm.NewAdapter(w), w: w}
 }
 
-// CreateMessage sends a single synchronous request to the Anthropic API and
-// returns the normalized response.
-func (c *AnthropicClient) CreateMessage(ctx context.Context, req llm.MessageRequest) (resp *llm.MessageResponse, err error) {
-	start := time.Now()
-	defer func() {
-		llm.ObserveRequestDuration("anthropic", req.Model, time.Since(start))
-		if err != nil {
-			llm.RecordError("anthropic", classifyAnthropicError(err))
-			return
-		}
-		if resp != nil {
-			llm.RecordTokens("anthropic", req.Model, resp.Usage)
-		}
-	}()
+// --- ProviderWire implementation on wire ---
 
-	hints, _ := req.Hints.(*AnthropicHints)
-	isReasoning := curatedModelsByName[req.Model].IsReasoning
+// ProviderName returns the Prometheus label for this provider.
+func (w *wire) ProviderName() string { return "anthropic" }
 
-	maxTokens := resolveMaxTokens(req, hints, isReasoning)
-	system := buildSystemBlocks(req, hints)
-
-	tools, nameMap, buildErr := buildTools(req.Tools)
-	if buildErr != nil {
-		err = fmt.Errorf("anthropic: building tools: %w", buildErr)
-		return
-	}
-	messages, buildErr := buildMessages(req.History, nameMap.OriginalToSanitized)
-	if buildErr != nil {
-		err = fmt.Errorf("anthropic: %w", buildErr)
-		return
-	}
-
-	params := anthropic.MessageNewParams{
-		Model:     anthropic.Model(req.Model),
-		MaxTokens: maxTokens,
-		System:    system,
-		Messages:  messages,
-		Tools:     tools,
-	}
-	if isReasoning {
-		params.Thinking = anthropic.ThinkingConfigParamUnion{
-			OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{},
-		}
-	}
-
-	sdkResp, sdkErr := c.client.Messages.New(ctx, params)
-	if sdkErr != nil {
-		err = wrapSDKError(sdkErr)
-		return
-	}
-
-	resp, err = translateResponse(sdkResp, nameMap.SanitizedToOriginal)
-	if err != nil {
-		err = fmt.Errorf("anthropic: translateResponse: %w", err)
-		return
-	}
-	return
-}
-
-// classifyAnthropicError maps an Anthropic SDK error to the fixed error_type
-// enum. Uses errors.As with a typed pointer variable per the two-step pattern.
-func classifyAnthropicError(err error) string {
+// ClassifyError maps an Anthropic SDK error to the fixed error_type enum.
+func (w *wire) ClassifyError(err error) string {
 	if et, ok := llm.ClassifyContextError(err); ok {
 		return et
 	}
@@ -131,11 +89,10 @@ func classifyAnthropicError(err error) string {
 	return metrics.ErrorTypeConnection
 }
 
-// StreamMessage opens a streaming request to the Anthropic API and emits
-// llm.MessageChunk values on the returned channel as events arrive. The channel
-// is closed when the stream ends. Pre-stream errors (e.g. tool schema failures)
-// are returned synchronously; mid-stream errors arrive as Err chunks.
-func (c *AnthropicClient) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
+// Call executes a synchronous request to the Anthropic API and returns the
+// normalized response. This is the body previously in AnthropicClient.CreateMessage
+// (minus the metrics-defer, which now lives in ProviderAdapter.CreateMessage).
+func (w *wire) Call(ctx context.Context, req llm.MessageRequest) (*llm.MessageResponse, error) {
 	hints, _ := req.Hints.(*AnthropicHints)
 	isReasoning := curatedModelsByName[req.Model].IsReasoning
 
@@ -164,16 +121,136 @@ func (c *AnthropicClient) StreamMessage(ctx context.Context, req llm.MessageRequ
 		}
 	}
 
-	stream := c.client.Messages.NewStreaming(ctx, params)
+	sdkResp, sdkErr := w.client.Messages.New(ctx, params)
+	if sdkErr != nil {
+		return nil, wrapSDKError(sdkErr)
+	}
+
+	resp, err := translateResponse(sdkResp, nameMap.SanitizedToOriginal)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: translateResponse: %w", err)
+	}
+	return resp, nil
+}
+
+// Stream opens a streaming request to the Anthropic API and returns the neutral
+// chunk channel. The accumulate-and-emit state machine lives in consumeStream.
+func (w *wire) Stream(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
+	hints, _ := req.Hints.(*AnthropicHints)
+	isReasoning := curatedModelsByName[req.Model].IsReasoning
+
+	maxTokens := resolveMaxTokens(req, hints, isReasoning)
+	system := buildSystemBlocks(req, hints)
+
+	tools, nameMap, err := buildTools(req.Tools)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: building tools: %w", err)
+	}
+	messages, err := buildMessages(req.History, nameMap.OriginalToSanitized)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: %w", err)
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(req.Model),
+		MaxTokens: maxTokens,
+		System:    system,
+		Messages:  messages,
+		Tools:     tools,
+	}
+	if isReasoning {
+		params.Thinking = anthropic.ThinkingConfigParamUnion{
+			OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{},
+		}
+	}
+
+	stream := w.client.Messages.NewStreaming(ctx, params)
 	out := make(chan llm.MessageChunk, 16)
 	go consumeStream(ctx, stream, out, nameMap.SanitizedToOriginal)
 	return out, nil
 }
 
+// ListModels returns a defensive copy of the curated Anthropic model list.
+func (w *wire) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
+	result := make([]llm.ModelInfo, len(curatedModels))
+	copy(result, curatedModels)
+	return result, nil
+}
+
+// ValidateModelName returns nil if modelName is in the curated model list or in
+// validationAliases (for backward compat with stored policies using dated pins).
+func (w *wire) ValidateModelName(_ context.Context, modelName string) error {
+	if _, ok := curatedModelsByName[modelName]; ok {
+		return nil
+	}
+	if _, ok := validationAliases[modelName]; ok {
+		return nil
+	}
+	names := make([]string, len(curatedModels))
+	for i, m := range curatedModels {
+		names[i] = m.DisplayName
+	}
+	return fmt.Errorf("unknown Anthropic model %q; available models: %s", modelName, strings.Join(names, ", "))
+}
+
+// ValidateOptions validates provider-specific options from the policy YAML.
+func (w *wire) ValidateOptions(options map[string]any) error {
+	return validateOptions(options)
+}
+
+// InvalidateModelCache is a no-op: the curated model list is static.
+func (w *wire) InvalidateModelCache() {}
+
+// --- Thin forwarders on AnthropicClient (zero-value safe, BLOCKING-1) ---
+//
+// These four methods are declared on the CONCRETE type so they satisfy the
+// LLMClient interface without promotion and a zero-value &AnthropicClient{}
+// is safe. They call package-level helpers directly — never the embedded
+// *ProviderAdapter — so a nil adapter cannot be dereferenced.
+
 // ValidateOptions validates provider-specific options from the policy YAML.
 // Accepted keys: "enable_prompt_caching" (bool), "max_tokens" (positive int).
 // All errors are collected before returning so the caller sees every problem at once.
 func (c *AnthropicClient) ValidateOptions(options map[string]any) error {
+	return validateOptions(options)
+}
+
+// ValidateModelName returns nil if modelName is in the curated model list or in
+// validationAliases (for backward compat with stored policies using dated pins).
+// No network call is made — validation is purely against the curated list.
+func (c *AnthropicClient) ValidateModelName(_ context.Context, modelName string) error {
+	if _, ok := curatedModelsByName[modelName]; ok {
+		return nil
+	}
+	if _, ok := validationAliases[modelName]; ok {
+		return nil
+	}
+	names := make([]string, len(curatedModels))
+	for i, m := range curatedModels {
+		names[i] = m.DisplayName
+	}
+	return fmt.Errorf("unknown Anthropic model %q; available models: %s", modelName, strings.Join(names, ", "))
+}
+
+// ListModels returns a defensive copy of the curated Anthropic model list.
+// No network call is made — this never panics even on a zero-value client.
+func (c *AnthropicClient) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
+	result := make([]llm.ModelInfo, len(curatedModels))
+	copy(result, curatedModels)
+	return result, nil
+}
+
+// InvalidateModelCache is a no-op: the curated model list is static and
+// requires no cache invalidation. The method exists to satisfy the LLMClient
+// interface so the provider registry's /api/v1/models/refresh path works.
+func (c *AnthropicClient) InvalidateModelCache() {}
+
+// --- Package-level helpers shared by both wire and AnthropicClient ---
+
+// validateOptions validates provider-specific options from the policy YAML.
+// Both the wire and the AnthropicClient forwarder call this so the logic lives
+// in one place without routing through the adapter.
+func validateOptions(options map[string]any) error {
 	if options == nil {
 		return nil
 	}
@@ -225,32 +302,6 @@ func (c *AnthropicClient) ValidateOptions(options map[string]any) error {
 	return nil
 }
 
-// ValidateModelName returns nil if modelName is in the curated model list or in
-// validationAliases (for backward compat with stored policies using dated pins).
-// No network call is made — validation is purely against the curated list.
-func (c *AnthropicClient) ValidateModelName(_ context.Context, modelName string) error {
-	if _, ok := curatedModelsByName[modelName]; ok {
-		return nil
-	}
-	if _, ok := validationAliases[modelName]; ok {
-		return nil
-	}
-
-	names := make([]string, len(curatedModels))
-	for i, m := range curatedModels {
-		names[i] = m.DisplayName
-	}
-	return fmt.Errorf("unknown Anthropic model %q; available models: %s", modelName, strings.Join(names, ", "))
-}
-
-// ListModels returns a defensive copy of the curated Anthropic model list.
-// No network call is made — this never panics even on a zero-value client.
-func (c *AnthropicClient) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
-	result := make([]llm.ModelInfo, len(curatedModels))
-	copy(result, curatedModels)
-	return result, nil
-}
-
 // humanizeModelName turns a raw Anthropic model ID into a human-readable label.
 // "claude-opus-4-6" → "Claude Opus 4.6"
 // Models that don't follow the expected pattern are returned unchanged.
@@ -284,11 +335,6 @@ func humanizeModelName(name string) string {
 	titleFamily := strings.ToUpper(family[:1]) + family[1:]
 	return fmt.Sprintf("Claude %s %s", titleFamily, strings.Join(vClean, "."))
 }
-
-// InvalidateModelCache is a no-op: the curated model list is static and
-// requires no cache invalidation. The method exists to satisfy the LLMClient
-// interface so the provider registry's /api/v1/models/refresh path works.
-func (c *AnthropicClient) InvalidateModelCache() {}
 
 // resolveMaxTokens determines the effective max_tokens for a request.
 // Precedence (highest to lowest):

--- a/internal/llm/contract/wire_contract_test.go
+++ b/internal/llm/contract/wire_contract_test.go
@@ -1,0 +1,772 @@
+// Package contract_test provides a cross-wire contract suite parameterized over
+// all four real ProviderWire implementations (anthropic, google, openai,
+// openaicompat). It asserts the provider-agnostic invariants that the individual
+// package-local tests leave implicit or incomplete:
+//
+//   - Continuity-state round-trip: the opaque state needed for multi-turn
+//     continuity survives a full response→history→outbound-request cycle (the
+//     token is parsed out of a response and then re-emitted on the wire when fed
+//     back through CreateMessage).
+//   - Tool-name round-trip: dots and other MCP-namespace characters survive
+//     sanitization on the way out and reverse-mapping on the way back.
+//   - Stop-reason normalization: provider-native stop strings map to the
+//     neutral llm.StopReason enum.
+//   - Usage extraction: InputTokens / OutputTokens (and ThinkingTokens where
+//     applicable) land in the right fields.
+//
+// The continuity-state carrier differs per provider (BLOCKING-3):
+//
+//   - anthropic / openai: ThinkingBlock.ProviderState (opaque JSON round-trip).
+//   - google: ToolCallBlock.ProviderMetadata["google.thought_signature"]
+//     (thought bytes attached to a FunctionCall part).
+//   - openaicompat: ThinkingBlocks are DROPPED (Chat Completions has no
+//     reasoning round-trip; sending a ThinkingBlock in history must not echo it
+//     back in the outbound chatRequest).
+package contract_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+	openaisdk_option "github.com/openai/openai-go/option"
+	"google.golang.org/genai"
+
+	"github.com/felag-engineering/gleipnir/internal/llm"
+	"github.com/felag-engineering/gleipnir/internal/llm/anthropic"
+	"github.com/felag-engineering/gleipnir/internal/llm/google"
+	"github.com/felag-engineering/gleipnir/internal/llm/openai"
+	"github.com/felag-engineering/gleipnir/internal/llm/openaicompat"
+)
+
+// --- Response body builders ---
+
+func anthropicResponse(stopReason, content string, inputTokens, outputTokens int) string {
+	return fmt.Sprintf(
+		`{"id":"msg_x","type":"message","role":"assistant","model":"claude-sonnet-4-6",`+
+			`"content":[%s],"stop_reason":%q,`+
+			`"usage":{"input_tokens":%d,"output_tokens":%d}}`,
+		content, stopReason, inputTokens, outputTokens,
+	)
+}
+
+func anthropicTextBody(inputTokens, outputTokens int) string {
+	return anthropicResponse("end_turn", `{"type":"text","text":"hello world"}`, inputTokens, outputTokens)
+}
+
+func anthropicToolCallBody() string {
+	return anthropicResponse("tool_use",
+		`{"type":"tool_use","id":"tu_1","name":"my_server_do_thing","input":{"q":"x"}}`, 10, 5)
+}
+
+func anthropicThinkingBody() string {
+	return anthropicResponse("end_turn",
+		`{"type":"thinking","thinking":"I think...","signature":"sig-abc"}`, 20, 10)
+}
+
+func anthropicMaxTokensBody() string {
+	return anthropicResponse("max_tokens", `{"type":"text","text":"truncated"}`, 5, 100)
+}
+
+func openaiResponse(status, outputItem string, inputTokens, outputTokens, reasoningTokens int) string {
+	return fmt.Sprintf(
+		`{"id":"resp_x","object":"response","created_at":1700000000,"model":"gpt-5","status":%q,`+
+			`"output":[%s],`+
+			`"usage":{"input_tokens":%d,"output_tokens":%d,"total_tokens":%d,`+
+			`"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":%d}}}`,
+		status, outputItem, inputTokens, outputTokens, inputTokens+outputTokens, reasoningTokens,
+	)
+}
+
+func openaiTextBody(inputTokens, outputTokens int) string {
+	msg := `{"id":"m1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello world","annotations":[]}]}`
+	return openaiResponse("completed", msg, inputTokens, outputTokens, 0)
+}
+
+func openaiToolCallBody() string {
+	fc := `{"id":"fc1","type":"function_call","call_id":"call_x","name":"my_server_do_thing","arguments":"{\"q\":\"x\"}","status":"completed"}`
+	return openaiResponse("completed", fc, 10, 8, 0)
+}
+
+func openaiThinkingBody() string {
+	rs := `{"id":"rs1","type":"reasoning","encrypted_content":"enc_xyz","summary":[{"type":"summary_text","text":"thinking"}],"status":"completed"}`
+	return openaiResponse("completed", rs, 5, 20, 15)
+}
+
+func openaiMaxTokensBody() string {
+	msg := `{"id":"m2","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"truncated","annotations":[]}]}`
+	return openaiResponse("incomplete", msg, 5, 100, 0)
+}
+
+func compatResponse(finishReason, content string, promptTokens, completionTokens int) string {
+	return fmt.Sprintf(
+		`{"id":"chatcmpl-x","choices":[{"index":0,"message":%s,"finish_reason":%q}],`+
+			`"usage":{"prompt_tokens":%d,"completion_tokens":%d}}`,
+		content, finishReason, promptTokens, completionTokens,
+	)
+}
+
+func compatTextBody(inputTokens, outputTokens int) string {
+	return compatResponse("stop", `{"role":"assistant","content":"hello world"}`, inputTokens, outputTokens)
+}
+
+func compatToolCallBody() string {
+	tc := `{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"my_server_do_thing","arguments":"{\"q\":\"x\"}"}}]}`
+	return compatResponse("tool_calls", tc, 10, 5)
+}
+
+func compatMaxTokensBody() string {
+	return compatResponse("length", `{"role":"assistant","content":"truncated"}`, 5, 100)
+}
+
+// --- Client constructors backed by httptest servers ---
+
+func newAnthropicClientJSON(t *testing.T, body string) llm.LLMClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return anthropic.NewClient("test-key",
+		option.WithBaseURL(srv.URL),
+		option.WithMaxRetries(0),
+	)
+}
+
+func newOpenAIClientJSON(t *testing.T, body string) llm.LLMClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return openai.NewClient("test-key",
+		openaisdk_option.WithHTTPClient(srv.Client()),
+		openaisdk_option.WithBaseURL(srv.URL),
+	)
+}
+
+func newCompatClientJSON(t *testing.T, body string) llm.LLMClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return openaicompat.NewClient(srv.URL, "test-key", openaicompat.WithHTTPClient(srv.Client()))
+}
+
+// captureServer returns an httptest server that always responds with respBody
+// and records the body of the most recent request it received into *lastReq.
+// The continuity round-trip tests use it to inspect what each wire re-emits when
+// a ProviderState-bearing ThinkingBlock is fed back through CreateMessage.
+func captureServer(t *testing.T, respBody string, lastReq *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*lastReq = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(respBody)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// --- Google fake generator ---
+
+// fakeGenerator satisfies the unexported google.contentGenerator interface
+// structurally: same method signatures, no need to name the interface.
+// See BLOCKING-3 in the plan — Google continuity uses ProviderMetadata, not
+// ThinkingBlock.ProviderState; the fakeGenerator drives the translateResponse
+// path via google.NewClientWithGenerator.
+type fakeGenerator struct {
+	response *genai.GenerateContentResponse
+	err      error
+
+	// lastContents records the contents of the most recent GenerateContent call,
+	// so the continuity round-trip test can inspect what buildContents re-emitted.
+	lastContents []*genai.Content
+}
+
+func (f *fakeGenerator) GenerateContent(_ context.Context, _ string, contents []*genai.Content, _ *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+	f.lastContents = contents
+	return f.response, f.err
+}
+
+func (f *fakeGenerator) GenerateContentStream(_ context.Context, _ string, _ []*genai.Content, _ *genai.GenerateContentConfig) iter.Seq2[*genai.GenerateContentResponse, error] {
+	return func(yield func(*genai.GenerateContentResponse, error) bool) {
+		yield(f.response, f.err)
+	}
+}
+
+func newGoogleClient(gen *fakeGenerator) llm.LLMClient {
+	return google.NewClientWithGenerator(gen)
+}
+
+// --- Shared test helpers ---
+
+func minimalHistory() []llm.ConversationTurn {
+	return []llm.ConversationTurn{
+		{Role: llm.RoleUser, Content: []llm.ContentBlock{llm.TextBlock{Text: "hello"}}},
+	}
+}
+
+func minimalRequest() llm.MessageRequest {
+	return llm.MessageRequest{
+		Model:   "test-model",
+		History: minimalHistory(),
+	}
+}
+
+func requestWithTool() llm.MessageRequest {
+	return llm.MessageRequest{
+		Model:   "test-model",
+		History: minimalHistory(),
+		Tools:   []llm.ToolDefinition{{Name: "my_server.do_thing", Description: "test"}},
+	}
+}
+
+// --- Contract test: stop-reason normalization ---
+
+// TestContract_StopReasonNormalization verifies that each provider maps its
+// native stop strings to the shared llm.StopReason enum values. This is the
+// primary invariant that lets the agent runtime be provider-agnostic.
+func TestContract_StopReasonNormalization(t *testing.T) {
+	type stopCase struct {
+		name       string
+		makeClient func() llm.LLMClient
+		req        llm.MessageRequest
+		want       llm.StopReason
+	}
+
+	cases := []stopCase{
+		// Anthropic
+		{
+			name:       "anthropic/end_turn",
+			makeClient: func() llm.LLMClient { return newAnthropicClientJSON(t, anthropicTextBody(5, 3)) },
+			req:        minimalRequest(),
+			want:       llm.StopReasonEndTurn,
+		},
+		{
+			name:       "anthropic/tool_use",
+			makeClient: func() llm.LLMClient { return newAnthropicClientJSON(t, anthropicToolCallBody()) },
+			req:        requestWithTool(),
+			want:       llm.StopReasonToolUse,
+		},
+		{
+			name:       "anthropic/max_tokens",
+			makeClient: func() llm.LLMClient { return newAnthropicClientJSON(t, anthropicMaxTokensBody()) },
+			req:        minimalRequest(),
+			want:       llm.StopReasonMaxTokens,
+		},
+		// OpenAI Responses API
+		{
+			name:       "openai/end_turn",
+			makeClient: func() llm.LLMClient { return newOpenAIClientJSON(t, openaiTextBody(5, 3)) },
+			req:        minimalRequest(),
+			want:       llm.StopReasonEndTurn,
+		},
+		{
+			name:       "openai/tool_use",
+			makeClient: func() llm.LLMClient { return newOpenAIClientJSON(t, openaiToolCallBody()) },
+			req:        requestWithTool(),
+			want:       llm.StopReasonToolUse,
+		},
+		{
+			name:       "openai/max_tokens",
+			makeClient: func() llm.LLMClient { return newOpenAIClientJSON(t, openaiMaxTokensBody()) },
+			req:        minimalRequest(),
+			want:       llm.StopReasonMaxTokens,
+		},
+		// OpenAI Chat Completions compatible
+		{
+			name:       "openaicompat/end_turn",
+			makeClient: func() llm.LLMClient { return newCompatClientJSON(t, compatTextBody(5, 3)) },
+			req:        minimalRequest(),
+			want:       llm.StopReasonEndTurn,
+		},
+		{
+			name:       "openaicompat/tool_use",
+			makeClient: func() llm.LLMClient { return newCompatClientJSON(t, compatToolCallBody()) },
+			req:        requestWithTool(),
+			want:       llm.StopReasonToolUse,
+		},
+		{
+			name:       "openaicompat/max_tokens",
+			makeClient: func() llm.LLMClient { return newCompatClientJSON(t, compatMaxTokensBody()) },
+			req:        minimalRequest(),
+			want:       llm.StopReasonMaxTokens,
+		},
+		// Google (via fakeGenerator)
+		{
+			name: "google/end_turn",
+			makeClient: func() llm.LLMClient {
+				return newGoogleClient(&fakeGenerator{
+					response: &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{{
+							Content:      &genai.Content{Parts: []*genai.Part{{Text: "hello"}}},
+							FinishReason: genai.FinishReasonStop,
+						}},
+						UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 5, CandidatesTokenCount: 3},
+					},
+				})
+			},
+			req:  minimalRequest(),
+			want: llm.StopReasonEndTurn,
+		},
+		{
+			name: "google/tool_use",
+			makeClient: func() llm.LLMClient {
+				return newGoogleClient(&fakeGenerator{
+					response: &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{{
+							Content: &genai.Content{Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{ID: "fc-1", Name: "my_server_do_thing", Args: map[string]any{"q": "x"}},
+							}}},
+							FinishReason: genai.FinishReasonStop,
+						}},
+						UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 10, CandidatesTokenCount: 5},
+					},
+				})
+			},
+			req:  requestWithTool(),
+			want: llm.StopReasonToolUse,
+		},
+		{
+			name: "google/max_tokens",
+			makeClient: func() llm.LLMClient {
+				return newGoogleClient(&fakeGenerator{
+					response: &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{{
+							Content:      &genai.Content{Parts: []*genai.Part{{Text: "truncated"}}},
+							FinishReason: genai.FinishReasonMaxTokens,
+						}},
+						UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 5, CandidatesTokenCount: 100},
+					},
+				})
+			},
+			req:  minimalRequest(),
+			want: llm.StopReasonMaxTokens,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := tc.makeClient()
+			resp, err := client.CreateMessage(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("CreateMessage: %v", err)
+			}
+			if resp.StopReason != tc.want {
+				t.Errorf("StopReason = %v, want %v", resp.StopReason, tc.want)
+			}
+		})
+	}
+}
+
+// --- Contract test: usage extraction ---
+
+// TestContract_UsageExtraction verifies that InputTokens, OutputTokens, and
+// (where available) ThinkingTokens are populated correctly across all providers.
+func TestContract_UsageExtraction(t *testing.T) {
+	type usageCase struct {
+		name         string
+		makeClient   func() llm.LLMClient
+		wantInput    int
+		wantOutput   int
+		wantThinking int
+	}
+
+	cases := []usageCase{
+		{
+			name:       "anthropic",
+			makeClient: func() llm.LLMClient { return newAnthropicClientJSON(t, anthropicTextBody(42, 17)) },
+			wantInput:  42,
+			wantOutput: 17,
+		},
+		{
+			name:       "openai",
+			makeClient: func() llm.LLMClient { return newOpenAIClientJSON(t, openaiTextBody(42, 17)) },
+			wantInput:  42,
+			wantOutput: 17,
+		},
+		{
+			name:         "openai_thinking_tokens",
+			makeClient:   func() llm.LLMClient { return newOpenAIClientJSON(t, openaiThinkingBody()) },
+			wantInput:    5,
+			wantOutput:   20,
+			wantThinking: 15,
+		},
+		{
+			name:       "openaicompat",
+			makeClient: func() llm.LLMClient { return newCompatClientJSON(t, compatTextBody(42, 17)) },
+			wantInput:  42,
+			wantOutput: 17,
+		},
+		{
+			name: "google",
+			makeClient: func() llm.LLMClient {
+				return newGoogleClient(&fakeGenerator{
+					response: &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{{
+							Content:      &genai.Content{Parts: []*genai.Part{{Text: "hi"}}},
+							FinishReason: genai.FinishReasonStop,
+						}},
+						UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+							PromptTokenCount:     42,
+							CandidatesTokenCount: 17,
+						},
+					},
+				})
+			},
+			wantInput:  42,
+			wantOutput: 17,
+		},
+		{
+			name: "google_thinking_tokens",
+			makeClient: func() llm.LLMClient {
+				return newGoogleClient(&fakeGenerator{
+					response: &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{{
+							Content:      &genai.Content{Parts: []*genai.Part{{Text: "answer"}}},
+							FinishReason: genai.FinishReasonStop,
+						}},
+						UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+							PromptTokenCount:     10,
+							CandidatesTokenCount: 5,
+							ThoughtsTokenCount:   30,
+						},
+					},
+				})
+			},
+			wantInput:    10,
+			wantOutput:   5,
+			wantThinking: 30,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := tc.makeClient()
+			resp, err := client.CreateMessage(context.Background(), minimalRequest())
+			if err != nil {
+				t.Fatalf("CreateMessage: %v", err)
+			}
+			if resp.Usage.InputTokens != tc.wantInput {
+				t.Errorf("InputTokens = %d, want %d", resp.Usage.InputTokens, tc.wantInput)
+			}
+			if resp.Usage.OutputTokens != tc.wantOutput {
+				t.Errorf("OutputTokens = %d, want %d", resp.Usage.OutputTokens, tc.wantOutput)
+			}
+			if tc.wantThinking != 0 && resp.Usage.ThinkingTokens != tc.wantThinking {
+				t.Errorf("ThinkingTokens = %d, want %d", resp.Usage.ThinkingTokens, tc.wantThinking)
+			}
+		})
+	}
+}
+
+// --- Contract test: tool-name round-trip ---
+
+// TestContract_ToolNameRoundTrip verifies that tool names containing '.' (the
+// MCP namespace separator) survive sanitization on the outbound request and
+// reverse-mapping on the inbound tool-call response. The tool name returned in
+// ToolCalls must not be empty.
+//
+// The fixture response returns the sanitized wire name ("my_server_do_thing" —
+// the '.' is replaced with '_' by every provider, since '.' is never in any
+// provider's allowedExtra set). The reverse-map must convert it back to the
+// original MCP name "my_server.do_thing"; the contract asserts that exact
+// round-trip so a broken reverse-map surfaces here, not just in per-provider
+// unit tests.
+func TestContract_ToolNameRoundTrip(t *testing.T) {
+	type toolCase struct {
+		name       string
+		makeClient func() llm.LLMClient
+	}
+
+	cases := []toolCase{
+		{
+			name:       "anthropic",
+			makeClient: func() llm.LLMClient { return newAnthropicClientJSON(t, anthropicToolCallBody()) },
+		},
+		{
+			name:       "openai",
+			makeClient: func() llm.LLMClient { return newOpenAIClientJSON(t, openaiToolCallBody()) },
+		},
+		{
+			name:       "openaicompat",
+			makeClient: func() llm.LLMClient { return newCompatClientJSON(t, compatToolCallBody()) },
+		},
+		{
+			name: "google",
+			makeClient: func() llm.LLMClient {
+				return newGoogleClient(&fakeGenerator{
+					response: &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{{
+							Content: &genai.Content{Parts: []*genai.Part{{
+								FunctionCall: &genai.FunctionCall{ID: "fc-1", Name: "my_server_do_thing", Args: map[string]any{"q": "x"}},
+							}}},
+							FinishReason: genai.FinishReasonStop,
+						}},
+						UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 10, CandidatesTokenCount: 5},
+					},
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := tc.makeClient()
+			resp, err := client.CreateMessage(context.Background(), requestWithTool())
+			if err != nil {
+				t.Fatalf("CreateMessage: %v", err)
+			}
+			if len(resp.ToolCalls) == 0 {
+				t.Fatal("expected at least one tool call in response")
+			}
+			if got := resp.ToolCalls[0].Name; got != "my_server.do_thing" {
+				t.Errorf("tool name not reverse-mapped to original: got %q, want %q", got, "my_server.do_thing")
+			}
+		})
+	}
+}
+
+// --- Contract test: continuity-state round-trip (per-provider carrier differs) ---
+//
+// Each test drives the full cycle through the exported Client + a real transport
+// stub: parse the continuity token out of a response, feed it back through a
+// second CreateMessage, and assert it re-appears on the outbound wire (or, for
+// openaicompat, is correctly dropped). The carrier differs per provider, so these
+// are separate tests rather than one table.
+
+// TestContract_ContinuityState_Anthropic asserts the full continuity round-trip
+// for Anthropic: the response carries ProviderState with a "signature" field
+// (response direction), and feeding that ThinkingBlock back through CreateMessage
+// re-emits the signature on the outbound wire (request direction) — the opaque
+// token Anthropic requires for extended-thinking continuity.
+func TestContract_ContinuityState_Anthropic(t *testing.T) {
+	var lastReq string
+	srv := captureServer(t, anthropicThinkingBody(), &lastReq)
+	client := anthropic.NewClient("test-key", option.WithBaseURL(srv.URL), option.WithMaxRetries(0))
+
+	// Response direction: the thinking block carries ProviderState with a signature.
+	resp, err := client.CreateMessage(context.Background(), minimalRequest())
+	if err != nil {
+		t.Fatalf("CreateMessage (response direction): %v", err)
+	}
+	if len(resp.Thinking) == 0 {
+		t.Fatal("expected at least one ThinkingBlock")
+	}
+
+	tb := resp.Thinking[0]
+	if tb.Provider != "anthropic" {
+		t.Errorf("ThinkingBlock.Provider = %q, want %q", tb.Provider, "anthropic")
+	}
+	if len(tb.ProviderState) == 0 {
+		t.Fatal("ThinkingBlock.ProviderState must not be empty for Anthropic thinking blocks")
+	}
+	var state struct {
+		Signature string `json:"signature"`
+	}
+	if err := json.Unmarshal(tb.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.Signature == "" {
+		t.Fatal("ThinkingBlock.ProviderState must contain a non-empty 'signature' field")
+	}
+
+	// Request direction: feed the thinking block back and assert the signature
+	// re-appears on the outbound wire — the round-trip that continuity depends on.
+	if _, err := client.CreateMessage(context.Background(), llm.MessageRequest{
+		Model: "claude-sonnet-4-6",
+		History: []llm.ConversationTurn{
+			{Role: llm.RoleUser, Content: []llm.ContentBlock{llm.TextBlock{Text: "hello"}}},
+			{Role: llm.RoleAssistant, Content: []llm.ContentBlock{tb, llm.TextBlock{Text: "answer"}}},
+		},
+	}); err != nil {
+		t.Fatalf("CreateMessage (request direction): %v", err)
+	}
+	if !strings.Contains(lastReq, state.Signature) {
+		t.Errorf("outbound request must echo the thinking signature %q for continuity; body=%s", state.Signature, lastReq)
+	}
+}
+
+// TestContract_ContinuityState_OpenAI asserts the full continuity round-trip for
+// OpenAI: the response carries ProviderState with an "encrypted_content" field
+// (response direction), and feeding that reasoning item back through
+// CreateMessage re-emits encrypted_content on the outbound wire (request
+// direction) — the opaque token OpenAI's Responses API requires to replay the
+// reasoning item on subsequent turns.
+func TestContract_ContinuityState_OpenAI(t *testing.T) {
+	var lastReq string
+	srv := captureServer(t, openaiThinkingBody(), &lastReq)
+	client := openai.NewClient("test-key",
+		openaisdk_option.WithHTTPClient(srv.Client()),
+		openaisdk_option.WithBaseURL(srv.URL),
+	)
+
+	// Response direction: the reasoning item carries ProviderState with encrypted_content.
+	resp, err := client.CreateMessage(context.Background(), minimalRequest())
+	if err != nil {
+		t.Fatalf("CreateMessage (response direction): %v", err)
+	}
+	if len(resp.Thinking) == 0 {
+		t.Fatal("expected at least one ThinkingBlock")
+	}
+
+	tb := resp.Thinking[0]
+	if tb.Provider != "openai" {
+		t.Errorf("ThinkingBlock.Provider = %q, want %q", tb.Provider, "openai")
+	}
+	if len(tb.ProviderState) == 0 {
+		t.Fatal("ThinkingBlock.ProviderState must not be empty for OpenAI reasoning items")
+	}
+	var state struct {
+		EncryptedContent string `json:"encrypted_content"`
+	}
+	if err := json.Unmarshal(tb.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal ProviderState: %v", err)
+	}
+	if state.EncryptedContent == "" {
+		t.Fatal("ThinkingBlock.ProviderState must contain a non-empty 'encrypted_content' field")
+	}
+
+	// Request direction: feed the reasoning item back and assert encrypted_content
+	// re-appears on the outbound wire — the round-trip that continuity depends on.
+	if _, err := client.CreateMessage(context.Background(), llm.MessageRequest{
+		Model: "gpt-5",
+		History: []llm.ConversationTurn{
+			{Role: llm.RoleUser, Content: []llm.ContentBlock{llm.TextBlock{Text: "hello"}}},
+			{Role: llm.RoleAssistant, Content: []llm.ContentBlock{tb, llm.TextBlock{Text: "answer"}}},
+		},
+	}); err != nil {
+		t.Fatalf("CreateMessage (request direction): %v", err)
+	}
+	if !strings.Contains(lastReq, state.EncryptedContent) {
+		t.Errorf("outbound request must echo encrypted_content %q for continuity; body=%s", state.EncryptedContent, lastReq)
+	}
+}
+
+// TestContract_ContinuityState_Google asserts the full continuity round-trip for
+// Google. Google has no ThinkingBlock.ProviderState — the thought bytes ride
+// ToolCallBlock.ProviderMetadata["google.thought_signature"], attached to a
+// FunctionCall part. The response direction surfaces them into the metadata map,
+// and feeding the tool call back through CreateMessage re-attaches them as
+// part.ThoughtSignature on the outbound contents.
+func TestContract_ContinuityState_Google(t *testing.T) {
+	sig := []byte{0xde, 0xad, 0xbe, 0xef}
+	gen := &fakeGenerator{
+		response: &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{Parts: []*genai.Part{{
+					FunctionCall:     &genai.FunctionCall{ID: "fc-1", Name: "do_thing", Args: map[string]any{"q": "x"}},
+					ThoughtSignature: sig,
+				}}},
+				FinishReason: genai.FinishReasonStop,
+			}},
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 10, CandidatesTokenCount: 5},
+		},
+	}
+	client := newGoogleClient(gen)
+
+	// Response direction: the thought signature surfaces into ProviderMetadata.
+	resp, err := client.CreateMessage(context.Background(), llm.MessageRequest{
+		Model:   "gemini-2.0-flash",
+		History: minimalHistory(),
+		Tools:   []llm.ToolDefinition{{Name: "do_thing", Description: "test"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage (response direction): %v", err)
+	}
+	if len(resp.ToolCalls) == 0 {
+		t.Fatal("expected at least one ToolCallBlock")
+	}
+
+	gotSig := resp.ToolCalls[0].ProviderMetadata["google.thought_signature"]
+	if len(gotSig) == 0 {
+		t.Fatal("ToolCallBlock.ProviderMetadata['google.thought_signature'] must not be empty when ThoughtSignature is set")
+	}
+	if string(gotSig) != string(sig) {
+		t.Errorf("thought_signature bytes = %v, want %v", gotSig, sig)
+	}
+
+	// Request direction: feed the tool call back and assert buildContents
+	// re-attaches the signature as part.ThoughtSignature on the outbound contents.
+	if _, err := client.CreateMessage(context.Background(), llm.MessageRequest{
+		Model: "gemini-2.0-flash",
+		History: []llm.ConversationTurn{
+			{Role: llm.RoleUser, Content: []llm.ContentBlock{llm.TextBlock{Text: "hello"}}},
+			{Role: llm.RoleAssistant, Content: []llm.ContentBlock{resp.ToolCalls[0]}},
+		},
+		Tools: []llm.ToolDefinition{{Name: "do_thing", Description: "test"}},
+	}); err != nil {
+		t.Fatalf("CreateMessage (request direction): %v", err)
+	}
+	var echoed []byte
+	for _, c := range gen.lastContents {
+		for _, p := range c.Parts {
+			if len(p.ThoughtSignature) > 0 {
+				echoed = p.ThoughtSignature
+			}
+		}
+	}
+	if string(echoed) != string(sig) {
+		t.Errorf("buildContents must re-attach thought_signature on the outbound part; got %v, want %v", echoed, sig)
+	}
+}
+
+// TestContract_ContinuityState_OpenAICompat asserts that ThinkingBlocks in
+// conversation history are DROPPED by the Chat Completions wire. Chat
+// Completions has no reasoning round-trip — the openaicompat provider must
+// silently omit them rather than forwarding them as unrecognized content.
+//
+// We capture the outbound HTTP request body and verify it contains no
+// "thinking" markers from the injected ThinkingBlock.
+func TestContract_ContinuityState_OpenAICompat(t *testing.T) {
+	var lastReq string
+	srv := captureServer(t, compatTextBody(5, 3), &lastReq)
+	client := openaicompat.NewClient(srv.URL, "test-key", openaicompat.WithHTTPClient(srv.Client()))
+
+	providerState, _ := json.Marshal(map[string]string{"signature": "sig-sentinel"})
+	history := []llm.ConversationTurn{
+		{Role: llm.RoleUser, Content: []llm.ContentBlock{llm.TextBlock{Text: "hello"}}},
+		{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentBlock{
+				llm.ThinkingBlock{
+					Provider:      "anthropic",
+					Text:          "internal-reasoning-sentinel",
+					ProviderState: providerState,
+				},
+				llm.TextBlock{Text: "I reasoned about this"},
+			},
+		},
+	}
+
+	resp, err := client.CreateMessage(context.Background(), llm.MessageRequest{
+		Model:   "gpt-4",
+		History: history,
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	if len(resp.Text) == 0 {
+		t.Fatal("expected non-empty text response")
+	}
+
+	if strings.Contains(lastReq, "sig-sentinel") {
+		t.Error("outbound request must not echo ThinkingBlock.ProviderState (thinking dropped for compat wire)")
+	}
+	if strings.Contains(lastReq, "internal-reasoning-sentinel") {
+		t.Error("outbound request must not echo ThinkingBlock.Text (thinking dropped for compat wire)")
+	}
+}

--- a/internal/llm/fake_wire.go
+++ b/internal/llm/fake_wire.go
@@ -1,0 +1,108 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/felag-engineering/gleipnir/internal/infra/metrics"
+)
+
+// FakeWire is a ProviderWire that returns scripted responses in sequence.
+// It is the "fifth adapter" described in issue #506: it slots into NewAdapter
+// so test code runs through the real metrics-defer choreography in ProviderAdapter
+// instead of bypassing it with a hand-rolled mock.
+//
+// Wrap it with NewAdapter (or use testutil.NewFakeClient) to get an LLMClient.
+//
+// FakeWire is safe for concurrent use.
+type FakeWire struct {
+	// Responses is the scripted sequence of responses. Call advances through
+	// this slice; an exhausted slice returns an error.
+	Responses []*MessageResponse
+
+	// name is the Prometheus label returned by ProviderName.
+	name string
+
+	mu       sync.Mutex
+	requests []*MessageRequest
+	callIdx  int
+}
+
+// NewFakeWire constructs a FakeWire that returns responses in the given order.
+// The provider name (the Prometheus label) is "fake".
+func NewFakeWire(responses ...*MessageResponse) *FakeWire {
+	return &FakeWire{
+		Responses: responses,
+		name:      "fake",
+	}
+}
+
+// Call returns the next scripted response and records the request.
+func (f *FakeWire) Call(_ context.Context, req MessageRequest) (*MessageResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests = append(f.requests, &req)
+	if f.callIdx >= len(f.Responses) {
+		return nil, fmt.Errorf("FakeWire: no more responses (called %d times, have %d)", f.callIdx+1, len(f.Responses))
+	}
+	resp := f.Responses[f.callIdx]
+	f.callIdx++
+	return resp, nil
+}
+
+// Stream delegates to Call and converts the response to a chunk channel using
+// StubStreamFromResponse, matching MockLLMClient.StreamMessage behavior exactly.
+func (f *FakeWire) Stream(ctx context.Context, req MessageRequest) (<-chan MessageChunk, error) {
+	resp, err := f.Call(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return StubStreamFromResponse(resp), nil
+}
+
+// ListModels returns nil (no model listing in the fake wire).
+func (f *FakeWire) ListModels(_ context.Context) ([]ModelInfo, error) { return nil, nil }
+
+// ValidateModelName returns nil (no validation in the fake wire).
+func (f *FakeWire) ValidateModelName(_ context.Context, _ string) error { return nil }
+
+// ValidateOptions returns nil (no validation in the fake wire).
+func (f *FakeWire) ValidateOptions(_ map[string]any) error { return nil }
+
+// InvalidateModelCache is a no-op for the fake wire.
+func (f *FakeWire) InvalidateModelCache() {}
+
+// ClassifyError maps errors to the fixed error_type enum, matching
+// MockLLMClient behavior: context errors become "timeout"; everything else
+// becomes "connection".
+func (f *FakeWire) ClassifyError(err error) string {
+	if et, ok := ClassifyContextError(err); ok {
+		return et
+	}
+	return metrics.ErrorTypeConnection
+}
+
+// ProviderName returns the Prometheus label for this fake provider.
+func (f *FakeWire) ProviderName() string {
+	if f.name != "" {
+		return f.name
+	}
+	return "fake"
+}
+
+// Calls returns the number of Call invocations.
+func (f *FakeWire) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callIdx
+}
+
+// Requests returns a copy of all captured requests in call order.
+func (f *FakeWire) Requests() []*MessageRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*MessageRequest, len(f.requests))
+	copy(out, f.requests)
+	return out
+}

--- a/internal/llm/google/client.go
+++ b/internal/llm/google/client.go
@@ -8,7 +8,6 @@ import (
 	"iter"
 	"log/slog"
 	"strings"
-	"time"
 
 	"google.golang.org/genai"
 
@@ -28,7 +27,19 @@ type contentGenerator interface {
 var _ llm.LLMClient = (*GeminiClient)(nil)
 
 // GeminiClient implements llm.LLMClient using the Google Gemini API.
+// It embeds *llm.ProviderAdapter which promotes CreateMessage and StreamMessage;
+// the four model/option methods are kept as thin explicit forwarders so that a
+// zero-value &GeminiClient{} is safe (BLOCKING-1, issue #506).
 type GeminiClient struct {
+	*llm.ProviderAdapter
+	w *wire
+}
+
+// wire implements llm.ProviderWire for the Google provider. It owns all
+// wire-specific work: param building, API call, response translation, and error
+// classification. The streaming state machine lives in consumeStream (stream.go),
+// called by Stream.
+type wire struct {
 	generator contentGenerator
 }
 
@@ -41,55 +52,39 @@ func NewClient(ctx context.Context, apiKey string) (*GeminiClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("google: creating client: %w", err)
 	}
-	return &GeminiClient{generator: client.Models}, nil
+	return newClientWithGenerator(client.Models), nil
 }
 
 // newClientWithGenerator constructs a GeminiClient with an injected generator.
-// Used in tests to avoid real API calls.
+// Used in tests to avoid real API calls. Unexported to keep the contentGenerator
+// type unexported; use NewClientWithGenerator for external test packages.
 func newClientWithGenerator(gen contentGenerator) *GeminiClient {
-	return &GeminiClient{generator: gen}
+	w := &wire{generator: gen}
+	return &GeminiClient{ProviderAdapter: llm.NewAdapter(w), w: w}
 }
 
-// CreateMessage sends a single synchronous request to the Gemini API and
-// returns the normalized response.
-func (c *GeminiClient) CreateMessage(ctx context.Context, req llm.MessageRequest) (resp *llm.MessageResponse, err error) {
-	start := time.Now()
-	defer func() {
-		llm.ObserveRequestDuration("google", req.Model, time.Since(start))
-		if err != nil {
-			llm.RecordError("google", classifyGoogleError(err))
-			return
-		}
-		if resp != nil {
-			llm.RecordTokens("google", req.Model, resp.Usage)
-		}
-	}()
-
-	hints, _ := req.Hints.(*GeminiHints)
-
-	// Build name mapping before translating history so tool names in
-	// ToolCallBlock/ToolResultBlock use the sanitized wire-format names.
-	names := llm.BuildNameMapping(req.Tools, "")
-	contents := buildContents(req.History, names)
-	config, err := buildConfig(req, hints, names)
-	if err != nil {
-		err = fmt.Errorf("building request config: %w", err)
-		return
-	}
-
-	sdkResp, sdkErr := c.generator.GenerateContent(ctx, req.Model, contents, config)
-	if sdkErr != nil {
-		err = wrapSDKError(sdkErr)
-		return
-	}
-
-	resp, err = translateResponse(sdkResp, names)
-	return
+// NewClientWithGenerator constructs a GeminiClient with an injected generator.
+// This is an exported test seam used by the cross-wire contract suite
+// (internal/llm/contract) to drive the Google wire without a real API key.
+// Production code should use NewClient.
+//
+// The contentGenerator parameter type is unexported, but Go's structural typing
+// lets an external package pass any value implementing the two genai methods:
+//
+//	GenerateContent(ctx, model, contents, config) (*genai.GenerateContentResponse, error)
+//	GenerateContentStream(ctx, model, contents, config) iter.Seq2[*genai.GenerateContentResponse, error]
+func NewClientWithGenerator(gen contentGenerator) *GeminiClient {
+	return newClientWithGenerator(gen)
 }
 
-// classifyGoogleError maps a Gemini SDK error to the fixed error_type enum.
+// --- ProviderWire implementation on wire ---
+
+// ProviderName returns the Prometheus label for this provider.
+func (w *wire) ProviderName() string { return "google" }
+
+// ClassifyError maps a Gemini SDK error to the fixed error_type enum.
 // genai.APIError is a value type, so the errors.As target is a pointer-to-value.
-func classifyGoogleError(err error) string {
+func (w *wire) ClassifyError(err error) string {
 	if et, ok := llm.ClassifyContextError(err); ok {
 		return et
 	}
@@ -100,11 +95,33 @@ func classifyGoogleError(err error) string {
 	return metrics.ErrorTypeConnection
 }
 
-// StreamMessage opens a streaming request to the Gemini API and emits
-// llm.MessageChunk values on the returned channel as responses arrive. The
-// channel is closed when the stream ends. Errors arrive as Err chunks rather
-// than synchronous returns because GenerateContentStream is a lazy iterator.
-func (c *GeminiClient) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
+// Call executes a synchronous request to the Gemini API and returns the
+// normalized response. This is the body previously in GeminiClient.CreateMessage
+// (minus the metrics-defer, which now lives in ProviderAdapter.CreateMessage).
+func (w *wire) Call(ctx context.Context, req llm.MessageRequest) (*llm.MessageResponse, error) {
+	hints, _ := req.Hints.(*GeminiHints)
+
+	// Build name mapping before translating history so tool names in
+	// ToolCallBlock/ToolResultBlock use the sanitized wire-format names.
+	names := llm.BuildNameMapping(req.Tools, "")
+	contents := buildContents(req.History, names)
+	config, err := buildConfig(req, hints, names)
+	if err != nil {
+		return nil, fmt.Errorf("building request config: %w", err)
+	}
+
+	sdkResp, sdkErr := w.generator.GenerateContent(ctx, req.Model, contents, config)
+	if sdkErr != nil {
+		return nil, wrapSDKError(sdkErr)
+	}
+
+	return translateResponse(sdkResp, names)
+}
+
+// Stream opens a streaming request to the Gemini API and returns the neutral
+// chunk channel. The accumulate-and-emit state machine lives in consumeStream
+// (stream.go).
+func (w *wire) Stream(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
 	hints, _ := req.Hints.(*GeminiHints)
 	names := llm.BuildNameMapping(req.Tools, "")
 	contents := buildContents(req.History, names)
@@ -113,11 +130,48 @@ func (c *GeminiClient) StreamMessage(ctx context.Context, req llm.MessageRequest
 		return nil, fmt.Errorf("building request config: %w", err)
 	}
 
-	seq := c.generator.GenerateContentStream(ctx, req.Model, contents, config)
+	seq := w.generator.GenerateContentStream(ctx, req.Model, contents, config)
 	out := make(chan llm.MessageChunk, 16)
 	go consumeStream(ctx, seq, out, names)
 	return out, nil
 }
+
+// ListModels returns a defensive copy of the curated Gemini model list.
+func (w *wire) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
+	result := make([]llm.ModelInfo, len(curatedModels))
+	copy(result, curatedModels)
+	return result, nil
+}
+
+// ValidateModelName returns nil if modelName is in the curated model list, or
+// a descriptive error if not.
+func (w *wire) ValidateModelName(_ context.Context, modelName string) error {
+	for _, m := range curatedModels {
+		if m.Name == modelName {
+			return nil
+		}
+	}
+	names := make([]string, len(curatedModels))
+	for i, m := range curatedModels {
+		names[i] = m.DisplayName
+	}
+	return fmt.Errorf("unknown Google model %q; available models: %s", modelName, strings.Join(names, ", "))
+}
+
+// ValidateOptions validates provider-specific options from the policy YAML.
+func (w *wire) ValidateOptions(options map[string]any) error {
+	_, err := parseHints(options)
+	return err
+}
+
+// InvalidateModelCache is a no-op: the curated model list is static.
+func (w *wire) InvalidateModelCache() {}
+
+// --- Thin forwarders on GeminiClient (zero-value safe, BLOCKING-1) ---
+//
+// These four methods are declared on the CONCRETE type so they satisfy the
+// LLMClient interface without promotion and a zero-value &GeminiClient{} is safe.
+// They call package-level helpers directly — never the embedded *ProviderAdapter.
 
 // ValidateOptions validates provider-specific options from the policy YAML.
 // Accepted keys: "thinking_level" (string), "thinking_budget" (int), "enable_grounding" (bool).
@@ -154,6 +208,8 @@ func (c *GeminiClient) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
 // requires no cache invalidation. The method exists to satisfy the LLMClient
 // interface so the provider registry's /api/v1/models/refresh path works.
 func (c *GeminiClient) InvalidateModelCache() {}
+
+// --- Request translation helpers ---
 
 // buildContents translates the provider-neutral conversation history into
 // genai Content structs. It performs a two-pass approach: first collecting

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	openaisdk "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -27,7 +26,20 @@ var _ llm.LLMClient = (*Client)(nil)
 // Client implements llm.LLMClient against the OpenAI Responses API via the
 // official openai-go SDK. Unlike the compat client, it uses the stateless
 // Responses API which provides native reasoning tokens and a typed surface.
+//
+// Client embeds *llm.ProviderAdapter which promotes CreateMessage and
+// StreamMessage. The four model/option methods are kept as thin explicit
+// forwarders so that a zero-value &Client{} is safe (BLOCKING-1, issue #506).
 type Client struct {
+	*llm.ProviderAdapter
+	w *wire
+}
+
+// wire implements llm.ProviderWire for the OpenAI provider. It owns all
+// wire-specific work: param building, SDK call, response translation, and error
+// classification. The streaming state machine lives in consumeStream (stream.go),
+// called by Stream.
+type wire struct {
 	sdk *openaisdk.Client
 }
 
@@ -38,51 +50,18 @@ type Client struct {
 func NewClient(apiKey string, opts ...option.RequestOption) *Client {
 	allOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, opts...)
 	sdk := openaisdk.NewClient(allOpts...)
-	return &Client{sdk: &sdk}
+	w := &wire{sdk: &sdk}
+	return &Client{ProviderAdapter: llm.NewAdapter(w), w: w}
 }
 
-// CreateMessage sends a single synchronous Responses API request and returns
-// the normalized response.
-func (c *Client) CreateMessage(ctx context.Context, req llm.MessageRequest) (resp *llm.MessageResponse, err error) {
-	start := time.Now()
-	defer func() {
-		llm.ObserveRequestDuration("openai", req.Model, time.Since(start))
-		if err != nil {
-			llm.RecordError("openai", classifyOpenAIError(err))
-			return
-		}
-		if resp != nil {
-			llm.RecordTokens("openai", req.Model, resp.Usage)
-		}
-	}()
+// --- ProviderWire implementation on wire ---
 
-	hints, _ := req.Hints.(*OpenAIHints)
+// ProviderName returns the Prometheus label for this provider.
+func (w *wire) ProviderName() string { return "openai" }
 
-	tools, names, buildErr := buildTools(req.Tools)
-	if buildErr != nil {
-		err = fmt.Errorf("openai: building tools: %w", buildErr)
-		return
-	}
-
-	params, buildErr := c.buildParams(req, hints, tools, names)
-	if buildErr != nil {
-		err = fmt.Errorf("openai: %w", buildErr)
-		return
-	}
-
-	sdkResp, sdkErr := c.sdk.Responses.New(ctx, params)
-	if sdkErr != nil {
-		err = wrapSDKError(sdkErr)
-		return
-	}
-
-	resp, err = translateResponse(sdkResp, names)
-	return
-}
-
-// classifyOpenAIError maps an OpenAI SDK error to the fixed error_type enum.
+// ClassifyError maps an OpenAI SDK error to the fixed error_type enum.
 // openaisdk.Error is a pointer type, so the errors.As target is **openaisdk.Error.
-func classifyOpenAIError(err error) string {
+func (w *wire) ClassifyError(err error) string {
 	if et, ok := llm.ClassifyContextError(err); ok {
 		return et
 	}
@@ -93,10 +72,10 @@ func classifyOpenAIError(err error) string {
 	return metrics.ErrorTypeConnection
 }
 
-// StreamMessage sends a streaming Responses API request and returns a channel
-// that delivers chunks as they arrive. Pre-stream errors are returned
-// synchronously. Mid-stream errors arrive as MessageChunk{Err: err}.
-func (c *Client) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
+// Call executes a synchronous Responses API request and returns the normalized
+// response. This is the body previously in Client.CreateMessage (minus the
+// metrics-defer, which now lives in ProviderAdapter.CreateMessage).
+func (w *wire) Call(ctx context.Context, req llm.MessageRequest) (*llm.MessageResponse, error) {
 	hints, _ := req.Hints.(*OpenAIHints)
 
 	tools, names, err := buildTools(req.Tools)
@@ -104,21 +83,122 @@ func (c *Client) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-c
 		return nil, fmt.Errorf("openai: building tools: %w", err)
 	}
 
-	params, err := c.buildParams(req, hints, tools, names)
+	params, err := buildParams(req, hints, tools, names)
 	if err != nil {
 		return nil, fmt.Errorf("openai: %w", err)
 	}
 
-	stream := c.sdk.Responses.NewStreaming(ctx, params)
+	sdkResp, sdkErr := w.sdk.Responses.New(ctx, params)
+	if sdkErr != nil {
+		return nil, wrapSDKError(sdkErr)
+	}
+
+	return translateResponse(sdkResp, names)
+}
+
+// Stream sends a streaming Responses API request and returns a channel that
+// delivers chunks as they arrive. The accumulate-and-emit state machine lives
+// in consumeStream (stream.go).
+func (w *wire) Stream(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
+	hints, _ := req.Hints.(*OpenAIHints)
+
+	tools, names, err := buildTools(req.Tools)
+	if err != nil {
+		return nil, fmt.Errorf("openai: building tools: %w", err)
+	}
+
+	params, err := buildParams(req, hints, tools, names)
+	if err != nil {
+		return nil, fmt.Errorf("openai: %w", err)
+	}
+
+	stream := w.sdk.Responses.NewStreaming(ctx, params)
 
 	out := make(chan llm.MessageChunk, 16)
 	go consumeStream(ctx, stream, out, names)
 	return out, nil
 }
 
+// ListModels returns a defensive copy of the curated OpenAI model list.
+func (w *wire) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
+	result := make([]llm.ModelInfo, len(curatedModels))
+	copy(result, curatedModels)
+	return result, nil
+}
+
+// ValidateModelName returns nil if name is in the curated model list, or a
+// descriptive error if not.
+func (w *wire) ValidateModelName(_ context.Context, name string) error {
+	if name == "" {
+		return errors.New("openai: model name is empty")
+	}
+	if _, ok := curatedModelsByName[name]; ok {
+		return nil
+	}
+	names := make([]string, len(curatedModels))
+	for i, m := range curatedModels {
+		names[i] = m.DisplayName
+	}
+	return fmt.Errorf("unknown OpenAI model %q; available models: %s", name, strings.Join(names, ", "))
+}
+
+// ValidateOptions validates provider-specific options from the policy YAML.
+func (w *wire) ValidateOptions(options map[string]any) error {
+	_, err := parseHints(options)
+	return err
+}
+
+// InvalidateModelCache is a no-op: the curated model list is static.
+func (w *wire) InvalidateModelCache() {}
+
+// --- Thin forwarders on Client (zero-value safe, BLOCKING-1) ---
+//
+// These four methods are declared on the CONCRETE type so they satisfy the
+// LLMClient interface without promotion and a zero-value &Client{} is safe.
+// They call package-level helpers directly — never the embedded *ProviderAdapter.
+
+// ValidateOptions validates provider-specific options from the policy YAML.
+// Accepted keys: temperature, top_p, reasoning_effort, max_output_tokens.
+func (c *Client) ValidateOptions(options map[string]any) error {
+	_, err := parseHints(options)
+	return err
+}
+
+// ListModels returns a defensive copy of the curated OpenAI model list.
+// No network call is made — this never panics even on a zero-value client.
+func (c *Client) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
+	result := make([]llm.ModelInfo, len(curatedModels))
+	copy(result, curatedModels)
+	return result, nil
+}
+
+// ValidateModelName returns nil if name is in the curated model list, or a
+// descriptive error if not. No network call is made.
+func (c *Client) ValidateModelName(_ context.Context, name string) error {
+	if name == "" {
+		return errors.New("openai: model name is empty")
+	}
+	if _, ok := curatedModelsByName[name]; ok {
+		return nil
+	}
+	names := make([]string, len(curatedModels))
+	for i, m := range curatedModels {
+		names[i] = m.DisplayName
+	}
+	return fmt.Errorf("unknown OpenAI model %q; available models: %s", name, strings.Join(names, ", "))
+}
+
+// InvalidateModelCache is a no-op: the curated model list is static and
+// requires no cache invalidation. The method exists to satisfy the LLMClient
+// interface so the provider registry's /api/v1/models/refresh path works.
+func (c *Client) InvalidateModelCache() {}
+
+// --- Package-level helpers ---
+
 // buildParams constructs the ResponseNewParams from a MessageRequest. Shared
-// between CreateMessage and StreamMessage.
-func (c *Client) buildParams(
+// between Call and Stream (was a method on *Client; moved here since it touches
+// no receiver state — only its arguments and the package-level curatedModelsByName).
+func buildParams(
 	req llm.MessageRequest,
 	hints *OpenAIHints,
 	tools []responses.ToolUnionParam,
@@ -174,42 +254,6 @@ func (c *Client) buildParams(
 
 	return params, nil
 }
-
-// ValidateOptions validates provider-specific options from the policy YAML.
-// Accepted keys: temperature, top_p, reasoning_effort, max_output_tokens.
-func (c *Client) ValidateOptions(options map[string]any) error {
-	_, err := parseHints(options)
-	return err
-}
-
-// ListModels returns a defensive copy of the curated OpenAI model list.
-// No network call is made — this never panics even on a zero-value client.
-func (c *Client) ListModels(_ context.Context) ([]llm.ModelInfo, error) {
-	result := make([]llm.ModelInfo, len(curatedModels))
-	copy(result, curatedModels)
-	return result, nil
-}
-
-// ValidateModelName returns nil if name is in the curated model list, or a
-// descriptive error if not. No network call is made.
-func (c *Client) ValidateModelName(_ context.Context, name string) error {
-	if name == "" {
-		return errors.New("openai: model name is empty")
-	}
-	if _, ok := curatedModelsByName[name]; ok {
-		return nil
-	}
-	names := make([]string, len(curatedModels))
-	for i, m := range curatedModels {
-		names[i] = m.DisplayName
-	}
-	return fmt.Errorf("unknown OpenAI model %q; available models: %s", name, strings.Join(names, ", "))
-}
-
-// InvalidateModelCache is a no-op: the curated model list is static and
-// requires no cache invalidation. The method exists to satisfy the LLMClient
-// interface so the provider registry's /api/v1/models/refresh path works.
-func (c *Client) InvalidateModelCache() {}
 
 // curatedModelIsReasoning reports whether model is marked IsReasoning in the
 // curated model list. Unknown models return false.

--- a/internal/llm/openaicompat/client.go
+++ b/internal/llm/openaicompat/client.go
@@ -23,7 +23,26 @@ var _ llm.LLMClient = (*Client)(nil)
 // The same client serves OpenAI itself and any OpenAI-compatible backend
 // (Ollama, vLLM, OpenRouter, etc.) — the only differences are baseURL and
 // apiKey, both set at construction time. See ADR-032.
+//
+// Client embeds *llm.ProviderAdapter which promotes CreateMessage and
+// StreamMessage. The four model/option methods are kept as thin explicit
+// forwarders delegating to the compatWire's cache so cache state is never
+// split across the adapter and the wire (BLOCKING-1, issue #506).
 type Client struct {
+	*llm.ProviderAdapter
+	w *compatWire
+}
+
+// compatWire implements llm.ProviderWire for the OpenAI-compatible provider.
+// Named compatWire (not wire) to avoid collision with the existing wire.go
+// HTTP-shape file in this package (BLOCKING-2, issue #506).
+//
+// compatWire carries the state that was previously on Client: the http client,
+// base URL, API key, provider name, and the model cache. The model cache state
+// (models + modelsUnavailable) lives here so it is never split across the wire
+// and the adapter. modelsUnavailable is intentionally unguarded by a mutex —
+// preserving the existing behavior exactly.
+type compatWire struct {
 	httpClient        *http.Client
 	baseURL           string
 	apiKey            string
@@ -33,7 +52,7 @@ type Client struct {
 }
 
 // Option is a functional option for configuring a Client.
-type Option func(*Client)
+type Option func(*compatWire)
 
 // WithHTTPClient injects a custom *http.Client. Tests pass srv.Client() from
 // an httptest.Server to route requests to the test server's TLS stack.
@@ -42,7 +61,7 @@ type Option func(*Client)
 // current at the time it runs, including one set by WithHTTPClient. Apply
 // WithHTTPClient before WithTimeout if you need both.
 func WithHTTPClient(hc *http.Client) Option {
-	return func(c *Client) {
+	return func(c *compatWire) {
 		c.httpClient = hc
 	}
 }
@@ -50,7 +69,7 @@ func WithHTTPClient(hc *http.Client) Option {
 // WithTimeout sets the request timeout on the Client's http.Client. If no
 // http.Client has been set yet (via WithHTTPClient), a new one is allocated.
 func WithTimeout(d time.Duration) Option {
-	return func(c *Client) {
+	return func(c *compatWire) {
 		if c.httpClient == nil {
 			c.httpClient = &http.Client{}
 		}
@@ -62,7 +81,7 @@ func WithTimeout(d time.Duration) Option {
 // When unset, CreateMessage falls back to "openaicompat". The loader sets this
 // to the admin-registered provider name so metrics reflect the configured backend.
 func WithProviderName(name string) Option {
-	return func(c *Client) { c.providerName = name }
+	return func(c *compatWire) { c.providerName = name }
 }
 
 // NewClient constructs a Client for the given base URL and API key.
@@ -71,84 +90,32 @@ func WithProviderName(name string) Option {
 // http.Client or timeout; any nil httpClient is defaulted to a 60-second
 // timeout client after options are applied.
 func NewClient(baseURL, apiKey string, opts ...Option) *Client {
-	c := &Client{
+	w := &compatWire{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		apiKey:  apiKey,
 		models:  llm.NewModelCache("OpenAI-compatible"),
 	}
 	for _, opt := range opts {
-		opt(c)
+		opt(w)
 	}
-	if c.httpClient == nil {
-		c.httpClient = &http.Client{Timeout: 60 * time.Second}
+	if w.httpClient == nil {
+		w.httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
-	return c
+	return &Client{ProviderAdapter: llm.NewAdapter(w), w: w}
 }
 
-// CreateMessage sends a single synchronous Chat Completions request and returns
-// the normalized response.
-func (c *Client) CreateMessage(ctx context.Context, req llm.MessageRequest) (resp *llm.MessageResponse, err error) {
-	start := time.Now()
-	defer func() {
-		provider := c.providerName
-		if provider == "" {
-			provider = "openaicompat"
-		}
-		llm.ObserveRequestDuration(provider, req.Model, time.Since(start))
-		if err != nil {
-			llm.RecordError(provider, classifyCompatError(err))
-			return
-		}
-		if resp != nil {
-			llm.RecordTokens(provider, req.Model, resp.Usage)
-		}
-	}()
+// --- ProviderWire implementation on compatWire ---
 
-	// OpenAI allows [a-zA-Z0-9_-] in tool names; build the mapping once and
-	// use it for both outbound sanitization and inbound reversal.
-	names := llm.BuildNameMapping(req.Tools, "-")
-	wireReq := BuildChatCompletionRequest(req, false, names)
-
-	var body []byte
-	body, err = json.Marshal(wireReq)
-	if err != nil {
-		err = fmt.Errorf("openai: marshalling request: %w", err)
-		return
+// ProviderName returns the Prometheus label, defaulting to "openaicompat".
+func (w *compatWire) ProviderName() string {
+	if w.providerName != "" {
+		return w.providerName
 	}
-
-	var httpResp *http.Response
-	httpResp, err = c.doRequest(ctx, http.MethodPost, "/chat/completions", bytes.NewReader(body))
-	if err != nil {
-		return
-	}
-	defer httpResp.Body.Close()
-
-	var raw []byte
-	raw, err = io.ReadAll(httpResp.Body)
-	if err != nil {
-		err = fmt.Errorf("openai: reading response body: %w", err)
-		return
-	}
-
-	if httpResp.StatusCode >= 400 {
-		err = wrapHTTPError(httpResp.StatusCode, raw)
-		return
-	}
-
-	var wire chatResponse
-	if umErr := json.Unmarshal(raw, &wire); umErr != nil {
-		err = fmt.Errorf("openai: decoding response: %w", umErr)
-		return
-	}
-
-	resp, err = ParseChatCompletionResponse(&wire, names)
-	return
+	return "openaicompat"
 }
 
-// classifyCompatError maps an openaicompat error to the fixed error_type enum.
-// wrapHTTPError wraps *llm.HTTPError so we can recover the status code here via
-// errors.As without re-parsing the raw HTTP response in the defer.
-func classifyCompatError(err error) string {
+// ClassifyError maps an openaicompat error to the fixed error_type enum.
+func (w *compatWire) ClassifyError(err error) string {
 	if et, ok := llm.ClassifyContextError(err); ok {
 		return et
 	}
@@ -167,12 +134,49 @@ func classifyCompatError(err error) string {
 	return metrics.ErrorTypeConnection
 }
 
-// StreamMessage sends a streaming Chat Completions request and returns a
+// Call executes a synchronous Chat Completions request and returns the
+// normalized response. This is the body previously in Client.CreateMessage
+// (minus the metrics-defer, which now lives in ProviderAdapter.CreateMessage).
+func (w *compatWire) Call(ctx context.Context, req llm.MessageRequest) (*llm.MessageResponse, error) {
+	// OpenAI allows [a-zA-Z0-9_-] in tool names; build the mapping once and
+	// use it for both outbound sanitization and inbound reversal.
+	names := llm.BuildNameMapping(req.Tools, "-")
+	wireReq := BuildChatCompletionRequest(req, false, names)
+
+	body, err := json.Marshal(wireReq)
+	if err != nil {
+		return nil, fmt.Errorf("openai: marshalling request: %w", err)
+	}
+
+	httpResp, err := w.doRequest(ctx, http.MethodPost, "/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	raw, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: reading response body: %w", err)
+	}
+
+	if httpResp.StatusCode >= 400 {
+		return nil, wrapHTTPError(httpResp.StatusCode, raw)
+	}
+
+	var wireResp chatResponse
+	if umErr := json.Unmarshal(raw, &wireResp); umErr != nil {
+		return nil, fmt.Errorf("openai: decoding response: %w", umErr)
+	}
+
+	return ParseChatCompletionResponse(&wireResp, names)
+}
+
+// Stream sends a streaming Chat Completions request and returns a
 // channel that delivers chunks as they arrive. Pre-stream HTTP errors (e.g.
 // 401, 429) are returned synchronously; mid-stream errors arrive on the
 // channel as MessageChunk{Err: err}. parseSSEStream owns closing resp.Body
 // and the out channel, so callers must not close either.
-func (c *Client) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
+func (w *compatWire) Stream(ctx context.Context, req llm.MessageRequest) (<-chan llm.MessageChunk, error) {
 	names := llm.BuildNameMapping(req.Tools, "-")
 	wireReq := BuildChatCompletionRequest(req, true, names)
 
@@ -181,7 +185,7 @@ func (c *Client) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-c
 		return nil, fmt.Errorf("openai: marshal stream request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/chat/completions", bytes.NewReader(body))
+	resp, err := w.doRequest(ctx, http.MethodPost, "/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -197,56 +201,85 @@ func (c *Client) StreamMessage(ctx context.Context, req llm.MessageRequest) (<-c
 	return out, nil
 }
 
-// ValidateOptions validates provider-specific options from the policy YAML.
-// Accepted keys: temperature, top_p, reasoning_effort, max_output_tokens.
-func (c *Client) ValidateOptions(options map[string]any) error {
-	_, err := parseHints(options)
-	return err
-}
-
 // ListModels returns the models available from the backend. Results are cached
 // after the first successful fetch; call InvalidateModelCache to force a refresh.
-func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
-	c.models.LoadOnce(func() (map[string]string, error) {
-		return c.fetchModels(ctx)
+func (w *compatWire) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	w.models.LoadOnce(func() (map[string]string, error) {
+		return w.fetchModels(ctx)
 	})
-	if c.modelsUnavailable {
+	if w.modelsUnavailable {
 		// The backend does not expose a /models endpoint (ADR-032 escape hatch).
 		return []llm.ModelInfo{}, nil
 	}
-	return c.models.ListModels()
+	return w.models.ListModels()
 }
 
 // ValidateModelName returns nil if name is recognized by the backend, or a
 // descriptive error. If the backend has no /models endpoint (404), any
 // non-empty name is accepted (ADR-032 escape hatch for unknown backends).
-func (c *Client) ValidateModelName(ctx context.Context, name string) error {
+func (w *compatWire) ValidateModelName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("openai: model name is empty")
 	}
-	c.models.LoadOnce(func() (map[string]string, error) {
-		return c.fetchModels(ctx)
+	w.models.LoadOnce(func() (map[string]string, error) {
+		return w.fetchModels(ctx)
 	})
-	if c.modelsUnavailable {
+	if w.modelsUnavailable {
 		// Unknown backend: we can't validate, so we accept any non-empty name.
 		return nil
 	}
-	return c.models.ValidateModelName(name)
+	return w.models.ValidateModelName(name)
+}
+
+// ValidateOptions validates provider-specific options from the policy YAML.
+func (w *compatWire) ValidateOptions(options map[string]any) error {
+	_, err := parseHints(options)
+	return err
 }
 
 // InvalidateModelCache clears the cached model list so the next call to
 // ListModels or ValidateModelName fetches fresh data from the backend.
-func (c *Client) InvalidateModelCache() {
-	c.models.Invalidate()
-	c.modelsUnavailable = false
+func (w *compatWire) InvalidateModelCache() {
+	w.models.Invalidate()
+	w.modelsUnavailable = false
 }
+
+// --- Thin forwarders on Client (zero-value safe, BLOCKING-1) ---
+//
+// These four methods are declared on the CONCRETE type so they satisfy the
+// LLMClient interface without promotion. They forward to the wire's cache
+// (which holds models + modelsUnavailable), never to the embedded adapter.
+// A real-world Client is always constructed via NewClient, so c.w is non-nil.
+
+// ValidateOptions validates provider-specific options from the policy YAML.
+// Accepted keys: temperature, top_p, reasoning_effort, max_output_tokens.
+func (c *Client) ValidateOptions(options map[string]any) error {
+	return c.w.ValidateOptions(options)
+}
+
+// ListModels returns the models available from the backend, with caching.
+func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	return c.w.ListModels(ctx)
+}
+
+// ValidateModelName returns nil if name is recognized by the backend.
+func (c *Client) ValidateModelName(ctx context.Context, name string) error {
+	return c.w.ValidateModelName(ctx, name)
+}
+
+// InvalidateModelCache clears the cached model list.
+func (c *Client) InvalidateModelCache() {
+	c.w.InvalidateModelCache()
+}
+
+// --- Internal helpers on compatWire ---
 
 // fetchModels calls GET /models and returns a map of id → id. The display name
 // equals the model ID because OpenAI-compatible backends don't expose human
 // readable names — using the id as DisplayName matches the unknown-backend
 // convention where we show exactly what you would type in the policy YAML.
-func (c *Client) fetchModels(ctx context.Context) (map[string]string, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/models", nil)
+func (w *compatWire) fetchModels(ctx context.Context) (map[string]string, error) {
+	resp, err := w.doRequest(ctx, http.MethodGet, "/models", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +288,7 @@ func (c *Client) fetchModels(ctx context.Context) (map[string]string, error) {
 	if resp.StatusCode == http.StatusNotFound {
 		// The backend doesn't implement /models. Mark it unavailable so callers
 		// skip validation entirely rather than blocking on a missing endpoint.
-		c.modelsUnavailable = true
+		w.modelsUnavailable = true
 		return map[string]string{}, nil
 	}
 
@@ -267,34 +300,34 @@ func (c *Client) fetchModels(ctx context.Context) (map[string]string, error) {
 		return nil, wrapHTTPError(resp.StatusCode, raw)
 	}
 
-	var wire modelsResponse
-	if err := json.Unmarshal(raw, &wire); err != nil {
+	var wireResp modelsResponse
+	if err := json.Unmarshal(raw, &wireResp); err != nil {
 		return nil, fmt.Errorf("openai: decoding models response: %w", err)
 	}
 
-	cache := make(map[string]string, len(wire.Data))
-	for _, entry := range wire.Data {
+	cache := make(map[string]string, len(wireResp.Data))
+	for _, entry := range wireResp.Data {
 		// id → id: display name equals the model ID for OpenAI-compatible backends
 		// because they don't surface human-readable names.
 		cache[entry.ID] = entry.ID
 	}
-	c.modelsUnavailable = false
+	w.modelsUnavailable = false
 	return cache, nil
 }
 
 // doRequest builds and executes an HTTP request against the backend. On
 // network error it returns ctx.Err() directly when the context is done, so
 // callers can use errors.Is(err, context.Canceled) without unwrapping.
-func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+func (w *compatWire) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, w.baseURL+path, body)
 	if err != nil {
 		return nil, fmt.Errorf("openai: building request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Authorization", "Bearer "+w.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := w.httpClient.Do(req)
 	if err != nil {
 		// Prefer the context error so callers can distinguish cancellation from
 		// network failures with errors.Is(err, context.Canceled).

--- a/internal/llm/wire.go
+++ b/internal/llm/wire.go
@@ -1,0 +1,51 @@
+package llm
+
+import "context"
+
+// ProviderWire is the interface each provider implements behind the shared
+// ProviderAdapter. It owns all wire-specific work (param building, SDK calls,
+// response translation, streaming) and returns neutral llm.* types.
+//
+// The streaming state machine stays inside each provider's Stream
+// implementation — see ADR-026 and the agreed scope for issue #506.
+//
+// ClassifyError already exists per-provider as an unexported function;
+// the interface promotes it to a method so the adapter's metrics-defer and
+// the FakeWire can call it without knowing the concrete type.
+//
+// ProviderName returns the Prometheus label string. openaicompat returns a
+// caller-configured name (defaulting to "openaicompat"), so the adapter reads
+// it at call time rather than capturing it once at construction.
+type ProviderWire interface {
+	// Call executes a synchronous request and returns the neutral response.
+	// It owns all provider-specific work: param building, SDK call, translation.
+	Call(ctx context.Context, req MessageRequest) (*MessageResponse, error)
+
+	// Stream executes a streaming request and returns the neutral chunk channel.
+	// The channel is closed when the stream ends or an error occurs.
+	// The per-provider accumulate-and-emit state machine lives inside this method.
+	Stream(ctx context.Context, req MessageRequest) (<-chan MessageChunk, error)
+
+	// ListModels returns the models available from this provider.
+	ListModels(ctx context.Context) ([]ModelInfo, error)
+
+	// ValidateModelName returns nil if modelName is recognized, or a descriptive
+	// error. May make a network call; results are cached by the implementation.
+	ValidateModelName(ctx context.Context, modelName string) error
+
+	// ValidateOptions validates provider-specific options from the policy YAML.
+	ValidateOptions(options map[string]any) error
+
+	// InvalidateModelCache clears any cached model list.
+	InvalidateModelCache()
+
+	// ClassifyError maps a provider SDK error to the fixed error_type enum
+	// used for Prometheus metrics. The per-provider logic (errors.As ladder)
+	// stays inside each wire implementation; the adapter calls this from its
+	// metrics-defer so the provider string is the only thing that differs.
+	ClassifyError(err error) string
+
+	// ProviderName returns the Prometheus label for this provider.
+	// openaicompat returns a caller-configured name, defaulting to "openaicompat".
+	ProviderName() string
+}

--- a/internal/testutil/mock_llm.go
+++ b/internal/testutil/mock_llm.go
@@ -10,6 +10,24 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/llm"
 )
 
+// NewFakeClient constructs a FakeWire backed by the scripted responses and
+// wraps it in a ProviderAdapter. Tests that care about the real adapter
+// choreography (metrics-defer, delegation path) should use this instead of
+// NewMockLLMClient. The returned FakeWire gives access to Requests()/Calls().
+func NewFakeClient(responses ...*llm.MessageResponse) (*llm.ProviderAdapter, *llm.FakeWire) {
+	w := llm.NewFakeWire(responses...)
+	return llm.NewAdapter(w), w
+}
+
+// NewFakeClientOnly constructs a FakeWire backed by the scripted responses and
+// returns only the ProviderAdapter as an llm.LLMClient. Use this in tests that
+// need the adapter choreography but don't need to inspect captured requests.
+// Use NewFakeClient when you also need Requests()/Calls() on the FakeWire.
+func NewFakeClientOnly(responses ...*llm.MessageResponse) llm.LLMClient {
+	c, _ := NewFakeClient(responses...)
+	return c
+}
+
 // --- LLMClient mocks ---
 
 // MockLLMClient implements llm.LLMClient by returning pre-canned responses in

--- a/internal/testutil/mock_llm_test.go
+++ b/internal/testutil/mock_llm_test.go
@@ -126,6 +126,111 @@ func TestMakeTextResponse(t *testing.T) {
 	}
 }
 
+func TestFakeWire_ScriptedSequence(t *testing.T) {
+	resp1 := testutil.MakeLLMTextResponse("first", llm.StopReasonEndTurn, 10, 5)
+	resp2 := testutil.MakeLLMTextResponse("second", llm.StopReasonEndTurn, 8, 4)
+
+	_, wire := testutil.NewFakeClient(resp1, resp2)
+
+	ctx := context.Background()
+
+	got1, err := wire.Call(ctx, llm.MessageRequest{})
+	if err != nil {
+		t.Fatalf("call 1: unexpected error: %v", err)
+	}
+	if got1 != resp1 {
+		t.Errorf("call 1: got %v, want %v", got1, resp1)
+	}
+
+	got2, err := wire.Call(ctx, llm.MessageRequest{})
+	if err != nil {
+		t.Fatalf("call 2: unexpected error: %v", err)
+	}
+	if got2 != resp2 {
+		t.Errorf("call 2: got %v, want %v", got2, resp2)
+	}
+}
+
+func TestFakeWire_ExhaustionError(t *testing.T) {
+	_, wire := testutil.NewFakeClient(
+		testutil.MakeLLMTextResponse("only one", llm.StopReasonEndTurn, 10, 5),
+	)
+
+	ctx := context.Background()
+
+	if _, err := wire.Call(ctx, llm.MessageRequest{}); err != nil {
+		t.Fatalf("call 1: unexpected error: %v", err)
+	}
+	_, err := wire.Call(ctx, llm.MessageRequest{})
+	if err == nil {
+		t.Fatal("call 2: expected error when responses exhausted, got nil")
+	}
+}
+
+func TestFakeWire_RequestCapture(t *testing.T) {
+	_, wire := testutil.NewFakeClient(
+		testutil.MakeLLMTextResponse("a", llm.StopReasonEndTurn, 10, 5),
+		testutil.MakeLLMTextResponse("b", llm.StopReasonEndTurn, 10, 5),
+	)
+
+	ctx := context.Background()
+	req1 := llm.MessageRequest{SystemPrompt: "prompt-one"}
+	req2 := llm.MessageRequest{SystemPrompt: "prompt-two"}
+
+	if _, err := wire.Call(ctx, req1); err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	if _, err := wire.Call(ctx, req2); err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+
+	reqs := wire.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("Requests() len = %d, want 2", len(reqs))
+	}
+	if reqs[0].SystemPrompt != "prompt-one" {
+		t.Errorf("reqs[0].SystemPrompt = %q, want %q", reqs[0].SystemPrompt, "prompt-one")
+	}
+	if reqs[1].SystemPrompt != "prompt-two" {
+		t.Errorf("reqs[1].SystemPrompt = %q, want %q", reqs[1].SystemPrompt, "prompt-two")
+	}
+	if wire.Calls() != 2 {
+		t.Errorf("Calls() = %d, want 2", wire.Calls())
+	}
+}
+
+func TestNewFakeClient_AdapterChoreography(t *testing.T) {
+	// NewFakeClient wraps FakeWire in a ProviderAdapter. CreateMessage on the
+	// adapter must route through the metrics-defer (no panic, no wrong code path)
+	// and return the scripted response.
+	resp := testutil.MakeLLMTextResponse("adapter works", llm.StopReasonEndTurn, 10, 5)
+	adapter, wire := testutil.NewFakeClient(resp)
+
+	got, err := adapter.CreateMessage(context.Background(), llm.MessageRequest{Model: "fake-model"})
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	if len(got.Text) == 0 || got.Text[0].Text != "adapter works" {
+		t.Errorf("response text = %v, want 'adapter works'", got.Text)
+	}
+	if wire.Calls() != 1 {
+		t.Errorf("wire.Calls() = %d, want 1", wire.Calls())
+	}
+}
+
+func TestNewFakeClientOnly_ReturnsClient(t *testing.T) {
+	resp := testutil.MakeLLMTextResponse("only client", llm.StopReasonEndTurn, 5, 3)
+	client := testutil.NewFakeClientOnly(resp)
+
+	got, err := client.CreateMessage(context.Background(), llm.MessageRequest{Model: "fake-model"})
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	if len(got.Text) == 0 || got.Text[0].Text != "only client" {
+		t.Errorf("response text = %v, want 'only client'", got.Text)
+	}
+}
+
 func TestMakeToolCallResponse(t *testing.T) {
 	input := map[string]any{"key": "value"}
 	resp := testutil.MakeToolCallResponse("my-server.do_thing", "tc-1", input)

--- a/internal/trigger/cron_test.go
+++ b/internal/trigger/cron_test.go
@@ -23,7 +23,7 @@ import (
 // cronAgentFactory returns an AgentFactory backed by a mock LLM client.
 func cronAgentFactory() run.AgentFactory {
 	return func(cfg agent.Config) (*agent.BoundAgent, error) {
-		cfg.LLMClient = testutil.NewMockLLMClient(
+		cfg.LLMClient = testutil.NewFakeClientOnly(
 			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 		)
 		return agent.New(cfg)

--- a/internal/trigger/integration_test.go
+++ b/internal/trigger/integration_test.go
@@ -116,7 +116,7 @@ func TestIntegration(t *testing.T) {
 		insertTestPolicy(t, store, "pol-happy", integrationPolicy)
 
 		// Two responses: tool-use on the first turn, then end-turn text.
-		router, manager := buildIntegrationRouter(store, registry, testutil.NewMockLLMClient(
+		router, manager := buildIntegrationRouter(store, registry, testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "stub-server.read_data", map[string]any{}, 10, 5),
 			testutil.MakeLLMTextResponse("All done.", llm.StopReasonEndTurn, 10, 5),
 		))
@@ -190,7 +190,7 @@ func TestIntegration(t *testing.T) {
 		store, registry := setupIntegrationFixture(t)
 		insertTestPolicy(t, store, "pol-concurrent", integrationPolicy)
 
-		router, manager := buildIntegrationRouter(store, registry, testutil.NewMockLLMClient(
+		router, manager := buildIntegrationRouter(store, registry, testutil.NewFakeClientOnly(
 			testutil.MakeLLMToolCallResponse("tu-1", "stub-server.read_data", map[string]any{}, 10, 5),
 			testutil.MakeLLMToolCallResponse("tu-2", "stub-server.read_data", map[string]any{}, 10, 5),
 			testutil.MakeLLMTextResponse("Done A.", llm.StopReasonEndTurn, 10, 5),

--- a/internal/trigger/notify_test.go
+++ b/internal/trigger/notify_test.go
@@ -22,7 +22,7 @@ import (
 // notifyPollerFactory returns an AgentFactory backed by a mock LLM client.
 func notifyPollerFactory() run.AgentFactory {
 	return func(cfg agent.Config) (*agent.BoundAgent, error) {
-		cfg.LLMClient = testutil.NewMockLLMClient(
+		cfg.LLMClient = testutil.NewFakeClientOnly(
 			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 		)
 		return agent.New(cfg)

--- a/internal/trigger/poll_test.go
+++ b/internal/trigger/poll_test.go
@@ -197,7 +197,7 @@ func insertTestPollPolicy(t *testing.T, store *db.Store, policyID, name, yamlStr
 // make real Claude API calls.
 func pollerFactory() run.AgentFactory {
 	return func(cfg agent.Config) (*agent.BoundAgent, error) {
-		cfg.LLMClient = testutil.NewMockLLMClient(
+		cfg.LLMClient = testutil.NewFakeClientOnly(
 			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 		)
 		return agent.New(cfg)

--- a/internal/trigger/scheduled_test.go
+++ b/internal/trigger/scheduled_test.go
@@ -51,7 +51,7 @@ agent:
 // no real Claude API calls are made during scheduler tests.
 func schedulerFactory() run.AgentFactory {
 	return func(cfg agent.Config) (*agent.BoundAgent, error) {
-		cfg.LLMClient = testutil.NewMockLLMClient(
+		cfg.LLMClient = testutil.NewFakeClientOnly(
 			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 		)
 		return agent.New(cfg)
@@ -616,7 +616,7 @@ func gatedSchedulerFactory(entered chan<- struct{}, release <-chan struct{}) run
 	return func(cfg agent.Config) (*agent.BoundAgent, error) {
 		once.Do(func() { close(entered) })
 		<-release
-		cfg.LLMClient = testutil.NewMockLLMClient(
+		cfg.LLMClient = testutil.NewFakeClientOnly(
 			testutil.MakeLLMTextResponse("done", llm.StopReasonEndTurn, 10, 5),
 		)
 		return agent.New(cfg)

--- a/internal/trigger/sse_integration_test.go
+++ b/internal/trigger/sse_integration_test.go
@@ -127,7 +127,7 @@ func drainSSEEvents(t *testing.T, resp *http.Response, n int, timeout time.Durat
 // the run. It is intentionally a new allocation per call so concurrent tests
 // don't share state.
 func sseOneTurnMsgs() llm.LLMClient {
-	return testutil.NewMockLLMClient(
+	return testutil.NewFakeClientOnly(
 		testutil.MakeLLMToolCallResponse("tu-sse", "stub-server.read_data", map[string]any{}, 10, 5),
 		testutil.MakeLLMTextResponse("Done.", llm.StopReasonEndTurn, 10, 5),
 	)


### PR DESCRIPTION
Closes #506

## What

Moves the shared LLM choreography behind a common adapter in `internal/llm` via a **shallow `ProviderWire` seam**, and uses it to undefer ADR-022 — closing the previously uneven cross-provider test coverage.

Before, each of the four provider adapters (anthropic / google / openai / openaicompat) re-implemented the identical `CreateMessage` metrics-defer choreography and there was no unified fake provider; agent-loop tests used a canned `MockLLMClient` that validated nothing provider-shaped. In particular, `ThinkingBlock.ProviderState` round-tripping was tested only for anthropic and openai — google and openaicompat had no equivalent coverage.

## How

**Shallow seam (the deep seam was explicitly rejected during design):**
- New `ProviderWire` interface (`internal/llm/wire.go`): each provider owns wire-level translation and returns neutral `llm.*` types (`Call`/`Stream`/`ListModels`/`ValidateModelName`/`ValidateOptions`/`InvalidateModelCache`/`ClassifyError`/`ProviderName`).
- New `ProviderAdapter` (`internal/llm/adapter.go`) satisfies `llm.LLMClient` and owns **only** the genuinely-identical choreography: the request-duration / token / error metrics defer, with `ClassifyError` delegated per-wire.
- Each provider's exported `Client` embeds `*llm.ProviderAdapter` and promotes **only** `CreateMessage`/`StreamMessage`. The four model/option methods stay as thin explicit forwarders on the concrete type so a zero-value `&Client{}` cannot nil-panic (a contract several existing tests depend on, kept passing **unedited**).
- **Streaming state machines stay per-provider** — the per-provider `consumeStream`/`parseSSEStream` accumulators are too structurally different (Anthropic block-index vs. OpenAI item-id vs. Google) to force through one accumulator. They are relocated, not rewritten.

**Test coverage (the real prize):**
- `FakeWire` (`internal/llm/fake_wire.go`, via `testutil.NewFakeClient`) is the fifth wire — agent / run / trigger tests now run through the **real** shared adapter instead of a hand-rolled mock.
- New cross-wire **contract suite** (`internal/llm/contract`, external test package to avoid the provider import cycle) asserts uniformly across all four real wires: continuity-state round-trip, tool-name round-trip, stop-reason normalization, and usage extraction. Continuity is provider-specific — anthropic/openai via `ThinkingBlock.ProviderState`, **google via `ToolCallBlock.ProviderMetadata["google.thought_signature"]`** (it has no `ProviderState`), and openaicompat asserts the thinking block is **dropped** (Chat Completions has no reasoning round-trip). This closes the google + openaicompat gap.
- `cross_provider_test.go` is superseded honestly — it keeps its agent-loop-level assertions, runs through the adapter, and points readers to the contract suite instead of claiming to cover provider specifics.

## Constraints honored

- **ADR-026 unchanged** — the `LLMClient` interface and agent runtime see nothing different; no provider's exported type name or constructor signature changed (factory.go untouched).
- **ADR-022 undeferred** — transport-level fake realized via the seam + contract suite.
- Relocation, not rewrite: wire translation logic is moved verbatim behind the seam.

## Design / review notes

- **Seam depth** and the **two-deliverable scope** (seam+fake-wire AND the contract suite) were settled with the maintainer before implementation.
- Adversarial plan review caught 3 blocking issues, all fixed before coding: (1) zero-value client nil-panic — solved by thin forwarders rather than pure promotion; (2) `openaicompat/wire.go` already holds HTTP-shape structs, so the ProviderWire impl there is named `compatWire`; (3) the google contract assertion uses `ProviderMetadata`, not a non-existent `ProviderState`.
- Code review: **APPROVED** in 1 cycle. Two non-blocking suggestions folded in: the tool-name round-trip now asserts the exact reverse-mapped original (was tautological), and `NewClientWithGenerator` documents its unexported-param method set.
- One minor deviation from the plan: openaicompat's internal `Option` functional-option type binds to `*compatWire` rather than `*Client` (zero practical impact — all option fields were already unexported, no external callers define custom options).

<details>
<summary>Architecture plan</summary>

See the seam design in `internal/llm/wire.go` + `adapter.go`; the four provider recompositions; `FakeWire`; and the contract suite. CLAUDE.md's Key packages section was updated to document the seam and the new `contract/` package.
</details>

---

Documentation updated: `CLAUDE.md` (Key packages → `internal/llm` seam + `contract/`), `docs/developer/ADR_Tracker.md` (ADR-022 Deferred→Decided, ADR-026 unchanged note).

🤖 Generated by the agentic dev loop. Code review cycles: 1. Brainstorming: not triggered (refined with maintainer pre-pipeline).
