### PR TITLE
fix(deps): bump js-yaml to 4.2.0 (moderate DoS advisory)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-query-devtools": "^5.100.14",
         "focus-trap-react": "^12.0.2",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "lucide-react": "^1.18.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -4527,9 +4527,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-query-devtools": "^5.100.14",
     "focus-trap-react": "^12.0.2",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "lucide-react": "^1.18.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
## Summary

The `vuln-scan-frontend` CI job (`npm audit --omit=dev`) reports **1 moderate severity vulnerability**: `js-yaml <=4.1.1` is vulnerable to a quadratic-complexity DoS in merge-key handling via repeated aliases ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)).

`js-yaml` is a direct production dependency (used by the YAML policy editor). This bumps it from `^4.1.1` to `^4.2.0` — the patched release.

## Verification

- `npm audit --omit=dev` now reports **0 vulnerabilities** (was 1 moderate).
- `npm run build` passes.
- All 1123 frontend unit tests pass.

Patch-level bump, no API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)