### PR TITLE
feat: extract plugin-instance lifecycle + config-write into deep modules

### DIFF
--- a/internal/admin/error_mapping_test.go
+++ b/internal/admin/error_mapping_test.go
@@ -1,0 +1,399 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
+)
+
+// parseErrorEnvelope decodes the full error envelope from a recorder for
+// detailed assertions (status + error + detail + issues).
+func parseErrorEnvelope(t *testing.T, rec *httptest.ResponseRecorder) struct {
+	Error  string              `json:"error"`
+	Detail string              `json:"detail"`
+	Issues []httputil.ErrorIssue `json:"issues"`
+} {
+	t.Helper()
+	var env struct {
+		Error  string              `json:"error"`
+		Detail string              `json:"detail"`
+		Issues []httputil.ErrorIssue `json:"issues"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	return env
+}
+
+// ─── TestMapLifecycleError ───────────────────────────────────────────────────
+
+func TestMapLifecycleError(t *testing.T) {
+	// A minimal PluginHandler is enough to call mapLifecycleError — the method
+	// only reads the error and writes to w. No DB or modules are needed.
+	h := &PluginHandler{}
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantMsg    string
+		wantDetail string
+	}{
+		// ── sentinel errors (errors.Is) ──────────────────────────────────────
+		{
+			name:       "503 ErrStoreUnavailable",
+			err:        ErrStoreUnavailable,
+			wantStatus: http.StatusServiceUnavailable,
+			wantMsg:    "plugin management not configured",
+			wantDetail: "",
+		},
+		{
+			name:       "404 ErrPluginNotFound",
+			err:        ErrPluginNotFound,
+			wantStatus: http.StatusNotFound,
+			wantMsg:    "plugin not found",
+			wantDetail: "",
+		},
+		{
+			name:       "404 ErrInstanceNotFound",
+			err:        ErrInstanceNotFound,
+			wantStatus: http.StatusNotFound,
+			wantMsg:    "instance not found",
+			wantDetail: "",
+		},
+		{
+			name:       "409 ErrAlreadyInactive",
+			err:        ErrAlreadyInactive,
+			wantStatus: http.StatusConflict,
+			wantMsg:    "instance is already deactivated",
+			wantDetail: "",
+		},
+		{
+			name:       "500 ErrRefetchFailed",
+			err:        ErrRefetchFailed,
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "state transition succeeded but re-fetch failed",
+			wantDetail: "",
+		},
+
+		// ── struct error types (errors.As) ───────────────────────────────────
+		{
+			name:       "409 TerminalStateError",
+			err:        TerminalStateError{State: model.PluginHealthStateSignatureInvalid},
+			wantStatus: http.StatusConflict,
+			wantMsg:    "cannot deactivate instance in terminal state",
+			wantDetail: "current state: signature_invalid",
+		},
+		{
+			name:       "409 InflightError Deactivate op",
+			err:        InflightError{Count: 3, Op: inflightOpDeactivate},
+			wantStatus: http.StatusConflict,
+			wantMsg:    "cannot deactivate while tool calls are in progress",
+			wantDetail: "3 in-flight calls",
+		},
+		{
+			name:       "409 InflightError Delete op",
+			err:        InflightError{Count: 7, Op: inflightOpDelete},
+			wantStatus: http.StatusConflict,
+			wantMsg:    "instance has in-flight tool calls",
+			wantDetail: "7 in-flight calls",
+		},
+		{
+			name:       "409 NotInactiveError",
+			err:        NotInactiveError{State: "healthy"},
+			wantStatus: http.StatusConflict,
+			wantMsg:    "instance is not deactivated",
+			wantDetail: "current state: healthy",
+		},
+		{
+			name:       "409 PolicyRefError",
+			err:        PolicyRefError{Names: []string{"daily-report", "weekly-sync"}},
+			wantStatus: http.StatusConflict,
+			wantMsg:    "instance is referenced by policies",
+			wantDetail: "daily-report, weekly-sync",
+		},
+		{
+			name:       "409 AudienceRefError",
+			err:        AudienceRefError{Names: []string{"ops-channel"}},
+			wantStatus: http.StatusConflict,
+			wantMsg:    "instance is referenced by audiences",
+			wantDetail: "ops-channel",
+		},
+		{
+			name:       "409 InstancesRemainError",
+			err:        InstancesRemainError{Names: []string{"prod", "staging"}},
+			wantStatus: http.StatusConflict,
+			wantMsg:    "all instances must be removed before uninstalling the plugin",
+			wantDetail: "prod, staging",
+		},
+
+		// ── lifecycleInternalError with distinct public messages ──────────────
+		{
+			name: "500 lifecycleInternalError: internal error",
+			err: &lifecycleInternalError{
+				PublicMsg: "internal error",
+				Detail:    "",
+				Err:       errors.New("db error"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "internal error",
+			wantDetail: "",
+		},
+		{
+			name: "500 lifecycleInternalError: failed to get plugin",
+			err: &lifecycleInternalError{
+				PublicMsg: "failed to get plugin",
+				Detail:    "",
+				Err:       errors.New("db error"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to get plugin",
+			wantDetail: "",
+		},
+		{
+			name: "500 lifecycleInternalError: failed to get instance",
+			err: &lifecycleInternalError{
+				PublicMsg: "failed to get instance",
+				Detail:    "",
+				Err:       errors.New("db error"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to get instance",
+			wantDetail: "",
+		},
+		{
+			name: "500 lifecycleInternalError: failed to set health state (carries detail)",
+			err: &lifecycleInternalError{
+				PublicMsg: "failed to set health state",
+				Detail:    "CAS conflict on health update",
+				Err:       errors.New("CAS conflict on health update"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to set health state",
+			wantDetail: "CAS conflict on health update",
+		},
+
+		// ── fallback: unknown error ───────────────────────────────────────────
+		{
+			name:       "500 unknown error falls through to default",
+			err:        errors.New("unexpected thing"),
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "unexpected thing",
+			wantDetail: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.mapLifecycleError(rec, tt.err)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d; body: %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			env := parseErrorEnvelope(t, rec)
+			if env.Error != tt.wantMsg {
+				t.Errorf("error = %q, want %q", env.Error, tt.wantMsg)
+			}
+			if env.Detail != tt.wantDetail {
+				t.Errorf("detail = %q, want %q", env.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+// ─── TestMapConfigError ──────────────────────────────────────────────────────
+
+func TestMapConfigError(t *testing.T) {
+	h := &PluginHandler{}
+
+	type row struct {
+		name       string
+		err        error
+		wantStatus int
+		wantMsg    string
+		wantDetail string
+		// wantIssues is non-nil for WriteValidationError responses; length is asserted.
+		wantIssueCount int
+	}
+
+	tests := []row{
+		// ── sentinel errors (errors.Is) ──────────────────────────────────────
+		{
+			name:       "404 ErrInstanceNotFound",
+			err:        ErrInstanceNotFound,
+			wantStatus: http.StatusNotFound,
+			wantMsg:    "instance not found",
+		},
+		{
+			name:       "404 ErrPluginNotFound",
+			err:        ErrPluginNotFound,
+			wantStatus: http.StatusNotFound,
+			wantMsg:    "plugin not found",
+		},
+		{
+			name:       "404 ErrPropertyNotFound",
+			err:        ErrPropertyNotFound,
+			wantStatus: http.StatusNotFound,
+			wantMsg:    "property not found in config_schema",
+		},
+		{
+			name:       "400 ErrNoSubscriptionSchema",
+			err:        ErrNoSubscriptionSchema,
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    "plugin declares no subscription_schema",
+		},
+		{
+			name:       "409 ErrCASConflict",
+			err:        ErrCASConflict,
+			wantStatus: http.StatusConflict,
+			wantMsg:    casConflictMsg,
+		},
+
+		// ── struct error types (errors.As) ───────────────────────────────────
+		{
+			name: "500 CorruptManifestError",
+			err: CorruptManifestError{
+				Detail: "yaml: mapping values are not allowed in this context",
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "corrupt manifest snapshot",
+			wantDetail: "yaml: mapping values are not allowed in this context",
+		},
+		{
+			name: "422 configValidationError (field issues → WriteValidationError)",
+			err: configValidationError{
+				Issues: []configvalidate.FieldError{
+					{Field: "api_key", Message: "required"},
+					{Field: "timeout", Message: "must be > 0"},
+				},
+			},
+			wantStatus:     http.StatusUnprocessableEntity,
+			wantMsg:        "validation failed",
+			wantIssueCount: 2,
+		},
+		{
+			name: "400 SentinelRejectedError bulk (WriteValidationError shape)",
+			err: SentinelRejectedError{
+				Issues: []configvalidate.FieldError{
+					{Field: "app_level_token", Message: "value is the redaction sentinel"},
+				},
+				Single: false,
+			},
+			wantStatus:     http.StatusBadRequest,
+			wantMsg:        "sentinel value rejected",
+			wantIssueCount: 1,
+		},
+		{
+			name: "400 SentinelRejectedError single (plain WriteError)",
+			err: SentinelRejectedError{
+				Single: true,
+			},
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    "value '***' is the redaction sentinel; submit the real secret",
+		},
+
+		// ── configInternalError with distinct public messages ─────────────────
+		{
+			name: "500 configInternalError: validation error (carries detail = err.Error())",
+			err: &configInternalError{
+				PublicMsg: "validation error",
+				Detail:    "schema engine returned unexpected error",
+				Err:       errors.New("schema engine returned unexpected error"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "validation error",
+			wantDetail: "schema engine returned unexpected error",
+		},
+		{
+			name: "500 configInternalError: failed to build scope validator (carries detail)",
+			err: &configInternalError{
+				PublicMsg: "failed to build scope validator",
+				Detail:    "unsupported schema keyword",
+				Err:       errors.New("unsupported schema keyword"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to build scope validator",
+			wantDetail: "unsupported schema keyword",
+		},
+		{
+			name: "500 configInternalError: failed to build config validator (carries detail)",
+			err: &configInternalError{
+				PublicMsg: "failed to build config validator",
+				Detail:    "unsupported schema keyword",
+				Err:       errors.New("unsupported schema keyword"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to build config validator",
+			wantDetail: "unsupported schema keyword",
+		},
+		{
+			name: "500 configInternalError: failed to update subscription scope (empty detail)",
+			err: &configInternalError{
+				PublicMsg: "failed to update subscription scope",
+				Detail:    "",
+				Err:       errors.New("db error"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to update subscription scope",
+			wantDetail: "",
+		},
+		{
+			name: "500 configInternalError: failed to update instance config (empty detail)",
+			err: &configInternalError{
+				PublicMsg: "failed to update instance config",
+				Detail:    "",
+				Err:       errors.New("db error"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to update instance config",
+			wantDetail: "",
+		},
+		{
+			name: "500 configInternalError: failed to get plugin",
+			err: &configInternalError{
+				PublicMsg: "failed to get plugin",
+				Detail:    "",
+				Err:       errors.New("db error"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "failed to get plugin",
+			wantDetail: "",
+		},
+
+		// ── fallback ─────────────────────────────────────────────────────────
+		{
+			name:       "500 unknown error falls through to default",
+			err:        errors.New("some unexpected condition"),
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "some unexpected condition",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.mapConfigError(rec, tt.err)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d; body: %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			env := parseErrorEnvelope(t, rec)
+			if env.Error != tt.wantMsg {
+				t.Errorf("error = %q, want %q", env.Error, tt.wantMsg)
+			}
+			if env.Detail != tt.wantDetail {
+				t.Errorf("detail = %q, want %q", env.Detail, tt.wantDetail)
+			}
+			if tt.wantIssueCount > 0 && len(env.Issues) != tt.wantIssueCount {
+				t.Errorf("issues count = %d, want %d", len(env.Issues), tt.wantIssueCount)
+			}
+		})
+	}
+}

--- a/internal/admin/error_mapping_test.go
+++ b/internal/admin/error_mapping_test.go
@@ -15,14 +15,14 @@ import (
 // parseErrorEnvelope decodes the full error envelope from a recorder for
 // detailed assertions (status + error + detail + issues).
 func parseErrorEnvelope(t *testing.T, rec *httptest.ResponseRecorder) struct {
-	Error  string              `json:"error"`
-	Detail string              `json:"detail"`
+	Error  string                `json:"error"`
+	Detail string                `json:"detail"`
 	Issues []httputil.ErrorIssue `json:"issues"`
 } {
 	t.Helper()
 	var env struct {
-		Error  string              `json:"error"`
-		Detail string              `json:"detail"`
+		Error  string                `json:"error"`
+		Detail string                `json:"detail"`
 		Issues []httputil.ErrorIssue `json:"issues"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {

--- a/internal/admin/instance_config.go
+++ b/internal/admin/instance_config.go
@@ -77,8 +77,8 @@ type configInternalError struct {
 	Err       error
 }
 
-func (e *configInternalError) Error() string    { return e.PublicMsg + ": " + e.Err.Error() }
-func (e *configInternalError) Unwrap() error    { return e.Err }
+func (e *configInternalError) Error() string { return e.PublicMsg + ": " + e.Err.Error() }
+func (e *configInternalError) Unwrap() error { return e.Err }
 
 // ─── InstanceConfigResult ────────────────────────────────────────────────────
 
@@ -708,4 +708,3 @@ func propertyExistsInSchema(schemaNode *yaml.Node, property string) bool {
 	_, exists := propertiesMap[property]
 	return exists
 }
-

--- a/internal/admin/instance_config.go
+++ b/internal/admin/instance_config.go
@@ -1,0 +1,711 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+)
+
+// ─── Typed errors for InstanceConfig ─────────────────────────────────────────
+
+// ErrNoSubscriptionSchema is returned by PutSubscriptionScope when the plugin's
+// manifest declares no subscription_schema.
+var ErrNoSubscriptionSchema = errors.New("plugin declares no subscription_schema")
+
+// ErrPropertyNotFound is returned by PutConfigProperty when the named property
+// does not exist in the manifest's config_schema.
+var ErrPropertyNotFound = errors.New("property not found in config_schema")
+
+// ErrCASConflict is returned when the CAS update writes zero rows (concurrent
+// modification). Maps to 409 casConflictMsg.
+var ErrCASConflict = errors.New(casConflictMsg)
+
+// CorruptManifestError is returned when the manifest snapshot cannot be parsed.
+// Maps to 500 "corrupt manifest snapshot", detail = parse error.
+type CorruptManifestError struct {
+	Detail string
+}
+
+func (e CorruptManifestError) Error() string {
+	return "corrupt manifest snapshot: " + e.Detail
+}
+
+// configValidationError carries field-level validation issues from
+// configvalidate.Validator.Validate() when len(issues) > 0. Maps to 422.
+type configValidationError struct {
+	Issues []configvalidate.FieldError
+}
+
+func (e configValidationError) Error() string {
+	return fmt.Sprintf("validation failed (%d issues)", len(e.Issues))
+}
+
+// SentinelRejectedError is returned when the caller submits the redaction
+// sentinel "***" for a secret field. Single indicates the per-property endpoint
+// (plain WriteError); otherwise bulk (WriteValidationError with issues slice).
+// Maps to 400 in both cases — shape differs per the plan's ERROR SURFACE.
+type SentinelRejectedError struct {
+	Issues []configvalidate.FieldError // populated for bulk PutConfig
+	Single bool                        // true for PutConfigProperty (single-field rejection)
+}
+
+func (e SentinelRejectedError) Error() string {
+	if e.Single {
+		return "value '***' is the redaction sentinel; submit the real secret"
+	}
+	return "sentinel value rejected"
+}
+
+// configInternalError wraps an internal failure with a public message for the
+// handler to write verbatim, plus an optional detail string and the underlying
+// error for logging. Mirrors lifecycleInternalError in instance_lifecycle.go.
+type configInternalError struct {
+	PublicMsg string
+	Detail    string // empty string → no detail in response (matches "failed to update …" cases)
+	Err       error
+}
+
+func (e *configInternalError) Error() string    { return e.PublicMsg + ": " + e.Err.Error() }
+func (e *configInternalError) Unwrap() error    { return e.Err }
+
+// ─── InstanceConfigResult ────────────────────────────────────────────────────
+
+// InstanceConfigResult is returned by the three config-write methods. The
+// Response field's ConfigJson is ALREADY REDACTED (ADR-049 fail-closed:
+// redaction happens inside the module so a handler bug cannot leak secrets).
+// The handler simply calls httputil.WriteJSON(200, result.Response).
+type InstanceConfigResult struct {
+	Response instanceResponse
+}
+
+// ─── InstanceConfigDeps ──────────────────────────────────────────────────────
+
+// InstanceConfigDeps holds all constructor-injected dependencies for
+// InstanceConfig. Trigger may be nil (PutSubscriptionScope is a no-op).
+type InstanceConfigDeps struct {
+	Q         PluginQuerier
+	Publisher event.Publisher
+	Clock     func() time.Time
+	Trigger   TriggerRestarter
+}
+
+// InstanceConfig owns the three config-write choreographies:
+// PutSubscriptionScope, PutConfig, and PutConfigProperty. It has no knowledge
+// of HTTP — all methods return InstanceConfigResult or typed errors.
+type InstanceConfig struct {
+	q         PluginQuerier
+	publisher event.Publisher
+	clock     func() time.Time
+	trigger   TriggerRestarter
+}
+
+// NewInstanceConfig constructs an InstanceConfig with the given deps.
+// clock defaults to time.Now when nil.
+func NewInstanceConfig(deps InstanceConfigDeps) *InstanceConfig {
+	clk := deps.Clock
+	if clk == nil {
+		clk = time.Now
+	}
+	return &InstanceConfig{
+		q:         deps.Q,
+		publisher: deps.Publisher,
+		clock:     clk,
+		trigger:   deps.Trigger,
+	}
+}
+
+// resolveConfigInstance fetches the instance row and verifies it belongs to
+// pluginID. Returns typed not-found errors so the handler can map them
+// without touching http.ResponseWriter.
+func (m *InstanceConfig) resolveConfigInstance(ctx context.Context, pluginID, instanceID string) (db.PluginInstance, error) {
+	row, err := m.q.GetPluginInstanceByID(ctx, instanceID)
+	if errors.Is(err, ErrNotFound) {
+		return db.PluginInstance{}, ErrInstanceNotFound
+	}
+	if err != nil {
+		return db.PluginInstance{}, &configInternalError{
+			PublicMsg: "failed to get instance",
+			Err:       err,
+		}
+	}
+	// Return 404 on mismatch to avoid leaking instance existence across plugins.
+	if row.PluginID != pluginID {
+		return db.PluginInstance{}, ErrInstanceNotFound
+	}
+	return row, nil
+}
+
+// PutSubscriptionScope validates scope against the manifest's subscription_schema,
+// persists the new scope (CAS-guarded via ADR-038), restarts the trigger stream,
+// and re-fetches (or synthesizes) the updated row with ConfigJson redacted.
+//
+// expected_version validation (nil → 400 "expected_version is required") stays
+// in the HANDLER — this method takes a plain int64.
+//
+// Typed errors: ErrInstanceNotFound, ErrPluginNotFound, CorruptManifestError,
+// ErrNoSubscriptionSchema, configInternalError ("failed to build scope validator",
+// "validation error", "failed to marshal scope", "failed to update subscription scope"),
+// configValidationError (422), ErrCASConflict (409).
+func (m *InstanceConfig) PutSubscriptionScope(ctx context.Context, pluginID, instanceID string, scope map[string]any, expectedVersion int64) (InstanceConfigResult, error) {
+	inst, err := m.resolveConfigInstance(ctx, pluginID, instanceID)
+	if err != nil {
+		return InstanceConfigResult{}, err
+	}
+
+	plugin, err := m.q.GetPluginByID(ctx, inst.PluginID)
+	if errors.Is(err, ErrNotFound) {
+		return InstanceConfigResult{}, ErrPluginNotFound
+	}
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{PublicMsg: "failed to get plugin", Err: err}
+	}
+
+	var manifest sdkmanifest.Manifest
+	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &manifest); parseErr != nil {
+		return InstanceConfigResult{}, CorruptManifestError{Detail: parseErr.Error()}
+	}
+	if manifest.SubscriptionSchema == nil {
+		return InstanceConfigResult{}, ErrNoSubscriptionSchema
+	}
+
+	validator, err := configvalidate.ForSubscriptionScope(&manifest)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to build scope validator",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	if scope == nil {
+		scope = map[string]any{}
+	}
+	fieldErrs, err := validator.Validate(scope)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "validation error",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	if len(fieldErrs) > 0 {
+		return InstanceConfigResult{}, configValidationError{Issues: fieldErrs}
+	}
+
+	scopeBytes, err := json.Marshal(scope)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to marshal scope",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	nowStr := m.clock().UTC().Format(time.RFC3339)
+	rows, err := m.q.UpdatePluginInstanceSubscriptionScope(ctx, db.UpdatePluginInstanceSubscriptionScopeParams{
+		SubscriptionScopeJson: string(scopeBytes),
+		UpdatedAt:             nowStr,
+		ID:                    instanceID,
+		ExpectedVersion:       expectedVersion,
+	})
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to update subscription scope",
+			Err:       err,
+		}
+	}
+	if rows == 0 {
+		return InstanceConfigResult{}, ErrCASConflict
+	}
+
+	// Ensure the trigger stream is running with the latest scope.
+	if m.trigger != nil {
+		m.trigger.Start(ctx, instanceID)
+		m.trigger.Restart(ctx, instanceID)
+	}
+
+	// Derive secret names for ConfigJson redaction (ADR-049). We use the
+	// manifest already loaded above — no second DB round-trip. This call has
+	// no textual counterpart in the old PutSubscriptionScope body (which
+	// delegated to writeInstanceResponseWithRedaction), but the outcome is
+	// byte-identical: ConfigJson is "***"-redacted in every branch.
+	secretNames, secretErr := configvalidate.SecretPropertyNames(manifest.ConfigSchema)
+	if secretErr != nil {
+		// Fail-closed (ADR-049): we cannot safely redact; surface as 500.
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to parse config schema",
+			Detail:    secretErr.Error(),
+			Err:       secretErr,
+		}
+	}
+
+	// Re-fetch to return the updated row. On failure synthesise the response
+	// from the pre-write snapshot + known deltas; secret fields must still be
+	// redacted in both paths (ADR-049).
+	updated, fetchErr := m.q.GetPluginInstanceByID(ctx, instanceID)
+	if fetchErr != nil {
+		synthetic := inst
+		synthetic.Version++
+		synthetic.UpdatedAt = nowStr
+		synthetic.SubscriptionScopeJson = string(scopeBytes)
+		redactedConfig, redactErr := configvalidate.RedactSecrets(synthetic.ConfigJson, secretNames)
+		if redactErr != nil {
+			return InstanceConfigResult{}, &configInternalError{
+				PublicMsg: "failed to redact config",
+				Detail:    redactErr.Error(),
+				Err:       redactErr,
+			}
+		}
+		return InstanceConfigResult{Response: instanceResponse{
+			ID:                    instanceID,
+			PluginID:              pluginID,
+			InstanceName:          synthetic.InstanceName,
+			State:                 synthetic.HealthState,
+			Detail:                synthetic.HealthDetail,
+			Version:               synthetic.Version,
+			UpdatedAt:             synthetic.UpdatedAt,
+			SubscriptionScopeJson: synthetic.SubscriptionScopeJson,
+			ConfigJson:            redactedConfig,
+		}}, nil
+	}
+
+	redactedConfig, redactErr := configvalidate.RedactSecrets(updated.ConfigJson, secretNames)
+	if redactErr != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to redact config",
+			Detail:    redactErr.Error(),
+			Err:       redactErr,
+		}
+	}
+	return InstanceConfigResult{Response: instanceResponse{
+		ID:                    updated.ID,
+		PluginID:              updated.PluginID,
+		InstanceName:          updated.InstanceName,
+		State:                 updated.HealthState,
+		Detail:                updated.HealthDetail,
+		Version:               updated.Version,
+		UpdatedAt:             updated.UpdatedAt,
+		SubscriptionScopeJson: updated.SubscriptionScopeJson,
+		ConfigJson:            redactedConfig,
+	}}, nil
+}
+
+// PutConfig validates cfg against the manifest's config_schema (nil schema
+// accepts anything), persists it (CAS-guarded via ADR-038), and returns the
+// updated instance row with ConfigJson redacted.
+//
+// expected_version nil-check stays in HANDLER. This method takes a plain int64.
+//
+// Typed errors: ErrInstanceNotFound, ErrPluginNotFound, CorruptManifestError,
+// configInternalError ("failed to parse config schema", "failed to build config
+// validator", "validation error", "failed to marshal config", "failed to update
+// instance config", "failed to redact config"), configValidationError (422),
+// SentinelRejectedError (bulk, Single=false) (400), ErrCASConflict (409).
+func (m *InstanceConfig) PutConfig(ctx context.Context, pluginID, instanceID string, cfg map[string]any, expectedVersion int64) (InstanceConfigResult, error) {
+	inst, err := m.resolveConfigInstance(ctx, pluginID, instanceID)
+	if err != nil {
+		return InstanceConfigResult{}, err
+	}
+
+	plugin, err := m.q.GetPluginByID(ctx, inst.PluginID)
+	if errors.Is(err, ErrNotFound) {
+		return InstanceConfigResult{}, ErrPluginNotFound
+	}
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{PublicMsg: "failed to get plugin", Err: err}
+	}
+
+	var manifest sdkmanifest.Manifest
+	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &manifest); parseErr != nil {
+		return InstanceConfigResult{}, CorruptManifestError{Detail: parseErr.Error()}
+	}
+
+	// Derive secret names for sentinel rejection and response redaction (ADR-049).
+	secretNames, err := configvalidate.SecretPropertyNames(manifest.ConfigSchema)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to parse config schema",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	// ForInstanceConfig returns a validator that accepts anything when ConfigSchema
+	// is nil (per Q7 in the plan). Do NOT early-return on nil schema — it is valid.
+	validator, err := configvalidate.ForInstanceConfig(&manifest)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to build config validator",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	fieldErrs, err := validator.Validate(cfg)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "validation error",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	if len(fieldErrs) > 0 {
+		return InstanceConfigResult{}, configValidationError{Issues: fieldErrs}
+	}
+
+	// Reject any secret field whose submitted value is the redaction sentinel.
+	// This prevents the round-trip clobber: UI reads "***", user hits Save,
+	// real secret would be overwritten with the sentinel (ADR-049 §5).
+	if offenders := configvalidate.ContainsRedactionSentinel(cfg, secretNames); len(offenders) > 0 {
+		issues := make([]configvalidate.FieldError, 0, len(offenders))
+		for _, field := range offenders {
+			issues = append(issues, configvalidate.FieldError{
+				Field:   field,
+				Message: "value '***' is the redaction sentinel; submit the real secret or omit the field to leave it unchanged",
+			})
+		}
+		return InstanceConfigResult{}, SentinelRejectedError{Issues: issues, Single: false}
+	}
+
+	configBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to marshal config",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	nowStr := m.clock().UTC().Format(time.RFC3339)
+	rows, err := m.q.UpdatePluginInstanceConfig(ctx, db.UpdatePluginInstanceConfigParams{
+		ConfigJson:      string(configBytes),
+		UpdatedAt:       nowStr,
+		ID:              instanceID,
+		ExpectedVersion: expectedVersion,
+	})
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to update instance config",
+			Err:       err,
+		}
+	}
+	if rows == 0 {
+		return InstanceConfigResult{}, ErrCASConflict
+	}
+
+	// Compute the redacted form of the written config once. Both the re-fetch
+	// success branch and the fallback synthesized branch use this value so
+	// neither path can emit raw secret JSON (ADR-049 §7, §6).
+	redactedWrittenConfig, err := configvalidate.RedactSecrets(string(configBytes), secretNames)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to redact config",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	// Re-fetch to return the updated row.
+	updated, fetchErr := m.q.GetPluginInstanceByID(ctx, instanceID)
+	if fetchErr != nil {
+		// The write succeeded; fall back to a synthesised response.
+		// Use the pre-computed redacted config — never the raw written bytes.
+		return InstanceConfigResult{Response: instanceResponse{
+			ID:                    instanceID,
+			PluginID:              pluginID,
+			InstanceName:          inst.InstanceName,
+			State:                 inst.HealthState,
+			Detail:                inst.HealthDetail,
+			Version:               inst.Version + 1,
+			UpdatedAt:             nowStr,
+			SubscriptionScopeJson: inst.SubscriptionScopeJson,
+			ConfigJson:            redactedWrittenConfig,
+		}}, nil
+	}
+
+	// Advance the readiness detail (config_missing → credentials_missing → "")
+	// so the admin UI tells the operator what's still missing. Best-effort —
+	// the config write has already committed; advanceInstanceReadiness logs
+	// failures internally.
+	m.advanceInstanceReadiness(ctx, updated, &manifest)
+	if refreshed, refetchErr := m.q.GetPluginInstanceByID(ctx, instanceID); refetchErr == nil {
+		updated = refreshed
+	}
+
+	// Redact the re-fetched config before returning.
+	redactedFetchedConfig, err := configvalidate.RedactSecrets(updated.ConfigJson, secretNames)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to redact config",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	return InstanceConfigResult{Response: instanceResponse{
+		ID:                    updated.ID,
+		PluginID:              updated.PluginID,
+		InstanceName:          updated.InstanceName,
+		State:                 updated.HealthState,
+		Detail:                updated.HealthDetail,
+		Version:               updated.Version,
+		UpdatedAt:             updated.UpdatedAt,
+		SubscriptionScopeJson: updated.SubscriptionScopeJson,
+		ConfigJson:            redactedFetchedConfig,
+	}}, nil
+}
+
+// PutConfigProperty updates a single property in the instance's config_json,
+// CAS-guarded via ADR-038. Mirrors the ADR-039 per-header pattern (ADR-049).
+//
+// expected_version nil-check stays in HANDLER. This method takes a plain int64.
+//
+// Typed errors: ErrInstanceNotFound, ErrPluginNotFound, CorruptManifestError,
+// ErrPropertyNotFound, configInternalError ("failed to parse config schema",
+// "failed to parse existing config", "failed to build config validator",
+// "validation error", "failed to marshal config", "failed to update instance
+// config", "failed to redact config"), configValidationError (422),
+// SentinelRejectedError (single, Single=true) (400), ErrCASConflict (409).
+func (m *InstanceConfig) PutConfigProperty(ctx context.Context, pluginID, instanceID, property string, value any, expectedVersion int64) (InstanceConfigResult, error) {
+	inst, err := m.resolveConfigInstance(ctx, pluginID, instanceID)
+	if err != nil {
+		return InstanceConfigResult{}, err
+	}
+
+	plugin, err := m.q.GetPluginByID(ctx, inst.PluginID)
+	if errors.Is(err, ErrNotFound) {
+		return InstanceConfigResult{}, ErrPluginNotFound
+	}
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{PublicMsg: "failed to get plugin", Err: err}
+	}
+
+	var manifest sdkmanifest.Manifest
+	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &manifest); parseErr != nil {
+		return InstanceConfigResult{}, CorruptManifestError{Detail: parseErr.Error()}
+	}
+
+	// Validate that the property name exists in the manifest's ConfigSchema.
+	if !propertyExistsInSchema(manifest.ConfigSchema, property) {
+		return InstanceConfigResult{}, ErrPropertyNotFound
+	}
+
+	// Derive secret names for sentinel rejection and redaction (ADR-049).
+	secretNames, err := configvalidate.SecretPropertyNames(manifest.ConfigSchema)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to parse config schema",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	// Reject the redaction sentinel — the caller must supply the real value.
+	if strVal, isStr := value.(string); isStr && strVal == configvalidate.RedactionSentinel {
+		return InstanceConfigResult{}, SentinelRejectedError{Single: true}
+	}
+
+	// Merge the new value into the existing config.
+	var cfg map[string]any
+	if inst.ConfigJson != "" && inst.ConfigJson != "{}" {
+		if err := json.Unmarshal([]byte(inst.ConfigJson), &cfg); err != nil {
+			return InstanceConfigResult{}, &configInternalError{
+				PublicMsg: "failed to parse existing config",
+				Detail:    err.Error(),
+				Err:       err,
+			}
+		}
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	cfg[property] = value
+
+	// Validate the full merged config against the schema.
+	validator, err := configvalidate.ForInstanceConfig(&manifest)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to build config validator",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	fieldErrs, err := validator.Validate(cfg)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "validation error",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	if len(fieldErrs) > 0 {
+		return InstanceConfigResult{}, configValidationError{Issues: fieldErrs}
+	}
+
+	configBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to marshal config",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	nowStr := m.clock().UTC().Format(time.RFC3339)
+	rows, err := m.q.UpdatePluginInstanceConfig(ctx, db.UpdatePluginInstanceConfigParams{
+		ConfigJson:      string(configBytes),
+		UpdatedAt:       nowStr,
+		ID:              instanceID,
+		ExpectedVersion: expectedVersion,
+	})
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to update instance config",
+			Err:       err,
+		}
+	}
+	if rows == 0 {
+		return InstanceConfigResult{}, ErrCASConflict
+	}
+
+	// Pre-compute the redacted form of the written config. Both the re-fetch
+	// success branch and the fallback synthesized branch use this value so
+	// neither path can emit raw secret JSON (ADR-049 §7).
+	redactedWrittenConfig, err := configvalidate.RedactSecrets(string(configBytes), secretNames)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to redact config",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	// Re-fetch to return the updated row.
+	updated, fetchErr := m.q.GetPluginInstanceByID(ctx, instanceID)
+	if fetchErr != nil {
+		// The write succeeded; fall back to a synthesised response.
+		// Use the pre-computed redacted config — never the raw written bytes.
+		return InstanceConfigResult{Response: instanceResponse{
+			ID:                    instanceID,
+			PluginID:              pluginID,
+			InstanceName:          inst.InstanceName,
+			State:                 inst.HealthState,
+			Detail:                inst.HealthDetail,
+			Version:               inst.Version + 1,
+			UpdatedAt:             nowStr,
+			SubscriptionScopeJson: inst.SubscriptionScopeJson,
+			ConfigJson:            redactedWrittenConfig,
+		}}, nil
+	}
+
+	// Redact the re-fetched config before returning.
+	redactedFetchedConfig, err := configvalidate.RedactSecrets(updated.ConfigJson, secretNames)
+	if err != nil {
+		return InstanceConfigResult{}, &configInternalError{
+			PublicMsg: "failed to redact config",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+	return InstanceConfigResult{Response: instanceResponse{
+		ID:                    updated.ID,
+		PluginID:              updated.PluginID,
+		InstanceName:          updated.InstanceName,
+		State:                 updated.HealthState,
+		Detail:                updated.HealthDetail,
+		Version:               updated.Version,
+		UpdatedAt:             updated.UpdatedAt,
+		SubscriptionScopeJson: updated.SubscriptionScopeJson,
+		ConfigJson:            redactedFetchedConfig,
+	}}, nil
+}
+
+// advanceInstanceReadiness re-evaluates the instance's readiness detail and
+// writes it back through SetHealthState if it has changed. Best-effort — any
+// failure is logged but not returned to the caller because the underlying
+// config/credentials write has already succeeded. Bypasses the update entirely
+// when the instance is not currently in unhealthy (e.g. already healthy, or
+// pending some other admin action).
+func (m *InstanceConfig) advanceInstanceReadiness(ctx context.Context, inst db.PluginInstance, manifest *sdkmanifest.Manifest) {
+	if model.PluginHealthState(inst.HealthState) != model.PluginHealthStateUnhealthy {
+		return
+	}
+	credentialsPresent := inst.CredentialsEncrypted != nil && *inst.CredentialsEncrypted != ""
+	wanted := computeInstanceReadinessDetail(manifest, inst.ConfigJson, credentialsPresent)
+	var currentDetail string
+	if inst.HealthDetail != nil {
+		currentDetail = *inst.HealthDetail
+	}
+	if wanted == currentDetail {
+		return
+	}
+	err := pluginstate.SetHealthState(ctx, m.q, m.publisher, inst.ID, pluginstate.OriginHost,
+		model.PluginHealthStateUnhealthy, wanted)
+	if err != nil && !errors.Is(err, pluginstate.ErrTransitionConflict) {
+		slog.WarnContext(ctx, "advanceInstanceReadiness: set health detail failed",
+			"instance_id", inst.ID, "from", currentDetail, "to", wanted, "err", err)
+	}
+}
+
+// computeInstanceReadinessDetail returns the appropriate health_detail string
+// for an instance that is sitting in PluginHealthStateUnhealthy, based on what
+// the operator still needs to configure. This is used after the operator saves
+// instance config or credentials so the admin UI tells them what's still
+// missing — without it, the detail stayed at "config_missing" forever even
+// after config was set, giving operators no signal what to do next.
+//
+// The returned string is empty when the instance has everything it needs and
+// is just waiting for the subprocess to come up healthy.
+func computeInstanceReadinessDetail(m *sdkmanifest.Manifest, configJSON string, credentialsPresent bool) string {
+	if configJSON == "" || configJSON == "{}" {
+		return "config_missing"
+	}
+	// Credentials are only required for auth strategies that consume them.
+	// "none" plugins (and unset strategy, which defaults to "none" in the parser)
+	// are config-only.
+	switch m.Auth.Strategy {
+	case "", sdkmanifest.AuthStrategyNone:
+		return "" // ready — subprocess will mark healthy on handshake
+	default:
+		if !credentialsPresent {
+			return "credentials_missing"
+		}
+		return "" // ready
+	}
+}
+
+// propertyExistsInSchema returns true when the named property appears in the
+// root-level properties map of schemaNode. Returns false when schemaNode is nil
+// or has no properties key (including schema-less plugins).
+func propertyExistsInSchema(schemaNode *yaml.Node, property string) bool {
+	if schemaNode == nil {
+		return false
+	}
+	var schema map[string]any
+	if err := schemaNode.Decode(&schema); err != nil {
+		return false
+	}
+	propertiesRaw, ok := schema["properties"]
+	if !ok {
+		return false
+	}
+	propertiesMap, ok := propertiesRaw.(map[string]any)
+	if !ok {
+		return false
+	}
+	_, exists := propertiesMap[property]
+	return exists
+}
+

--- a/internal/admin/instance_config_test.go
+++ b/internal/admin/instance_config_test.go
@@ -1,0 +1,467 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
+)
+
+// Manifest fixtures used by config module tests. Shared with the handler
+// tests (same package) via plugin_handler_test.go declarations, so we do
+// not redeclare them here.
+
+// newTestInstanceConfig builds an InstanceConfig with a fixed clock and the
+// given querier. opts is a variadic list of functional options.
+func newTestInstanceConfig(q PluginQuerier, opts ...func(*InstanceConfigDeps)) *InstanceConfig {
+	deps := InstanceConfigDeps{
+		Q:     q,
+		Clock: func() time.Time { return time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC) },
+	}
+	for _, o := range opts {
+		o(&deps)
+	}
+	return NewInstanceConfig(deps)
+}
+
+func withConfigTrigger(r TriggerRestarter) func(*InstanceConfigDeps) {
+	return func(d *InstanceConfigDeps) { d.Trigger = r }
+}
+
+// ─── PutSubscriptionScope ────────────────────────────────────────────────────
+
+func TestInstanceConfig_PutSubscriptionScope(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ErrInstanceNotFound when instance missing", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: triggerManifestWithScope})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutSubscriptionScope(ctx, "plugin-1", "nonexistent", map[string]any{}, 0)
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("ErrInstanceNotFound when instance belongs to different plugin", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: triggerManifestWithScope})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-other", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutSubscriptionScope(ctx, "plugin-1", "inst-1", map[string]any{}, 0)
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("ErrNoSubscriptionSchema when manifest has no subscription_schema", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-2", Name: "p", ManifestSnapshot: triggerManifestNoScope})
+		q.seed(db.PluginInstance{ID: "inst-2", PluginID: "plugin-2", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutSubscriptionScope(ctx, "plugin-2", "inst-2", map[string]any{"x": "y"}, 0)
+		if !errors.Is(err, ErrNoSubscriptionSchema) {
+			t.Errorf("err = %v, want ErrNoSubscriptionSchema", err)
+		}
+	})
+
+	t.Run("configValidationError on invalid scope", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-3", Name: "p", ManifestSnapshot: triggerManifestWithScope})
+		q.seed(db.PluginInstance{ID: "inst-3", PluginID: "plugin-3", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		// "channels" is required; "bad_field" is rejected by additionalProperties:false.
+		_, err := m.PutSubscriptionScope(ctx, "plugin-3", "inst-3", map[string]any{"bad_field": "x"}, 0)
+		var valErr configValidationError
+		if !errors.As(err, &valErr) {
+			t.Errorf("err = %v, want configValidationError", err)
+		}
+		if len(valErr.Issues) == 0 {
+			t.Error("configValidationError.Issues is empty, want at least one issue")
+		}
+	})
+
+	t.Run("ErrCASConflict on stale version", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-4", Name: "p", ManifestSnapshot: triggerManifestWithScope})
+		q.seed(db.PluginInstance{ID: "inst-4", PluginID: "plugin-4", HealthState: "healthy", Version: 5})
+		q.scopeCASFailOnID = "inst-4"
+		m := newTestInstanceConfig(q)
+		_, err := m.PutSubscriptionScope(ctx, "plugin-4", "inst-4", map[string]any{"channels": []any{"#ops"}}, 5)
+		if !errors.Is(err, ErrCASConflict) {
+			t.Errorf("err = %v, want ErrCASConflict", err)
+		}
+	})
+
+	t.Run("happy path: scope persisted, trigger restarted, secret config redacted", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-sec", Name: "p", ManifestSnapshot: triggerManifestWithScopeAndSecret})
+		q.seed(db.PluginInstance{
+			ID:                    "inst-sec",
+			PluginID:              "plugin-sec",
+			InstanceName:          "prod",
+			ConfigJson:            `{"app_level_token":"real-secret"}`,
+			SubscriptionScopeJson: "{}",
+			HealthState:           "healthy",
+			Version:               1,
+			UpdatedAt:             "2026-05-01T00:00:00Z",
+		})
+		restarter := &fakeTriggerRestarter{}
+		m := newTestInstanceConfig(q, withConfigTrigger(restarter))
+
+		result, err := m.PutSubscriptionScope(ctx, "plugin-sec", "inst-sec", map[string]any{"channels": []any{"#alerts"}}, 1)
+		if err != nil {
+			t.Fatalf("PutSubscriptionScope: unexpected error: %v", err)
+		}
+		if result.Response.ConfigJson == "" {
+			t.Error("ConfigJson must not be empty")
+		}
+		// Secret field must be redacted.
+		if result.Response.ConfigJson == `{"app_level_token":"real-secret"}` {
+			t.Error("ConfigJson must have redacted secret; got raw value")
+		}
+	})
+
+	t.Run("200 synthesised response: secret still redacted when re-fetch fails", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-sec2", Name: "p", ManifestSnapshot: triggerManifestWithScopeAndSecret})
+		q.seed(db.PluginInstance{
+			ID:                    "inst-sec2",
+			PluginID:              "plugin-sec2",
+			InstanceName:          "prod",
+			ConfigJson:            `{"app_level_token":"xoxb-secret"}`,
+			SubscriptionScopeJson: "{}",
+			HealthState:           "healthy",
+			Version:               1,
+			UpdatedAt:             "2026-05-01T00:00:00Z",
+		})
+		// First call to GetPluginInstanceByID succeeds (resolveConfigInstance).
+		// Second call (re-fetch after scope write) fails → synthesised response path.
+		q.getInstanceErrAfterN["inst-sec2"] = 1
+
+		m := newTestInstanceConfig(q)
+		result, err := m.PutSubscriptionScope(ctx, "plugin-sec2", "inst-sec2", map[string]any{"channels": []any{"#x"}}, 1)
+		if err != nil {
+			t.Fatalf("PutSubscriptionScope: unexpected error: %v", err)
+		}
+		// Even on synthesised path, secret must be redacted.
+		if result.Response.ConfigJson == `{"app_level_token":"xoxb-secret"}` {
+			t.Error("ConfigJson must be redacted even in synthesised response")
+		}
+	})
+}
+
+// ─── PutConfig ───────────────────────────────────────────────────────────────
+
+func TestInstanceConfig_PutConfig(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ErrInstanceNotFound when instance missing", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfig(ctx, "plugin-1", "nonexistent", map[string]any{}, 0)
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("SentinelRejectedError (bulk) when secret field contains redaction sentinel", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfig(ctx, "plugin-1", "inst-1", map[string]any{
+			"app_level_token": configvalidate.RedactionSentinel,
+		}, 0)
+		var sentErr SentinelRejectedError
+		if !errors.As(err, &sentErr) {
+			t.Errorf("err = %v, want SentinelRejectedError", err)
+		}
+		if sentErr.Single {
+			t.Error("SentinelRejectedError.Single should be false for bulk PutConfig")
+		}
+		if len(sentErr.Issues) == 0 {
+			t.Error("SentinelRejectedError.Issues should list offending fields")
+		}
+	})
+
+	t.Run("configValidationError on schema violation", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestYAML})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		// app_level_token is required but missing.
+		_, err := m.PutConfig(ctx, "plugin-1", "inst-1", map[string]any{"other_field": "x"}, 0)
+		var valErr configValidationError
+		if !errors.As(err, &valErr) {
+			t.Errorf("err = %v, want configValidationError", err)
+		}
+	})
+
+	t.Run("ErrCASConflict on stale version", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 3})
+		q.configCASFailOnID = "inst-1"
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfig(ctx, "plugin-1", "inst-1", map[string]any{"key": "val"}, 3)
+		if !errors.Is(err, ErrCASConflict) {
+			t.Errorf("err = %v, want ErrCASConflict", err)
+		}
+	})
+
+	t.Run("happy path: secret redacted in response", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			InstanceName: "prod",
+			HealthState:  "healthy",
+			Version:      0,
+			UpdatedAt:    "2026-05-01T00:00:00Z",
+		})
+		m := newTestInstanceConfig(q)
+		result, err := m.PutConfig(ctx, "plugin-1", "inst-1", map[string]any{"app_level_token": "xoxb-real"}, 0)
+		if err != nil {
+			t.Fatalf("PutConfig: unexpected error: %v", err)
+		}
+		if result.Response.ConfigJson == `{"app_level_token":"xoxb-real"}` {
+			t.Error("secret field must be redacted in response")
+		}
+		if result.Response.ConfigJson == "" {
+			t.Error("ConfigJson must not be empty")
+		}
+	})
+
+	t.Run("happy path: nil schema accepts anything", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			InstanceName: "prod",
+			HealthState:  "healthy",
+			Version:      0,
+			UpdatedAt:    "2026-05-01T00:00:00Z",
+		})
+		m := newTestInstanceConfig(q)
+		result, err := m.PutConfig(ctx, "plugin-1", "inst-1", map[string]any{"arbitrary_key": 42}, 0)
+		if err != nil {
+			t.Fatalf("PutConfig: unexpected error (nil schema must accept any object): %v", err)
+		}
+		if result.Response.ID != "inst-1" {
+			t.Errorf("Response.ID = %q, want %q", result.Response.ID, "inst-1")
+		}
+	})
+
+	t.Run("synthesised response: secret still redacted when re-fetch fails", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			InstanceName: "prod",
+			HealthState:  "healthy",
+			Version:      0,
+			UpdatedAt:    "2026-05-01T00:00:00Z",
+		})
+		// resolveConfigInstance (call 1) succeeds; re-fetch after write (call 2) fails.
+		q.getInstanceErrAfterN["inst-1"] = 1
+		m := newTestInstanceConfig(q)
+		result, err := m.PutConfig(ctx, "plugin-1", "inst-1", map[string]any{"app_level_token": "xoxb-secret"}, 0)
+		if err != nil {
+			t.Fatalf("PutConfig: unexpected error: %v", err)
+		}
+		if result.Response.ConfigJson == `{"app_level_token":"xoxb-secret"}` {
+			t.Error("secret must be redacted even in synthesised response path")
+		}
+	})
+}
+
+// ─── PutConfigProperty ───────────────────────────────────────────────────────
+
+func TestInstanceConfig_PutConfigProperty(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ErrInstanceNotFound when instance missing", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "plugin-1", "nonexistent", "app_level_token", "val", 0)
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("ErrPropertyNotFound when property absent from config_schema", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "plugin-1", "inst-1", "nonexistent_prop", "val", 0)
+		if !errors.Is(err, ErrPropertyNotFound) {
+			t.Errorf("err = %v, want ErrPropertyNotFound", err)
+		}
+	})
+
+	t.Run("SentinelRejectedError (single) when value is redaction sentinel", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "plugin-1", "inst-1", "app_level_token", configvalidate.RedactionSentinel, 0)
+		var sentErr SentinelRejectedError
+		if !errors.As(err, &sentErr) {
+			t.Errorf("err = %v, want SentinelRejectedError", err)
+		}
+		if !sentErr.Single {
+			t.Error("SentinelRejectedError.Single should be true for per-property endpoint")
+		}
+	})
+
+	t.Run("ErrCASConflict on stale version", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			InstanceName: "prod",
+			HealthState:  "healthy",
+			ConfigJson:   `{"app_level_token":"old"}`,
+			Version:      3,
+		})
+		q.configCASFailOnID = "inst-1"
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "plugin-1", "inst-1", "app_level_token", "new-val", 3)
+		if !errors.Is(err, ErrCASConflict) {
+			t.Errorf("err = %v, want ErrCASConflict", err)
+		}
+	})
+
+	t.Run("happy path: property merged, secret redacted in response", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			InstanceName: "prod",
+			HealthState:  "healthy",
+			ConfigJson:   `{}`,
+			Version:      0,
+			UpdatedAt:    "2026-05-01T00:00:00Z",
+		})
+		m := newTestInstanceConfig(q)
+		result, err := m.PutConfigProperty(ctx, "plugin-1", "inst-1", "app_level_token", "xoxb-real", 0)
+		if err != nil {
+			t.Fatalf("PutConfigProperty: unexpected error: %v", err)
+		}
+		if result.Response.ConfigJson == `{"app_level_token":"xoxb-real"}` {
+			t.Error("secret must be redacted in response")
+		}
+		if result.Response.ID != "inst-1" {
+			t.Errorf("Response.ID = %q, want inst-1", result.Response.ID)
+		}
+	})
+
+	t.Run("synthesised response: secret redacted when re-fetch fails", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestWithSecret})
+		q.seed(db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			InstanceName: "prod",
+			HealthState:  "healthy",
+			ConfigJson:   `{}`,
+			Version:      0,
+			UpdatedAt:    "2026-05-01T00:00:00Z",
+		})
+		// resolveConfigInstance (call 1) succeeds; re-fetch after write (call 2) fails.
+		q.getInstanceErrAfterN["inst-1"] = 1
+		m := newTestInstanceConfig(q)
+		result, err := m.PutConfigProperty(ctx, "plugin-1", "inst-1", "app_level_token", "secret-val", 0)
+		if err != nil {
+			t.Fatalf("PutConfigProperty: unexpected error: %v", err)
+		}
+		if result.Response.ConfigJson == `{"app_level_token":"secret-val"}` {
+			t.Error("secret must be redacted even in synthesised response")
+		}
+	})
+
+	t.Run("ErrPropertyNotFound returns immediately (no nil-schema path)", func(t *testing.T) {
+		// When config_schema is nil, propertyExistsInSchema returns false for any
+		// property name. This means PutConfigProperty always returns ErrPropertyNotFound
+		// for a schema-less plugin, preventing arbitrary key injection.
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "plugin-1", "inst-1", "any_property", "val", 0)
+		if !errors.Is(err, ErrPropertyNotFound) {
+			t.Errorf("err = %v, want ErrPropertyNotFound for schema-less plugin", err)
+		}
+	})
+}
+
+
+// ─── propertyExistsInSchema ──────────────────────────────────────────────────
+
+func TestPropertyExistsInSchema(t *testing.T) {
+	// propertyExistsInSchema is tested indirectly through PutConfigProperty:
+	// a known property name must NOT return ErrPropertyNotFound, while an
+	// absent one must.
+
+	ctx := context.Background()
+
+	t.Run("nil schema → ErrPropertyNotFound for any name", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "p", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst", PluginID: "p", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "p", "inst", "any_property", "val", 0)
+		if !errors.Is(err, ErrPropertyNotFound) {
+			t.Errorf("err = %v, want ErrPropertyNotFound for nil config_schema", err)
+		}
+	})
+
+	const manifestWithProp = `schema_version: v1
+name: p
+version: 1.0.0
+services:
+  tool: v1
+auth:
+  mode: instance_credentials
+  strategy: none
+config_schema:
+  type: object
+  properties:
+    app_level_token:
+      type: string
+`
+
+	t.Run("declared property → found (not ErrPropertyNotFound)", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "p", Name: "p", ManifestSnapshot: manifestWithProp})
+		q.seed(db.PluginInstance{ID: "inst", PluginID: "p", HealthState: "healthy", ConfigJson: "{}", Version: 0, UpdatedAt: "2026-05-01T00:00:00Z"})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "p", "inst", "app_level_token", "val", 0)
+		if errors.Is(err, ErrPropertyNotFound) {
+			t.Errorf("declared property should be found, got ErrPropertyNotFound")
+		}
+	})
+
+	t.Run("undeclared property → ErrPropertyNotFound", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "p", Name: "p", ManifestSnapshot: manifestWithProp})
+		q.seed(db.PluginInstance{ID: "inst", PluginID: "p", HealthState: "healthy", Version: 0})
+		m := newTestInstanceConfig(q)
+		_, err := m.PutConfigProperty(ctx, "p", "inst", "nonexistent_prop", "val", 0)
+		if !errors.Is(err, ErrPropertyNotFound) {
+			t.Errorf("undeclared property: err = %v, want ErrPropertyNotFound", err)
+		}
+	})
+}

--- a/internal/admin/instance_config_test.go
+++ b/internal/admin/instance_config_test.go
@@ -407,7 +407,6 @@ func TestInstanceConfig_PutConfigProperty(t *testing.T) {
 	})
 }
 
-
 // ─── propertyExistsInSchema ──────────────────────────────────────────────────
 
 func TestPropertyExistsInSchema(t *testing.T) {

--- a/internal/admin/instance_lifecycle.go
+++ b/internal/admin/instance_lifecycle.go
@@ -126,8 +126,8 @@ type lifecycleInternalError struct {
 	Err       error
 }
 
-func (e *lifecycleInternalError) Error() string    { return e.PublicMsg + ": " + e.Err.Error() }
-func (e *lifecycleInternalError) Unwrap() error    { return e.Err }
+func (e *lifecycleInternalError) Error() string { return e.PublicMsg + ": " + e.Err.Error() }
+func (e *lifecycleInternalError) Unwrap() error { return e.Err }
 
 // ─── InstanceLifecycleDeps ───────────────────────────────────────────────────
 

--- a/internal/admin/instance_lifecycle.go
+++ b/internal/admin/instance_lifecycle.go
@@ -1,0 +1,634 @@
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/http/auth"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
+	"github.com/felag-engineering/gleipnir/internal/policy"
+)
+
+// ─── Typed errors for InstanceLifecycle ──────────────────────────────────────
+//
+// Sentinel (no data) and struct (data-carrying) errors for each gate and
+// failure branch. Handlers map these to the EXACT current status codes and
+// response bodies (preserved byte-for-byte from the old inline handlers).
+
+// ErrStoreUnavailable is returned by Delete and Uninstall when the *db.Store
+// has not been injected (503 "plugin management not configured"). This check
+// must come FIRST — before any querier call — preserving the current order in
+// the old handlers.
+var ErrStoreUnavailable = errors.New("plugin management not configured")
+
+// ErrPluginNotFound is returned when GetPluginByID returns ErrNotFound (=sql.ErrNoRows).
+var ErrPluginNotFound = errors.New("plugin not found")
+
+// ErrInstanceNotFound is returned when GetPluginInstanceByID returns ErrNotFound, or
+// when the fetched instance belongs to a different plugin (plugin/instance mismatch —
+// return 404, not 403, to avoid leaking instance existence across plugins).
+var ErrInstanceNotFound = errors.New("instance not found")
+
+// ErrAlreadyInactive is returned by Deactivate when the instance is already inactive.
+var ErrAlreadyInactive = errors.New("instance is already deactivated")
+
+// ErrRefetchFailed is returned when the state-transition write succeeded but the
+// subsequent GetPluginInstanceByID re-fetch failed. MUST NOT be synthesized;
+// returning raw config would risk emitting unredacted secrets (ADR-049).
+var ErrRefetchFailed = errors.New("state transition succeeded but re-fetch failed")
+
+// TerminalStateError is returned by Deactivate when the instance is in a
+// terminal health state (signature_invalid or verification_error) that cannot
+// transition to inactive.
+type TerminalStateError struct {
+	State model.PluginHealthState
+}
+
+func (e TerminalStateError) Error() string {
+	return fmt.Sprintf("cannot deactivate instance in terminal state; current state: %s", e.State)
+}
+
+// inflightOp identifies which operation produced an InflightError, so the
+// handler can pick the correct error message string.
+type inflightOp int
+
+const (
+	inflightOpDeactivate inflightOp = iota
+	inflightOpDelete
+)
+
+// InflightError is returned by Deactivate and Delete when in-flight tool calls
+// are present. Op controls which message the handler formats (the two callers
+// produce different 409 bodies per the plan's ERROR SURFACE table).
+type InflightError struct {
+	Count int
+	Op    inflightOp
+}
+
+func (e InflightError) Error() string {
+	return fmt.Sprintf("in-flight calls: %d", e.Count)
+}
+
+// NotInactiveError is returned by Activate when the instance is not in inactive state.
+type NotInactiveError struct {
+	State string
+}
+
+func (e NotInactiveError) Error() string {
+	return fmt.Sprintf("instance is not deactivated; current state: %s", e.State)
+}
+
+// PolicyRefError is returned by Delete when policies still reference the instance.
+type PolicyRefError struct {
+	Names []string
+}
+
+func (e PolicyRefError) Error() string {
+	return "instance is referenced by policies: " + strings.Join(e.Names, ", ")
+}
+
+// AudienceRefError is returned by Delete when audience entries still reference the instance.
+type AudienceRefError struct {
+	Names []string
+}
+
+func (e AudienceRefError) Error() string {
+	return "instance is referenced by audiences: " + strings.Join(e.Names, ", ")
+}
+
+// InstancesRemainError is returned by Uninstall when instances still exist.
+type InstancesRemainError struct {
+	Names []string
+}
+
+func (e InstancesRemainError) Error() string {
+	return "all instances must be removed before uninstalling the plugin: " + strings.Join(e.Names, ", ")
+}
+
+// lifecycleInternalError wraps an internal failure with a public message that
+// the handler writes verbatim as the response body, plus the underlying error
+// for logging. This keeps all exact-string literals in one place (the module),
+// so the handler's switch arm only needs to read PublicMsg and Detail.
+type lifecycleInternalError struct {
+	PublicMsg string
+	Detail    string
+	Err       error
+}
+
+func (e *lifecycleInternalError) Error() string    { return e.PublicMsg + ": " + e.Err.Error() }
+func (e *lifecycleInternalError) Unwrap() error    { return e.Err }
+
+// ─── InstanceLifecycleDeps ───────────────────────────────────────────────────
+
+// InstanceLifecycleDeps holds all constructor-injected dependencies for
+// InstanceLifecycle. All fields have sane nil-safe defaults (nil procMgr/trigger/
+// inflight/unreg = safe no-ops; empty pluginsDir = skip FS cleanup).
+type InstanceLifecycleDeps struct {
+	Q          PluginQuerier
+	Store      *db.Store
+	Publisher  event.Publisher
+	Clock      func() time.Time
+	ProcMgr    PluginProcessManager
+	Trigger    TriggerRestarter
+	Inflight   InflightCounter
+	Unreg      ToolUnregistrar
+	PluginsDir string
+}
+
+// InstanceLifecycle owns the four plugin-instance lifecycle transitions:
+// Deactivate, Activate, Delete, and Uninstall. It has no knowledge of HTTP —
+// all methods return domain objects or typed errors that the handler maps.
+//
+// Shared deps (processManager, pluginsDir) are also held by PluginHandler for
+// non-extracted handlers (CreateInstance/ApprovePlugin/RejectPlugin). Wire the
+// same instance/value to both from main.go.
+type InstanceLifecycle struct {
+	q          PluginQuerier
+	store      *db.Store
+	publisher  event.Publisher
+	clock      func() time.Time
+	procMgr    PluginProcessManager
+	trigger    TriggerRestarter
+	inflight   InflightCounter
+	unreg      ToolUnregistrar
+	pluginsDir string
+}
+
+// NewInstanceLifecycle constructs an InstanceLifecycle with the given deps.
+// clock defaults to time.Now when nil.
+func NewInstanceLifecycle(deps InstanceLifecycleDeps) *InstanceLifecycle {
+	clk := deps.Clock
+	if clk == nil {
+		clk = time.Now
+	}
+	return &InstanceLifecycle{
+		q:          deps.Q,
+		store:      deps.Store,
+		publisher:  deps.Publisher,
+		clock:      clk,
+		procMgr:    deps.ProcMgr,
+		trigger:    deps.Trigger,
+		inflight:   deps.Inflight,
+		unreg:      deps.Unreg,
+		pluginsDir: deps.PluginsDir,
+	}
+}
+
+// resolveLifecycleInstance fetches the instance row and verifies it belongs to
+// pluginID. Returns ErrPluginNotFound / ErrInstanceNotFound on the respective
+// failure paths (including the plugin/instance mismatch, which returns
+// ErrInstanceNotFound to avoid leaking instance existence across plugins).
+func (m *InstanceLifecycle) resolveLifecycleInstance(ctx context.Context, pluginID, instanceID string) (db.Plugin, db.PluginInstance, error) {
+	plugin, err := m.q.GetPluginByID(ctx, pluginID)
+	if errors.Is(err, ErrNotFound) {
+		return db.Plugin{}, db.PluginInstance{}, ErrPluginNotFound
+	}
+	if err != nil {
+		return db.Plugin{}, db.PluginInstance{}, &lifecycleInternalError{
+			PublicMsg: "failed to get plugin",
+			Err:       err,
+		}
+	}
+
+	inst, err := m.q.GetPluginInstanceByID(ctx, instanceID)
+	if errors.Is(err, ErrNotFound) {
+		return db.Plugin{}, db.PluginInstance{}, ErrInstanceNotFound
+	}
+	if err != nil {
+		return db.Plugin{}, db.PluginInstance{}, &lifecycleInternalError{
+			PublicMsg: "failed to get instance",
+			Err:       err,
+		}
+	}
+	// Return 404 on mismatch to avoid leaking instance existence across plugins.
+	if inst.PluginID != pluginID {
+		return db.Plugin{}, db.PluginInstance{}, ErrInstanceNotFound
+	}
+	return plugin, inst, nil
+}
+
+// Deactivate soft-deactivates the instance: gates on in-flight calls, transitions
+// health to inactive, stops subprocess and trigger stream, emits audit event,
+// and re-fetches the updated row. Returns the re-fetched row on success.
+//
+// Typed errors: ErrPluginNotFound, ErrInstanceNotFound, ErrAlreadyInactive,
+// TerminalStateError, InflightError(Op=inflightOpDeactivate), ErrRefetchFailed,
+// lifecycleInternalError (failed to set health state).
+func (m *InstanceLifecycle) Deactivate(ctx context.Context, pluginID, instanceID string) (db.PluginInstance, error) {
+	_, inst, err := m.resolveLifecycleInstance(ctx, pluginID, instanceID)
+	if err != nil {
+		return db.PluginInstance{}, err
+	}
+
+	current := model.PluginHealthState(inst.HealthState)
+
+	if current == model.PluginHealthStateInactive {
+		return db.PluginInstance{}, ErrAlreadyInactive
+	}
+
+	// Terminal states cannot transition to inactive (state machine enforces this,
+	// but we surface a clear error before hitting ErrIllegalTransition).
+	if current == model.PluginHealthStateSignatureInvalid || current == model.PluginHealthStateVerificationError {
+		return db.PluginInstance{}, TerminalStateError{State: current}
+	}
+
+	// Gate on zero in-flight tool calls. TOCTOU is acceptable here: a new call
+	// arriving after this check will fail at the dispatch layer once the subprocess
+	// is stopped. The gate prevents disrupting calls that are actively running.
+	if m.inflight != nil {
+		count := m.inflight.InflightCountByInstance(inst.InstanceName)
+		if count > 0 {
+			return db.PluginInstance{}, InflightError{Count: count, Op: inflightOpDeactivate}
+		}
+	}
+
+	if err := pluginstate.SetHealthState(ctx, m.q, m.publisher, instanceID, pluginstate.OriginHost,
+		model.PluginHealthStateInactive, "deactivated by admin"); err != nil {
+		return db.PluginInstance{}, &lifecycleInternalError{
+			PublicMsg: "failed to set health state",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	// Best-effort subprocess stop (5s deadline — same pattern as DeleteInstance).
+	if m.procMgr != nil {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := m.procMgr.Stop(stopCtx, instanceID); err != nil {
+			slog.WarnContext(ctx, "deactivate instance: subprocess stop failed",
+				"instance_id", instanceID, "err", err)
+		}
+		cancel()
+	}
+
+	// Best-effort trigger stream stop.
+	if m.trigger != nil {
+		m.trigger.Stop(instanceID)
+	}
+
+	nowStr := m.clock().UTC().Format(time.RFC3339Nano)
+	m.writeAuditEvent(ctx, auditInstanceDeactivated, "info", nowStr, map[string]any{
+		"plugin_id":     pluginID,
+		"instance_id":   instanceID,
+		"instance_name": inst.InstanceName,
+	})
+
+	// Re-fetch to return the current row after the state transition.
+	updated, err := m.q.GetPluginInstanceByID(ctx, instanceID)
+	if err != nil {
+		// State write succeeded but the re-fetch failed. Return ErrRefetchFailed —
+		// the client can re-fetch via GET. We must not synthesize a response here
+		// because config_json may contain unredacted secrets (ADR-049).
+		slog.WarnContext(ctx, "deactivate instance: re-fetch after transition failed",
+			"instance_id", instanceID, "err", err)
+		return db.PluginInstance{}, ErrRefetchFailed
+	}
+	return updated, nil
+}
+
+// Activate re-activates a previously deactivated instance: transitions health
+// to unhealthy, spawns the subprocess, starts the trigger stream, emits an
+// audit event, and re-fetches the updated row.
+//
+// Typed errors: ErrPluginNotFound, ErrInstanceNotFound, NotInactiveError,
+// ErrRefetchFailed, lifecycleInternalError (failed to set health state).
+func (m *InstanceLifecycle) Activate(ctx context.Context, pluginID, instanceID string) (db.PluginInstance, error) {
+	_, inst, err := m.resolveLifecycleInstance(ctx, pluginID, instanceID)
+	if err != nil {
+		return db.PluginInstance{}, err
+	}
+
+	if model.PluginHealthState(inst.HealthState) != model.PluginHealthStateInactive {
+		return db.PluginInstance{}, NotInactiveError{State: inst.HealthState}
+	}
+
+	// Transition to unhealthy first. The subprocess handshake will drive the
+	// state to healthy once the process comes up.
+	if err := pluginstate.SetHealthState(ctx, m.q, m.publisher, instanceID, pluginstate.OriginHost,
+		model.PluginHealthStateUnhealthy, "reactivated by admin"); err != nil {
+		return db.PluginInstance{}, &lifecycleInternalError{
+			PublicMsg: "failed to set health state",
+			Detail:    err.Error(),
+			Err:       err,
+		}
+	}
+
+	// Best-effort subprocess spawn. StartByPluginID spawns all instances for the
+	// plugin; siblings already running return "already running" (swallowed internally).
+	// Use context.Background() — r.Context() WriteTimeout applies to HTTP requests;
+	// the spawn must outlive the request (matches the original handler's behavior).
+	if m.procMgr != nil {
+		if err := m.procMgr.StartByPluginID(context.Background(), pluginID); err != nil {
+			slog.WarnContext(ctx, "activate instance: spawn failed", "plugin_id", pluginID, "err", err)
+		}
+	}
+
+	// Best-effort trigger stream start.
+	if m.trigger != nil {
+		m.trigger.Start(ctx, instanceID)
+	}
+
+	nowStr := m.clock().UTC().Format(time.RFC3339Nano)
+	m.writeAuditEvent(ctx, auditInstanceActivated, "info", nowStr, map[string]any{
+		"plugin_id":     pluginID,
+		"instance_id":   instanceID,
+		"instance_name": inst.InstanceName,
+	})
+
+	// Re-fetch to return the current row after the state transition.
+	updated, err := m.q.GetPluginInstanceByID(ctx, instanceID)
+	if err != nil {
+		// State write succeeded but the re-fetch failed. Return ErrRefetchFailed —
+		// the client can re-fetch via GET. We must not synthesize a response here
+		// because config_json may contain unredacted secrets (ADR-049).
+		slog.WarnContext(ctx, "activate instance: re-fetch after transition failed",
+			"instance_id", instanceID, "err", err)
+		return db.PluginInstance{}, ErrRefetchFailed
+	}
+	return updated, nil
+}
+
+// Delete hard-deletes a single plugin instance after verifying no policies or
+// audiences reference it and no tool calls are in flight. Returns nil on success.
+//
+// ErrStoreUnavailable is checked FIRST (before any querier call), preserving
+// the current 503-before-DB-access order.
+//
+// Typed errors: ErrStoreUnavailable, ErrPluginNotFound, ErrInstanceNotFound,
+// PolicyRefError, AudienceRefError, InflightError(Op=inflightOpDelete),
+// lifecycleInternalError ("internal error" for tx/cleanup steps).
+func (m *InstanceLifecycle) Delete(ctx context.Context, pluginID, instanceID string) error {
+	// 503 check FIRST — before any DB access (preserves current handler order).
+	if m.store == nil {
+		return ErrStoreUnavailable
+	}
+
+	_, inst, err := m.resolveLifecycleInstance(ctx, pluginID, instanceID)
+	if err != nil {
+		return err
+	}
+
+	// Policy reference guard: refuse deletion if any policy still references
+	// this instance's tools or subscribed trigger.
+	policyRefs, err := policy.ScanPolicyToolRefsForInstance(ctx, m.q, inst.InstanceName)
+	if err != nil {
+		slog.ErrorContext(ctx, "delete instance: scan policy refs", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	if len(policyRefs) > 0 {
+		names := make([]string, len(policyRefs))
+		for i, r := range policyRefs {
+			names[i] = r.Name
+		}
+		return PolicyRefError{Names: names}
+	}
+
+	// Audience reference guard: refuse deletion if any audience entry references this instance.
+	audienceEntries, err := m.q.ListAudienceEntriesByInstance(ctx, instanceID)
+	if err != nil {
+		slog.ErrorContext(ctx, "delete instance: list audience entries", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	if len(audienceEntries) > 0 {
+		// Deduplicate audience names — one instance can appear in multiple entries
+		// of the same audience.
+		seen := make(map[string]bool)
+		var audienceNames []string
+		for _, ae := range audienceEntries {
+			if !seen[ae.AudienceName] {
+				seen[ae.AudienceName] = true
+				audienceNames = append(audienceNames, ae.AudienceName)
+			}
+		}
+		return AudienceRefError{Names: audienceNames}
+	}
+
+	// In-flight gate: refuse deletion if tool calls are actively dispatched to this instance.
+	if m.inflight != nil {
+		count := m.inflight.InflightCountByInstance(inst.InstanceName)
+		if count > 0 {
+			return InflightError{Count: count, Op: inflightOpDelete}
+		}
+	}
+
+	// Best-effort subprocess stop before DB cleanup so in-flight RPCs don't hit
+	// a half-deleted instance. A wedged subprocess must not block DB cleanup.
+	if m.procMgr != nil {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := m.procMgr.Stop(stopCtx, instanceID); err != nil {
+			slog.WarnContext(ctx, "delete instance: subprocess stop failed",
+				"instance_id", instanceID, "err", err)
+		}
+		cancel()
+	}
+
+	// Transactional delete in FK-safe order (ADR-003 sqlc/no-ORM):
+	//   1. plugin_pending_requests (RESTRICT FK — must clear first)
+	//   2. plugin_oauth_nonces (instance_id FK)
+	//   3. plugin_instances row (audit events use SET NULL so history survives)
+	tx, err := m.store.DB().BeginTx(ctx, nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "delete instance: begin tx", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	defer func() {
+		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+			slog.ErrorContext(ctx, "delete instance: rollback failed", "err", rbErr)
+		}
+	}()
+
+	q := db.New(tx)
+	if err := q.DeletePluginPendingRequestsByInstance(ctx, instanceID); err != nil {
+		slog.ErrorContext(ctx, "delete instance: clear pending requests", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	if err := q.DeletePluginOAuthNoncesByInstance(ctx, instanceID); err != nil {
+		slog.ErrorContext(ctx, "delete instance: clear oauth nonces", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	if _, err := q.DeletePluginInstance(ctx, instanceID); err != nil {
+		slog.ErrorContext(ctx, "delete instance: delete row", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	if err := tx.Commit(); err != nil {
+		slog.ErrorContext(ctx, "delete instance: commit", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+
+	// Best-effort tool-namespace release. Nil-safe: not yet wired in main.go
+	// (see ToolUnregistrar godoc and TODO at main.go). #194 follow-up will add
+	// the one-line wire-up.
+	if m.unreg != nil {
+		m.unreg.UnregisterInstance(ctx, inst.InstanceName)
+	}
+
+	nowStr := m.clock().UTC().Format(time.RFC3339Nano)
+	m.writeAuditEvent(ctx, auditInstanceDeleted, "info", nowStr, map[string]any{
+		"plugin_id":     pluginID,
+		"instance_id":   instanceID,
+		"instance_name": inst.InstanceName,
+	})
+	return nil
+}
+
+// Uninstall removes the plugin and all its (already-deleted) instances. It
+// gates on zero instances remaining, stops all subprocesses (10s deadline),
+// removes pending requests and OAuth nonces per instance in a transaction,
+// deletes the plugin row (which cascades to plugin_instances), and removes the
+// binary directory from disk (containment-checked, best-effort).
+//
+// ErrStoreUnavailable is checked FIRST (before any querier call).
+//
+// Typed errors: ErrStoreUnavailable, ErrPluginNotFound,
+// InstancesRemainError, lifecycleInternalError ("internal error").
+func (m *InstanceLifecycle) Uninstall(ctx context.Context, pluginID string) error {
+	// 503 check FIRST — before any DB access (preserves current handler order).
+	if m.store == nil {
+		return ErrStoreUnavailable
+	}
+
+	plugin, err := m.q.GetPluginByID(ctx, pluginID)
+	if errors.Is(err, ErrNotFound) {
+		return ErrPluginNotFound
+	}
+	if err != nil {
+		return &lifecycleInternalError{PublicMsg: "failed to get plugin", Err: err}
+	}
+
+	// Collect all instances. Per #243: removing the plugin (binary + manifest)
+	// requires all instances to be removed first — per-instance Delete enforces
+	// the policy/audience/in-flight gates individually.
+	instances, err := m.q.ListPluginInstancesByPlugin(ctx, pluginID)
+	if err != nil {
+		slog.ErrorContext(ctx, "uninstall: list instances", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+
+	if len(instances) > 0 {
+		names := make([]string, len(instances))
+		for i, inst := range instances {
+			names[i] = inst.InstanceName
+		}
+		return InstancesRemainError{Names: names}
+	}
+
+	// Best-effort: stop all running subprocesses before clearing rows.
+	if m.procMgr != nil {
+		stopCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		if err := m.procMgr.StopByPluginID(stopCtx, pluginID); err != nil {
+			slog.WarnContext(ctx, "uninstall: stop subprocesses failed",
+				"plugin_id", pluginID, "err", err)
+		}
+		cancel()
+	}
+
+	// Transactional delete (ADR-003):
+	//   1. For each instance: clear pending requests + OAuth nonces (RESTRICT FKs).
+	//   2. DeletePlugin — cascades to plugin_instances via ON DELETE CASCADE.
+	tx, err := m.store.DB().BeginTx(ctx, nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "uninstall: begin tx", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	defer func() {
+		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+			slog.ErrorContext(ctx, "uninstall: rollback failed", "err", rbErr)
+		}
+	}()
+
+	q := db.New(tx)
+	for _, inst := range instances {
+		if err := q.DeletePluginPendingRequestsByInstance(ctx, inst.ID); err != nil {
+			slog.ErrorContext(ctx, "uninstall: clear pending requests",
+				"instance_id", inst.ID, "err", err)
+			return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+		}
+		if err := q.DeletePluginOAuthNoncesByInstance(ctx, inst.ID); err != nil {
+			slog.ErrorContext(ctx, "uninstall: clear oauth nonces",
+				"instance_id", inst.ID, "err", err)
+			return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+		}
+	}
+	if _, err := q.DeletePlugin(ctx, pluginID); err != nil {
+		slog.ErrorContext(ctx, "uninstall: delete plugin", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+	if err := tx.Commit(); err != nil {
+		slog.ErrorContext(ctx, "uninstall: commit", "err", err)
+		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
+	}
+
+	// Best-effort tool-namespace release for each instance. Nil-safe.
+	if m.unreg != nil {
+		for _, inst := range instances {
+			m.unreg.UnregisterInstance(ctx, inst.InstanceName)
+		}
+	}
+
+	// Post-commit: remove the binary directory from disk.
+	// Containment check (fail-closed per ADR-001): only remove paths that are
+	// strictly within pluginsDir. A path that starts with ".." after filepath.Rel
+	// is a traversal attempt — we refuse and log a warning.
+	binaryPathRemoved := false
+	if plugin.BinaryPath != nil && m.pluginsDir != "" {
+		dir := filepath.Dir(*plugin.BinaryPath)
+		rel, relErr := filepath.Rel(m.pluginsDir, dir)
+		if relErr != nil || strings.HasPrefix(rel, "..") {
+			slog.WarnContext(ctx, "uninstall: binary path escapes plugins dir — skipping removal",
+				"binary_path", *plugin.BinaryPath,
+				"plugins_dir", m.pluginsDir)
+		} else {
+			if err := os.RemoveAll(dir); err != nil {
+				slog.WarnContext(ctx, "uninstall: remove binary dir failed",
+					"dir", dir, "err", err)
+			} else {
+				binaryPathRemoved = true
+			}
+		}
+	}
+
+	nowStr := m.clock().UTC().Format(time.RFC3339Nano)
+	m.writeAuditEvent(ctx, auditPluginUninstalled, "info", nowStr, map[string]any{
+		"plugin_id":           pluginID,
+		"plugin_name":         plugin.Name,
+		"plugin_version":      plugin.PluginVersion,
+		"instance_count":      len(instances),
+		"binary_path_removed": binaryPathRemoved,
+	})
+	return nil
+}
+
+// writeAuditEvent inserts a plugin-level audit row with the calling user as
+// actor when one is on the request context. Failures are logged but not
+// surfaced — the upstream DB change has already committed.
+// This is InstanceLifecycle's own copy — it must NOT back-reference PluginHandler.
+func (m *InstanceLifecycle) writeAuditEvent(ctx context.Context, eventType, severity, nowStr string, payload map[string]any) {
+	caller, _ := auth.UserFromContext(ctx)
+	var actorUserID *string
+	if caller != nil {
+		actorUserID = &caller.ID
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	_, err := m.q.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+		PluginInstanceID: nil,
+		EventType:        eventType,
+		Severity:         severity,
+		ActorUserID:      actorUserID,
+		PayloadJson:      string(payloadJSON),
+		CreatedAt:        nowStr,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "audit event failed", "event_type", eventType, "err", err)
+	}
+}

--- a/internal/admin/instance_lifecycle_test.go
+++ b/internal/admin/instance_lifecycle_test.go
@@ -1,0 +1,646 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func newTestLifecycle(q PluginQuerier, store *db.Store, opts ...func(*InstanceLifecycleDeps)) *InstanceLifecycle {
+	deps := InstanceLifecycleDeps{
+		Q:     q,
+		Store: store,
+		Clock: func() time.Time { return time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC) },
+	}
+	for _, o := range opts {
+		o(&deps)
+	}
+	return NewInstanceLifecycle(deps)
+}
+
+func withProcMgr(pm PluginProcessManager) func(*InstanceLifecycleDeps) {
+	return func(d *InstanceLifecycleDeps) { d.ProcMgr = pm }
+}
+
+func withTrigger(t TriggerRestarter) func(*InstanceLifecycleDeps) {
+	return func(d *InstanceLifecycleDeps) { d.Trigger = t }
+}
+
+func withInflight(c InflightCounter) func(*InstanceLifecycleDeps) {
+	return func(d *InstanceLifecycleDeps) { d.Inflight = c }
+}
+
+func withPluginsDir(dir string) func(*InstanceLifecycleDeps) {
+	return func(d *InstanceLifecycleDeps) { d.PluginsDir = dir }
+}
+
+func withUnreg(u ToolUnregistrar) func(*InstanceLifecycleDeps) {
+	return func(d *InstanceLifecycleDeps) { d.Unreg = u }
+}
+
+// ─── Deactivate ──────────────────────────────────────────────────────────────
+
+func TestInstanceLifecycle_Deactivate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ErrPluginNotFound when plugin missing", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		m := newTestLifecycle(q, nil)
+		_, err := m.Deactivate(ctx, "nonexistent", "inst-1")
+		if !errors.Is(err, ErrPluginNotFound) {
+			t.Errorf("err = %v, want ErrPluginNotFound", err)
+		}
+	})
+
+	t.Run("ErrInstanceNotFound when instance missing", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		m := newTestLifecycle(q, nil)
+		_, err := m.Deactivate(ctx, "plugin-1", "nonexistent-inst")
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("ErrInstanceNotFound when instance belongs to different plugin", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-other", InstanceName: "prod", HealthState: "healthy"})
+		m := newTestLifecycle(q, nil)
+		_, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("ErrAlreadyInactive when already inactive", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "inactive"})
+		m := newTestLifecycle(q, nil)
+		_, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		if !errors.Is(err, ErrAlreadyInactive) {
+			t.Errorf("err = %v, want ErrAlreadyInactive", err)
+		}
+	})
+
+	t.Run("TerminalStateError for signature_invalid state", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "signature_invalid"})
+		m := newTestLifecycle(q, nil)
+		_, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		var termErr TerminalStateError
+		if !errors.As(err, &termErr) {
+			t.Errorf("err = %v, want TerminalStateError", err)
+		}
+	})
+
+	t.Run("TerminalStateError for verification_error state", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "verification_error"})
+		m := newTestLifecycle(q, nil)
+		_, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		var termErr TerminalStateError
+		if !errors.As(err, &termErr) {
+			t.Errorf("err = %v, want TerminalStateError", err)
+		}
+	})
+
+	t.Run("InflightError with Op=inflightOpDeactivate when calls in progress", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		m := newTestLifecycle(q, nil,
+			withInflight(&fakeInflightCounter{counts: map[string]int{"prod": 2}}),
+		)
+		_, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		var inflightErr InflightError
+		if !errors.As(err, &inflightErr) {
+			t.Errorf("err = %v, want InflightError", err)
+		}
+		if inflightErr.Count != 2 {
+			t.Errorf("InflightError.Count = %d, want 2", inflightErr.Count)
+		}
+		if inflightErr.Op != inflightOpDeactivate {
+			t.Errorf("InflightError.Op = %v, want inflightOpDeactivate", inflightErr.Op)
+		}
+	})
+
+	t.Run("happy path: transitions health to inactive, stops subprocess and trigger", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+
+		pm := &fakeProcessManager{}
+		restarter := &fakeTriggerRestarter{}
+		m := newTestLifecycle(q, nil,
+			withProcMgr(pm),
+			withTrigger(restarter),
+			withInflight(&fakeInflightCounter{counts: map[string]int{"prod": 0}}),
+		)
+
+		inst, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		if err != nil {
+			t.Fatalf("Deactivate: unexpected error: %v", err)
+		}
+		if inst.HealthState != "inactive" {
+			t.Errorf("HealthState = %q, want \"inactive\"", inst.HealthState)
+		}
+		// Subprocess must have been stopped.
+		pm.mu.Lock()
+		stopped := pm.stoppedIDs
+		pm.mu.Unlock()
+		if len(stopped) != 1 || stopped[0] != "inst-1" {
+			t.Errorf("Stop called with %v, want [inst-1]", stopped)
+		}
+	})
+
+	t.Run("ErrRefetchFailed when re-fetch after transition fails", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+		// GetPluginInstanceByID call order:
+		//   1. resolveLifecycleInstance (succeeds)
+		//   2. pluginstate.SetHealthState internally (succeeds)
+		//   3. re-fetch after transition (should fail → ErrRefetchFailed)
+		q.getInstanceErrAfterN["inst-1"] = 2
+
+		m := newTestLifecycle(q, nil,
+			withInflight(&fakeInflightCounter{counts: map[string]int{"prod": 0}}),
+		)
+		_, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		if !errors.Is(err, ErrRefetchFailed) {
+			t.Errorf("err = %v, want ErrRefetchFailed", err)
+		}
+	})
+
+	t.Run("nil inflight: proceeds without in-flight check", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy", Version: 0})
+		// No inflight dep — must not panic.
+		m := newTestLifecycle(q, nil)
+		_, err := m.Deactivate(ctx, "plugin-1", "inst-1")
+		if err != nil {
+			t.Fatalf("Deactivate: unexpected error: %v", err)
+		}
+	})
+}
+
+// ─── Activate ────────────────────────────────────────────────────────────────
+
+func TestInstanceLifecycle_Activate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ErrPluginNotFound when plugin missing", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		m := newTestLifecycle(q, nil)
+		_, err := m.Activate(ctx, "nonexistent", "inst-1")
+		if !errors.Is(err, ErrPluginNotFound) {
+			t.Errorf("err = %v, want ErrPluginNotFound", err)
+		}
+	})
+
+	t.Run("ErrInstanceNotFound when instance missing", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		m := newTestLifecycle(q, nil)
+		_, err := m.Activate(ctx, "plugin-1", "nonexistent-inst")
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("NotInactiveError when instance is healthy", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		m := newTestLifecycle(q, nil)
+		_, err := m.Activate(ctx, "plugin-1", "inst-1")
+		var notInactive NotInactiveError
+		if !errors.As(err, &notInactive) {
+			t.Errorf("err = %v, want NotInactiveError", err)
+		}
+		if notInactive.State != "healthy" {
+			t.Errorf("NotInactiveError.State = %q, want \"healthy\"", notInactive.State)
+		}
+	})
+
+	t.Run("happy path: transitions to unhealthy, spawns subprocess, starts trigger", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "inactive", Version: 0})
+
+		pm := &fakeProcessManager{}
+		restarter := &fakeTriggerRestarter{}
+		m := newTestLifecycle(q, nil,
+			withProcMgr(pm),
+			withTrigger(restarter),
+		)
+
+		inst, err := m.Activate(ctx, "plugin-1", "inst-1")
+		if err != nil {
+			t.Fatalf("Activate: unexpected error: %v", err)
+		}
+		if inst.HealthState != "unhealthy" {
+			t.Errorf("HealthState = %q, want \"unhealthy\"", inst.HealthState)
+		}
+		// Subprocess must have been started.
+		pm.mu.Lock()
+		started := pm.startedByPlugin
+		pm.mu.Unlock()
+		if len(started) != 1 || started[0] != "plugin-1" {
+			t.Errorf("StartByPluginID called with %v, want [plugin-1]", started)
+		}
+	})
+
+	t.Run("ErrRefetchFailed when re-fetch after transition fails", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "inactive", Version: 0})
+		// GetPluginInstanceByID call order:
+		//   1. resolveLifecycleInstance (succeeds)
+		//   2. pluginstate.SetHealthState internally (succeeds)
+		//   3. re-fetch after transition (should fail → ErrRefetchFailed)
+		q.getInstanceErrAfterN["inst-1"] = 2
+
+		m := newTestLifecycle(q, nil)
+		_, err := m.Activate(ctx, "plugin-1", "inst-1")
+		if !errors.Is(err, ErrRefetchFailed) {
+			t.Errorf("err = %v, want ErrRefetchFailed", err)
+		}
+	})
+
+	t.Run("nil procMgr: does not panic", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "inactive", Version: 0})
+		m := newTestLifecycle(q, nil) // no procMgr
+		_, err := m.Activate(ctx, "plugin-1", "inst-1")
+		if err != nil {
+			t.Fatalf("Activate: unexpected error: %v", err)
+		}
+	})
+}
+
+// ─── Delete ──────────────────────────────────────────────────────────────────
+
+func TestInstanceLifecycle_Delete(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ErrStoreUnavailable when store is nil", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		m := newTestLifecycle(q, nil) // no store
+		err := m.Delete(ctx, "plugin-1", "inst-1")
+		if !errors.Is(err, ErrStoreUnavailable) {
+			t.Errorf("err = %v, want ErrStoreUnavailable", err)
+		}
+	})
+
+	t.Run("ErrPluginNotFound when plugin missing", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		m := newTestLifecycle(q, store)
+		err := m.Delete(ctx, "nonexistent", "inst-1")
+		if !errors.Is(err, ErrPluginNotFound) {
+			t.Errorf("err = %v, want ErrPluginNotFound", err)
+		}
+	})
+
+	t.Run("ErrInstanceNotFound when instance missing", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		m := newTestLifecycle(q, store)
+		err := m.Delete(ctx, "plugin-1", "nonexistent-inst")
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("err = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("PolicyRefError when policies reference the instance", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "slack-prod", HealthState: "healthy"})
+		q.seedPolicy(db.Policy{
+			ID:   "pol-1",
+			Name: "Incident Policy",
+			Yaml: "trigger:\n  type: webhook\ncapabilities:\n  tools:\n    - tool: slack-prod.post_message\n",
+		})
+		m := newTestLifecycle(q, store)
+		err := m.Delete(ctx, "plugin-1", "inst-1")
+		var policyRef PolicyRefError
+		if !errors.As(err, &policyRef) {
+			t.Errorf("err = %v, want PolicyRefError", err)
+		}
+		if len(policyRef.Names) != 1 || policyRef.Names[0] != "Incident Policy" {
+			t.Errorf("PolicyRefError.Names = %v, want [Incident Policy]", policyRef.Names)
+		}
+	})
+
+	t.Run("AudienceRefError when audience entries reference the instance", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		q.seedAudienceEntries("inst-1", []db.ListAudienceEntriesByInstanceRow{
+			{ID: "ae-1", AudienceID: "aud-1", PluginInstanceID: "inst-1", AudienceName: "ops-audience"},
+		})
+		m := newTestLifecycle(q, store)
+		err := m.Delete(ctx, "plugin-1", "inst-1")
+		var audRef AudienceRefError
+		if !errors.As(err, &audRef) {
+			t.Errorf("err = %v, want AudienceRefError", err)
+		}
+		if len(audRef.Names) != 1 || audRef.Names[0] != "ops-audience" {
+			t.Errorf("AudienceRefError.Names = %v, want [ops-audience]", audRef.Names)
+		}
+	})
+
+	t.Run("AudienceRefError deduplicates audience names", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		// Two entries with the same audience name → deduplicated to one name.
+		q.seedAudienceEntries("inst-1", []db.ListAudienceEntriesByInstanceRow{
+			{ID: "ae-1", AudienceID: "aud-1", PluginInstanceID: "inst-1", AudienceName: "ops-audience"},
+			{ID: "ae-2", AudienceID: "aud-1", PluginInstanceID: "inst-1", AudienceName: "ops-audience"},
+		})
+		m := newTestLifecycle(q, store)
+		err := m.Delete(ctx, "plugin-1", "inst-1")
+		var audRef AudienceRefError
+		if !errors.As(err, &audRef) {
+			t.Errorf("err = %v, want AudienceRefError", err)
+		}
+		if len(audRef.Names) != 1 {
+			t.Errorf("AudienceRefError.Names = %v, want exactly 1 unique name", audRef.Names)
+		}
+	})
+
+	t.Run("InflightError with Op=inflightOpDelete when calls in progress", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		m := newTestLifecycle(q, store,
+			withInflight(&fakeInflightCounter{counts: map[string]int{"prod": 5}}),
+		)
+		err := m.Delete(ctx, "plugin-1", "inst-1")
+		var inflightErr InflightError
+		if !errors.As(err, &inflightErr) {
+			t.Errorf("err = %v, want InflightError", err)
+		}
+		if inflightErr.Op != inflightOpDelete {
+			t.Errorf("InflightError.Op = %v, want inflightOpDelete", inflightErr.Op)
+		}
+		if inflightErr.Count != 5 {
+			t.Errorf("InflightError.Count = %d, want 5", inflightErr.Count)
+		}
+	})
+
+	t.Run("happy path: subprocess stopped, row deleted, audit event emitted", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		seedStorePlugin(t, store, "plugin-1", "p", nil)
+		seedStoreInstance(t, store, "inst-1", "plugin-1", "prod")
+
+		pm := &fakeProcessManager{}
+		m := newTestLifecycle(q, store, withProcMgr(pm))
+		err := m.Delete(ctx, "plugin-1", "inst-1")
+		if err != nil {
+			t.Fatalf("Delete: unexpected error: %v", err)
+		}
+
+		// Subprocess must have been stopped.
+		pm.mu.Lock()
+		stopped := pm.stoppedIDs
+		pm.mu.Unlock()
+		if len(stopped) != 1 || stopped[0] != "inst-1" {
+			t.Errorf("Stop called with %v, want [inst-1]", stopped)
+		}
+
+		// Row must be removed from the real store.
+		if storeHasInstance(t, store, "inst-1") {
+			t.Error("instance should be deleted from store after Delete")
+		}
+
+		// Audit event must be emitted.
+		found := false
+		for _, ev := range q.auditEvents {
+			if ev.EventType == auditInstanceDeleted {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected plugin_instance_deleted audit event")
+		}
+	})
+
+	t.Run("succeeds with nil processManager (no panic)", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		seedStorePlugin(t, store, "plugin-1", "p", nil)
+		seedStoreInstance(t, store, "inst-1", "plugin-1", "prod")
+
+		m := newTestLifecycle(q, store) // nil procMgr
+		if err := m.Delete(ctx, "plugin-1", "inst-1"); err != nil {
+			t.Fatalf("Delete: unexpected error: %v", err)
+		}
+		if storeHasInstance(t, store, "inst-1") {
+			t.Error("instance should be deleted even with nil processManager")
+		}
+	})
+
+	t.Run("succeeds even when subprocess Stop returns error", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		seedStorePlugin(t, store, "plugin-1", "p", nil)
+		seedStoreInstance(t, store, "inst-1", "plugin-1", "prod")
+
+		pm := &fakeProcessManager{stopErr: errors.New("subprocess wedged")}
+		m := newTestLifecycle(q, store, withProcMgr(pm))
+		if err := m.Delete(ctx, "plugin-1", "inst-1"); err != nil {
+			t.Fatalf("Delete: unexpected error: %v", err)
+		}
+		if storeHasInstance(t, store, "inst-1") {
+			t.Error("instance should be deleted from store despite Stop failure")
+		}
+	})
+}
+
+// ─── Uninstall ───────────────────────────────────────────────────────────────
+
+func TestInstanceLifecycle_Uninstall(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ErrStoreUnavailable when store is nil", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		m := newTestLifecycle(q, nil) // no store
+		err := m.Uninstall(ctx, "plugin-1")
+		if !errors.Is(err, ErrStoreUnavailable) {
+			t.Errorf("err = %v, want ErrStoreUnavailable", err)
+		}
+	})
+
+	t.Run("ErrPluginNotFound when plugin missing", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		m := newTestLifecycle(q, store)
+		err := m.Uninstall(ctx, "nonexistent")
+		if !errors.Is(err, ErrPluginNotFound) {
+			t.Errorf("err = %v, want ErrPluginNotFound", err)
+		}
+	})
+
+	t.Run("InstancesRemainError when instances still exist", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "my-plugin", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-a", PluginID: "plugin-1", InstanceName: "slack-prod", HealthState: "healthy"})
+		q.seed(db.PluginInstance{ID: "inst-b", PluginID: "plugin-1", InstanceName: "slack-staging", HealthState: "healthy"})
+		m := newTestLifecycle(q, store)
+		err := m.Uninstall(ctx, "plugin-1")
+		var remainErr InstancesRemainError
+		if !errors.As(err, &remainErr) {
+			t.Errorf("err = %v, want InstancesRemainError", err)
+		}
+		if len(remainErr.Names) != 2 {
+			t.Errorf("InstancesRemainError.Names = %v, want 2 names", remainErr.Names)
+		}
+	})
+
+	t.Run("happy path with binary dir: plugin deleted, dir removed", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		pluginsDir := t.TempDir()
+		binaryDir := filepath.Join(pluginsDir, "installed", "my-plugin")
+		if err := os.MkdirAll(binaryDir, 0o755); err != nil {
+			t.Fatalf("create binary dir: %v", err)
+		}
+		binaryPath := filepath.Join(binaryDir, "my-plugin")
+		if err := os.WriteFile(binaryPath, []byte("fake binary"), 0o755); err != nil {
+			t.Fatalf("write binary: %v", err)
+		}
+		bp := binaryPath
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-2", Name: "my-plugin", ManifestSnapshot: instanceConfigManifestNoSchema, BinaryPath: &bp})
+		seedStorePlugin(t, store, "plugin-2", "my-plugin", &bp)
+
+		pm := &fakeProcessManager{}
+		m := newTestLifecycle(q, store, withProcMgr(pm), withPluginsDir(pluginsDir))
+		if err := m.Uninstall(ctx, "plugin-2"); err != nil {
+			t.Fatalf("Uninstall: unexpected error: %v", err)
+		}
+
+		if storeHasPlugin(t, store, "plugin-2") {
+			t.Error("plugin should be deleted from store after Uninstall")
+		}
+		if _, err := os.Stat(binaryDir); !os.IsNotExist(err) {
+			t.Errorf("expected binary dir to be removed, stat err: %v", err)
+		}
+
+		found := false
+		for _, ev := range q.auditEvents {
+			if ev.EventType == auditPluginUninstalled {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected plugin_uninstalled audit event")
+		}
+	})
+
+	t.Run("binary path outside pluginsDir: FS skipped, plugin still deleted", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		pluginsDir := t.TempDir()
+		outsidePath := filepath.Join("/tmp", "evil", "binary")
+		bp := outsidePath
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-evil", Name: "evil", ManifestSnapshot: instanceConfigManifestNoSchema, BinaryPath: &bp})
+		seedStorePlugin(t, store, "plugin-evil", "evil", &bp)
+
+		m := newTestLifecycle(q, store, withPluginsDir(pluginsDir))
+		if err := m.Uninstall(ctx, "plugin-evil"); err != nil {
+			t.Fatalf("Uninstall: unexpected error: %v", err)
+		}
+		if storeHasPlugin(t, store, "plugin-evil") {
+			t.Error("plugin should be deleted from store even when containment check fails")
+		}
+	})
+
+	t.Run("nil binary path: no FS op, plugin still deleted", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-2", Name: "no-binary", ManifestSnapshot: instanceConfigManifestNoSchema, BinaryPath: nil})
+		seedStorePlugin(t, store, "plugin-2", "no-binary", nil)
+
+		m := newTestLifecycle(q, store, withPluginsDir(t.TempDir()))
+		if err := m.Uninstall(ctx, "plugin-2"); err != nil {
+			t.Fatalf("Uninstall: unexpected error: %v", err)
+		}
+		if storeHasPlugin(t, store, "plugin-2") {
+			t.Error("plugin should be deleted even when binary_path is nil")
+		}
+	})
+
+	t.Run("nil processManager: succeeds without panic", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-3", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		seedStorePlugin(t, store, "plugin-3", "p", nil)
+
+		m := newTestLifecycle(q, store) // nil procMgr
+		if err := m.Uninstall(ctx, "plugin-3"); err != nil {
+			t.Fatalf("Uninstall: unexpected error: %v", err)
+		}
+	})
+
+	t.Run("InflightError Op field distinguishes Deactivate vs Delete", func(t *testing.T) {
+		// The InflightError returned by Deactivate uses inflightOpDeactivate,
+		// while Delete uses inflightOpDelete. This difference drives the handler's
+		// error message selection.
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
+		counter := &fakeInflightCounter{counts: map[string]int{"prod": 1}}
+
+		m := newTestLifecycle(q, nil, withInflight(counter))
+		_, deactivateErr := m.Deactivate(ctx, "plugin-1", "inst-1")
+		var deactivateInflight InflightError
+		if !errors.As(deactivateErr, &deactivateInflight) {
+			t.Fatalf("Deactivate: expected InflightError, got %v", deactivateErr)
+		}
+		if deactivateInflight.Op != inflightOpDeactivate {
+			t.Errorf("Deactivate InflightError.Op = %v, want inflightOpDeactivate", deactivateInflight.Op)
+		}
+
+		store := newPluginTestStore(t)
+		m2 := newTestLifecycle(q, store, withInflight(counter))
+		deleteErr := m2.Delete(ctx, "plugin-1", "inst-1")
+		var deleteInflight InflightError
+		if !errors.As(deleteErr, &deleteInflight) {
+			t.Fatalf("Delete: expected InflightError, got %v", deleteErr)
+		}
+		if deleteInflight.Op != inflightOpDelete {
+			t.Errorf("Delete InflightError.Op = %v, want inflightOpDelete", deleteInflight.Op)
+		}
+	})
+}

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -735,7 +735,6 @@ func (h *PluginHandler) unblockInstances(
 	return count
 }
 
-
 // resolveInstance fetches the instance row for instanceID and verifies that it
 // belongs to pluginID. On any error it writes the appropriate HTTP response and
 // returns false, so callers can early-return. This is the instance-first variant

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"gopkg.in/yaml.v3"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
 	"github.com/felag-engineering/gleipnir/internal/http/auth"
@@ -26,7 +25,6 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
 	pluginmanifest "github.com/felag-engineering/gleipnir/internal/plugin/manifest"
 	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
-	"github.com/felag-engineering/gleipnir/internal/policy"
 	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
 )
@@ -188,90 +186,55 @@ type RSSAggregator interface {
 	Aggregate() (totalBytes uint64, count int, perInstance []RSSSample)
 }
 
+// PluginHandlerDeps holds all constructor-injected dependencies for PluginHandler.
+// This replaces the 8 SetXxx late-bind setters (compile-checked per issue #504).
+//
+// processManager and pluginsDir are held by BOTH PluginHandler (for
+// CreateInstance/ApprovePlugin and RejectPlugin respectively) AND by the
+// InstanceLifecycle module. Wire the SAME instance/value to both from main.go.
+type PluginHandlerDeps struct {
+	Q              PluginQuerier
+	Publisher      event.Publisher
+	Clock          func() time.Time
+	Installer      PluginInstaller      // nil disables Install (503)
+	RSSAggregator  RSSAggregator        // nil disables GetPluginRSS (503)
+	ProcessManager PluginProcessManager // nil skips subprocess spawn in CreateInstance/ApprovePlugin
+	PluginsDir     string               // empty disables FS cleanup in RejectPlugin
+	Lifecycle      *InstanceLifecycle   // extracted lifecycle module
+	Config         *InstanceConfig      // extracted config module
+}
+
 // PluginHandler handles plugin-related admin endpoints.
 type PluginHandler struct {
-	q                PluginQuerier
-	publisher        event.Publisher
-	clock            func() time.Time
-	triggerRestarter TriggerRestarter     // may be nil if plugins are disabled
-	installer        PluginInstaller      // may be nil if GLEIPNIR_PLUGINS_ENABLED=false
-	store            *db.Store            // nil disables DeleteInstance and Uninstall (503)
-	pluginsDir       string               // empty disables FS cleanup in Uninstall
-	processManager   PluginProcessManager // nil means skip subprocess Stop
-	toolUnregistrar  ToolUnregistrar      // nil until #194 wires tools.Registrar
-	inflightCounter  InflightCounter      // may be nil; gates deactivate/delete on zero in-flight calls
-	rssAggregator    RSSAggregator        // nil when plugins are disabled; GetPluginRSS returns 503
+	q              PluginQuerier
+	publisher      event.Publisher
+	clock          func() time.Time
+	installer      PluginInstaller      // may be nil if GLEIPNIR_PLUGINS_ENABLED=false
+	pluginsDir     string               // empty disables FS cleanup in RejectPlugin
+	processManager PluginProcessManager // nil means skip subprocess spawn in CreateInstance/ApprovePlugin
+	rssAggregator  RSSAggregator        // nil when plugins are disabled; GetPluginRSS returns 503
+	lifecycle      *InstanceLifecycle   // owns Deactivate/Activate/Delete/Uninstall
+	config         *InstanceConfig      // owns PutSubscriptionScope/PutConfig/PutConfigProperty
 }
 
-// NewPluginHandler returns a PluginHandler backed by the given querier, event
-// publisher, and clock. publisher may be nil — events are skipped when nil.
-// clock may be nil — time.Now is used as the default.
-func NewPluginHandler(q PluginQuerier, publisher event.Publisher, clock func() time.Time) *PluginHandler {
-	if clock == nil {
-		clock = time.Now
+// NewPluginHandler constructs a PluginHandler from the given deps struct.
+// clock defaults to time.Now when nil. All other nil-able deps are nil-safe.
+func NewPluginHandler(deps PluginHandlerDeps) *PluginHandler {
+	clk := deps.Clock
+	if clk == nil {
+		clk = time.Now
 	}
-	return &PluginHandler{q: q, publisher: publisher, clock: clock}
-}
-
-// SetTriggerRestarter wires the TriggerRestarter (typically *plugintrigger.Supervisor)
-// into the handler after it is constructed. Called from main.go after the supervisor
-// is created so construction order does not create an import cycle.
-func (h *PluginHandler) SetTriggerRestarter(r TriggerRestarter) {
-	h.triggerRestarter = r
-}
-
-// SetInstaller wires the PluginInstaller into the handler. A nil installer
-// disables the Install endpoint (returns 503). Called from main.go after
-// loader.StartWatcher runs so plugins disabled mode is handled cleanly.
-func (h *PluginHandler) SetInstaller(inst PluginInstaller) {
-	h.installer = inst
-}
-
-// SetStore wires the *db.Store into the handler so DeleteInstance and Uninstall
-// can open transactions via store.DB().BeginTx. A nil store disables both
-// endpoints (returns 503). Called from main.go unconditionally because *db.Store
-// is always available — the transactional delete path needs it regardless of
-// whether the plugin subsystem is enabled.
-func (h *PluginHandler) SetStore(s *db.Store) {
-	h.store = s
-}
-
-// SetPluginsDir sets the plugins directory used for FS cleanup during Uninstall.
-// An empty string disables binary removal (DB rows are still deleted). Called
-// from main.go inside the plugins-enabled block.
-func (h *PluginHandler) SetPluginsDir(dir string) {
-	h.pluginsDir = dir
-}
-
-// SetProcessManager wires the PluginProcessManager so DeleteInstance and
-// Uninstall can stop subprocesses before clearing DB rows. A nil manager skips
-// subprocess stop (DB-only cleanup, matching the kitchen-sink recovery path).
-func (h *PluginHandler) SetProcessManager(pm PluginProcessManager) {
-	h.processManager = pm
-}
-
-// SetToolUnregistrar wires the ToolUnregistrar for post-delete tool-namespace
-// cleanup. Currently not called from main.go — tools.Registrar is not yet in
-// the live process path (see TODO at main.go). A nil unregistrar is a no-op.
-// When #194 wires tools.New(arbiter, ...), add the one-line wire-up there.
-func (h *PluginHandler) SetToolUnregistrar(u ToolUnregistrar) {
-	h.toolUnregistrar = u
-}
-
-// SetInflightCounter wires the InflightCounter (typically *dispatch.Pool) for
-// the in-flight gate in DeactivateInstance and DeleteInstance. A nil counter
-// skips the gate (safe default for tests and the GLEIPNIR_PLUGINS_ENABLED=false
-// path). Called from main.go inside the plugins-enabled block.
-func (h *PluginHandler) SetInflightCounter(ic InflightCounter) {
-	h.inflightCounter = ic
-}
-
-// SetRSSAggregator wires the RSSAggregator (a main.go adapter wrapping
-// *process.RSSSampler) into the handler. A nil aggregator disables
-// GetPluginRSS (returns 503). Called from main.go inside the plugins-enabled
-// block after the RSSSampler is constructed.
-func (h *PluginHandler) SetRSSAggregator(a RSSAggregator) {
-	h.rssAggregator = a
+	return &PluginHandler{
+		q:              deps.Q,
+		publisher:      deps.Publisher,
+		clock:          clk,
+		installer:      deps.Installer,
+		pluginsDir:     deps.PluginsDir,
+		processManager: deps.ProcessManager,
+		rssAggregator:  deps.RSSAggregator,
+		lifecycle:      deps.Lifecycle,
+		config:         deps.Config,
+	}
 }
 
 // pluginRSSResponse is the JSON shape returned by GetPluginRSS.
@@ -654,94 +617,12 @@ func (h *PluginHandler) PutSubscriptionScope(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	inst, ok := h.resolveInstance(ctx, w, pluginID, instanceID)
-	if !ok {
-		return
-	}
-
-	plugin, err := h.q.GetPluginByID(ctx, inst.PluginID)
-	if errors.Is(err, ErrNotFound) {
-		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
-		return
-	}
+	result, err := h.config.PutSubscriptionScope(ctx, pluginID, instanceID, req.Scope, *req.ExpectedVersion)
 	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
+		h.mapConfigError(w, err)
 		return
 	}
-
-	var m sdkmanifest.Manifest
-	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &m); parseErr != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "corrupt manifest snapshot", parseErr.Error())
-		return
-	}
-	if m.SubscriptionSchema == nil {
-		httputil.WriteError(w, http.StatusBadRequest, "plugin declares no subscription_schema", "")
-		return
-	}
-
-	validator, err := configvalidate.ForSubscriptionScope(&m)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to build scope validator", err.Error())
-		return
-	}
-	scope := req.Scope
-	if scope == nil {
-		scope = map[string]any{}
-	}
-	fieldErrs, err := validator.Validate(scope)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "validation error", err.Error())
-		return
-	}
-	if len(fieldErrs) > 0 {
-		httputil.WriteValidationError(w, http.StatusUnprocessableEntity, "validation failed", "", toErrorIssues(fieldErrs))
-		return
-	}
-
-	scopeBytes, err := json.Marshal(scope)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to marshal scope", err.Error())
-		return
-	}
-
-	nowStr := h.clock().UTC().Format(time.RFC3339)
-	rows, err := h.q.UpdatePluginInstanceSubscriptionScope(ctx, db.UpdatePluginInstanceSubscriptionScopeParams{
-		SubscriptionScopeJson: string(scopeBytes),
-		UpdatedAt:             nowStr,
-		ID:                    instanceID,
-		ExpectedVersion:       *req.ExpectedVersion,
-	})
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to update subscription scope", "")
-		return
-	}
-	if rows == 0 {
-		httputil.WriteError(w, http.StatusConflict, casConflictMsg, "")
-		return
-	}
-
-	// Ensure the trigger stream is running with the latest scope. Start is
-	// a no-op if already supervised; Restart cancels and re-opens so the
-	// plugin picks up the new scope. Both are needed because instances
-	// created after boot were never supervised by StartAll.
-	if h.triggerRestarter != nil {
-		h.triggerRestarter.Start(ctx, instanceID)
-		h.triggerRestarter.Restart(ctx, instanceID)
-	}
-
-	// Re-fetch to return the updated row. On failure synthesise the response
-	// from the pre-write snapshot + known deltas; secret fields must still be
-	// redacted in both paths (ADR-049).
-	updated, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if err != nil {
-		synthetic := inst
-		synthetic.Version++
-		synthetic.UpdatedAt = nowStr
-		synthetic.SubscriptionScopeJson = string(scopeBytes)
-		h.writeInstanceResponseWithRedaction(ctx, w, pluginID, synthetic)
-		return
-	}
-	h.writeInstanceResponseWithRedaction(ctx, w, pluginID, updated)
+	httputil.WriteJSON(w, http.StatusOK, result.Response)
 }
 
 // putInstanceConfigRequest is the JSON body for
@@ -771,147 +652,12 @@ func (h *PluginHandler) PutInstanceConfig(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	inst, ok := h.resolveInstance(ctx, w, pluginID, instanceID)
-	if !ok {
-		return
-	}
-
-	plugin, err := h.q.GetPluginByID(ctx, inst.PluginID)
-	if errors.Is(err, ErrNotFound) {
-		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
-		return
-	}
+	result, err := h.config.PutConfig(ctx, pluginID, instanceID, req.Config, *req.ExpectedVersion)
 	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
+		h.mapConfigError(w, err)
 		return
 	}
-
-	var m sdkmanifest.Manifest
-	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &m); parseErr != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "corrupt manifest snapshot", parseErr.Error())
-		return
-	}
-
-	// Derive the set of secret property names for sentinel rejection and
-	// response redaction (ADR-049).
-	secretNames, err := configvalidate.SecretPropertyNames(m.ConfigSchema)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to parse config schema", err.Error())
-		return
-	}
-
-	// ForInstanceConfig returns a validator that accepts anything when ConfigSchema is nil
-	// (per Q7 in the plan). Do NOT early-return on nil schema — it is valid.
-	validator, err := configvalidate.ForInstanceConfig(&m)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to build config validator", err.Error())
-		return
-	}
-	cfg := req.Config
-	if cfg == nil {
-		cfg = map[string]any{}
-	}
-	fieldErrs, err := validator.Validate(cfg)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "validation error", err.Error())
-		return
-	}
-	if len(fieldErrs) > 0 {
-		httputil.WriteValidationError(w, http.StatusUnprocessableEntity, "validation failed", "", toErrorIssues(fieldErrs))
-		return
-	}
-
-	// Reject any secret field whose submitted value is the redaction sentinel.
-	// This prevents the round-trip clobber: UI reads "***", user hits Save,
-	// real secret would be overwritten with the sentinel (ADR-049 §5).
-	if offenders := configvalidate.ContainsRedactionSentinel(cfg, secretNames); len(offenders) > 0 {
-		issues := make([]httputil.ErrorIssue, 0, len(offenders))
-		for _, field := range offenders {
-			issues = append(issues, httputil.ErrorIssue{
-				Field:   field,
-				Message: "value '***' is the redaction sentinel; submit the real secret or omit the field to leave it unchanged",
-			})
-		}
-		httputil.WriteValidationError(w, http.StatusBadRequest, "sentinel value rejected", "", issues)
-		return
-	}
-
-	configBytes, err := json.Marshal(cfg)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to marshal config", err.Error())
-		return
-	}
-
-	nowStr := h.clock().UTC().Format(time.RFC3339)
-	rows, err := h.q.UpdatePluginInstanceConfig(ctx, db.UpdatePluginInstanceConfigParams{
-		ConfigJson:      string(configBytes),
-		UpdatedAt:       nowStr,
-		ID:              instanceID,
-		ExpectedVersion: *req.ExpectedVersion,
-	})
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to update instance config", "")
-		return
-	}
-	if rows == 0 {
-		httputil.WriteError(w, http.StatusConflict, casConflictMsg, "")
-		return
-	}
-
-	// Compute the redacted form of the written config once. Both the re-fetch
-	// success branch and the fallback synthesized branch use this value so
-	// neither path can emit raw secret JSON (ADR-049 §7, §6).
-	redactedWrittenConfig, err := configvalidate.RedactSecrets(string(configBytes), secretNames)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to redact config", err.Error())
-		return
-	}
-
-	// Re-fetch to return the updated row.
-	updated, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if err != nil {
-		// The write succeeded; fall back to a synthesised response.
-		// Use the pre-computed redacted config — never the raw written bytes.
-		httputil.WriteJSON(w, http.StatusOK, instanceResponse{
-			ID:                    instanceID,
-			PluginID:              pluginID,
-			InstanceName:          inst.InstanceName,
-			State:                 inst.HealthState,
-			Detail:                inst.HealthDetail,
-			Version:               inst.Version + 1,
-			UpdatedAt:             nowStr,
-			SubscriptionScopeJson: inst.SubscriptionScopeJson,
-			ConfigJson:            redactedWrittenConfig,
-		})
-		return
-	}
-
-	// Advance the readiness detail (config_missing → credentials_missing → "")
-	// so the admin UI tells the operator what's still missing. Best-effort —
-	// the config write has already committed; advanceInstanceReadiness logs
-	// failures internally.
-	h.advanceInstanceReadiness(ctx, updated, &m)
-	if refreshed, refetchErr := h.q.GetPluginInstanceByID(ctx, instanceID); refetchErr == nil {
-		updated = refreshed
-	}
-
-	// Redact the re-fetched config before returning.
-	redactedFetchedConfig, err := configvalidate.RedactSecrets(updated.ConfigJson, secretNames)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to redact config", err.Error())
-		return
-	}
-	httputil.WriteJSON(w, http.StatusOK, instanceResponse{
-		ID:                    updated.ID,
-		PluginID:              updated.PluginID,
-		InstanceName:          updated.InstanceName,
-		State:                 updated.HealthState,
-		Detail:                updated.HealthDetail,
-		Version:               updated.Version,
-		UpdatedAt:             updated.UpdatedAt,
-		SubscriptionScopeJson: updated.SubscriptionScopeJson,
-		ConfigJson:            redactedFetchedConfig,
-	})
+	httputil.WriteJSON(w, http.StatusOK, result.Response)
 }
 
 // putInstanceConfigPropertyRequest is the JSON body for
@@ -947,169 +693,12 @@ func (h *PluginHandler) PutInstanceConfigProperty(w http.ResponseWriter, r *http
 		return
 	}
 
-	inst, ok := h.resolveInstance(ctx, w, pluginID, instanceID)
-	if !ok {
-		return
-	}
-
-	plugin, err := h.q.GetPluginByID(ctx, inst.PluginID)
-	if errors.Is(err, ErrNotFound) {
-		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
-		return
-	}
+	result, err := h.config.PutConfigProperty(ctx, pluginID, instanceID, property, req.Value, *req.ExpectedVersion)
 	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
+		h.mapConfigError(w, err)
 		return
 	}
-
-	var m sdkmanifest.Manifest
-	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &m); parseErr != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "corrupt manifest snapshot", parseErr.Error())
-		return
-	}
-
-	// Validate that the property name exists in the manifest's ConfigSchema.
-	// A property not in the schema cannot be set via this endpoint; use the
-	// bulk PUT for schema-less plugins.
-	if !propertyExistsInSchema(m.ConfigSchema, property) {
-		httputil.WriteError(w, http.StatusNotFound, "property not found in config_schema", "")
-		return
-	}
-
-	// Derive secret names for sentinel rejection and redaction (ADR-049).
-	secretNames, err := configvalidate.SecretPropertyNames(m.ConfigSchema)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to parse config schema", err.Error())
-		return
-	}
-
-	// Reject the redaction sentinel — the caller must supply the real value.
-	if strVal, isStr := req.Value.(string); isStr && strVal == configvalidate.RedactionSentinel {
-		httputil.WriteError(w, http.StatusBadRequest,
-			"value '***' is the redaction sentinel; submit the real secret",
-			"")
-		return
-	}
-
-	// Merge the new value into the existing config.
-	var cfg map[string]any
-	if inst.ConfigJson != "" && inst.ConfigJson != "{}" {
-		if err := json.Unmarshal([]byte(inst.ConfigJson), &cfg); err != nil {
-			httputil.WriteError(w, http.StatusInternalServerError, "failed to parse existing config", err.Error())
-			return
-		}
-	}
-	if cfg == nil {
-		cfg = map[string]any{}
-	}
-	cfg[property] = req.Value
-
-	// Validate the full merged config against the schema.
-	validator, err := configvalidate.ForInstanceConfig(&m)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to build config validator", err.Error())
-		return
-	}
-	fieldErrs, err := validator.Validate(cfg)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "validation error", err.Error())
-		return
-	}
-	if len(fieldErrs) > 0 {
-		httputil.WriteValidationError(w, http.StatusUnprocessableEntity, "validation failed", "", toErrorIssues(fieldErrs))
-		return
-	}
-
-	configBytes, err := json.Marshal(cfg)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to marshal config", err.Error())
-		return
-	}
-
-	nowStr := h.clock().UTC().Format(time.RFC3339)
-	rows, err := h.q.UpdatePluginInstanceConfig(ctx, db.UpdatePluginInstanceConfigParams{
-		ConfigJson:      string(configBytes),
-		UpdatedAt:       nowStr,
-		ID:              instanceID,
-		ExpectedVersion: *req.ExpectedVersion,
-	})
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to update instance config", "")
-		return
-	}
-	if rows == 0 {
-		httputil.WriteError(w, http.StatusConflict, casConflictMsg, "")
-		return
-	}
-
-	// Pre-compute the redacted form of the written config. Both the re-fetch
-	// success branch and the fallback synthesized branch use this value so
-	// neither path can emit raw secret JSON (ADR-049 §7).
-	redactedWrittenConfig, err := configvalidate.RedactSecrets(string(configBytes), secretNames)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to redact config", err.Error())
-		return
-	}
-
-	// Re-fetch to return the updated row.
-	updated, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if err != nil {
-		// The write succeeded; fall back to a synthesised response.
-		// Use the pre-computed redacted config — never the raw written bytes.
-		httputil.WriteJSON(w, http.StatusOK, instanceResponse{
-			ID:                    instanceID,
-			PluginID:              pluginID,
-			InstanceName:          inst.InstanceName,
-			State:                 inst.HealthState,
-			Detail:                inst.HealthDetail,
-			Version:               inst.Version + 1,
-			UpdatedAt:             nowStr,
-			SubscriptionScopeJson: inst.SubscriptionScopeJson,
-			ConfigJson:            redactedWrittenConfig,
-		})
-		return
-	}
-
-	// Redact the re-fetched config before returning.
-	redactedFetchedConfig, err := configvalidate.RedactSecrets(updated.ConfigJson, secretNames)
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to redact config", err.Error())
-		return
-	}
-	httputil.WriteJSON(w, http.StatusOK, instanceResponse{
-		ID:                    updated.ID,
-		PluginID:              updated.PluginID,
-		InstanceName:          updated.InstanceName,
-		State:                 updated.HealthState,
-		Detail:                updated.HealthDetail,
-		Version:               updated.Version,
-		UpdatedAt:             updated.UpdatedAt,
-		SubscriptionScopeJson: updated.SubscriptionScopeJson,
-		ConfigJson:            redactedFetchedConfig,
-	})
-}
-
-// propertyExistsInSchema returns true when the named property appears in the
-// root-level properties map of schemaNode. Returns false when schemaNode is nil
-// or has no properties key (including schema-less plugins).
-func propertyExistsInSchema(schemaNode *yaml.Node, property string) bool {
-	if schemaNode == nil {
-		return false
-	}
-	var schema map[string]any
-	if err := schemaNode.Decode(&schema); err != nil {
-		return false
-	}
-	propertiesRaw, ok := schema["properties"]
-	if !ok {
-		return false
-	}
-	propertiesMap, ok := propertiesRaw.(map[string]any)
-	if !ok {
-		return false
-	}
-	_, exists := propertiesMap[property]
-	return exists
+	httputil.WriteJSON(w, http.StatusOK, result.Response)
 }
 
 // unblockInstances transitions every instance of pluginID currently in fromState
@@ -1146,59 +735,6 @@ func (h *PluginHandler) unblockInstances(
 	return count
 }
 
-// computeInstanceReadinessDetail returns the appropriate health_detail string
-// for an instance that is sitting in PluginHealthStateUnhealthy, based on what
-// the operator still needs to configure. This is used after the operator saves
-// instance config or credentials so the admin UI tells them what's still
-// missing — without it, the detail stayed at "config_missing" forever even
-// after config was set, giving operators no signal what to do next.
-//
-// The returned string is empty when the instance has everything it needs and
-// is just waiting for the subprocess to come up healthy.
-func computeInstanceReadinessDetail(m *sdkmanifest.Manifest, configJSON string, credentialsPresent bool) string {
-	if configJSON == "" || configJSON == "{}" {
-		return "config_missing"
-	}
-	// Credentials are only required for auth strategies that consume them.
-	// "none" plugins (and unset strategy, which defaults to "none" in the parser)
-	// are config-only.
-	switch m.Auth.Strategy {
-	case "", sdkmanifest.AuthStrategyNone:
-		return "" // ready — subprocess will mark healthy on handshake
-	default:
-		if !credentialsPresent {
-			return "credentials_missing"
-		}
-		return "" // ready
-	}
-}
-
-// advanceInstanceReadiness re-evaluates the instance's readiness detail and
-// writes it back through SetHealthState if it has changed. Best-effort — any
-// failure is logged but not returned to the caller because the underlying
-// config/credentials write has already succeeded. Bypasses the update entirely
-// when the instance is not currently in unhealthy (e.g. already healthy, or
-// pending some other admin action).
-func (h *PluginHandler) advanceInstanceReadiness(ctx context.Context, inst db.PluginInstance, m *sdkmanifest.Manifest) {
-	if model.PluginHealthState(inst.HealthState) != model.PluginHealthStateUnhealthy {
-		return
-	}
-	credentialsPresent := inst.CredentialsEncrypted != nil && *inst.CredentialsEncrypted != ""
-	wanted := computeInstanceReadinessDetail(m, inst.ConfigJson, credentialsPresent)
-	var currentDetail string
-	if inst.HealthDetail != nil {
-		currentDetail = *inst.HealthDetail
-	}
-	if wanted == currentDetail {
-		return
-	}
-	err := pluginstate.SetHealthState(ctx, h.q, h.publisher, inst.ID, pluginstate.OriginHost,
-		model.PluginHealthStateUnhealthy, wanted)
-	if err != nil && !errors.Is(err, pluginstate.ErrTransitionConflict) {
-		slog.WarnContext(ctx, "advanceInstanceReadiness: set health detail failed",
-			"instance_id", inst.ID, "from", currentDetail, "to", wanted, "err", err)
-	}
-}
 
 // resolveInstance fetches the instance row for instanceID and verifies that it
 // belongs to pluginID. On any error it writes the appropriate HTTP response and
@@ -1246,6 +782,128 @@ func joinNames[T any](items []T, name func(T) string) string {
 		names[i] = name(item)
 	}
 	return strings.Join(names, ", ")
+}
+
+// mapLifecycleError maps a typed error from InstanceLifecycle to the EXACT
+// current HTTP status code and response body. Every distinct string here was
+// verified against the old inline handlers (ERROR SURFACE in plan.md).
+func (h *PluginHandler) mapLifecycleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrStoreUnavailable):
+		httputil.WriteError(w, http.StatusServiceUnavailable, "plugin management not configured", "")
+	case errors.Is(err, ErrPluginNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
+	case errors.Is(err, ErrInstanceNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
+	case errors.Is(err, ErrAlreadyInactive):
+		httputil.WriteError(w, http.StatusConflict, "instance is already deactivated", "")
+	case errors.Is(err, ErrRefetchFailed):
+		httputil.WriteError(w, http.StatusInternalServerError, "state transition succeeded but re-fetch failed", "")
+	default:
+		var termErr TerminalStateError
+		if errors.As(err, &termErr) {
+			httputil.WriteError(w, http.StatusConflict,
+				"cannot deactivate instance in terminal state",
+				fmt.Sprintf("current state: %s", termErr.State))
+			return
+		}
+		var inflightErr InflightError
+		if errors.As(err, &inflightErr) {
+			switch inflightErr.Op {
+			case inflightOpDeactivate:
+				httputil.WriteError(w, http.StatusConflict,
+					"cannot deactivate while tool calls are in progress",
+					fmt.Sprintf("%d in-flight calls", inflightErr.Count))
+			default: // inflightOpDelete
+				httputil.WriteError(w, http.StatusConflict,
+					"instance has in-flight tool calls",
+					fmt.Sprintf("%d in-flight calls", inflightErr.Count))
+			}
+			return
+		}
+		var notInactiveErr NotInactiveError
+		if errors.As(err, &notInactiveErr) {
+			httputil.WriteError(w, http.StatusConflict,
+				"instance is not deactivated",
+				fmt.Sprintf("current state: %s", notInactiveErr.State))
+			return
+		}
+		var policyRefErr PolicyRefError
+		if errors.As(err, &policyRefErr) {
+			httputil.WriteError(w, http.StatusConflict,
+				"instance is referenced by policies",
+				strings.Join(policyRefErr.Names, ", "))
+			return
+		}
+		var audienceRefErr AudienceRefError
+		if errors.As(err, &audienceRefErr) {
+			httputil.WriteError(w, http.StatusConflict,
+				"instance is referenced by audiences",
+				strings.Join(audienceRefErr.Names, ", "))
+			return
+		}
+		var instancesRemainErr InstancesRemainError
+		if errors.As(err, &instancesRemainErr) {
+			httputil.WriteError(w, http.StatusConflict,
+				"all instances must be removed before uninstalling the plugin",
+				strings.Join(instancesRemainErr.Names, ", "))
+			return
+		}
+		var internalErr *lifecycleInternalError
+		if errors.As(err, &internalErr) {
+			httputil.WriteError(w, http.StatusInternalServerError, internalErr.PublicMsg, internalErr.Detail)
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, err.Error(), "")
+	}
+}
+
+// mapConfigError maps a typed error from InstanceConfig to the EXACT current
+// HTTP status code and response body. Every distinct string here was verified
+// against the old inline handlers (ERROR SURFACE in plan.md).
+func (h *PluginHandler) mapConfigError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrInstanceNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
+	case errors.Is(err, ErrPluginNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
+	case errors.Is(err, ErrPropertyNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "property not found in config_schema", "")
+	case errors.Is(err, ErrNoSubscriptionSchema):
+		httputil.WriteError(w, http.StatusBadRequest, "plugin declares no subscription_schema", "")
+	case errors.Is(err, ErrCASConflict):
+		httputil.WriteError(w, http.StatusConflict, casConflictMsg, "")
+	default:
+		var corruptErr CorruptManifestError
+		if errors.As(err, &corruptErr) {
+			httputil.WriteError(w, http.StatusInternalServerError, "corrupt manifest snapshot", corruptErr.Detail)
+			return
+		}
+		var valErr configValidationError
+		if errors.As(err, &valErr) {
+			httputil.WriteValidationError(w, http.StatusUnprocessableEntity, "validation failed", "", toErrorIssues(valErr.Issues))
+			return
+		}
+		var sentinelErr SentinelRejectedError
+		if errors.As(err, &sentinelErr) {
+			if sentinelErr.Single {
+				// Per-property endpoint: plain error, exact current message.
+				httputil.WriteError(w, http.StatusBadRequest,
+					"value '***' is the redaction sentinel; submit the real secret", "")
+			} else {
+				// Bulk PUT: validation-style response with issues slice.
+				issues := toErrorIssues(sentinelErr.Issues)
+				httputil.WriteValidationError(w, http.StatusBadRequest, "sentinel value rejected", "", issues)
+			}
+			return
+		}
+		var internalErr *configInternalError
+		if errors.As(err, &internalErr) {
+			httputil.WriteError(w, http.StatusInternalServerError, internalErr.PublicMsg, internalErr.Detail)
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, err.Error(), "")
+	}
 }
 
 // writeAuditEvent inserts a plugin-level audit row (PluginInstanceID = nil) with
@@ -1348,98 +1006,11 @@ func (h *PluginHandler) DeactivateInstance(w http.ResponseWriter, r *http.Reques
 	pluginID := chi.URLParam(r, "id")
 	instanceID := chi.URLParam(r, "iid")
 
-	if _, err := h.q.GetPluginByID(ctx, pluginID); err != nil {
-		if errors.Is(err, ErrNotFound) {
-			httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
-		} else {
-			httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
-		}
-		return
-	}
-
-	inst, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if errors.Is(err, ErrNotFound) {
-		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
-		return
-	}
+	updated, err := h.lifecycle.Deactivate(ctx, pluginID, instanceID)
 	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to get instance", "")
+		h.mapLifecycleError(w, err)
 		return
 	}
-	if inst.PluginID != pluginID {
-		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
-		return
-	}
-
-	current := model.PluginHealthState(inst.HealthState)
-
-	if current == model.PluginHealthStateInactive {
-		httputil.WriteError(w, http.StatusConflict, "instance is already deactivated", "")
-		return
-	}
-
-	// Terminal states cannot transition to inactive (state machine enforces this,
-	// but we surface a clear error here before hitting ErrIllegalTransition).
-	if current == model.PluginHealthStateSignatureInvalid || current == model.PluginHealthStateVerificationError {
-		httputil.WriteError(w, http.StatusConflict,
-			"cannot deactivate instance in terminal state",
-			fmt.Sprintf("current state: %s", current))
-		return
-	}
-
-	// Gate on zero in-flight tool calls. TOCTOU is acceptable here: a new call
-	// arriving after this check will fail at the dispatch layer once the subprocess
-	// is stopped. The gate prevents disrupting calls that are actively running.
-	if h.inflightCounter != nil {
-		count := h.inflightCounter.InflightCountByInstance(inst.InstanceName)
-		if count > 0 {
-			httputil.WriteError(w, http.StatusConflict,
-				"cannot deactivate while tool calls are in progress",
-				fmt.Sprintf("%d in-flight calls", count))
-			return
-		}
-	}
-
-	if err := pluginstate.SetHealthState(ctx, h.q, h.publisher, instanceID, pluginstate.OriginHost,
-		model.PluginHealthStateInactive, "deactivated by admin"); err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to set health state", err.Error())
-		return
-	}
-
-	// Best-effort subprocess stop (5s deadline — same pattern as DeleteInstance).
-	if h.processManager != nil {
-		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		if err := h.processManager.Stop(stopCtx, instanceID); err != nil {
-			slog.WarnContext(ctx, "deactivate instance: subprocess stop failed",
-				"instance_id", instanceID, "err", err)
-		}
-		cancel()
-	}
-
-	// Best-effort trigger stream stop.
-	if h.triggerRestarter != nil {
-		h.triggerRestarter.Stop(instanceID)
-	}
-
-	nowStr := h.clock().UTC().Format(time.RFC3339Nano)
-	h.writeAuditEvent(ctx, auditInstanceDeactivated, "info", nowStr, map[string]any{
-		"plugin_id":     pluginID,
-		"instance_id":   instanceID,
-		"instance_name": inst.InstanceName,
-	})
-
-	// Re-fetch to return the current row after the state transition.
-	updated, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if err != nil {
-		// State write succeeded but the re-fetch failed. Return 500 — the client
-		// can re-fetch via GET. We must not synthesize a response here because
-		// config_json may contain unredacted secrets (ADR-049).
-		slog.WarnContext(ctx, "deactivate instance: re-fetch after transition failed",
-			"instance_id", instanceID, "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "state transition succeeded but re-fetch failed", "")
-		return
-	}
-
 	h.writeInstanceResponseWithRedaction(ctx, w, pluginID, updated)
 }
 
@@ -1460,76 +1031,11 @@ func (h *PluginHandler) ActivateInstance(w http.ResponseWriter, r *http.Request)
 	pluginID := chi.URLParam(r, "id")
 	instanceID := chi.URLParam(r, "iid")
 
-	if _, err := h.q.GetPluginByID(ctx, pluginID); err != nil {
-		if errors.Is(err, ErrNotFound) {
-			httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
-		} else {
-			httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
-		}
-		return
-	}
-
-	inst, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if errors.Is(err, ErrNotFound) {
-		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
-		return
-	}
+	updated, err := h.lifecycle.Activate(ctx, pluginID, instanceID)
 	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to get instance", "")
+		h.mapLifecycleError(w, err)
 		return
 	}
-	if inst.PluginID != pluginID {
-		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
-		return
-	}
-
-	if model.PluginHealthState(inst.HealthState) != model.PluginHealthStateInactive {
-		httputil.WriteError(w, http.StatusConflict,
-			"instance is not deactivated",
-			fmt.Sprintf("current state: %s", inst.HealthState))
-		return
-	}
-
-	// Transition to unhealthy first. The subprocess handshake will drive the
-	// state to healthy once the process comes up.
-	if err := pluginstate.SetHealthState(ctx, h.q, h.publisher, instanceID, pluginstate.OriginHost,
-		model.PluginHealthStateUnhealthy, "reactivated by admin"); err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to set health state", err.Error())
-		return
-	}
-
-	// Best-effort subprocess spawn. StartByPluginID spawns all instances for the
-	// plugin; siblings already running return "already running" (swallowed internally).
-	if h.processManager != nil {
-		if err := h.processManager.StartByPluginID(context.Background(), pluginID); err != nil {
-			slog.WarnContext(ctx, "activate instance: spawn failed", "plugin_id", pluginID, "err", err)
-		}
-	}
-
-	// Best-effort trigger stream start.
-	if h.triggerRestarter != nil {
-		h.triggerRestarter.Start(ctx, instanceID)
-	}
-
-	nowStr := h.clock().UTC().Format(time.RFC3339Nano)
-	h.writeAuditEvent(ctx, auditInstanceActivated, "info", nowStr, map[string]any{
-		"plugin_id":     pluginID,
-		"instance_id":   instanceID,
-		"instance_name": inst.InstanceName,
-	})
-
-	// Re-fetch to return the current row after the state transition.
-	updated, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if err != nil {
-		// State write succeeded but the re-fetch failed. Return 500 — the client
-		// can re-fetch via GET. We must not synthesize a response here because
-		// config_json may contain unredacted secrets (ADR-049).
-		slog.WarnContext(ctx, "activate instance: re-fetch after transition failed",
-			"instance_id", instanceID, "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "state transition succeeded but re-fetch failed", "")
-		return
-	}
-
 	h.writeInstanceResponseWithRedaction(ctx, w, pluginID, updated)
 }
 
@@ -1773,303 +1279,42 @@ func (h *PluginHandler) CreateInstance(w http.ResponseWriter, r *http.Request) {
 //   - 204 — deleted
 //   - 404 — plugin or instance not found (also returned on plugin/instance mismatch)
 //   - 409 — audience or policy references still exist
-//   - 503 — plugin store not configured (SetStore not called)
+//   - 503 — plugin store not configured (store == nil)
 //   - 500 — DB or unexpected error
 func (h *PluginHandler) DeleteInstance(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		httputil.WriteError(w, http.StatusServiceUnavailable, "plugin management not configured", "")
-		return
-	}
 	ctx := r.Context()
 	pluginID := chi.URLParam(r, "id")
 	instanceID := chi.URLParam(r, "iid")
 
-	// Verify the instance exists and belongs to the given plugin.
-	if _, err := h.q.GetPluginByID(ctx, pluginID); err != nil {
-		if errors.Is(err, ErrNotFound) {
-			httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
-		} else {
-			httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
-		}
+	if err := h.lifecycle.Delete(ctx, pluginID, instanceID); err != nil {
+		h.mapLifecycleError(w, err)
 		return
 	}
-	inst, err := h.q.GetPluginInstanceByID(ctx, instanceID)
-	if errors.Is(err, ErrNotFound) {
-		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
-		return
-	}
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to get instance", "")
-		return
-	}
-	// Return 404 (not 403) on a plugin/instance mismatch to avoid leaking
-	// instance existence across plugins.
-	if inst.PluginID != pluginID {
-		httputil.WriteError(w, http.StatusNotFound, "instance not found", "")
-		return
-	}
-
-	// Policy reference guard: refuse deletion if any policy still references
-	// this instance's tools or subscribed trigger. TOCTOU with concurrent policy
-	// create is acceptable — mirrors the audience-delete precedent.
-	policyRefs, err := policy.ScanPolicyToolRefsForInstance(ctx, h.q, inst.InstanceName)
-	if err != nil {
-		slog.ErrorContext(ctx, "delete instance: scan policy refs", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	if len(policyRefs) > 0 {
-		httputil.WriteError(w, http.StatusConflict, "instance is referenced by policies",
-			joinNames(policyRefs, func(r policy.ToolPolicyRef) string { return r.Name }))
-		return
-	}
-
-	// Audience reference guard: refuse deletion if any audience entry references
-	// this instance (the operator must update audiences first).
-	audienceEntries, err := h.q.ListAudienceEntriesByInstance(ctx, instanceID)
-	if err != nil {
-		slog.ErrorContext(ctx, "delete instance: list audience entries", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	if len(audienceEntries) > 0 {
-		// Deduplicate audience names — one instance can appear in multiple entries
-		// of the same audience.
-		seen := make(map[string]bool)
-		var audienceNames []string
-		for _, ae := range audienceEntries {
-			if !seen[ae.AudienceName] {
-				seen[ae.AudienceName] = true
-				audienceNames = append(audienceNames, ae.AudienceName)
-			}
-		}
-		httputil.WriteError(w, http.StatusConflict,
-			"instance is referenced by audiences", strings.Join(audienceNames, ", "))
-		return
-	}
-
-	// In-flight gate: refuse deletion if tool calls are actively dispatched to
-	// this instance. TOCTOU is acceptable — mirrors the policy/audience guards.
-	if h.inflightCounter != nil {
-		count := h.inflightCounter.InflightCountByInstance(inst.InstanceName)
-		if count > 0 {
-			httputil.WriteError(w, http.StatusConflict,
-				"instance has in-flight tool calls",
-				fmt.Sprintf("%d in-flight calls", count))
-			return
-		}
-	}
-
-	// Best-effort subprocess stop before DB cleanup so in-flight RPCs don't hit
-	// a half-deleted instance. A wedged subprocess must not block DB cleanup.
-	if h.processManager != nil {
-		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		if err := h.processManager.Stop(stopCtx, instanceID); err != nil {
-			slog.WarnContext(ctx, "delete instance: subprocess stop failed",
-				"instance_id", instanceID, "err", err)
-		}
-		cancel()
-	}
-
-	// Transactional delete in FK-safe order:
-	//   1. plugin_pending_requests (RESTRICT FK — must clear first)
-	//   2. plugin_oauth_nonces (instance_id FK)
-	//   3. plugin_instances row (audit events use SET NULL so history survives)
-	tx, err := h.store.DB().BeginTx(ctx, nil)
-	if err != nil {
-		slog.ErrorContext(ctx, "delete instance: begin tx", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	defer func() {
-		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
-			slog.ErrorContext(ctx, "delete instance: rollback failed", "err", rbErr)
-		}
-	}()
-
-	q := db.New(tx)
-	if err := q.DeletePluginPendingRequestsByInstance(ctx, instanceID); err != nil {
-		slog.ErrorContext(ctx, "delete instance: clear pending requests", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	if err := q.DeletePluginOAuthNoncesByInstance(ctx, instanceID); err != nil {
-		slog.ErrorContext(ctx, "delete instance: clear oauth nonces", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	if _, err := q.DeletePluginInstance(ctx, instanceID); err != nil {
-		slog.ErrorContext(ctx, "delete instance: delete row", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	if err := tx.Commit(); err != nil {
-		slog.ErrorContext(ctx, "delete instance: commit", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-
-	// Best-effort tool-namespace release. Nil-safe: not yet wired in main.go
-	// (see SetToolUnregistrar godoc and TODO at main.go). #194 follow-up will
-	// add the one-line wire-up.
-	if h.toolUnregistrar != nil {
-		h.toolUnregistrar.UnregisterInstance(ctx, inst.InstanceName)
-	}
-
-	nowStr := h.clock().UTC().Format(time.RFC3339Nano)
-	h.writeAuditEvent(ctx, auditInstanceDeleted, "info", nowStr, map[string]any{
-		"plugin_id":     pluginID,
-		"instance_id":   instanceID,
-		"instance_name": inst.InstanceName,
-	})
-
 	w.WriteHeader(http.StatusNoContent)
 }
 
 // Uninstall handles DELETE /api/v1/admin/plugins/{id}.
 //
-// Validates that no policies or audience entries reference any of the plugin's
-// instances, stops all subprocesses (best-effort), removes pending requests and
-// OAuth nonces for every instance in a transaction, then removes the plugin row
-// (which cascades to plugin_instances). After the commit, removes the plugin
-// binary directory from disk (best-effort, containment-checked). Emits an audit
-// event on success.
+// Validates that no instances remain, stops all subprocesses (best-effort),
+// removes pending requests and OAuth nonces for every instance in a transaction,
+// then removes the plugin row (which cascades to plugin_instances). After the
+// commit, removes the plugin binary directory from disk (best-effort,
+// containment-checked). Emits an audit event on success.
 //
 // Status codes:
 //   - 204 — uninstalled
 //   - 404 — plugin not found
-//   - 409 — audience or policy references still exist
-//   - 503 — plugin store not configured (SetStore not called)
+//   - 409 — instances still exist
+//   - 503 — plugin store not configured (store == nil)
 //   - 500 — DB or unexpected error
 func (h *PluginHandler) Uninstall(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		httputil.WriteError(w, http.StatusServiceUnavailable, "plugin management not configured", "")
-		return
-	}
 	ctx := r.Context()
 	pluginID := chi.URLParam(r, "id")
 
-	plugin, err := h.q.GetPluginByID(ctx, pluginID)
-	if errors.Is(err, ErrNotFound) {
-		httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
+	if err := h.lifecycle.Uninstall(ctx, pluginID); err != nil {
+		h.mapLifecycleError(w, err)
 		return
 	}
-	if err != nil {
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to get plugin", "")
-		return
-	}
-
-	// Collect all instances. Per the issue (#243): removing the plugin (binary +
-	// manifest) requires all instances to be removed first — per-instance
-	// DeleteInstance enforces the policy/audience/in-flight gates individually.
-	// This simpler gate avoids duplicating those checks here.
-	instances, err := h.q.ListPluginInstancesByPlugin(ctx, pluginID)
-	if err != nil {
-		slog.ErrorContext(ctx, "uninstall: list instances", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-
-	if len(instances) > 0 {
-		httputil.WriteError(w, http.StatusConflict,
-			"all instances must be removed before uninstalling the plugin",
-			joinNames(instances, func(inst db.PluginInstance) string { return inst.InstanceName }))
-		return
-	}
-
-	// Best-effort: stop all running subprocesses before clearing rows.
-	if h.processManager != nil {
-		stopCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		if err := h.processManager.StopByPluginID(stopCtx, pluginID); err != nil {
-			slog.WarnContext(ctx, "uninstall: stop subprocesses failed",
-				"plugin_id", pluginID, "err", err)
-		}
-		cancel()
-	}
-
-	// Transactional delete:
-	//   1. For each instance: clear pending requests + OAuth nonces (RESTRICT FKs).
-	//   2. DeletePlugin — cascades to plugin_instances via ON DELETE CASCADE.
-	tx, err := h.store.DB().BeginTx(ctx, nil)
-	if err != nil {
-		slog.ErrorContext(ctx, "uninstall: begin tx", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	defer func() {
-		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
-			slog.ErrorContext(ctx, "uninstall: rollback failed", "err", rbErr)
-		}
-	}()
-
-	q := db.New(tx)
-	for _, inst := range instances {
-		if err := q.DeletePluginPendingRequestsByInstance(ctx, inst.ID); err != nil {
-			slog.ErrorContext(ctx, "uninstall: clear pending requests",
-				"instance_id", inst.ID, "err", err)
-			httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-			return
-		}
-		if err := q.DeletePluginOAuthNoncesByInstance(ctx, inst.ID); err != nil {
-			slog.ErrorContext(ctx, "uninstall: clear oauth nonces",
-				"instance_id", inst.ID, "err", err)
-			httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-			return
-		}
-	}
-	if _, err := q.DeletePlugin(ctx, pluginID); err != nil {
-		slog.ErrorContext(ctx, "uninstall: delete plugin", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-	if err := tx.Commit(); err != nil {
-		slog.ErrorContext(ctx, "uninstall: commit", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-
-	// Best-effort tool-namespace release for each instance. Nil-safe.
-	if h.toolUnregistrar != nil {
-		for _, inst := range instances {
-			h.toolUnregistrar.UnregisterInstance(ctx, inst.InstanceName)
-		}
-	}
-
-	// Post-commit: remove the binary directory from disk.
-	// Containment check (fail-closed per ADR-001): only remove paths that are
-	// strictly within pluginsDir. A path that starts with ".." after filepath.Rel
-	// is a traversal attempt — we refuse and log a warning.
-	//
-	// Note: if the fsnotify watcher is mid-publishBundle at the moment of
-	// RemoveAll, the newly extracted bundle may land with a nil binary_path.
-	// In that case the operator may need to re-install via the upload endpoint.
-	binaryPathRemoved := false
-	if plugin.BinaryPath != nil && h.pluginsDir != "" {
-		dir := filepath.Dir(*plugin.BinaryPath)
-		rel, relErr := filepath.Rel(h.pluginsDir, dir)
-		if relErr != nil || strings.HasPrefix(rel, "..") {
-			slog.WarnContext(ctx, "uninstall: binary path escapes plugins dir — skipping removal",
-				"binary_path", *plugin.BinaryPath,
-				"plugins_dir", h.pluginsDir)
-		} else {
-			if err := os.RemoveAll(dir); err != nil {
-				slog.WarnContext(ctx, "uninstall: remove binary dir failed",
-					"dir", dir, "err", err)
-			} else {
-				binaryPathRemoved = true
-			}
-		}
-	}
-
-	nowStr := h.clock().UTC().Format(time.RFC3339Nano)
-	h.writeAuditEvent(ctx, auditPluginUninstalled, "info", nowStr, map[string]any{
-		"plugin_id":           pluginID,
-		"plugin_name":         plugin.Name,
-		"plugin_version":      plugin.PluginVersion,
-		"instance_count":      len(instances),
-		"binary_path_removed": binaryPathRemoved,
-	})
-
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/admin/plugin_handler_install_test.go
+++ b/internal/admin/plugin_handler_install_test.go
@@ -180,10 +180,13 @@ func TestPluginHandler_Install(t *testing.T) {
 			if tt.seedPlugin != nil {
 				q.seedPlugin(*tt.seedPlugin)
 			}
-			h := NewPluginHandler(q, nil, fixedClock)
+			var inst PluginInstaller
 			if tt.installer != nil {
-				h.SetInstaller(tt.installer)
+				inst = tt.installer
 			}
+			h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+				installer: inst,
+			})
 
 			rec := serveInstall(h, tt.body)
 
@@ -321,7 +324,7 @@ func TestPluginHandler_CreateInstance(t *testing.T) {
 				q.createInstanceErr = tt.createInstanceErr
 			}
 
-			h := NewPluginHandler(q, nil, fixedClock)
+			h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 			rec := serveCreateInstance(h, pluginID, []byte(tt.body))
 
 			if rec.Code != tt.wantStatus {
@@ -377,8 +380,7 @@ func TestPluginHandler_CreateInstance(t *testing.T) {
 			Status:        "active",
 		})
 		pm := &fakeProcessManager{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetProcessManager(pm)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{procMgr: pm})
 
 		rec := serveCreateInstance(h, pluginID, []byte(`{"instance_name":"spawn-test"}`))
 		if rec.Code != http.StatusCreated {
@@ -402,8 +404,7 @@ func TestPluginHandler_CreateInstance(t *testing.T) {
 			Status:        "active",
 		})
 		pm := &fakeProcessManager{startErr: errors.New("binary not found")}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetProcessManager(pm)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{procMgr: pm})
 
 		rec := serveCreateInstance(h, pluginID, []byte(`{"instance_name":"spawn-fail-test"}`))
 		// The row was created; spawn failure must not retroactively change the status.
@@ -420,8 +421,8 @@ func TestPluginHandler_CreateInstance(t *testing.T) {
 			PluginVersion: "0.1.0",
 			Status:        "active",
 		})
-		h := NewPluginHandler(q, nil, fixedClock)
-		// No SetProcessManager — simulates GLEIPNIR_PLUGINS_ENABLED=false path.
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
+		// No processManager — simulates GLEIPNIR_PLUGINS_ENABLED=false path.
 
 		rec := serveCreateInstance(h, pluginID, []byte(`{"instance_name":"no-pm-test"}`))
 		if rec.Code != http.StatusCreated {
@@ -438,8 +439,7 @@ func TestPluginHandler_CreateInstance(t *testing.T) {
 			Status:        "active",
 		})
 		pm := &fakeProcessManager{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetProcessManager(pm)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{procMgr: pm})
 
 		// Empty instance_name triggers a 400 before the DB insert.
 		rec := serveCreateInstance(h, pluginID, []byte(`{"instance_name":""}`))

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -326,6 +326,50 @@ func (f *fakePluginQuerier) seedPolicy(p db.Policy) {
 	f.policies = append(f.policies, p)
 }
 
+// testPluginHandlerConfig holds optional dependencies for newTestPluginHandler.
+// Zero-value is safe: all fields are nil-able and treated as no-op.
+type testPluginHandlerConfig struct {
+	store      *db.Store
+	procMgr    PluginProcessManager
+	trigger    TriggerRestarter
+	inflight   InflightCounter
+	unreg      ToolUnregistrar
+	pluginsDir string
+	installer  PluginInstaller
+	rssAgg     RSSAggregator
+}
+
+// newTestPluginHandler builds InstanceLifecycle + InstanceConfig + PluginHandler
+// from a single querier and clock, wiring all optional deps from cfg. It is the
+// shared constructor for all ~97 test sites so a future API change touches one
+// place, not 97.
+func newTestPluginHandler(q PluginQuerier, clock func() time.Time, cfg testPluginHandlerConfig) *PluginHandler {
+	lifecycle := NewInstanceLifecycle(InstanceLifecycleDeps{
+		Q:          q,
+		Store:      cfg.store,
+		ProcMgr:    cfg.procMgr,
+		Trigger:    cfg.trigger,
+		Inflight:   cfg.inflight,
+		Unreg:      cfg.unreg,
+		PluginsDir: cfg.pluginsDir,
+	})
+	instanceConfig := NewInstanceConfig(InstanceConfigDeps{
+		Q:       q,
+		Trigger: cfg.trigger,
+		Clock:   clock,
+	})
+	return NewPluginHandler(PluginHandlerDeps{
+		Q:              q,
+		Clock:          clock,
+		Installer:      cfg.installer,
+		RSSAggregator:  cfg.rssAgg,
+		ProcessManager: cfg.procMgr,
+		PluginsDir:     cfg.pluginsDir,
+		Lifecycle:      lifecycle,
+		Config:         instanceConfig,
+	})
+}
+
 func TestPluginHandler_GetInstance(t *testing.T) {
 	detail := "verified by host"
 
@@ -392,7 +436,7 @@ func TestPluginHandler_GetInstance(t *testing.T) {
 					ManifestSnapshot: instanceConfigManifestNoSchema,
 				})
 			}
-			h := NewPluginHandler(q, nil, nil)
+			h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins/"+tt.pluginID+"/instances/"+tt.instanceID, nil)
 			req = withChiParams(req, map[string]string{"id": tt.pluginID, "iid": tt.instanceID})
@@ -447,7 +491,7 @@ func TestGetInstance_RedactsSecretConfigField(t *testing.T) {
 		UpdatedAt:    "2026-01-01T00:00:00Z",
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
 	rec := httptest.NewRecorder()
@@ -494,7 +538,7 @@ func TestGetInstance_ManifestParseFails_500(t *testing.T) {
 		UpdatedAt:   "2026-01-01T00:00:00Z",
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
 	rec := httptest.NewRecorder()
@@ -523,7 +567,7 @@ func TestPutInstanceConfig_RejectsSentinelInSecretField(t *testing.T) {
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	// Submitting "***" for a secret field must be rejected.
 	body := `{"config":{"app_level_token":"***"},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -555,7 +599,7 @@ func TestPutInstanceConfig_AllowsSentinelInNonSecretField(t *testing.T) {
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{"any_field":"***"},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -587,7 +631,7 @@ func TestPutInstanceConfig_ResponseRedactsWrittenSecret(t *testing.T) {
 		UpdatedAt:   "2026-01-01T00:00:00Z",
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{"app_level_token":"xapp-real-secret"},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -652,7 +696,7 @@ func TestPutInstanceConfig_FallbackResponseRedactsWrittenSecret(t *testing.T) {
 	})
 
 	q := &failOnSecondGetInstance{fakePluginQuerier: base, targetID: "inst-1"}
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 
 	body := `{"config":{"app_level_token":"xapp-real-secret"},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -698,7 +742,7 @@ func TestPutInstanceConfigProperty_HappyPath(t *testing.T) {
 		UpdatedAt:   "2026-01-01T00:00:00Z",
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"value":"xapp-new-real-token","expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1", "property": "app_level_token"})
@@ -751,7 +795,7 @@ func TestPutInstanceConfigProperty_UnknownProperty(t *testing.T) {
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"value":"whatever","expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1", "property": "nonexistent_field"})
@@ -780,7 +824,7 @@ func TestPutInstanceConfigProperty_RejectsSentinelValue(t *testing.T) {
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"value":"***","expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1", "property": "app_level_token"})
@@ -810,7 +854,7 @@ func TestPutInstanceConfigProperty_VersionConflict(t *testing.T) {
 	})
 	q.configCASFailOnID = "inst-1"
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"value":"xapp-new","expected_version":5}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1", "property": "app_level_token"})
@@ -843,7 +887,7 @@ func TestPutInstanceConfigProperty_FallbackResponseRedactsWrittenSecret(t *testi
 	})
 
 	q := &failOnSecondGetInstance{fakePluginQuerier: base, targetID: "inst-1"}
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 
 	body := `{"value":"xapp-real-secret","expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -897,7 +941,7 @@ func TestPluginHandler_AcceptNewKey(t *testing.T) {
 		_, newB64 := makeTestPubkey(t)
 		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/accept-new-key", bytes.NewBufferString(body))
 		req = withChiParams(req, map[string]string{"id": "plugin-1"})
 		rec := httptest.NewRecorder()
@@ -950,7 +994,7 @@ func TestPluginHandler_AcceptNewKey(t *testing.T) {
 		_, newB64 := makeTestPubkey(t)
 		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-2/accept-new-key", bytes.NewBufferString(body))
 		req = withChiParams(req, map[string]string{"id": "plugin-2"})
 		rec := httptest.NewRecorder()
@@ -986,7 +1030,7 @@ func TestPluginHandler_AcceptNewKey(t *testing.T) {
 		oldPubkey, _ := makeTestPubkey(t)
 		q.seedPlugin(db.Plugin{ID: "plugin-3", Name: "p", TrustedPubkey: string(oldPubkey), Version: 0})
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 
 		// Not valid base64.
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"candidate_pubkey": "not-valid-base64!!!"}`))
@@ -1013,7 +1057,7 @@ func TestPluginHandler_AcceptNewKey(t *testing.T) {
 		_, newB64 := makeTestPubkey(t)
 		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 		req = withChiParams(req, map[string]string{"id": "nonexistent"})
 		rec := httptest.NewRecorder()
@@ -1033,7 +1077,7 @@ func TestPluginHandler_AcceptNewKey(t *testing.T) {
 		_, newB64 := makeTestPubkey(t)
 		body := fmt.Sprintf(`{"candidate_pubkey": %q}`, newB64)
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 		req = withChiParams(req, map[string]string{"id": "plugin-4"})
 		rec := httptest.NewRecorder()
@@ -1097,7 +1141,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		// Seed the pending manifest row as if a material change was previously detected.
 		q.seedPendingManifest("plugin-1", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/accept-manifest", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-1"})
 		rec := httptest.NewRecorder()
@@ -1151,7 +1195,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		})
 		q.seedPendingManifest("plugin-2", []byte(v2ManifestWithRequiredField), "1.0.0", "2.0.0")
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-2/accept-manifest", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-2"})
 		rec := httptest.NewRecorder()
@@ -1183,7 +1227,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-3", Name: "test-plugin", ManifestSnapshot: v1ManifestYAML, Version: 0})
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-3/accept-manifest", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-3"})
 		rec := httptest.NewRecorder()
@@ -1197,7 +1241,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 	t.Run("plugin not found returns 404", func(t *testing.T) {
 		q := newFakePluginQuerier()
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/nonexistent/accept-manifest", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "nonexistent"})
 		rec := httptest.NewRecorder()
@@ -1220,7 +1264,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		q.seedPendingManifest("plugin-4", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 		q.casFailOn = "plugin-4" // trigger CAS miss on UpdatePluginManifest
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-4/accept-manifest", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-4"})
 		rec := httptest.NewRecorder()
@@ -1243,7 +1287,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		})
 		q.seedPendingManifest("plugin-5", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-5/accept-manifest", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-5"})
 		// Inject an authenticated user so AcceptManifest can record actor_user_id.
@@ -1300,7 +1344,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		// Only the target plugin has a pending manifest row.
 		q.seedPendingManifest("plugin-target", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-target"})
 		rec := httptest.NewRecorder()
@@ -1329,7 +1373,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		})
 		// No pending manifest row seeded.
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-nopending"})
 		rec := httptest.NewRecorder()
@@ -1352,7 +1396,7 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 		})
 		q.seedPendingManifest("plugin-twiceaccept", []byte(v2ManifestYAML), "1.0.0", "2.0.0")
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		// First accept succeeds and deletes the pending row.
 		req1 := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
 		req1 = withChiParams(req1, map[string]string{"id": "plugin-twiceaccept"})
@@ -1420,8 +1464,7 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 		})
 
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{trigger: restarter})
 
 		body := `{"scope":{"channels":["#incidents","#ops"]},"expected_version":2}`
 		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -1447,9 +1490,8 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 
 	t.Run("400 missing expected_version", func(t *testing.T) {
 		q := newFakePluginQuerier()
-		h := NewPluginHandler(q, nil, fixedClock)
 		restarter := &fakeTriggerRestarter{}
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{trigger: restarter})
 
 		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(`{"scope":{}}`))
 		req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -1480,8 +1522,7 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 		})
 
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{trigger: restarter})
 
 		body := `{"scope":{"channels":["#a"]},"expected_version":0}`
 		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -1513,8 +1554,7 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 		})
 
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{trigger: restarter})
 
 		// "channels" is required but absent; additionalProperties:false means extra keys are rejected.
 		body := `{"scope":{"bad_field":"x"},"expected_version":0}`
@@ -1548,8 +1588,7 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 		q.scopeCASFailOnID = "inst-4"
 
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{trigger: restarter})
 
 		// Send expected_version=5 but scopeCASFailOnID will force 0 rows.
 		body := `{"scope":{"channels":["#x"]},"expected_version":5}`
@@ -1575,7 +1614,7 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 			Version:     0,
 		})
 
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 
 		body := `{"scope":{},"expected_version":0}`
 		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -1609,8 +1648,7 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 		})
 
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{trigger: restarter})
 
 		body := `{"scope":{"channels":["#alerts"]},"expected_version":1}`
 		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -1664,8 +1702,7 @@ func TestPluginHandler_PutSubscriptionScope(t *testing.T) {
 		q.getInstanceErrAfterN["inst-sec2"] = 1
 
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{trigger: restarter})
 
 		body := `{"scope":{"channels":["#alerts"]},"expected_version":1}`
 		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -1722,7 +1759,7 @@ func TestPluginHandler_PutInstanceConfig_HappyPath(t *testing.T) {
 		UpdatedAt:    "2026-01-01T00:00:00Z",
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{"app_level_token":"xapp-1-test"},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -1766,7 +1803,7 @@ func TestPluginHandler_PutInstanceConfig_ValidationFailure_422(t *testing.T) {
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	// Missing required app_level_token.
 	body := `{"config":{},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -1796,7 +1833,7 @@ func TestPluginHandler_PutInstanceConfig_NoSchema_AcceptsAnyObject(t *testing.T)
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{"any":"value","nested":{"x":1}},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -1811,7 +1848,7 @@ func TestPluginHandler_PutInstanceConfig_NoSchema_AcceptsAnyObject(t *testing.T)
 func TestPluginHandler_PutInstanceConfig_MissingExpectedVersion_400(t *testing.T) {
 	fixedClock := func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
 	q := newFakePluginQuerier()
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 
 	body := `{"config":{"app_level_token":"tok"}}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
@@ -1842,7 +1879,7 @@ func TestPluginHandler_PutInstanceConfig_CASConflict_409(t *testing.T) {
 	})
 	q.configCASFailOnID = "inst-1"
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{},"expected_version":5}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -1858,7 +1895,7 @@ func TestPluginHandler_PutInstanceConfig_InstanceNotFound_404(t *testing.T) {
 	fixedClock := func() time.Time { return time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC) }
 	q := newFakePluginQuerier()
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-missing"})
@@ -1880,7 +1917,7 @@ func TestPluginHandler_PutInstanceConfig_PluginIDMismatch_404(t *testing.T) {
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -1909,7 +1946,7 @@ func TestPluginHandler_PutInstanceConfig_MalformedManifest_500(t *testing.T) {
 		Version:     0,
 	})
 
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 	body := `{"config":{},"expected_version":0}`
 	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
 	req = withChiParams(req, map[string]string{"id": "plugin-1", "iid": "inst-1"})
@@ -1962,7 +1999,7 @@ func TestPluginHandler_DeactivateInstance(t *testing.T) {
 
 	t.Run("404 unknown plugin", func(t *testing.T) {
 		q := newFakePluginQuerier()
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveDeactivateInstance(h, "nonexistent-plugin", "inst-1")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 for unknown plugin", rec.Code)
@@ -1972,7 +2009,7 @@ func TestPluginHandler_DeactivateInstance(t *testing.T) {
 	t.Run("404 unknown instance", func(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveDeactivateInstance(h, "plugin-1", "nonexistent-inst")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 for unknown instance", rec.Code)
@@ -1983,7 +2020,7 @@ func TestPluginHandler_DeactivateInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-other", InstanceName: "prod", HealthState: "healthy"})
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveDeactivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 on plugin/instance mismatch", rec.Code)
@@ -1994,7 +2031,7 @@ func TestPluginHandler_DeactivateInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "inactive"})
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveDeactivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409 when already inactive", rec.Code)
@@ -2005,7 +2042,7 @@ func TestPluginHandler_DeactivateInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "signature_invalid"})
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveDeactivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409 for terminal state", rec.Code)
@@ -2019,8 +2056,7 @@ func TestPluginHandler_DeactivateInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetInflightCounter(&fakeInflightCounter{counts: map[string]int{"prod": 3}})
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{inflight: &fakeInflightCounter{counts: map[string]int{"prod": 3}}})
 		rec := serveDeactivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409 for in-flight calls", rec.Code)
@@ -2041,10 +2077,11 @@ func TestPluginHandler_DeactivateInstance(t *testing.T) {
 
 		pm := &fakeProcessManager{}
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetProcessManager(pm)
-		h.SetTriggerRestarter(restarter)
-		h.SetInflightCounter(&fakeInflightCounter{counts: map[string]int{"prod": 0}})
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			procMgr:  pm,
+			trigger:  restarter,
+			inflight: &fakeInflightCounter{counts: map[string]int{"prod": 0}},
+		})
 
 		rec := serveDeactivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusOK {
@@ -2083,7 +2120,7 @@ func TestPluginHandler_ActivateInstance(t *testing.T) {
 
 	t.Run("404 unknown plugin", func(t *testing.T) {
 		q := newFakePluginQuerier()
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveActivateInstance(h, "nonexistent-plugin", "inst-1")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 for unknown plugin", rec.Code)
@@ -2093,7 +2130,7 @@ func TestPluginHandler_ActivateInstance(t *testing.T) {
 	t.Run("404 unknown instance", func(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveActivateInstance(h, "plugin-1", "nonexistent-inst")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 for unknown instance", rec.Code)
@@ -2104,7 +2141,7 @@ func TestPluginHandler_ActivateInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-other", InstanceName: "prod", HealthState: "inactive"})
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveActivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 on plugin/instance mismatch", rec.Code)
@@ -2115,7 +2152,7 @@ func TestPluginHandler_ActivateInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveActivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409 when not inactive", rec.Code)
@@ -2132,9 +2169,10 @@ func TestPluginHandler_ActivateInstance(t *testing.T) {
 
 		pm := &fakeProcessManager{}
 		restarter := &fakeTriggerRestarter{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetProcessManager(pm)
-		h.SetTriggerRestarter(restarter)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			procMgr: pm,
+			trigger: restarter,
+		})
 
 		rec := serveActivateInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusOK {
@@ -2227,7 +2265,7 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 
 	t.Run("503 when store is nil", func(t *testing.T) {
 		q := newFakePluginQuerier()
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		// store not wired: DeleteInstance must return 503.
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusServiceUnavailable {
@@ -2238,8 +2276,7 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 	t.Run("404 unknown plugin", func(t *testing.T) {
 		store := newPluginTestStore(t)
 		q := newFakePluginQuerier()
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 		rec := serveDeleteInstance(h, "nonexistent-plugin", "inst-1")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 for unknown plugin", rec.Code)
@@ -2250,8 +2287,7 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 		store := newPluginTestStore(t)
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 		rec := serveDeleteInstance(h, "plugin-1", "nonexistent-inst")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 for unknown instance", rec.Code)
@@ -2263,8 +2299,7 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-other", InstanceName: "prod", HealthState: "healthy"})
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 on plugin/instance mismatch", rec.Code)
@@ -2276,9 +2311,10 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 		q := newFakePluginQuerier()
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-1", PluginID: "plugin-1", InstanceName: "prod", HealthState: "healthy"})
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
-		h.SetInflightCounter(&fakeInflightCounter{counts: map[string]int{"prod": 3}})
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			store:    store,
+			inflight: &fakeInflightCounter{counts: map[string]int{"prod": 3}},
+		})
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409 for in-flight calls", rec.Code)
@@ -2297,8 +2333,7 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 			{ID: "ae-1", AudienceID: "aud-1", PluginInstanceID: "inst-1", AudienceName: "ops-audience"},
 			{ID: "ae-2", AudienceID: "aud-1", PluginInstanceID: "inst-1", AudienceName: "ops-audience"},
 		})
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409 for audience reference", rec.Code)
@@ -2320,8 +2355,7 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 			Name: "Slack Policy",
 			Yaml: "trigger:\n  type: webhook\ncapabilities:\n  tools:\n    - tool: slack-prod.post_message\n",
 		})
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409 for policy reference", rec.Code)
@@ -2342,9 +2376,10 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 		seedStoreInstance(t, store, "inst-1", "plugin-1", "prod")
 
 		pm := &fakeProcessManager{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
-		h.SetProcessManager(pm)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			store:   store,
+			procMgr: pm,
+		})
 
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusNoContent {
@@ -2386,9 +2421,10 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 		seedStoreInstance(t, store, "inst-1", "plugin-1", "prod")
 
 		pm := &fakeProcessManager{stopErr: errors.New("subprocess wedged")}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
-		h.SetProcessManager(pm)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			store:   store,
+			procMgr: pm,
+		})
 
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
 		if rec.Code != http.StatusNoContent {
@@ -2408,8 +2444,7 @@ func TestPluginHandler_DeleteInstance(t *testing.T) {
 		seedStorePlugin(t, store, "plugin-1", "p", nil)
 		seedStoreInstance(t, store, "inst-1", "plugin-1", "prod")
 
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 		// No processManager set — must not panic.
 
 		rec := serveDeleteInstance(h, "plugin-1", "inst-1")
@@ -2427,7 +2462,7 @@ func TestPluginHandler_Uninstall(t *testing.T) {
 
 	t.Run("503 when store is nil", func(t *testing.T) {
 		q := newFakePluginQuerier()
-		h := NewPluginHandler(q, nil, fixedClock)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 		rec := serveUninstall(h, "plugin-1")
 		if rec.Code != http.StatusServiceUnavailable {
 			t.Errorf("status = %d, want 503 when store is nil", rec.Code)
@@ -2437,8 +2472,7 @@ func TestPluginHandler_Uninstall(t *testing.T) {
 	t.Run("404 unknown plugin", func(t *testing.T) {
 		store := newPluginTestStore(t)
 		q := newFakePluginQuerier()
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 		rec := serveUninstall(h, "nonexistent")
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404 for unknown plugin", rec.Code)
@@ -2454,8 +2488,7 @@ func TestPluginHandler_Uninstall(t *testing.T) {
 		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "my-plugin", ManifestSnapshot: instanceConfigManifestNoSchema})
 		q.seed(db.PluginInstance{ID: "inst-a", PluginID: "plugin-1", InstanceName: "slack-prod", HealthState: "healthy"})
 		q.seed(db.PluginInstance{ID: "inst-b", PluginID: "plugin-1", InstanceName: "slack-staging", HealthState: "healthy"})
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 
 		rec := serveUninstall(h, "plugin-1")
 		if rec.Code != http.StatusConflict {
@@ -2498,10 +2531,11 @@ func TestPluginHandler_Uninstall(t *testing.T) {
 		seedStorePlugin(t, store, "plugin-2", "my-plugin", &bp)
 
 		pm := &fakeProcessManager{}
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
-		h.SetProcessManager(pm)
-		h.SetPluginsDir(pluginsDir)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			store:      store,
+			procMgr:    pm,
+			pluginsDir: pluginsDir,
+		})
 
 		rec := serveUninstall(h, "plugin-2")
 		if rec.Code != http.StatusNoContent {
@@ -2547,9 +2581,10 @@ func TestPluginHandler_Uninstall(t *testing.T) {
 		// Seed real store so DELETE finds the row.
 		seedStorePlugin(t, store, "plugin-2", "no-binary", nil)
 
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
-		h.SetPluginsDir(t.TempDir())
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			store:      store,
+			pluginsDir: t.TempDir(),
+		})
 
 		rec := serveUninstall(h, "plugin-2")
 		if rec.Code != http.StatusNoContent {
@@ -2576,9 +2611,10 @@ func TestPluginHandler_Uninstall(t *testing.T) {
 		})
 		seedStorePlugin(t, store, "plugin-evil", "evil", &bp)
 
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
-		h.SetPluginsDir(pluginsDir)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{
+			store:      store,
+			pluginsDir: pluginsDir,
+		})
 
 		rec := serveUninstall(h, "plugin-evil")
 		if rec.Code != http.StatusNoContent {
@@ -2596,8 +2632,7 @@ func TestPluginHandler_Uninstall(t *testing.T) {
 		q.seedPlugin(db.Plugin{ID: "plugin-3", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
 		seedStorePlugin(t, store, "plugin-3", "p", nil)
 
-		h := NewPluginHandler(q, nil, fixedClock)
-		h.SetStore(store)
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{store: store})
 
 		rec := serveUninstall(h, "plugin-3")
 		if rec.Code != http.StatusNoContent {
@@ -2715,7 +2750,7 @@ func TestApprovePlugin_HappyPath(t *testing.T) {
 		Status:           "pending_review",
 		Version:          0,
 	})
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/approve", nil)
 	req = withChiParams(req, map[string]string{"id": "plugin-1"})
@@ -2759,7 +2794,7 @@ func TestApprovePlugin_HappyPath(t *testing.T) {
 
 func TestApprovePlugin_NotFound(t *testing.T) {
 	q := newFakePluginQuerier()
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "missing-plugin"})
@@ -2781,7 +2816,7 @@ func TestApprovePlugin_AlreadyActive(t *testing.T) {
 		Status:           "active",
 		Version:          0,
 	})
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "plugin-1"})
@@ -2806,7 +2841,7 @@ func TestRejectPlugin_HappyPath(t *testing.T) {
 		Status:           "pending_review",
 		Version:          0,
 	})
-	h := NewPluginHandler(q, nil, fixedClock)
+	h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "plugin-1"})
@@ -2846,7 +2881,7 @@ func TestRejectPlugin_HappyPath(t *testing.T) {
 
 func TestRejectPlugin_NotFound(t *testing.T) {
 	q := newFakePluginQuerier()
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "missing-plugin"})
@@ -2868,7 +2903,7 @@ func TestRejectPlugin_AlreadyActive(t *testing.T) {
 		Status:           "active",
 		Version:          0,
 	})
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "plugin-1"})
@@ -2913,7 +2948,7 @@ func TestGetPluginDetail_HappyPath(t *testing.T) {
 		Version:          0,
 		CreatedAt:        "2026-01-01T00:00:00Z",
 	})
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins/plugin-1", nil)
 	req = withChiParams(req, map[string]string{"id": "plugin-1"})
@@ -2970,7 +3005,7 @@ func TestGetPluginDetail_HappyPath(t *testing.T) {
 
 func TestGetPluginDetail_NotFound(t *testing.T) {
 	q := newFakePluginQuerier()
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req = withChiParams(req, map[string]string{"id": "missing"})
@@ -2986,7 +3021,7 @@ func TestGetPluginDetail_NotFound(t *testing.T) {
 
 func TestListPlugins_Empty(t *testing.T) {
 	q := newFakePluginQuerier()
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins", nil)
 	rec := httptest.NewRecorder()
@@ -3034,7 +3069,7 @@ func TestListPlugins_MixedStatuses(t *testing.T) {
 		HealthState:  "healthy",
 		Version:      0,
 	})
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins", nil)
 	rec := httptest.NewRecorder()
@@ -3090,7 +3125,7 @@ func (s *stubRSSAggregator) Aggregate() (uint64, int, []RSSSample) {
 }
 
 func TestPluginHandler_GetPluginRSS_NilAggregator(t *testing.T) {
-	h := NewPluginHandler(newFakePluginQuerier(), nil, nil)
+	h := newTestPluginHandler(newFakePluginQuerier(), nil, testPluginHandlerConfig{})
 	// No aggregator wired — plugins are disabled.
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins/rss", nil)
@@ -3125,8 +3160,7 @@ func TestPluginHandler_GetPluginRSS_WithData(t *testing.T) {
 		},
 	}
 
-	h := NewPluginHandler(newFakePluginQuerier(), nil, nil)
-	h.SetRSSAggregator(agg)
+	h := newTestPluginHandler(newFakePluginQuerier(), nil, testPluginHandlerConfig{rssAgg: agg})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins/rss", nil)
 	rec := httptest.NewRecorder()
@@ -3161,8 +3195,7 @@ func TestPluginHandler_GetPluginRSS_WithData(t *testing.T) {
 func TestPluginHandler_GetPluginRSS_ZeroInstances(t *testing.T) {
 	agg := &stubRSSAggregator{total: 0, count: 0, samples: nil}
 
-	h := NewPluginHandler(newFakePluginQuerier(), nil, nil)
-	h.SetRSSAggregator(agg)
+	h := newTestPluginHandler(newFakePluginQuerier(), nil, testPluginHandlerConfig{rssAgg: agg})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plugins/rss", nil)
 	rec := httptest.NewRecorder()
@@ -3267,7 +3300,7 @@ func TestGetPluginSBOM_Success(t *testing.T) {
 		BinaryPath:       &binaryPath,
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	rec := serveGetSBOM(h, "plugin-sbom")
 
 	if rec.Code != http.StatusOK {
@@ -3282,7 +3315,7 @@ func TestGetPluginSBOM_Success(t *testing.T) {
 }
 
 func TestGetPluginSBOM_NotFound_NoPlugin(t *testing.T) {
-	h := NewPluginHandler(newFakePluginQuerier(), nil, nil)
+	h := newTestPluginHandler(newFakePluginQuerier(), nil, testPluginHandlerConfig{})
 	rec := serveGetSBOM(h, "plugin-missing")
 
 	if rec.Code != http.StatusNotFound {
@@ -3299,7 +3332,7 @@ func TestGetPluginSBOM_NotFound_NoBinaryPath(t *testing.T) {
 		BinaryPath:       nil, // no bundle on disk
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	rec := serveGetSBOM(h, "plugin-nobinary")
 
 	if rec.Code != http.StatusNotFound {
@@ -3319,7 +3352,7 @@ func TestGetPluginSBOM_NotFound_NoSBOMField(t *testing.T) {
 		BinaryPath:       &binaryPath,
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	rec := serveGetSBOM(h, "plugin-nosbom")
 
 	if rec.Code != http.StatusNotFound {
@@ -3340,7 +3373,7 @@ func TestGetPluginSBOM_NotFound_FileMissing(t *testing.T) {
 		BinaryPath:       &binaryPath,
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	rec := serveGetSBOM(h, "plugin-filemissing")
 
 	if rec.Code != http.StatusNotFound {
@@ -3360,7 +3393,7 @@ func TestGetPluginSBOM_PathTraversal(t *testing.T) {
 		BinaryPath:       &binaryPath,
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	rec := serveGetSBOM(h, "plugin-traversal")
 
 	if rec.Code != http.StatusNotFound {
@@ -3384,7 +3417,7 @@ func TestGetPluginSBOM_FallbackContentType(t *testing.T) {
 		BinaryPath:       &binaryPath,
 	})
 
-	h := NewPluginHandler(q, nil, nil)
+	h := newTestPluginHandler(q, nil, testPluginHandlerConfig{})
 	rec := serveGetSBOM(h, "plugin-spdx")
 
 	if rec.Code != http.StatusOK {

--- a/main.go
+++ b/main.go
@@ -372,12 +372,12 @@ func run(cfg config.Config) error {
 	// InstanceLifecycleDeps AND the PluginHandlerDeps — both holders use the
 	// one shared instance (plan §DEPS THAT STAY).
 	var (
-		pluginProcMgr   admin.PluginProcessManager
-		pluginTrigger   admin.TriggerRestarter
-		pluginInflight  admin.InflightCounter
+		pluginProcMgr    admin.PluginProcessManager
+		pluginTrigger    admin.TriggerRestarter
+		pluginInflight   admin.InflightCounter
 		pluginPluginsDir string
-		pluginInstaller admin.PluginInstaller
-		pluginRSSAgg    admin.RSSAggregator
+		pluginInstaller  admin.PluginInstaller
+		pluginRSSAgg     admin.RSSAggregator
 	)
 	if rt != nil {
 		if rt.TriggerSupervisor != nil {

--- a/main.go
+++ b/main.go
@@ -361,12 +361,74 @@ func run(cfg config.Config) error {
 		}
 	}
 
+	// Build InstanceLifecycle and InstanceConfig modules before PluginHandler so
+	// all deps are constructor-injected (no late-bind setters, per issue #504).
+	//
+	// Conditional deps: processManager/trigger/pool are nil when plugins are
+	// disabled. store is always wired (DB-only cleanup works even when disabled).
+	// pluginsDir is empty when plugins disabled (disables FS cleanup in Uninstall).
+	//
+	// processManager and pluginsDir are shared by reference/value into BOTH the
+	// InstanceLifecycleDeps AND the PluginHandlerDeps — both holders use the
+	// one shared instance (plan §DEPS THAT STAY).
+	var (
+		pluginProcMgr   admin.PluginProcessManager
+		pluginTrigger   admin.TriggerRestarter
+		pluginInflight  admin.InflightCounter
+		pluginPluginsDir string
+		pluginInstaller admin.PluginInstaller
+		pluginRSSAgg    admin.RSSAggregator
+	)
+	if rt != nil {
+		if rt.TriggerSupervisor != nil {
+			pluginTrigger = rt.TriggerSupervisor
+		}
+		if rt.Loader().Installer() != nil {
+			pluginInstaller = rt.Loader().Installer()
+			if mgr := rt.Manager(); mgr != nil {
+				pluginProcMgr = mgr
+				pluginPluginsDir = cfg.PluginsDir
+				pluginInflight = rt.Pool
+			}
+		}
+		if mgr := rt.Manager(); mgr != nil {
+			rssSampler := process.NewRSSSampler(mgr.Snapshot)
+			rssSampler.Start(ctx, 30*time.Second)
+			pluginRSSAgg = rssAggregatorAdapter{sampler: rssSampler}
+		}
+	}
+
+	pluginLifecycle := admin.NewInstanceLifecycle(admin.InstanceLifecycleDeps{
+		Q:          store.Queries(),
+		Store:      store,
+		Publisher:  broadcaster,
+		ProcMgr:    pluginProcMgr,
+		Trigger:    pluginTrigger,
+		Inflight:   pluginInflight,
+		PluginsDir: pluginPluginsDir,
+	})
+	pluginConfig := admin.NewInstanceConfig(admin.InstanceConfigDeps{
+		Q:         store.Queries(),
+		Publisher: broadcaster,
+		Trigger:   pluginTrigger,
+	})
+	pluginAdmin := admin.NewPluginHandler(admin.PluginHandlerDeps{
+		Q:              store.Queries(),
+		Publisher:      broadcaster,
+		Installer:      pluginInstaller,
+		RSSAggregator:  pluginRSSAgg,
+		ProcessManager: pluginProcMgr,
+		PluginsDir:     pluginPluginsDir,
+		Lifecycle:      pluginLifecycle,
+		Config:         pluginConfig,
+	})
+
 	handlers := api.HandlerBundle{
 		AuthHandler:              authHandler,
 		SettingsHandler:          settingsHandler,
 		AdminHandler:             adminHandler,
 		OpenAICompatHandler:      openaiCompatHandler,
-		PluginAdminHandler:       admin.NewPluginHandler(store.Queries(), broadcaster, nil),
+		PluginAdminHandler:       pluginAdmin,
 		PluginOAuthHandler:       pluginOAuthHandler,
 		PluginCredentialsHandler: pluginCredHandler,
 		AudienceHandler:          audienceH,
@@ -374,46 +436,6 @@ func run(cfg config.Config) error {
 		WebhookHandler:           webhookHandler,
 		SSEHandler:               sseHandler,
 		PolicyWebhookHandler:     policyWebhookHandler,
-	}
-
-	// Wire the trigger supervisor into the plugin admin handler so that
-	// PutSubscriptionScope can restart the stream after a scope change.
-	if rt != nil && rt.TriggerSupervisor != nil && handlers.PluginAdminHandler != nil {
-		handlers.PluginAdminHandler.SetTriggerRestarter(rt.TriggerSupervisor)
-	}
-
-	// Wire the *db.Store unconditionally so DeleteInstance and Uninstall can
-	// open transactions via store.DB().BeginTx. This is always needed — the
-	// transactional delete path works even when the plugin subsystem is
-	// disabled (DB-only cleanup for the kitchen-sink recovery use case).
-	if handlers.PluginAdminHandler != nil {
-		handlers.PluginAdminHandler.SetStore(store)
-	}
-
-	// Wire the shared Installer into the plugin admin handler so both the
-	// fsnotify watcher and the Install endpoint use the same pipeline instance.
-	// Installer() returns nil when plugins are disabled, which disables the
-	// install endpoint cleanly (returns 503).
-	if rt != nil && rt.Loader().Installer() != nil && handlers.PluginAdminHandler != nil {
-		handlers.PluginAdminHandler.SetInstaller(rt.Loader().Installer())
-		// Wire the process manager and plugins dir for subprocess stop + FS
-		// cleanup during Uninstall. Only available when plugins are enabled and
-		// the manager was successfully started.
-		if mgr := rt.Manager(); mgr != nil {
-			handlers.PluginAdminHandler.SetProcessManager(mgr)
-			handlers.PluginAdminHandler.SetPluginsDir(cfg.PluginsDir)
-			handlers.PluginAdminHandler.SetInflightCounter(rt.Pool)
-		}
-	}
-
-	// Wire the RSS sampler. When plugins are disabled, rssAggregator is never
-	// set and GetPluginRSS returns 503.
-	if rt != nil {
-		if mgr := rt.Manager(); mgr != nil && handlers.PluginAdminHandler != nil {
-			rssSampler := process.NewRSSSampler(mgr.Snapshot)
-			rssSampler.Start(ctx, 30*time.Second)
-			handlers.PluginAdminHandler.SetRSSAggregator(rssAggregatorAdapter{sampler: rssSampler})
-		}
 	}
 
 	// Register the post-install spawn hook so that a fresh install (via the


### PR DESCRIPTION
Closes #504

## Summary

Behavior-preserving refactor that pulls the plugin-instance **lifecycle** choreography (`Deactivate`/`Activate`/`Delete`/`Uninstall`) and the **config-write** choreography (`PutInstanceConfig`/`PutInstanceConfigProperty`/`PutSubscriptionScope`) out of the admin HTTP handlers into two deep, constructor-injected modules in `package admin`:

- **`InstanceLifecycle`** (`internal/admin/instance_lifecycle.go`) — owns the four transitions, including the ~99% duplicated `Delete`/`Uninstall` choreography (in-flight gate, policy/audience reference guards, 5s subprocess stop, FK-safe transactional cleanup of `plugin_pending_requests` + `plugin_oauth_nonces`, CAS write, audit event, tool-namespace unregister, bundle-dir removal).
- **`InstanceConfig`** (`internal/admin/instance_config.go`) — owns the config-write path (manifest parse → secret-name derivation → ADR-049 sentinel rejection → schema validation → CAS write → redaction).

The HTTP handlers now shrink to **decode → call module → map typed errors to status codes**. The 8 `SetXxx` post-construction setters are replaced with **constructor injection** (`NewPluginHandler`/`NewInstanceLifecycle`/`NewInstanceConfig` take `Deps` structs — compile-checked, no more silent no-op on a forgotten `Set`). `processManager` and `pluginsDir` are shared with the non-extracted `CreateInstance`/`ApprovePlugin`/`RejectPlugin` handlers.

`internal/admin/plugin_handler.go` shrank by ~989 lines.

## Behavior preservation

This is a pure refactor — **every status code, `error` message, and `detail` string is byte-identical** to before. The plan enumerated each distinct response (the two in-flight 409 phrasings, the `"internal error"` vs `"failed to get plugin"` vs `"failed to get instance"` 500 bodies, the three `"validation error"` 500s, the bulk-vs-per-property sentinel-rejection shape difference, etc.). ADR-049 fail-closed redaction is preserved: the lifecycle path redacts in the handler via `writeInstanceResponseWithRedaction`; the config path redacts inside the module (handler does a dumb `WriteJSON`).

## Tests

- New `instance_lifecycle_test.go` (26 subtests) and `instance_config_test.go` (20 subtests) — **table-driven, call the module methods directly (no httptest)**, covering every typed error, nil-dep safety, the containment guard, and the `PutSubscriptionScope` synthesized-branch-still-redacts case.
- New `error_mapping_test.go` (33 subtests) — drives `mapLifecycleError`/`mapConfigError` directly, asserting status + message + detail for every distinct case (both in-flight 409 phrasings explicitly).
- The retained httptest suites (`plugin_handler_test.go`, `plugin_handler_install_test.go`, ~97 sites migrated to a `newTestPluginHandler` helper) keep all status-code/body assertions unchanged — the behavior-preservation oracle.

`go build ./...`, `go vet ./...`, `go test ./...` (52 packages) and `go test -race ./internal/admin/...` all pass.

## Package placement

The architect chose to keep both modules **in `package admin`** rather than a new `internal/plugin/*` sub-package: `internal/admin` already imports every dependency the choreography needs (zero new import edges), and the candidate-relocation interfaces are referenced by `plugin/*`/`policy` only in comments — relocating them would add edges for a `gleipnirctl` caller that doesn't yet exist. The modules never touch `http.ResponseWriter`, so a future sub-package extraction stays trivial.

<details>
<summary>Architecture plan</summary>

See the full plan in the dev-loop run. Key decisions: deep modules return `(domain object | typed error)` and never write HTTP responses; `store` moves to `InstanceLifecycle` only (transactional cleanup via `db.New(tx)`); `pluginsDir`/`processManager` are shared by reference with `PluginHandler`; exhaustive typed-error → HTTP-status mapping table reproduces every current response; ADR-049/ADR-038/ADR-003 honored.

</details>

## Process

- Review cycles: **2** (cycle 1 caught a missing error-mapping table test; cycle 2 approved).
- Brainstorming: not triggered (issue was well-specified).
- CLAUDE.md: no updates needed (no new package/env-var/route/ADR; API surface unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.
