### PR TITLE
refactor: one claimRequestTimeout helper for the approval/feedback timeout race (#505)

### DIFF
--- a/internal/execution/agent/approval.go
+++ b/internal/execution/agent/approval.go
@@ -222,35 +222,24 @@ func (h *ApprovalHandler) Wait(ctx context.Context, runID string, entry resolved
 		logctx.Logger(ctx).WarnContext(ctx, "approval timeout reached",
 			"tool", internalName,
 			"timeout", entry.tool.Timeout.String())
-		now := time.Now().UTC().Format(time.RFC3339Nano)
-		// Race the scanner: only the first writer (rows==1) owns the error step.
-		// If the scanner already resolved it (rows==0), return a sentinel error so
-		// Run() still terminates, but skip logAuditError to avoid a duplicate step.
-		rows, dbErr := h.sm.Queries().UpdateApprovalRequestStatus(
-			context.Background(),
-			db.UpdateApprovalRequestStatusParams{
-				Status:    string(model.ApprovalStatusTimeout),
-				DecidedAt: &now,
-				Note:      nil,
-				ID:        approvalID,
+		// Race the timeout scanner for the pending row (#505): claimRequestTimeout
+		// owns the rows==1/rows==0 branch and the error-step write.
+		return claimRequestTimeout(ctx, h.audit, timeoutClaim{
+			name:      "approval",
+			runID:     runID,
+			requestID: approvalID,
+			claim: func(dbCtx context.Context, now string) (int64, error) {
+				return h.sm.Queries().UpdateApprovalRequestStatus(dbCtx, db.UpdateApprovalRequestStatusParams{
+					Status:    string(model.ApprovalStatusTimeout),
+					DecidedAt: &now,
+					Note:      nil,
+					ID:        approvalID,
+				})
 			},
-		)
-		if dbErr != nil {
-			logctx.Logger(ctx).WarnContext(ctx, "failed to update approval status on timeout", "approval_id", approvalID, "err", dbErr)
-		}
-		if rows == 1 {
-			err := fmt.Errorf("approval timeout for tool %s", internalName)
-			logAuditError(ctx, h.audit, Step{
-				RunID:   runID,
-				Type:    model.StepTypeError,
-				Content: model.ErrorStepContent{Message: err.Error(), Code: model.ErrorCodeApprovalRejected},
-			})
-			return err
-		}
-		// Scanner won the race: it already wrote the error step and transitioned
-		// the run. Return a sentinel so Run() knows to stop, but avoid a duplicate step.
-		logctx.Logger(ctx).DebugContext(ctx, "approval already resolved by scanner", "approval_id", approvalID)
-		return fmt.Errorf("approval timeout for tool %s: already resolved by scanner", internalName)
+			errorCode:   model.ErrorCodeApprovalRejected,
+			wonMessage:  fmt.Sprintf("approval timeout for tool %s", internalName),
+			lostMessage: fmt.Sprintf("approval timeout for tool %s: already resolved by scanner", internalName),
+		})
 	case <-ctx.Done():
 		return fmt.Errorf("context cancelled waiting for approval: %w", ctx.Err())
 	}

--- a/internal/execution/agent/channel.go
+++ b/internal/execution/agent/channel.go
@@ -5,13 +5,7 @@ package agent
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
-	"time"
-
-	"github.com/felag-engineering/gleipnir/internal/db"
-	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
-	"github.com/felag-engineering/gleipnir/internal/model"
 )
 
 // ErrUnknownRequestID is returned by inAppChannel.Resolve when the given
@@ -32,20 +26,9 @@ type notifyRequest struct {
 	Message string
 }
 
-// feedbackRequest carries the arguments for a blocking operator-response request.
-type feedbackRequest struct {
-	RunID         string
-	FeedbackID    string
-	ToolName      string
-	ProposedInput string // maps to the inputJSON argument in Wait; only used in state-machine payload
-	Message       string
-	Timeout       time.Duration
-	ExpiresAt     string
-}
-
 // inAppChannel is the in-process feedback channel implementation. It stores
 // pending requests in a waiter map keyed by feedback_id and routes Resolve calls
-// back to the blocking Request call. It satisfies the channel interface.
+// back to the FeedbackHandler.Wait select that registered the waiter.
 type inAppChannel struct {
 	audit   *AuditWriter
 	sm      *RunStateMachine
@@ -66,124 +49,6 @@ func newInAppChannel(audit *AuditWriter, sm *RunStateMachine) *inAppChannel {
 // feedback_request step directly in the UI; no separate notification is needed.
 func (c *inAppChannel) Notify(_ context.Context, _ notifyRequest) error {
 	return nil
-}
-
-// Request registers a waiter for req.FeedbackID, transitions the run to
-// waiting_for_feedback, then blocks until Resolve delivers a response, the
-// timeout fires, or the context is cancelled.
-//
-// The waiter is registered BEFORE the state transition so that any concurrent
-// Resolve call arriving immediately after the SSE event (which fires on transition)
-// is never lost — relevant once #179 wires SubmitFeedback to Resolve.
-func (c *inAppChannel) Request(ctx context.Context, req feedbackRequest) (string, error) {
-	// 1. Allocate the buffered channel first (cap 1 — Resolve never blocks).
-	ch := make(chan inAppResponse, 1)
-
-	// 2. Register BEFORE state transition so an immediate Resolve cannot miss us.
-	c.mu.Lock()
-	c.waiters[req.FeedbackID] = ch
-	c.mu.Unlock()
-
-	// 3. Deferred unregister: if we return for any reason (timeout, ctx cancel,
-	//    or after a successful response), remove the waiter entry so a late
-	//    Resolve gets ErrUnknownRequestID rather than sending to a leaked channel.
-	defer func() {
-		c.mu.Lock()
-		delete(c.waiters, req.FeedbackID)
-		c.mu.Unlock()
-	}()
-
-	// 4. Write the audit step.
-	if err := c.audit.Write(ctx, Step{
-		RunID: req.RunID,
-		Type:  model.StepTypeFeedbackRequest,
-		Content: map[string]any{
-			"feedback_id": req.FeedbackID,
-			"tool":        req.ToolName,
-			"message":     req.Message,
-			"expires_at":  req.ExpiresAt,
-		},
-	}); err != nil {
-		return "", fmt.Errorf("writing feedback_request step: %w", err)
-	}
-
-	// 5. Transition to waiting_for_feedback.
-	if err := c.sm.Transition(ctx, model.RunStatusWaitingForFeedback, "", WithFeedbackPayload(FeedbackPayload{
-		FeedbackID:    req.FeedbackID,
-		ToolName:      req.ToolName,
-		ProposedInput: req.ProposedInput,
-		Message:       req.Message,
-		ExpiresAt:     req.ExpiresAt,
-	})); err != nil {
-		return "", fmt.Errorf("transitioning run to waiting_for_feedback: %w", err)
-	}
-
-	// nil timeoutCh (when Timeout == 0) blocks forever in the select,
-	// meaning no in-process timeout is applied. Use NewTimer so we can Stop it
-	// on early response — time.After leaks until the duration fires.
-	var timeoutCh <-chan time.Time
-	if req.Timeout > 0 {
-		timer := time.NewTimer(req.Timeout)
-		defer timer.Stop()
-		timeoutCh = timer.C
-	}
-
-	// 6. Block until one of the three arms fires.
-	select {
-	case resp := <-ch:
-		if err := c.audit.Write(ctx, Step{
-			RunID:   req.RunID,
-			Type:    model.StepTypeFeedbackResponse,
-			Content: map[string]any{"feedback_id": req.FeedbackID, "response": resp.text},
-		}); err != nil {
-			return "", fmt.Errorf("writing feedback_response step: %w", err)
-		}
-		if err := c.sm.Transition(ctx, model.RunStatusRunning, ""); err != nil {
-			return "", fmt.Errorf("transitioning run back to running after feedback: %w", err)
-		}
-		return resp.text, nil
-	case <-timeoutCh:
-		logctx.Logger(ctx).WarnContext(ctx, "feedback timeout reached",
-			"tool", req.ToolName,
-			"timeout", req.Timeout.String())
-		now := time.Now().UTC().Format(time.RFC3339Nano)
-		// Race the scanner: only the first writer (rows==1) owns the error step.
-		// If the scanner already resolved it (rows==0), return a sentinel error so
-		// Run() still terminates, but skip logAuditError to avoid a duplicate step.
-		//
-		// Use a fresh Background context (not the parent ctx) so this fire-and-forget
-		// DB write is not cancelled if the parent run context is already done, while
-		// still bounding the write to 5s to avoid an indefinite hang.
-		dbCtx, dbCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer dbCancel()
-		rows, dbErr := c.sm.Queries().UpdateFeedbackRequestStatus(
-			dbCtx,
-			db.UpdateFeedbackRequestStatusParams{
-				Status:     "timed_out",
-				Response:   nil,
-				ResolvedAt: &now,
-				ID:         req.FeedbackID,
-			},
-		)
-		if dbErr != nil {
-			logctx.Logger(ctx).WarnContext(ctx, "failed to update feedback status on timeout", "feedback_id", req.FeedbackID, "err", dbErr)
-		}
-		if rows == 1 {
-			err := fmt.Errorf("feedback timeout: operator did not respond within %s", req.Timeout)
-			logAuditError(ctx, c.audit, Step{
-				RunID:   req.RunID,
-				Type:    model.StepTypeError,
-				Content: model.ErrorStepContent{Message: err.Error(), Code: model.ErrorCodeFeedbackTimeout},
-			})
-			return "", err
-		}
-		// Scanner won the race: it already wrote the error step and transitioned
-		// the run. Return a sentinel so Run() knows to stop, but avoid a duplicate step.
-		logctx.Logger(ctx).DebugContext(ctx, "feedback already resolved by scanner", "feedback_id", req.FeedbackID)
-		return "", fmt.Errorf("feedback timeout: already resolved by scanner for tool %s", req.ToolName)
-	case <-ctx.Done():
-		return "", fmt.Errorf("context cancelled waiting for feedback: %w", ctx.Err())
-	}
 }
 
 // RegisterWaiter allocates a buffered channel (cap 1) for feedbackID, stores it
@@ -208,6 +73,37 @@ func (c *inAppChannel) UnregisterWaiter(feedbackID string) {
 	delete(c.waiters, feedbackID)
 	c.mu.Unlock()
 }
+
+// waiter is a registered in-app waiter bound to its own cleanup. It is returned
+// by registerWaiter already registered, and the response channel is reachable
+// only through responses() — you cannot obtain something to wait on without
+// having registered first. That makes the register-before-transition ordering
+// structural (the caller holds a registered waiter before it transitions) rather
+// than a comment-enforced convention, and couples release() to the exact
+// feedbackID so cleanup cannot target the wrong entry or be forgotten.
+type waiter struct {
+	c          *inAppChannel
+	feedbackID string
+	ch         <-chan inAppResponse
+}
+
+// registerWaiter registers an in-app waiter for feedbackID and returns a handle
+// bundling its response channel with its cleanup.
+func (c *inAppChannel) registerWaiter(feedbackID string) *waiter {
+	return &waiter{
+		c:          c,
+		feedbackID: feedbackID,
+		ch:         c.RegisterWaiter(feedbackID),
+	}
+}
+
+// responses returns the receive-only channel the operator response arrives on.
+func (w *waiter) responses() <-chan inAppResponse { return w.ch }
+
+// release unregisters the waiter. Safe to call more than once (UnregisterWaiter
+// tolerates a missing entry), so it works as a deferred cleanup regardless of
+// which Wait branch returns.
+func (w *waiter) release() { w.c.UnregisterWaiter(w.feedbackID) }
 
 // Resolve delivers a response to the waiter registered for requestID.
 //

--- a/internal/execution/agent/channel_test.go
+++ b/internal/execution/agent/channel_test.go
@@ -1,126 +1,65 @@
-// Package agent — channel_test.go covers inAppChannel in isolation.
-// Tests construct inAppChannel directly via newInAppChannel (bypassing
-// FeedbackHandler) so they cannot regress the production path.
+// Package agent — channel_test.go covers the inAppChannel waiter map in
+// isolation: RegisterWaiter / Resolve / UnregisterWaiter, the production
+// primitives FeedbackHandler.Wait drives. The audit-step and run-transition
+// behavior that wraps these primitives is covered through the real handler in
+// feedback_test.go (e.g. TestFeedbackHandler_Wait_ResponseReceived); these tests
+// deliberately exercise the map mechanics alone so a concurrency regression in
+// Resolve surfaces here rather than buried in a handler test.
 package agent
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/testutil"
 )
 
-// newInAppChannelForTest is a helper that seeds a DB with a policy and run,
-// then returns a ready-to-use inAppChannel together with the store and
-// AuditWriter so individual tests can inspect the audit trail.
-func newInAppChannelForTest(t *testing.T, runID string) (*inAppChannel, *db.Store, *AuditWriter) {
+// newInAppChannelForTest seeds a minimal store + state machine so newInAppChannel
+// has its non-nil dependencies, then returns a ready-to-use inAppChannel. The
+// waiter-map primitives under test (RegisterWaiter/Resolve/UnregisterWaiter)
+// touch neither the DB nor the AuditWriter, so tests drive them directly.
+func newInAppChannelForTest(t *testing.T, runID string) *inAppChannel {
 	t.Helper()
 	s := testutil.NewTestStore(t)
 	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
 	testutil.InsertRun(t, s, runID, "p1", model.RunStatusRunning)
 
-	pub := &capturePublisher{}
-	sm := NewRunStateMachine(runID, model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
+	sm := NewRunStateMachine(runID, model.RunStatusRunning, s.DB(), s.Queries())
 	w := NewAuditWriter(s.Queries())
 	t.Cleanup(func() { w.Close() }) //nolint:errcheck
 
-	ch := newInAppChannel(w, sm)
-	return ch, s, w
+	return newInAppChannel(w, sm)
 }
 
-// TestInAppChannel_Resolve_DeliversToWaiter verifies the happy path: a goroutine
-// calls Request, the waiter appears in the DB, Resolve delivers the response, and
-// the run transitions back to running with both audit steps present.
+// TestInAppChannel_Resolve_DeliversToWaiter verifies the happy path: a registered
+// waiter receives the operator response delivered by Resolve.
 func TestInAppChannel_Resolve_DeliversToWaiter(t *testing.T) {
-	const runID = "run1"
-	inApp, s, w := newInAppChannelForTest(t, runID)
+	inApp := newInAppChannelForTest(t, "run1")
 
-	type result struct {
-		text string
-		err  error
-	}
-	done := make(chan result, 1)
+	ch := inApp.RegisterWaiter("fb-1")
 
-	go func() {
-		text, err := inApp.Request(context.Background(), feedbackRequest{
-			RunID:      runID,
-			FeedbackID: "fb-1",
-			ToolName:   AskOperatorToolName,
-			Message:    "please answer",
-			Timeout:    2 * time.Second,
-		})
-		done <- result{text, err}
-	}()
-
-	// Poll until the feedback row appears in the DB (mirrors feedback_test.go lines 145-158).
-	deadline := time.Now().Add(2 * time.Second)
-	var feedbackID string
-	for time.Now().Before(deadline) {
-		rows, err := s.GetPendingFeedbackRequestsByRun(context.Background(), runID)
-		if err != nil {
-			t.Fatalf("GetPendingFeedbackRequestsByRun: %v", err)
-		}
-		if len(rows) > 0 {
-			feedbackID = rows[0].ID
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-	if feedbackID == "" {
-		t.Fatal("timed out waiting for feedback row to appear in DB")
-	}
-
-	if err := inApp.Resolve(feedbackID, "operator response"); err != nil {
+	if err := inApp.Resolve("fb-1", "operator response"); err != nil {
 		t.Fatalf("Resolve: unexpected error: %v", err)
 	}
 
 	select {
-	case res := <-done:
-		if res.err != nil {
-			t.Fatalf("Request: unexpected error: %v", res.err)
+	case resp := <-ch:
+		if resp.text != "operator response" {
+			t.Errorf("response = %q, want %q", resp.text, "operator response")
 		}
-		if res.text != "operator response" {
-			t.Errorf("response = %q, want %q", res.text, "operator response")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Request did not return within 2s")
-	}
-
-	// Flush writer and verify both audit steps exist.
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	steps, err := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: runID, After: -1, Limit: listAll})
-	if err != nil {
-		t.Fatalf("ListRunSteps: %v", err)
-	}
-	var hasFeedbackRequest, hasFeedbackResponse bool
-	for _, step := range steps {
-		switch step.Type {
-		case string(model.StepTypeFeedbackRequest):
-			hasFeedbackRequest = true
-		case string(model.StepTypeFeedbackResponse):
-			hasFeedbackResponse = true
-		}
-	}
-	if !hasFeedbackRequest {
-		t.Error("expected feedback_request step in audit trail")
-	}
-	if !hasFeedbackResponse {
-		t.Error("expected feedback_response step in audit trail")
+	case <-time.After(time.Second):
+		t.Fatal("Resolve did not deliver to the waiter within 1s")
 	}
 }
 
 // TestInAppChannel_Resolve_UnknownRequestID verifies that Resolve on a fresh
 // channel with no registered waiter returns ErrUnknownRequestID.
 func TestInAppChannel_Resolve_UnknownRequestID(t *testing.T) {
-	inApp, _, _ := newInAppChannelForTest(t, "run1")
+	inApp := newInAppChannelForTest(t, "run1")
 
 	err := inApp.Resolve("nonexistent-id", "body")
 	if !errors.Is(err, ErrUnknownRequestID) {
@@ -128,26 +67,19 @@ func TestInAppChannel_Resolve_UnknownRequestID(t *testing.T) {
 	}
 }
 
-// TestInAppChannel_Resolve_AfterTimeout_ReturnsUnknown verifies that once a
-// Request returns due to timeout the deferred unregister has already run, so a
-// subsequent Resolve call yields ErrUnknownRequestID.
-func TestInAppChannel_Resolve_AfterTimeout_ReturnsUnknown(t *testing.T) {
-	const runID = "run1"
-	inApp, _, _ := newInAppChannelForTest(t, runID)
+// TestInAppChannel_Resolve_AfterRelease_ReturnsUnknown verifies that once a
+// waiter is released (the production analog: FeedbackHandler.Wait returns via
+// timeout or ctx-cancel and its deferred release runs), a subsequent Resolve
+// call yields ErrUnknownRequestID rather than sending to a leaked channel.
+func TestInAppChannel_Resolve_AfterRelease_ReturnsUnknown(t *testing.T) {
+	inApp := newInAppChannelForTest(t, "run1")
 
-	// 20ms timeout — short enough to make the test fast, long enough to be reliable.
-	_, _ = inApp.Request(context.Background(), feedbackRequest{
-		RunID:      runID,
-		FeedbackID: "fb-timeout",
-		ToolName:   AskOperatorToolName,
-		Message:    "please answer",
-		Timeout:    20 * time.Millisecond,
-	})
-	// Request has returned — deferred delete must have run by now.
+	_ = inApp.RegisterWaiter("fb-timeout")
+	inApp.UnregisterWaiter("fb-timeout")
 
 	err := inApp.Resolve("fb-timeout", "late response")
 	if !errors.Is(err, ErrUnknownRequestID) {
-		t.Errorf("Resolve after timeout = %v, want ErrUnknownRequestID", err)
+		t.Errorf("Resolve after release = %v, want ErrUnknownRequestID", err)
 	}
 }
 
@@ -155,139 +87,42 @@ func TestInAppChannel_Resolve_AfterTimeout_ReturnsUnknown(t *testing.T) {
 // and the second returns ErrUnknownRequestID (delete-under-lock prevents double
 // delivery).
 func TestInAppChannel_Resolve_DoubleCall(t *testing.T) {
-	const runID = "run1"
-	inApp, s, _ := newInAppChannelForTest(t, runID)
+	inApp := newInAppChannelForTest(t, "run1")
 
-	done := make(chan error, 1)
-	go func() {
-		_, err := inApp.Request(context.Background(), feedbackRequest{
-			RunID:      runID,
-			FeedbackID: "fb-double",
-			ToolName:   AskOperatorToolName,
-			Message:    "please answer",
-			Timeout:    2 * time.Second,
-		})
-		done <- err
-	}()
+	ch := inApp.RegisterWaiter("fb-double")
 
-	// Wait for the feedback row (mirrors feedback_test.go lines 145-158).
-	deadline := time.Now().Add(2 * time.Second)
-	var feedbackID string
-	for time.Now().Before(deadline) {
-		rows, err := s.GetPendingFeedbackRequestsByRun(context.Background(), runID)
-		if err != nil {
-			t.Fatalf("GetPendingFeedbackRequestsByRun: %v", err)
-		}
-		if len(rows) > 0 {
-			feedbackID = rows[0].ID
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-	if feedbackID == "" {
-		t.Fatal("timed out waiting for feedback row to appear in DB")
-	}
-
-	if err := inApp.Resolve(feedbackID, "first"); err != nil {
+	if err := inApp.Resolve("fb-double", "first"); err != nil {
 		t.Fatalf("first Resolve: unexpected error: %v", err)
 	}
+	<-ch // drain the delivered response so the channel state mirrors production
 
-	// Drain the goroutine.
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Request did not return within 2s after first Resolve")
-	}
-
-	err := inApp.Resolve(feedbackID, "second")
+	err := inApp.Resolve("fb-double", "second")
 	if !errors.Is(err, ErrUnknownRequestID) {
 		t.Errorf("second Resolve = %v, want ErrUnknownRequestID", err)
 	}
 }
 
-// TestInAppChannel_Resolve_Concurrent launches 50 concurrent Request goroutines
-// each with a unique feedback_id, then resolves all 50 from 50 concurrent Resolve
-// goroutines. All responses must be delivered correctly and the waiter map must be
-// empty afterwards. The test is -race clean.
+// TestInAppChannel_Resolve_Concurrent registers 50 waiters with unique
+// feedback_ids, then resolves all 50 from 50 concurrent goroutines. All responses
+// must be delivered correctly and the waiter map must be empty afterwards. The
+// test is -race clean.
 func TestInAppChannel_Resolve_Concurrent(t *testing.T) {
 	const N = 50
-	s := testutil.NewTestStore(t)
+	inApp := newInAppChannelForTest(t, "run1")
 
-	// Seed a policy + N runs, each needing its own run/state-machine because
-	// RunStateMachine is bound to a single runID.
-	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
-
-	type entry struct {
-		inApp      *inAppChannel
-		feedbackID string
-		done       chan error
-	}
-
-	entries := make([]entry, N)
+	chans := make([]<-chan inAppResponse, N)
 	for i := 0; i < N; i++ {
-		runID := fmt.Sprintf("run-%d", i)
-		testutil.InsertRun(t, s, runID, "p1", model.RunStatusRunning)
-
-		pub := &capturePublisher{}
-		sm := NewRunStateMachine(runID, model.RunStatusRunning, s.DB(), s.Queries(), WithStateMachinePublisher(pub))
-		w := NewAuditWriter(s.Queries())
-		t.Cleanup(func() { w.Close() }) //nolint:errcheck
-
-		fbID := fmt.Sprintf("fb-%d", i)
-		entries[i] = entry{
-			inApp:      newInAppChannel(w, sm),
-			feedbackID: fbID,
-			done:       make(chan error, 1),
-		}
+		chans[i] = inApp.RegisterWaiter(fmt.Sprintf("fb-%d", i))
 	}
 
-	// Launch all Request goroutines.
-	var startWg sync.WaitGroup
-	startWg.Add(N)
-	for i := 0; i < N; i++ {
-		i := i
-		e := entries[i]
-		runID := fmt.Sprintf("run-%d", i)
-		go func() {
-			startWg.Done()
-			_, err := e.inApp.Request(context.Background(), feedbackRequest{
-				RunID:      runID,
-				FeedbackID: e.feedbackID,
-				ToolName:   AskOperatorToolName,
-				Message:    "concurrent request",
-				Timeout:    5 * time.Second,
-			})
-			e.done <- err
-		}()
-	}
-	startWg.Wait()
-
-	// Wait for all waiters to appear in the waiter map before resolving.
-	// Poll each inAppChannel until its waiter is registered.
-	deadline := time.Now().Add(2 * time.Second)
-	for i := 0; i < N; i++ {
-		e := entries[i]
-		for time.Now().Before(deadline) {
-			e.inApp.mu.Lock()
-			_, registered := e.inApp.waiters[e.feedbackID]
-			e.inApp.mu.Unlock()
-			if registered {
-				break
-			}
-			time.Sleep(time.Millisecond)
-		}
-	}
-
-	// Resolve all 50 from 50 concurrent goroutines.
 	var resolveWg sync.WaitGroup
 	resolveWg.Add(N)
 	resolveErrs := make([]error, N)
 	for i := 0; i < N; i++ {
 		i := i
-		e := entries[i]
 		go func() {
 			defer resolveWg.Done()
-			resolveErrs[i] = e.inApp.Resolve(e.feedbackID, fmt.Sprintf("response-%d", i))
+			resolveErrs[i] = inApp.Resolve(fmt.Sprintf("fb-%d", i), fmt.Sprintf("response-%d", i))
 		}()
 	}
 	resolveWg.Wait()
@@ -298,25 +133,23 @@ func TestInAppChannel_Resolve_Concurrent(t *testing.T) {
 		}
 	}
 
-	// Collect all Request results.
-	for i, e := range entries {
+	// Every waiter must have received its own response.
+	for i := 0; i < N; i++ {
 		select {
-		case err := <-e.done:
-			if err != nil {
-				t.Errorf("Request[%d]: unexpected error: %v", i, err)
+		case resp := <-chans[i]:
+			if want := fmt.Sprintf("response-%d", i); resp.text != want {
+				t.Errorf("waiter[%d] received %q, want %q", i, resp.text, want)
 			}
-		case <-time.After(5 * time.Second):
-			t.Errorf("Request[%d] did not return within 5s", i)
+		case <-time.After(time.Second):
+			t.Errorf("waiter[%d] received no response within 1s", i)
 		}
 	}
 
-	// All waiter maps must be empty after delivery.
-	for i, e := range entries {
-		e.inApp.mu.Lock()
-		remaining := len(e.inApp.waiters)
-		e.inApp.mu.Unlock()
-		if remaining != 0 {
-			t.Errorf("inApp[%d].waiters has %d entries, want 0", i, remaining)
-		}
+	// The waiter map must be empty after delivery.
+	inApp.mu.Lock()
+	remaining := len(inApp.waiters)
+	inApp.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("inApp.waiters has %d entries, want 0", remaining)
 	}
 }

--- a/internal/execution/agent/feedback.go
+++ b/internal/execution/agent/feedback.go
@@ -190,10 +190,11 @@ func (h *FeedbackHandler) Wait(ctx context.Context, runID, toolName, inputJSON, 
 	// Pre-register the in-app waiter BEFORE the state transition.  This preserves
 	// the invariant from the original inAppChannel.Request: a Resolve call arriving
 	// immediately after the SSE event (which fires on transition) is never lost.
-	// On the plugin path the waiter is unused; UnregisterWaiter is deferred so it
-	// is cleaned up regardless of which branch executes.
-	ch := h.inApp.RegisterWaiter(feedbackID)
-	defer h.inApp.UnregisterWaiter(feedbackID)
+	// The waiter handle bundles registration with its cleanup; on the plugin path
+	// the waiter is unused; release is deferred so it is cleaned up regardless of
+	// which branch executes.
+	waiter := h.inApp.registerWaiter(feedbackID)
+	defer waiter.release()
 
 	// Phase 1: write audit step and transition — always runs regardless of dispatch path.
 	if err := h.audit.Write(ctx, Step{
@@ -254,7 +255,7 @@ func (h *FeedbackHandler) Wait(ctx context.Context, runID, toolName, inputJSON, 
 	}
 
 	// Phase 2b: in-app waiter path (no dispatcher or fallback from plugin path).
-	// ch was registered before Phase 1; deferred UnregisterWaiter handles cleanup.
+	// The waiter was registered before Phase 1; deferred release handles cleanup.
 
 	// nil timeoutCh (when feedbackTimeout == 0) blocks forever in the select,
 	// meaning no in-process timeout is applied. Use NewTimer so we can Stop it
@@ -267,7 +268,7 @@ func (h *FeedbackHandler) Wait(ctx context.Context, runID, toolName, inputJSON, 
 	}
 
 	select {
-	case resp := <-ch:
+	case resp := <-waiter.responses():
 		if err := h.audit.Write(ctx, Step{
 			RunID:   runID,
 			Type:    model.StepTypeFeedbackResponse,
@@ -291,35 +292,24 @@ func (h *FeedbackHandler) Wait(ctx context.Context, runID, toolName, inputJSON, 
 		logctx.Logger(ctx).WarnContext(ctx, "feedback timeout reached",
 			"tool", toolName,
 			"timeout", feedbackTimeout.String())
-		now := time.Now().UTC().Format(time.RFC3339Nano)
-		// Race the scanner: only the first writer (rows==1) owns the error step.
-		// If the scanner already resolved it (rows==0), return a sentinel error so
-		// Run() still terminates, but skip logAuditError to avoid a duplicate step.
-		rows, dbErr := h.sm.Queries().UpdateFeedbackRequestStatus(
-			context.Background(),
-			db.UpdateFeedbackRequestStatusParams{
-				Status:     "timed_out",
-				Response:   nil,
-				ResolvedAt: &now,
-				ID:         feedbackID,
+		// Race the timeout scanner for the pending row (#505): claimRequestTimeout
+		// owns the rows==1/rows==0 branch and the error-step write.
+		return "", claimRequestTimeout(ctx, h.audit, timeoutClaim{
+			name:      "feedback",
+			runID:     runID,
+			requestID: feedbackID,
+			claim: func(dbCtx context.Context, now string) (int64, error) {
+				return h.sm.Queries().UpdateFeedbackRequestStatus(dbCtx, db.UpdateFeedbackRequestStatusParams{
+					Status:     "timed_out",
+					Response:   nil,
+					ResolvedAt: &now,
+					ID:         feedbackID,
+				})
 			},
-		)
-		if dbErr != nil {
-			logctx.Logger(ctx).WarnContext(ctx, "failed to update feedback status on timeout", "feedback_id", feedbackID, "err", dbErr)
-		}
-		if rows == 1 {
-			err := fmt.Errorf("feedback timeout: operator did not respond within %s", feedbackTimeout)
-			logAuditError(ctx, h.audit, Step{
-				RunID:   runID,
-				Type:    model.StepTypeError,
-				Content: model.ErrorStepContent{Message: err.Error(), Code: model.ErrorCodeFeedbackTimeout},
-			})
-			return "", err
-		}
-		// Scanner won the race: it already wrote the error step and transitioned
-		// the run. Return a sentinel so Run() knows to stop, but avoid a duplicate step.
-		logctx.Logger(ctx).DebugContext(ctx, "feedback already resolved by scanner", "feedback_id", feedbackID)
-		return "", fmt.Errorf("feedback timeout: already resolved by scanner for tool %s", toolName)
+			errorCode:   model.ErrorCodeFeedbackTimeout,
+			wonMessage:  fmt.Sprintf("feedback timeout: operator did not respond within %s", feedbackTimeout),
+			lostMessage: fmt.Sprintf("feedback timeout: already resolved by scanner for tool %s", toolName),
+		})
 
 	case <-ctx.Done():
 		return "", fmt.Errorf("context cancelled waiting for feedback: %w", ctx.Err())

--- a/internal/execution/agent/operator_timeout.go
+++ b/internal/execution/agent/operator_timeout.go
@@ -1,0 +1,88 @@
+// Package agent — operator_timeout.go owns the two-writer timeout race shared by
+// the approval and feedback handlers (#505). Both handlers suspend a run waiting
+// for an operator and, on the in-app path, race a background timeout scanner
+// (internal/timeout) to claim the pending row. Before this helper that race —
+// claim, branch on rows, write-or-skip the error step, return win-or-sentinel —
+// was copy-pasted into approval.go, feedback.go, and a dead third copy in
+// channel.go, and had already drifted (only one copy bounded the claim write).
+package agent
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/infra/logctx"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// timeoutClaim captures the per-domain inputs to the shared timeout race. The
+// approval and feedback handlers differ only in the claim query, the error code,
+// and the two human-readable messages; everything else (the bounded-context
+// claim, the rows==1/rows==0 branch, the error-step write) is identical and lives
+// in claimRequestTimeout.
+type timeoutClaim struct {
+	// name labels log lines ("approval" | "feedback").
+	name string
+
+	// runID and requestID identify the suspended run and its pending row.
+	runID     string
+	requestID string
+
+	// claim runs the conditional UPDATE ... WHERE status='pending' and returns
+	// the number of rows affected. The closure binds the domain-specific query
+	// (UpdateApprovalRequestStatus / UpdateFeedbackRequestStatus) and timeout
+	// status string. now is a UTC RFC3339Nano timestamp for the resolution time.
+	claim func(ctx context.Context, now string) (int64, error)
+
+	// errorCode is written into the error step when this caller wins the race.
+	errorCode model.ErrorCode
+
+	// wonMessage is both the returned error and the error-step message when this
+	// caller wins (rows==1). lostMessage is the sentinel error returned when the
+	// scanner already claimed the row (rows==0) — no error step is written, since
+	// the scanner already wrote one.
+	wonMessage  string
+	lostMessage string
+}
+
+// claimRequestTimeout runs the two-writer timeout race against the timeout
+// scanner. The conditional UPDATE inside c.claim is the arbitration primitive:
+// exactly one writer sees rows==1 and owns the side effects.
+//
+//   - rows==1: this caller won. Write the error step and return wonMessage.
+//   - rows==0: the scanner already claimed the row and wrote its own error step
+//     and run transition. Skip the error step (avoid a duplicate) and return the
+//     lostMessage sentinel so Run() still terminates the run.
+//
+// The claim write runs on a fresh background context bounded to 5s: a fresh
+// context so the fire-and-forget write is not cancelled when the parent run
+// context is already done, and bounded so a stalled DB cannot hang the write
+// indefinitely. The error-step write uses the parent ctx (the timer fired, so
+// ctx is still live) to preserve log correlation.
+func claimRequestTimeout(ctx context.Context, audit *AuditWriter, c timeoutClaim) error {
+	dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	rows, err := c.claim(dbCtx, now)
+	if err != nil {
+		logctx.Logger(ctx).WarnContext(ctx, "failed to update "+c.name+" status on timeout",
+			c.name+"_id", c.requestID, "err", err)
+	}
+
+	if rows == 1 {
+		logAuditError(ctx, audit, Step{
+			RunID:   c.runID,
+			Type:    model.StepTypeError,
+			Content: model.ErrorStepContent{Message: c.wonMessage, Code: c.errorCode},
+		})
+		return errors.New(c.wonMessage)
+	}
+
+	// Scanner won the race: it already wrote the error step and transitioned the
+	// run. Return a sentinel so Run() knows to stop, but avoid a duplicate step.
+	logctx.Logger(ctx).DebugContext(ctx, c.name+" already resolved by scanner",
+		c.name+"_id", c.requestID)
+	return errors.New(c.lostMessage)
+}

--- a/internal/execution/agent/operator_timeout_test.go
+++ b/internal/execution/agent/operator_timeout_test.go
@@ -1,0 +1,117 @@
+// Package agent — operator_timeout_test.go covers claimRequestTimeout, the
+// shared two-writer timeout race extracted in #505. Both branches are tested
+// once here through the single helper interface: the rows==1 win path (this
+// caller owns the error step) and the rows==0 scanner-wins path (no error step,
+// sentinel error). The claim seam is a fake closure so the test asserts the
+// helper's branching independent of any approval/feedback query.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+)
+
+func TestClaimRequestTimeout(t *testing.T) {
+	tests := []struct {
+		name          string
+		claimRows     int64
+		claimErr      error
+		wantErrMsg    string
+		wantErrorStep bool
+		wantStepCode  model.ErrorCode
+		wantStepMsg   string
+	}{
+		{
+			name:          "handler wins the race",
+			claimRows:     1,
+			wantErrMsg:    "feedback timeout: won",
+			wantErrorStep: true,
+			wantStepCode:  model.ErrorCodeFeedbackTimeout,
+			wantStepMsg:   "feedback timeout: won",
+		},
+		{
+			name:          "scanner already claimed the row",
+			claimRows:     0,
+			wantErrMsg:    "feedback timeout: lost",
+			wantErrorStep: false,
+		},
+		{
+			name:          "claim write error falls through to sentinel",
+			claimRows:     0,
+			claimErr:      errors.New("db stalled"),
+			wantErrMsg:    "feedback timeout: lost",
+			wantErrorStep: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const runID = "run1"
+			s := testutil.NewTestStore(t)
+			testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+			testutil.InsertRun(t, s, runID, "p1", model.RunStatusRunning)
+
+			w := NewAuditWriter(s.Queries())
+
+			err := claimRequestTimeout(context.Background(), w, timeoutClaim{
+				name:      "feedback",
+				runID:     runID,
+				requestID: "fb-1",
+				claim: func(_ context.Context, _ string) (int64, error) {
+					return tc.claimRows, tc.claimErr
+				},
+				errorCode:   model.ErrorCodeFeedbackTimeout,
+				wonMessage:  "feedback timeout: won",
+				lostMessage: "feedback timeout: lost",
+			})
+
+			if err == nil || err.Error() != tc.wantErrMsg {
+				t.Fatalf("claimRequestTimeout error = %v, want %q", err, tc.wantErrMsg)
+			}
+
+			// Flush the audit writer so any enqueued error step has landed.
+			if cerr := w.Close(); cerr != nil {
+				t.Fatalf("AuditWriter.Close: %v", cerr)
+			}
+
+			steps, lerr := s.ListRunSteps(context.Background(), db.ListRunStepsParams{RunID: runID, After: -1, Limit: listAll})
+			if lerr != nil {
+				t.Fatalf("ListRunSteps: %v", lerr)
+			}
+
+			var errorSteps []db.RunStep
+			for _, step := range steps {
+				if step.Type == string(model.StepTypeError) {
+					errorSteps = append(errorSteps, step)
+				}
+			}
+
+			if !tc.wantErrorStep {
+				if len(errorSteps) != 0 {
+					t.Fatalf("expected no error step (scanner owns it), got %d", len(errorSteps))
+				}
+				return
+			}
+
+			if len(errorSteps) != 1 {
+				t.Fatalf("expected exactly 1 error step, got %d", len(errorSteps))
+			}
+			var content model.ErrorStepContent
+			if uerr := json.Unmarshal([]byte(errorSteps[0].Content), &content); uerr != nil {
+				t.Fatalf("unmarshal error step content: %v", uerr)
+			}
+			if content.Code != tc.wantStepCode {
+				t.Errorf("error step code = %q, want %q", content.Code, tc.wantStepCode)
+			}
+			if content.Message != tc.wantStepMsg {
+				t.Errorf("error step message = %q, want %q", content.Message, tc.wantStepMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #505.

## Problem

The two-writer timeout race — *claim the pending row, branch on `rows`, write-or-skip the error step, return win-or-sentinel* — was implemented **three times**: `approval.go`, `feedback.go`, and a dead third copy in `channel.go`'s `inAppChannel.Request`. The copies had **already drifted**: only `channel.go` bounded the claim write, while `approval.go`/`feedback.go` used an unbounded `context.Background()` that could hang on a stalled DB. Register-before-transition was a comment-enforced convention, not a constraint.

Two claims in the issue were inaccurate and worth recording:
- `inAppChannel.Request` had **zero production callers** (`FeedbackHandler.Wait` uses `RegisterWaiter`/`UnregisterWaiter` + its own `select`) — it was dead code kept alive only by its tests, not "a third copy tested indirectly."
- The scanner-wins (`rows==0`) path was **already tested** for both live handlers. The only *untested* copy of the race was the one in dead code.

## Change

- **New `operator_timeout.go`** — one `claimRequestTimeout` helper owns the race (`rows==1` → write error step + return; `rows==0` → sentinel, no step). Each handler passes a domain-specific `claim` closure. Error strings/codes are byte-identical to before; every claim write is now bounded to 5s (fixes the drift).
- **`approval.go` / `feedback.go`** — inline timeout arms collapse to one helper call.
- **`channel.go`** — delete the dead `Request` method + orphaned `feedbackRequest` struct + now-unused imports. Add a `waiter` handle that exposes the response channel only after registration, making register-before-transition **structural**.
- **`channel_test.go`** — retargeted onto the real `RegisterWaiter`/`Resolve`/`UnregisterWaiter` primitives (the audit/transition coverage it duplicated already lives in `feedback_test.go`).
- **New `operator_timeout_test.go`** — the race protocol tested once through the helper's `claim` seam: win, scanner-wins, and claim-error → sentinel.

Net ~290 tracked lines removed.

## Scope note

This is the **targeted** reading of #505, not the literal "deep `OperatorRequest` module + two adapters." Approval and feedback differ in response type (`bool` vs `string`), waiter mechanism (per-run channel via `RunManager` vs per-id waiter map), success-path side effects, and CAS ownership — a single lifecycle-owning module would need so many strategy callbacks it would mirror the shallow `timeout.Config` shape rather than be a deep module. The triplicated race and the unenforced ordering are the real wins, captured here.

## Testing

- `go build ./...` clean
- `go test ./...` passes (full suite, run because this touches shared run-lifecycle primitives)
- `go test ./internal/execution/agent/ -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)