### PR TITLE
feat(llm): harden openaicompat — stream retry, reasoning flag, gpt-5

### DIFF
--- a/internal/llm/model_cache.go
+++ b/internal/llm/model_cache.go
@@ -11,16 +11,31 @@ import (
 // a single provider. It is safe for concurrent use.
 type ModelCache struct {
 	providerName string
-	mu           sync.RWMutex
-	cache        map[string]string // model name → display name
-	err          error
-	loaded       bool
+	// isReasoning, when set, classifies each cached model's IsReasoning flag in
+	// ListModels. It is nil for providers that fetch an opaque model list with no
+	// way to tell reasoning models apart — those report IsReasoning=false.
+	isReasoning func(modelName string) bool
+	mu          sync.RWMutex
+	cache       map[string]string // model name → display name
+	err         error
+	loaded      bool
 }
 
 // NewModelCache returns a ModelCache that will use providerName in error
-// messages (e.g. "Anthropic", "Google").
+// messages (e.g. "Anthropic", "Google"). Models listed from this cache always
+// report IsReasoning=false; use NewModelCacheWithReasoning to classify them.
 func NewModelCache(providerName string) ModelCache {
 	return ModelCache{providerName: providerName}
+}
+
+// NewModelCacheWithReasoning returns a ModelCache that classifies each model's
+// IsReasoning flag via the isReasoning predicate when building ListModels output.
+// Providers (e.g. openaicompat) that fetch a flat model list and infer reasoning
+// support from the model ID supply their heuristic here so the admin model picker
+// flags reasoning-capable backends correctly. A nil predicate behaves exactly
+// like NewModelCache.
+func NewModelCacheWithReasoning(providerName string, isReasoning func(modelName string) bool) ModelCache {
+	return ModelCache{providerName: providerName, isReasoning: isReasoning}
 }
 
 // LoadOnce fetches models via the provided closure if not already loaded.
@@ -90,7 +105,11 @@ func (mc *ModelCache) ListModels() ([]ModelInfo, error) {
 
 	models := make([]ModelInfo, 0, len(mc.cache))
 	for name, displayName := range mc.cache {
-		models = append(models, ModelInfo{Name: name, DisplayName: displayName})
+		info := ModelInfo{Name: name, DisplayName: displayName}
+		if mc.isReasoning != nil {
+			info.IsReasoning = mc.isReasoning(name)
+		}
+		models = append(models, info)
 	}
 	sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
 	return models, nil

--- a/internal/llm/model_cache_test.go
+++ b/internal/llm/model_cache_test.go
@@ -145,6 +145,45 @@ func TestModelCache_ListModels(t *testing.T) {
 	})
 }
 
+func TestModelCache_WithReasoning_ClassifiesListModels(t *testing.T) {
+	// Classifier flags any model whose name starts with "r-" as reasoning.
+	isReasoning := func(name string) bool { return strings.HasPrefix(name, "r-") }
+	mc := llm.NewModelCacheWithReasoning("TestProvider", isReasoning)
+	mc.LoadOnce(func() (map[string]string, error) {
+		return map[string]string{"r-think": "Reasoner", "plain": "Plain"}, nil
+	})
+
+	models, err := mc.ListModels()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := make(map[string]bool, len(models))
+	for _, m := range models {
+		got[m.Name] = m.IsReasoning
+	}
+	if !got["r-think"] {
+		t.Error("expected r-think to be classified IsReasoning=true")
+	}
+	if got["plain"] {
+		t.Error("expected plain to be classified IsReasoning=false")
+	}
+}
+
+func TestModelCache_WithoutReasoning_DefaultsFalse(t *testing.T) {
+	// The plain constructor leaves the classifier nil → every model is non-reasoning.
+	mc := llm.NewModelCache("TestProvider")
+	mc.LoadOnce(func() (map[string]string, error) {
+		return map[string]string{"o3-mini": "o3-mini"}, nil
+	})
+	models, err := mc.ListModels()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 1 || models[0].IsReasoning {
+		t.Errorf("expected single non-reasoning model, got %+v", models)
+	}
+}
+
 func TestModelCache_Invalidate_AllowsRefetch(t *testing.T) {
 	mc := llm.NewModelCache("TestProvider")
 	callCount := 0

--- a/internal/llm/openaicompat/client.go
+++ b/internal/llm/openaicompat/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -93,7 +92,10 @@ func NewClient(baseURL, apiKey string, opts ...Option) *Client {
 	w := &compatWire{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		apiKey:  apiKey,
-		models:  llm.NewModelCache("OpenAI-compatible"),
+		// isReasoningModel is the same heuristic the translator uses to route
+		// max_completion_tokens / reasoning_effort, reused here so reasoning models
+		// served by a compat backend surface IsReasoning=true in the model picker.
+		models: llm.NewModelCacheWithReasoning("OpenAI-compatible", isReasoningModel),
 	}
 	for _, opt := range opts {
 		opt(w)
@@ -131,6 +133,10 @@ func compatRetryDecision(err error) llm.RetryDecision {
 }
 
 // ClassifyError maps an openaicompat error to the fixed error_type enum.
+// Mirrors the google wire's three-branch shape: a cancelled/timed-out context is
+// "timeout"; an HTTP error defers to the shared per-status policy; everything else
+// (dial failure, DNS error, connection reset — none of which carry an HTTP status)
+// is a connection error.
 func (w *compatWire) ClassifyError(err error) string {
 	if et, ok := llm.ClassifyContextError(err); ok {
 		return et
@@ -138,14 +144,6 @@ func (w *compatWire) ClassifyError(err error) string {
 	var httpErr *llm.HTTPError
 	if errors.As(err, &httpErr) {
 		return llm.ClassifyHTTPStatus(httpErr.StatusCode)
-	}
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
-		return metrics.ErrorTypeConnection
-	}
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
-		return metrics.ErrorTypeConnection
 	}
 	return metrics.ErrorTypeConnection
 }
@@ -210,15 +208,33 @@ func (w *compatWire) Stream(ctx context.Context, req llm.MessageRequest) (<-chan
 		return nil, fmt.Errorf("openai: marshal stream request: %w", err)
 	}
 
-	resp, err := w.doRequest(ctx, http.MethodPost, "/chat/completions", bytes.NewReader(body))
-	if err != nil {
+	// Retry stream ESTABLISHMENT the same way the sync Call path does: a pre-stream
+	// 429/5xx or connection blip when opening the stream is exactly as transient as
+	// on a sync request, and at this point no bytes have reached the caller yet.
+	// Once the SSE body starts flowing, mid-stream failures surface on the channel
+	// and are NOT retried — a partial stream cannot be replayed. Each attempt
+	// re-issues with a fresh body reader and drains+closes the failed response
+	// before the next try; the successful response's body stays open for the SSE
+	// goroutine.
+	//
+	// The Google wire has the same establishment-retry gap, but its SDK returns a
+	// lazy iter.Seq2 with no synchronous establishment step to wrap — closing that
+	// gap there needs first-event-drain logic and is tracked separately.
+	var resp *http.Response
+	if err := llm.DoWithRetry(ctx, llm.DefaultRetryConfig, w.ProviderName(), compatRetryDecision, func() error {
+		r, doErr := w.doRequest(ctx, http.MethodPost, "/chat/completions", bytes.NewReader(body))
+		if doErr != nil {
+			return doErr
+		}
+		if r.StatusCode >= 400 {
+			raw, _ := io.ReadAll(r.Body)
+			r.Body.Close()
+			return wrapHTTPError(r.StatusCode, r.Header, raw)
+		}
+		resp = r
+		return nil
+	}); err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode >= 400 {
-		raw, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		return nil, wrapHTTPError(resp.StatusCode, resp.Header, raw)
 	}
 
 	out := make(chan llm.MessageChunk, 16)

--- a/internal/llm/openaicompat/client_test.go
+++ b/internal/llm/openaicompat/client_test.go
@@ -220,6 +220,34 @@ func TestListModels_HappyPathAndCache(t *testing.T) {
 	}
 }
 
+// TestListModels_ClassifiesReasoning confirms compat-backend models are flagged
+// IsReasoning via the same o-series heuristic the translator uses for token-field
+// routing: o3-mini is reasoning; the gpt-4o family is not.
+func TestListModels_ClassifiesReasoning(t *testing.T) {
+	fixture := loadFixture(t, "models_response.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	models, err := newTestClient(srv).ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]bool{"gpt-4o": false, "gpt-4o-mini": false, "o3-mini": true}
+	got := make(map[string]bool, len(models))
+	for _, m := range models {
+		got[m.Name] = m.IsReasoning
+	}
+	for name, wantReasoning := range want {
+		if got[name] != wantReasoning {
+			t.Errorf("model %q IsReasoning = %v; want %v", name, got[name], wantReasoning)
+		}
+	}
+}
+
 func TestListModels_404IsEmptySlice(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/llm/openaicompat/retry_test.go
+++ b/internal/llm/openaicompat/retry_test.go
@@ -128,6 +128,88 @@ func TestCreateMessage_RetriesOn429(t *testing.T) {
 	}
 }
 
+// TestStreamMessage_RetriesOnTransientEstablishment proves the streaming path
+// retries stream ESTABLISHMENT the same way the sync Call path does: two pre-stream
+// 503s are retried and the eventual SSE body streams normally. Mirrors the sync
+// TestCreateMessage_RetriesOn429 but exercises StreamMessage.
+func TestStreamMessage_RetriesOnTransientEstablishment(t *testing.T) {
+	orig := llm.DefaultRetryConfig
+	llm.SetDefaultRetryConfig(llm.RetryConfig{
+		MaxAttempts:    4,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     5 * time.Millisecond,
+	})
+	t.Cleanup(func() { llm.DefaultRetryConfig = orig })
+
+	streamBody := loadFixture(t, "stream_chunks_text.txt")
+	var calls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 { // fail the first two attempts with a transient 503
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"error":{"message":"overloaded"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write(streamBody)
+	}))
+	defer srv.Close()
+
+	ch, err := newTestClient(srv).StreamMessage(context.Background(), llm.MessageRequest{Model: "gpt-4o"})
+	if err != nil {
+		t.Fatalf("expected stream to establish after retries, got %v", err)
+	}
+
+	var accumulated string
+	for chunk := range ch {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		if chunk.Text != nil {
+			accumulated += *chunk.Text
+		}
+	}
+	if accumulated != "Hello world" {
+		t.Errorf("accumulated text = %q; want %q", accumulated, "Hello world")
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 establishment attempts (2 retries), got %d", got)
+	}
+}
+
+// TestStreamMessage_DoesNotRetryOn4xx confirms a deterministic client error on
+// stream establishment (here 400) is terminal even with a generous attempt budget
+// — the classifier, not the budget, must stop the retry.
+func TestStreamMessage_DoesNotRetryOn4xx(t *testing.T) {
+	orig := llm.DefaultRetryConfig
+	llm.SetDefaultRetryConfig(llm.RetryConfig{MaxAttempts: 4, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond})
+	t.Cleanup(func() { llm.DefaultRetryConfig = orig })
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"bad request"}}`))
+	}))
+	defer srv.Close()
+
+	ch, err := newTestClient(srv).StreamMessage(context.Background(), llm.MessageRequest{Model: "gpt-4o"})
+	if err == nil {
+		t.Fatal("expected error for 400 establishment, got nil")
+	}
+	if ch != nil {
+		t.Error("expected nil channel on establishment error")
+	}
+	var httpErr *llm.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected a 400 HTTPError, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 attempt (no retry on 4xx), got %d", got)
+	}
+}
+
 // TestCreateMessage_ExhaustsRetriesOn429 confirms a persistent 429 fails after
 // the attempt budget is spent and surfaces the rate-limit error.
 func TestCreateMessage_ExhaustsRetriesOn429(t *testing.T) {

--- a/internal/llm/openaicompat/translate.go
+++ b/internal/llm/openaicompat/translate.go
@@ -67,16 +67,16 @@ func BuildChatCompletionRequest(req llm.MessageRequest, stream bool, names llm.T
 			p := *hints.TopP
 			out.TopP = &p
 		}
-		// reasoning_effort is an o-series-only parameter; sending it to other
-		// models causes a 400 error from OpenAI.
-		if hints.ReasoningEffort != nil && isOSeriesModel(req.Model) {
+		// reasoning_effort is a reasoning-model-only parameter; sending it to a
+		// non-reasoning model causes a 400 error from OpenAI.
+		if hints.ReasoningEffort != nil && isReasoningModel(req.Model) {
 			e := *hints.ReasoningEffort
 			out.ReasoningEffort = &e
 		}
 	}
 	if effectiveMax > 0 {
 		v := effectiveMax
-		if isOSeriesModel(req.Model) {
+		if isReasoningModel(req.Model) {
 			out.MaxCompletionTokens = &v
 		} else {
 			out.MaxTokens = &v
@@ -247,21 +247,29 @@ func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping, 
 	return out, nil
 }
 
-// isOSeriesModel returns true when the model should route max_tokens to
-// max_completion_tokens and honor reasoning_effort. The heuristic is:
-// name starts with "o<digit>" (o1, o3, o4) or contains "reasoning".
-// Contained to this function; no other place in the package pattern-matches
-// on model names.
-func isOSeriesModel(model string) bool {
+// isReasoningModel reports whether model is an OpenAI-style reasoning model: the
+// o-series (o1/o3/o4…), the gpt-5 family, or any name containing "reasoning". It
+// is the single signal behind three request-shaping decisions for OpenAI-style
+// backends — routing the token cap to max_completion_tokens (which OpenAI requires
+// for these models and rejects max_tokens for), gating reasoning_effort, and the
+// IsReasoning model-picker badge.
+//
+// This is a name-based heuristic because the standard OpenAI-compat /models
+// endpoint advertises no per-model capabilities. Backends that DO advertise them
+// (e.g. OpenRouter's per-model supported_parameters / max_completion_tokens) are a
+// deferred follow-up (#539): parse those fields opportunistically and let real
+// capability data override this heuristic when present, falling back here only when
+// absent.
+//
+// Contained to this function; no other place in the package pattern-matches on
+// model names.
+func isReasoningModel(model string) bool {
 	if strings.Contains(model, "reasoning") {
 		return true
 	}
-	if len(model) < 2 {
-		return false
+	if strings.HasPrefix(model, "gpt-5") {
+		return true
 	}
-	if model[0] != 'o' {
-		return false
-	}
-	c := model[1]
-	return c >= '0' && c <= '9'
+	// o-series: name starts with o<digit> (o1, o3, o4, ...).
+	return len(model) >= 2 && model[0] == 'o' && model[1] >= '0' && model[1] <= '9'
 }

--- a/internal/llm/openaicompat/translate_test.go
+++ b/internal/llm/openaicompat/translate_test.go
@@ -287,6 +287,33 @@ func TestBuildChatCompletionRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "MaxTokens with bare gpt-5 uses max_completion_tokens",
+			in: llm.MessageRequest{
+				Model:     "gpt-5",
+				MaxTokens: 1024,
+			},
+			check: func(t *testing.T, req chatRequest) {
+				if req.MaxTokens != nil {
+					t.Errorf("MaxTokens should be nil for gpt-5, got %+v", req.MaxTokens)
+				}
+				if req.MaxCompletionTokens == nil || *req.MaxCompletionTokens != 1024 {
+					t.Errorf("MaxCompletionTokens: %+v", req.MaxCompletionTokens)
+				}
+			},
+		},
+		{
+			name: "reasoning_effort passed through for bare gpt-5",
+			in: llm.MessageRequest{
+				Model: "gpt-5",
+				Hints: &OpenAIHints{ReasoningEffort: strp("high")},
+			},
+			check: func(t *testing.T, req chatRequest) {
+				if req.ReasoningEffort == nil || *req.ReasoningEffort != "high" {
+					t.Errorf("reasoning_effort: %+v", req.ReasoningEffort)
+				}
+			},
+		},
+		{
 			name: "hints populate temperature and top_p",
 			in: llm.MessageRequest{
 				Model: "gpt-4o",
@@ -373,14 +400,18 @@ func TestBuildChatCompletionRequest_StreamFlag(t *testing.T) {
 	}
 }
 
-// isOSeriesModel is exported via test helper to lock the heuristic.
-func TestIsOSeriesModel(t *testing.T) {
+// TestIsReasoningModel locks the model-name heuristic that drives token-field
+// routing, reasoning_effort gating, and the IsReasoning picker badge.
+func TestIsReasoningModel(t *testing.T) {
 	cases := map[string]bool{
 		"o1":              true,
 		"o1-mini":         true,
 		"o3":              true,
 		"o3-mini":         true,
 		"o4-mini":         true,
+		"gpt-5":           true, // bare gpt-5 family must route to max_completion_tokens
+		"gpt-5-mini":      true,
+		"gpt-5-nano":      true,
 		"gpt-5-reasoning": true,
 		"gpt-4o":          false,
 		"gpt-4o-mini":     false,
@@ -388,8 +419,8 @@ func TestIsOSeriesModel(t *testing.T) {
 		"llama3.1:70b":    false,
 	}
 	for model, want := range cases {
-		if got := isOSeriesModel(model); got != want {
-			t.Errorf("isOSeriesModel(%q) = %v, want %v", model, got, want)
+		if got := isReasoningModel(model); got != want {
+			t.Errorf("isReasoningModel(%q) = %v, want %v", model, got, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

A focused pass over `internal/llm/openaicompat`, reviewing it against ADR-032/033. The provider was recently refactored (ProviderWire seam #534, retry loop #537), so this is targeted hardening rather than a rewrite — three behavior fixes plus a dead-code cleanup.

## Changes

| Change | Why |
|--------|-----|
| **Stream establishment retries** transient pre-stream failures (429 / 5xx / connection) | The sync `Call` path already retried via `DoWithRetry`; opening a stream did not. A pre-stream 429/503 is exactly as transient. Mid-stream errors are still surfaced on the channel and **not** retried — a partial stream can't be replayed. |
| **Compat models report `IsReasoning`** | The model picker previously flagged every compat-backend model as non-reasoning, even genuine o-series/gpt-5 models. Now classified via the same heuristic the translator already uses. |
| **`gpt-5` family routing fix** (`isOSeriesModel` → `isReasoningModel`) | Bare `gpt-5`/`gpt-5-mini`/`gpt-5-nano` slipped through to `max_tokens` + dropped `reasoning_effort`. OpenAI *requires* `max_completion_tokens` for these and rejects `max_tokens` → silent breakage. Only `gpt-5-reasoning` matched before. |
| **Dead-code cleanup in `ClassifyError`** | The `net.DNSError` / `net.OpError` branches returned the same value as the fallback. Removed them + the now-unused `net` import; matches the google wire's shape. |

## Design notes

- **No new shared `DoStreamWithRetry` helper.** Google's wire has the same establishment-retry gap, but its SDK returns a lazy `iter.Seq2` with no synchronous step to wrap — a shared helper would have exactly one usable caller. Reused the existing `DoWithRetry` and documented the Google gap in-code instead.
- **`ModelCache` change is zero-blast-radius.** Only openaicompat uses the dynamic cache; the new `NewModelCacheWithReasoning` constructor leaves `NewModelCache` and every other provider untouched.
- **Stayed generic** on the model-capability question (per maintainer steer): no flavor/profile column, no base_url host-matching, no non-standard endpoint probing. The one fix here needs zero backend knowledge.

## Deferred (tracked in #539)

Using endpoint-advertised per-model capabilities (OpenRouter `supported_parameters` / `max_completion_tokens`, etc.) as a precedence layer over the name heuristic. Deferred because it needs live-schema verification, mainly benefits OpenRouter today, and the standard `/v1/models` is too thin elsewhere. The seam is documented in the `isReasoningModel` doc comment.

## Testing

- `go test -race ./internal/llm/...` — all pass; vet + gofmt clean.
- New: `TestStreamMessage_RetriesOnTransientEstablishment`, `TestStreamMessage_DoesNotRetryOn4xx`, `TestListModels_ClassifiesReasoning`, `TestModelCache_WithReasoning_*`, `TestModelCache_WithoutReasoning_DefaultsFalse`, `TestIsReasoningModel` (+ `gpt-5` request-shaping cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)