### PR TITLE
feat: surface reasoning_content from openai-compat backends as thinking steps

### DIFF
--- a/internal/llm/contract/wire_contract_test.go
+++ b/internal/llm/contract/wire_contract_test.go
@@ -19,9 +19,12 @@
 //   - anthropic / openai: ThinkingBlock.ProviderState (opaque JSON round-trip).
 //   - google: ToolCallBlock.ProviderMetadata["google.thought_signature"]
 //     (thought bytes attached to a FunctionCall part).
-//   - openaicompat: ThinkingBlocks are DROPPED (Chat Completions has no
-//     reasoning round-trip; sending a ThinkingBlock in history must not echo it
-//     back in the outbound chatRequest).
+//   - openaicompat: REQUEST-direction ThinkingBlocks (history fed back through
+//     CreateMessage) are DROPPED — Chat Completions has no reasoning round-trip,
+//     so sending a ThinkingBlock in history must not echo it back in the outbound
+//     chatRequest. RESPONSE-direction reasoning_content from thinking-capable
+//     backends (LM Studio, Ollama ≥0.5, vLLM, llama.cpp) IS surfaced as
+//     llm.ThinkingBlocks on the way in — see TestContract_ReasoningContent_OpenAICompat.
 package contract_test
 
 import (
@@ -721,6 +724,29 @@ func TestContract_ContinuityState_Google(t *testing.T) {
 	}
 	if string(echoed) != string(sig) {
 		t.Errorf("buildContents must re-attach thought_signature on the outbound part; got %v, want %v", echoed, sig)
+	}
+}
+
+// TestContract_ReasoningContent_OpenAICompat verifies that reasoning_content
+// returned by an OpenAI-compatible backend in a sync response is surfaced as a
+// ThinkingBlock in the normalized llm.MessageResponse. This is the response
+// direction; the request-direction drop is asserted by
+// TestContract_ContinuityState_OpenAICompat below.
+func TestContract_ReasoningContent_OpenAICompat(t *testing.T) {
+	const reasoningSentinel = "<reasoning-sentinel>"
+	msgJSON := `{"role":"assistant","content":"answer","reasoning_content":"` + reasoningSentinel + `"}`
+	body := compatResponse("stop", msgJSON, 5, 3)
+	client := newCompatClientJSON(t, body)
+
+	resp, err := client.CreateMessage(context.Background(), llm.MessageRequest{Model: "gpt-4"})
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	if len(resp.Thinking) != 1 {
+		t.Fatalf("want 1 ThinkingBlock, got %d", len(resp.Thinking))
+	}
+	if resp.Thinking[0].Text != reasoningSentinel {
+		t.Errorf("ThinkingBlock.Text = %q, want %q", resp.Thinking[0].Text, reasoningSentinel)
 	}
 }
 

--- a/internal/llm/openaicompat/client.go
+++ b/internal/llm/openaicompat/client.go
@@ -168,7 +168,7 @@ func (w *compatWire) Call(ctx context.Context, req llm.MessageRequest) (*llm.Mes
 		return nil, fmt.Errorf("openai: decoding response: %w", umErr)
 	}
 
-	return ParseChatCompletionResponse(&wireResp, names)
+	return ParseChatCompletionResponse(&wireResp, names, w.ProviderName())
 }
 
 // Stream sends a streaming Chat Completions request and returns a
@@ -197,7 +197,7 @@ func (w *compatWire) Stream(ctx context.Context, req llm.MessageRequest) (<-chan
 	}
 
 	out := make(chan llm.MessageChunk, 16)
-	go parseSSEStream(ctx, resp.Body, out, names)
+	go parseSSEStream(ctx, resp.Body, out, names, w.ProviderName())
 	return out, nil
 }
 

--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -14,17 +14,23 @@ import (
 
 // parseSSEStream reads OpenAI Chat Completions SSE from body and emits
 // llm.MessageChunk values on out. The channel is always closed exactly once.
-// Text deltas are emitted as they arrive; tool calls are buffered per
-// delta.index and emitted as complete blocks when the stream's
-// finish_reason arrives. The `names` mapping reverses sanitized wire-format
-// tool names back to the original Gleipnir names when flushing tool calls;
-// pass an empty mapping to disable rewriting.
+// Text deltas are emitted as they arrive; reasoning_content deltas from
+// thinking-capable backends (LM Studio, Ollama ≥0.5, vLLM, llama.cpp) are
+// emitted as Thinking chunks immediately before any Content chunk in the same
+// delta — reasoning precedes the answer. Tool calls are buffered per
+// delta.index and emitted as complete blocks when the stream's finish_reason
+// arrives. The `names` mapping reverses sanitized wire-format tool names back
+// to the original Gleipnir names when flushing tool calls; pass an empty
+// mapping to disable rewriting.
+//
+// providerName is the admin-registered backend name (from ProviderWire.ProviderName)
+// and is used as ThinkingBlock.Provider on emitted Thinking chunks.
 //
 // Error handling: any parse or I/O error emits a final MessageChunk{Err: err}
 // and closes the channel. Context cancellation emits {Err: ctx.Err()} and
 // closes the channel. A stream that ends without a [DONE] terminator is
 // treated as an error.
-func parseSSEStream(ctx context.Context, body io.ReadCloser, out chan<- llm.MessageChunk, names llm.ToolNameMapping) {
+func parseSSEStream(ctx context.Context, body io.ReadCloser, out chan<- llm.MessageChunk, names llm.ToolNameMapping, providerName string) {
 	defer close(out)
 	defer body.Close()
 
@@ -87,6 +93,13 @@ func parseSSEStream(ctx context.Context, body io.ReadCloser, out chan<- llm.Mess
 		}
 
 		for _, choice := range chunk.Choices {
+			// Emit reasoning_content before content so that when one delta carries
+			// both fields the thinking chunk precedes the text chunk — reasoning
+			// precedes the answer, and each chunk carries at most one content field.
+			if choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "" {
+				thinking := *choice.Delta.ReasoningContent
+				out <- llm.MessageChunk{Thinking: &llm.ThinkingBlock{Provider: providerName, Text: thinking, Redacted: false}}
+			}
 			if choice.Delta.Content != nil && *choice.Delta.Content != "" {
 				text := *choice.Delta.Content
 				out <- llm.MessageChunk{Text: &text}

--- a/internal/llm/openaicompat/stream_test.go
+++ b/internal/llm/openaicompat/stream_test.go
@@ -33,7 +33,7 @@ func collectChunks(t *testing.T, ch <-chan llm.MessageChunk) []llm.MessageChunk 
 func TestParseSSEStream_TextOnly(t *testing.T) {
 	body := loadStreamFixture(t, "stream_chunks_text.txt")
 	ch := make(chan llm.MessageChunk, 16)
-	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{})
+	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{}, "openaicompat")
 	chunks := collectChunks(t, ch)
 
 	var text strings.Builder
@@ -63,7 +63,7 @@ func TestParseSSEStream_TextOnly(t *testing.T) {
 func TestParseSSEStream_ToolCallsAreEmittedComplete(t *testing.T) {
 	body := loadStreamFixture(t, "stream_chunks_with_tool_calls.txt")
 	ch := make(chan llm.MessageChunk, 16)
-	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{})
+	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{}, "openaicompat")
 	chunks := collectChunks(t, ch)
 
 	var toolCallChunks int
@@ -94,7 +94,7 @@ func TestParseSSEStream_ToolCallsAreEmittedComplete(t *testing.T) {
 func TestParseSSEStream_UsageChunkPopulatesFinalUsage(t *testing.T) {
 	body := loadStreamFixture(t, "stream_chunks_with_usage.txt")
 	ch := make(chan llm.MessageChunk, 16)
-	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{})
+	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{}, "openaicompat")
 	chunks := collectChunks(t, ch)
 
 	var gotUsage *llm.TokenUsage
@@ -116,7 +116,7 @@ func TestParseSSEStream_NoDoneTerminatorIsError(t *testing.T) {
 		`data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}` + "\n\n",
 	))
 	ch := make(chan llm.MessageChunk, 16)
-	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{})
+	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{}, "openaicompat")
 	chunks := collectChunks(t, ch)
 
 	// Stream ends without [DONE] → final chunk should carry an error.
@@ -134,7 +134,7 @@ func TestParseSSEStream_MalformedJSONIsError(t *testing.T) {
 		`data: {not-valid-json` + "\n\n" + `data: [DONE]` + "\n\n",
 	))
 	ch := make(chan llm.MessageChunk, 16)
-	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{})
+	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{}, "openaicompat")
 	chunks := collectChunks(t, ch)
 	var sawErr bool
 	for _, c := range chunks {
@@ -159,7 +159,7 @@ func TestParseSSEStream_ContextCancellation(t *testing.T) {
 	slow := &blockingReader{done: ctx.Done()}
 	out := make(chan llm.MessageChunk, 4)
 
-	go parseSSEStream(ctx, slow, out, llm.ToolNameMapping{})
+	go parseSSEStream(ctx, slow, out, llm.ToolNameMapping{}, "openaicompat")
 	cancel()
 
 	// Expect the channel to close; expect a context-related error on the last chunk.
@@ -195,7 +195,7 @@ func (b *blockingReader) Close() error {
 func TestParseSSEStream_ChannelClosedExactlyOnce(t *testing.T) {
 	body := loadStreamFixture(t, "stream_chunks_text.txt")
 	ch := make(chan llm.MessageChunk, 16)
-	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{})
+	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{}, "openaicompat")
 	for range ch {
 	}
 	// Second receive on a closed channel must not panic.
@@ -207,5 +207,67 @@ func TestParseSSEStream_ChannelClosedExactlyOnce(t *testing.T) {
 	_, ok := <-ch
 	if ok {
 		t.Error("channel should be closed")
+	}
+}
+
+// TestParseSSEStream_ReasoningContent verifies that delta.reasoning_content from
+// thinking-capable OpenAI-compatible backends is surfaced as Thinking chunks with
+// the correct Provider, and that when one delta carries both reasoning_content and
+// content the Thinking chunk is emitted first (thinking precedes the answer).
+func TestParseSSEStream_ReasoningContent(t *testing.T) {
+	const providerName = "lmstudio"
+	body := loadStreamFixture(t, "stream_chunks_with_reasoning.txt")
+	ch := make(chan llm.MessageChunk, 32)
+	go parseSSEStream(context.Background(), body, ch, llm.ToolNameMapping{}, providerName)
+	chunks := collectChunks(t, ch)
+
+	// No error chunks.
+	for _, c := range chunks {
+		if c.Err != nil {
+			t.Fatalf("unexpected error chunk: %v", c.Err)
+		}
+	}
+
+	// Assemble the full reasoning text from all Thinking chunks.
+	var reasoning strings.Builder
+	for _, c := range chunks {
+		if c.Thinking != nil {
+			reasoning.WriteString(c.Thinking.Text)
+		}
+	}
+	wantReasoning := "I should think carefully.The answer is 42."
+	if reasoning.String() != wantReasoning {
+		t.Errorf("assembled reasoning text = %q, want %q", reasoning.String(), wantReasoning)
+	}
+
+	// All Thinking chunks must carry the configured provider name.
+	for i, c := range chunks {
+		if c.Thinking != nil && c.Thinking.Provider != providerName {
+			t.Errorf("chunk[%d].Thinking.Provider = %q, want %q", i, c.Thinking.Provider, providerName)
+		}
+	}
+
+	// The delta that carries both reasoning_content and content must emit a
+	// Thinking chunk immediately before a Text chunk. Find the boundary and assert
+	// the ordering: the last Thinking chunk precedes the first Text chunk that
+	// follows it.
+	var lastThinkingIdx, firstTextAfterThinkingIdx int = -1, -1
+	for i, c := range chunks {
+		if c.Thinking != nil {
+			lastThinkingIdx = i
+		}
+	}
+	for i, c := range chunks {
+		if c.Text != nil && i >= lastThinkingIdx {
+			firstTextAfterThinkingIdx = i
+			break
+		}
+	}
+	if firstTextAfterThinkingIdx == -1 {
+		t.Fatal("expected at least one Text chunk after the last Thinking chunk")
+	}
+	if firstTextAfterThinkingIdx != lastThinkingIdx+1 {
+		t.Errorf("expected text chunk immediately after the last thinking chunk; "+
+			"lastThinkingIdx=%d firstTextAfterThinkingIdx=%d", lastThinkingIdx, firstTextAfterThinkingIdx)
 	}
 }

--- a/internal/llm/openaicompat/testdata/stream_chunks_with_reasoning.txt
+++ b/internal/llm/openaicompat/testdata/stream_chunks_with_reasoning.txt
@@ -1,0 +1,10 @@
+data: {"choices":[{"index":0,"delta":{"reasoning_content":"I should"},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"reasoning_content":" think carefully."},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{"reasoning_content":"The answer is 42.","content":"42"},"finish_reason":null}]}
+
+data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+

--- a/internal/llm/openaicompat/translate.go
+++ b/internal/llm/openaicompat/translate.go
@@ -171,7 +171,10 @@ func translateUserTurn(blocks []llm.ContentBlock) []chatMessage {
 // through unchanged (used by tests that don't exercise tool calls). Returns
 // an error only on malformed tool call arguments — all other abnormalities
 // (unknown finish reasons, missing usage details) degrade gracefully.
-func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping) (*llm.MessageResponse, error) {
+//
+// providerName is the admin-registered backend name (from ProviderWire.ProviderName)
+// and is used as ThinkingBlock.Provider when reasoning_content is surfaced.
+func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping, providerName string) (*llm.MessageResponse, error) {
 	out := &llm.MessageResponse{}
 	if len(wire.Choices) == 0 {
 		return out, nil
@@ -186,6 +189,17 @@ func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping) 
 	// having to filter blank thought steps.
 	if choice.Message.Content != nil && strings.TrimSpace(*choice.Message.Content) != "" {
 		out.Text = []llm.TextBlock{{Text: *choice.Message.Content}}
+	}
+
+	// reasoning_content is emitted by thinking-capable OpenAI-compatible backends
+	// (LM Studio, Ollama ≥0.5, vLLM, llama.cpp). Apply the same whitespace guard
+	// as Content above — some backends emit "\n" even when there is no real reasoning.
+	if choice.Message.ReasoningContent != nil && strings.TrimSpace(*choice.Message.ReasoningContent) != "" {
+		out.Thinking = append(out.Thinking, llm.ThinkingBlock{
+			Provider: providerName,
+			Text:     *choice.Message.ReasoningContent,
+			Redacted: false,
+		})
 	}
 
 	for _, tc := range choice.Message.ToolCalls {
@@ -226,9 +240,10 @@ func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping) 
 		}
 	}
 
-	// Thinking is always nil for OpenAI — reasoning content is not surfaced
-	// by the Chat Completions endpoint. See ADR-032 §2 ("Why Chat Completions
-	// only, not the Responses API").
+	// reasoning_content from OpenAI-compatible backends is surfaced as
+	// ThinkingBlocks above. The official OpenAI Chat Completions endpoint simply
+	// never sends the field, so official OpenAI calls produce zero ThinkingBlocks
+	// here — ADR-032 §2 ("Why Chat Completions only") is unaffected.
 	return out, nil
 }
 

--- a/internal/llm/openaicompat/translate_test.go
+++ b/internal/llm/openaicompat/translate_test.go
@@ -421,15 +421,16 @@ func TestBuildChatCompletionRequest_JSONRoundTrip(t *testing.T) {
 
 func TestParseChatCompletionResponse(t *testing.T) {
 	cases := []struct {
-		name        string
-		fixture     string
-		wantText    string
-		wantCalls   int
-		wantStop    llm.StopReason
-		wantInTok   int
-		wantOutTok  int
-		wantThinkTk int
-		wantErr     bool
+		name         string
+		fixture      string
+		wantText     string
+		wantCalls    int
+		wantStop     llm.StopReason
+		wantInTok    int
+		wantOutTok   int
+		wantThinkTk  int
+		wantThinking int // number of ThinkingBlocks expected in resp.Thinking
+		wantErr      bool
 	}{
 		{
 			name:     "text only",
@@ -450,6 +451,8 @@ func TestParseChatCompletionResponse(t *testing.T) {
 			wantInTok: 50, wantOutTok: 20,
 		},
 		{
+			// reasoning_tokens is present but no reasoning_content field — token
+			// accounting only; zero ThinkingBlocks must be produced.
 			name:     "o-series reasoning tokens",
 			fixture:  "chat_response_o_series_with_reasoning_tokens.json",
 			wantText: "42", wantStop: llm.StopReasonEndTurn,
@@ -478,7 +481,7 @@ func TestParseChatCompletionResponse(t *testing.T) {
 			if err := json.Unmarshal(raw, &wire); err != nil {
 				t.Fatalf("unmarshal: %v", err)
 			}
-			resp, err := ParseChatCompletionResponse(&wire, llm.ToolNameMapping{})
+			resp, err := ParseChatCompletionResponse(&wire, llm.ToolNameMapping{}, "openaicompat")
 			if err != nil {
 				t.Fatalf("parse: %v", err)
 			}
@@ -505,8 +508,8 @@ func TestParseChatCompletionResponse(t *testing.T) {
 			if resp.Usage.ThinkingTokens != tc.wantThinkTk {
 				t.Errorf("thinking tokens: got %d, want %d", resp.Usage.ThinkingTokens, tc.wantThinkTk)
 			}
-			if resp.Thinking != nil {
-				t.Errorf("Thinking should always be nil for OpenAI, got %+v", resp.Thinking)
+			if len(resp.Thinking) != tc.wantThinking {
+				t.Errorf("ThinkingBlocks: got %d, want %d (%+v)", len(resp.Thinking), tc.wantThinking, resp.Thinking)
 			}
 		})
 	}
@@ -528,7 +531,7 @@ func TestParseChatCompletionResponse_MalformedToolArguments(t *testing.T) {
 			FinishReason: "tool_calls",
 		}},
 	}
-	if _, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{}); err == nil {
+	if _, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{}, "openaicompat"); err == nil {
 		t.Error("expected error for malformed tool arguments")
 	}
 }
@@ -554,7 +557,7 @@ func TestParseChatCompletionResponse_WhitespaceContent(t *testing.T) {
 				FinishReason: "tool_calls",
 			}},
 		}
-		resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{})
+		resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{}, "openaicompat")
 		if err != nil {
 			t.Fatalf("content %q: parse: %v", raw, err)
 		}
@@ -567,6 +570,72 @@ func TestParseChatCompletionResponse_WhitespaceContent(t *testing.T) {
 	}
 }
 
+// TestParseChatCompletionResponse_ReasoningContent verifies that reasoning_content
+// from thinking-capable OpenAI-compatible backends (LM Studio, Ollama ≥0.5, etc.)
+// is surfaced as a ThinkingBlock, and that whitespace-only values are dropped just
+// like whitespace-only content.
+func TestParseChatCompletionResponse_ReasoningContent(t *testing.T) {
+	const providerName = "lmstudio"
+	const reasoningText = "I should think about this carefully."
+
+	t.Run("non-empty reasoning_content produces one ThinkingBlock", func(t *testing.T) {
+		rc := reasoningText
+		answer := "The answer is 42."
+		wire := &chatResponse{
+			Choices: []chatChoice{{
+				Message: chatMessage{
+					Role:             "assistant",
+					Content:          &answer,
+					ReasoningContent: &rc,
+				},
+				FinishReason: "stop",
+			}},
+			Usage: &chatUsage{PromptTokens: 5, CompletionTokens: 10},
+		}
+		resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{}, providerName)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if len(resp.Thinking) != 1 {
+			t.Fatalf("want 1 ThinkingBlock, got %d", len(resp.Thinking))
+		}
+		tb := resp.Thinking[0]
+		if tb.Text != reasoningText {
+			t.Errorf("ThinkingBlock.Text = %q, want %q", tb.Text, reasoningText)
+		}
+		if tb.Provider != providerName {
+			t.Errorf("ThinkingBlock.Provider = %q, want %q", tb.Provider, providerName)
+		}
+		if tb.Redacted {
+			t.Error("ThinkingBlock.Redacted must be false")
+		}
+	})
+
+	// Whitespace-only reasoning_content must be dropped, same as whitespace-only content.
+	for _, raw := range []string{"\n", "\n\n", "  ", "\t\n"} {
+		raw := raw
+		t.Run("whitespace-only reasoning_content is dropped: "+raw, func(t *testing.T) {
+			rc := raw
+			wire := &chatResponse{
+				Choices: []chatChoice{{
+					Message: chatMessage{
+						Role:             "assistant",
+						ReasoningContent: &rc,
+					},
+					FinishReason: "stop",
+				}},
+			}
+			resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{}, providerName)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if len(resp.Thinking) != 0 {
+				t.Errorf("whitespace reasoning_content %q: want 0 ThinkingBlocks, got %d", raw, len(resp.Thinking))
+			}
+		})
+	}
+}
+
 func TestParseChatCompletionResponse_UnknownFinishReason(t *testing.T) {
 	s := "hi"
 	wire := &chatResponse{
@@ -575,7 +644,7 @@ func TestParseChatCompletionResponse_UnknownFinishReason(t *testing.T) {
 			FinishReason: "something_new",
 		}},
 	}
-	resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{})
+	resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{}, "openaicompat")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -593,7 +662,7 @@ func TestParseChatCompletionResponse_MissingUsageDetails(t *testing.T) {
 		}},
 		Usage: &chatUsage{PromptTokens: 5, CompletionTokens: 10},
 	}
-	resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{})
+	resp, err := ParseChatCompletionResponse(wire, llm.ToolNameMapping{}, "openaicompat")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -653,7 +722,7 @@ func TestToolNameSanitization_RoundTrip(t *testing.T) {
 		},
 		FinishReason: "tool_calls",
 	}}}
-	parsed, err := ParseChatCompletionResponse(resp, names)
+	parsed, err := ParseChatCompletionResponse(resp, names, "openaicompat")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/internal/llm/openaicompat/wire.go
+++ b/internal/llm/openaicompat/wire.go
@@ -33,11 +33,17 @@ type streamOptions struct {
 //   - system/user/assistant with text only: Content is a string.
 //   - assistant with tool calls and no text: Content is nil (JSON null).
 //   - tool: Content is a string; ToolCallID is set.
+//
+// ReasoningContent is the chain-of-thought field emitted by reasoning-capable
+// OpenAI-compatible backends (LM Studio, Ollama ≥0.5, vLLM, llama.cpp). It is
+// present only in responses — the Chat Completions API has no round-trip for it
+// in the request direction, so it is never set when building outbound messages.
 type chatMessage struct {
-	Role       string         `json:"role"`
-	Content    *string        `json:"content"` // pointer so we can emit JSON null
-	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string         `json:"tool_call_id,omitempty"`
+	Role             string         `json:"role"`
+	Content          *string        `json:"content"` // pointer so we can emit JSON null
+	ReasoningContent *string        `json:"reasoning_content,omitempty"`
+	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
+	ToolCallID       string         `json:"tool_call_id,omitempty"`
 }
 
 type chatToolCall struct {
@@ -116,8 +122,9 @@ type streamChoice struct {
 }
 
 type streamDelta struct {
-	Content   *string              `json:"content,omitempty"`
-	ToolCalls []streamToolCallPart `json:"tool_calls,omitempty"`
+	Content          *string              `json:"content,omitempty"`
+	ReasoningContent *string              `json:"reasoning_content,omitempty"`
+	ToolCalls        []streamToolCallPart `json:"tool_calls,omitempty"`
 }
 
 type streamToolCallPart struct {


### PR DESCRIPTION
Closes #273

## Summary

OpenAI-compatible backends (LM Studio, Ollama ≥0.5, vLLM, llama.cpp) now return chain-of-thought under `reasoning_content` (sync response) and `delta.reasoning_content` (SSE stream). The `openaicompat` wire was discarding all of it, so the run timeline showed model output but none of its reasoning.

This surfaces that reasoning as `llm.ThinkingBlock`s:

- **Sync path** (`ParseChatCompletionResponse`): a non-empty `reasoning_content` becomes one `ThinkingBlock` in `out.Thinking`, with the same whitespace-drop guard already used for `Content`.
- **Stream path** (`parseSSEStream`): `delta.reasoning_content` is emitted as `MessageChunk{Thinking: ...}`. When one SSE delta carries both reasoning and content, the thinking chunk is emitted first, then the text chunk — honoring the `MessageChunk` one-block-per-chunk invariant.
- **Provider attribution**: instead of hardcoding a provider string, the configured backend name (`w.ProviderName()`, set to the admin-registered name via `WithProviderName`/`loader.go`) is threaded through both functions and set on `ThinkingBlock.Provider`. This means audit reasoning and Prometheus metrics share one backend identity.

Token accounting (`reasoning_tokens` → `ThinkingTokens`) was already wired and is left untouched. Redacted-thinking round-trip stays out of scope (`Redacted: false`), and the request/history direction is unchanged — Chat Completions has no reasoning round-trip, so `translateAssistantTurn` still drops inbound `ThinkingBlock`s. ADR-032 is unaffected; only the stale inline comments were corrected.

## Tests

- `translate_test.go` — round-trips a response with `reasoning_content` (asserts Text + Provider + `Redacted: false`); whitespace-only reasoning drops; the o-series token-only fixture still yields zero ThinkingBlocks.
- `stream_test.go` — new SSE fixture with reasoning deltas plus a both-fields delta; asserts assembled reasoning text, provider attribution, and thinking-before-text ordering.
- `contract/wire_contract_test.go` — new `TestContract_ReasoningContent_OpenAICompat` exercises the full exported `CreateMessage` path; the request-direction drop remains pinned by the unchanged `TestContract_ContinuityState_OpenAICompat`. Stale package-doc comment corrected.

## Implementation notes

- **Review cycles:** 1 (APPROVE on first review; two non-blocking readability nits applied).
- **Plan review:** the adversarial plan-reviewer caught a missed file — `internal/llm/contract/wire_contract_test.go` had a now-stale "ThinkingBlocks are DROPPED" comment and a coverage gap — which was added before implementation.
- **CLAUDE.md:** no updates needed (no new package/env-var/route/domain-type/ADR).

<details>
<summary>Architecture plan</summary>

7 files changed: `wire.go` (add `ReasoningContent` to `chatMessage` + `streamDelta`), `translate.go` + `stream.go` (parse + thread `providerName`), `client.go` (pass `w.ProviderName()` at both call sites), `translate_test.go` + `stream_test.go` + `contract/wire_contract_test.go` (tests) + new `testdata/stream_chunks_with_reasoning.txt` fixture. All 14 call sites of the two signature-changed functions updated.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
