### PR TITLE
feat: fix EncryptionKeyNotice rotation copy + add Opus 4.8 to model catalog

### DIFF
--- a/frontend/src/components/admin/EncryptionKeyNotice.tsx
+++ b/frontend/src/components/admin/EncryptionKeyNotice.tsx
@@ -20,7 +20,10 @@ export function EncryptionKeyNotice() {
           Provider API keys and webhook secrets are encrypted with this key. If it is lost, every
           credential stored in the database becomes permanently unrecoverable.
         </p>
-        <p className={styles.footnote}>Key rotation is not supported in v1.0 — see Operations docs.</p>
+        <p className={styles.footnote}>
+          To rotate this key, stop the server first, then run{' '}
+          <code>gleipnirctl rotate-key</code> to re-encrypt all credentials in one transaction.
+        </p>
       </div>
     </div>
   )

--- a/frontend/src/constants/pricing.test.ts
+++ b/frontend/src/constants/pricing.test.ts
@@ -48,6 +48,10 @@ describe('estimateCost', () => {
     expect(estimateCost('Sonnet 4.6', 1000)).toBeGreaterThan(0)
   })
 
+  it('Opus 4.8 with ~1000 tokens returns non-zero cost', () => {
+    expect(estimateCost('Opus 4.8', 1000)).toBeGreaterThan(0)
+  })
+
   it('Opus 4.7 with ~1000 tokens returns non-zero cost', () => {
     expect(estimateCost('Opus 4.7', 1000)).toBeGreaterThan(0)
   })

--- a/frontend/src/constants/pricing.ts
+++ b/frontend/src/constants/pricing.ts
@@ -10,6 +10,7 @@
 // public pricing pages — suitable for dashboard charts, not billing.
 export const MODEL_PRICING: Record<string, { input: number; output: number }> = {
   // Anthropic curated models.
+  'Opus 4.8':   { input: 5.00 / 1_000_000,  output: 25.00 / 1_000_000 },
   'Opus 4.7':   { input: 5.00 / 1_000_000,  output: 25.00 / 1_000_000 },
   'Opus 4.6':   { input: 5.00 / 1_000_000,  output: 25.00 / 1_000_000 },
   'Sonnet 4.6': { input: 3.00 / 1_000_000,  output: 15.00 / 1_000_000 },

--- a/internal/http/api/modelnames.go
+++ b/internal/http/api/modelnames.go
@@ -14,6 +14,7 @@ package api
 // each provider's curated list has an entry here.
 var ModelDisplayNames = map[string]string{
 	// Anthropic curated models (from internal/llm/anthropic/models.go curatedModels).
+	"claude-opus-4-8":   "Opus 4.8",
 	"claude-opus-4-7":   "Opus 4.7",
 	"claude-opus-4-6":   "Opus 4.6",
 	"claude-sonnet-4-6": "Sonnet 4.6",

--- a/internal/llm/anthropic/models.go
+++ b/internal/llm/anthropic/models.go
@@ -14,6 +14,7 @@ import "github.com/felag-engineering/gleipnir/internal/llm"
 // curatedModels is the display list returned by ListModels. The order here is
 // the order users see in the UI — most capable first within each generation.
 var curatedModels = []llm.ModelInfo{
+	{Name: "claude-opus-4-8", DisplayName: "Claude Opus 4.8", IsReasoning: true},
 	{Name: "claude-opus-4-7", DisplayName: "Claude Opus 4.7", IsReasoning: true},
 	{Name: "claude-opus-4-6", DisplayName: "Claude Opus 4.6", IsReasoning: true},
 	{Name: "claude-sonnet-4-6", DisplayName: "Claude Sonnet 4.6", IsReasoning: true},


### PR DESCRIPTION
Closes #542

## Summary

Two related admin-surface changes:

### 1. Fix stale EncryptionKeyNotice copy (#542)

The `EncryptionKeyNotice` banner on the Models page (`/admin/models`) had a stale footnote claiming encryption-key rotation was unsupported. Rotation **is** supported via `gleipnirctl rotate-key`. Updated the footnote to point operators to the command (in a `<code>` element) and note the server must be stopped first — consistent with the procedure documented in `CLAUDE.md`.

**Before:** `Key rotation is not supported in v1.0 — see Operations docs.`
**After:** `To rotate this key, stop the server first, then run gleipnirctl rotate-key to re-encrypt all credentials in one transaction.`

### 2. Add Claude Opus 4.8 to the model catalog

Added `claude-opus-4-8` (Claude Opus 4.8) to the curated Anthropic model list so it is selectable on `/admin/models`. Opus 4.8 shares Opus 4.7's API surface, so no runtime changes were needed. Kept the model-catalog sync chain consistent across all four touch points (curated list → display-name mapping → frontend pricing → `$0.00` regression guard).

OpenAI (GPT-5 / GPT-4.1) and Google (Gemini 3) catalogs were already current and left unchanged. Fable 5 was intentionally **not** added — it has a different API surface (always-on thinking, `refusal` stop reason, 30-day retention) that would need agent-loop verification beyond a catalog edit.

## Details

- **Files changed:**
  - `frontend/src/components/admin/EncryptionKeyNotice.tsx` (copy fix)
  - `internal/llm/anthropic/models.go` (curated model list)
  - `internal/http/api/modelnames.go` (display-name mapping; enforced by the drift test)
  - `frontend/src/constants/pricing.ts` (blended cost rates, $5/$25 per MTok)
  - `frontend/src/constants/pricing.test.ts` ($0.00 regression guard)
- **Tests:** Go suite (incl. `TestAllCuratedModelsHaveDisplayNames` drift test) and frontend vitest both pass via the commit hook gate.
- **Review cycles:** 1 (copy fix approved on first pass)
- **CLAUDE.md:** No updates needed — both changes are within already-documented surfaces.

🤖 Generated by the agentic dev loop.
