### PR TITLE
refactor(api): split plugin-instance projection out of audience handler

### DIFF
--- a/internal/http/api/audience_handler.go
+++ b/internal/http/api/audience_handler.go
@@ -102,232 +102,9 @@ type audienceReferencesDTO struct {
 	InFlightRuns []inFlightRunDTO `json:"in_flight_runs"`
 }
 
-// pluginEventExampleDTO is a single named example payload for a plugin event kind.
-// Used by the "Test against sample" feature in the policy editor (spec §7.5).
-type pluginEventExampleDTO struct {
-	Name    string      `json:"name"`
-	Payload interface{} `json:"payload"`
-}
-
-// pluginToolDTO describes a single tool declared by a plugin's manifest.
-// Used by the admin UI detail pane to list what tools the plugin provides.
-type pluginToolDTO struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-// pluginEventKindDTO is a single event kind from an installed plugin instance's
-// manifest — used by the trigger picker to show plugin-sourced trigger options.
-type pluginEventKindDTO struct {
-	Kind          string                  `json:"kind"`
-	Description   string                  `json:"description"`
-	BindingSchema interface{}             `json:"binding_schema,omitempty"`
-	Examples      []pluginEventExampleDTO `json:"examples,omitempty"`
-}
-
-// pluginInstanceForAudienceDTO describes one installed plugin instance for use
-// in the audience editor and trigger picker. Second consumer: the trigger
-// picker (#219) reads event_kinds to populate plugin-sourced entries.
-type pluginInstanceForAudienceDTO struct {
-	ID                 string               `json:"id"`
-	PluginID           string               `json:"plugin_id"`
-	PluginName         string               `json:"plugin_name"`
-	InstanceName       string               `json:"instance_name"`
-	State              string               `json:"state"`
-	ImplementsNotify   bool                 `json:"implements_notify"`
-	ImplementsRequest  bool                 `json:"implements_request"`
-	ConfigSchema       interface{}          `json:"config_schema"`
-	EventKinds         []pluginEventKindDTO `json:"event_kinds"`
-	SubscriptionSchema interface{}          `json:"subscription_schema"`
-	SubscriptionScope  map[string]any       `json:"subscription_scope"`
-	Version            int64                `json:"version"`
-	// AuthStrategy is the auth strategy declared in the manifest (e.g.
-	// "oauth2_authcode", "oauth2_clientcred", "static_api_key"). Used by the
-	// admin UI to decide whether to show the Re-authorize button (#228).
-	AuthStrategy string `json:"auth_strategy"`
-	// HealthDetail is the detail string from the most recent health transition.
-	// Omitted when empty. Used together with AuthStrategy to gate the
-	// Re-authorize banner: detail prefix "oauth refresh failed" + oauth strategy
-	// → show the button.
-	HealthDetail string `json:"health_detail,omitempty"`
-	// LastOauthCallbackUrl is the OAuth callback URL recorded the last time this
-	// instance completed an OAuth flow. Omitted when nil (never authorized). Used
-	// by the admin/plugins page to help operators understand which URL needs to be
-	// updated in the provider after a public_url change (#230).
-	LastOauthCallbackUrl string `json:"last_oauth_callback_url,omitempty"`
-	// PluginVersion is the SemVer version string from the manifest (e.g. "1.0.0").
-	// Used by the admin/plugins page to display the version on each plugin card.
-	PluginVersion string `json:"plugin_version"`
-	// Services lists the gRPC services declared by the plugin manifest.
-	// Possible values: "tool", "trigger", "channel". Omitted when empty.
-	// Used by the admin/plugins page to render service badges on plugin cards.
-	Services []string `json:"services,omitempty"`
-	// Tools lists tool declarations from the plugin manifest (ToolService plugins
-	// only). Each entry carries the tool name and description for the admin UI
-	// detail pane. Omitted when the plugin declares no tools.
-	Tools []pluginToolDTO `json:"tools,omitempty"`
-}
-
-// ListPluginInstances handles GET /api/v1/admin/plugin-instances.
-// Returns all installed plugin instances with their manifest-derived
-// capabilities for use in the audience editor and trigger picker.
-func (h *AudienceHandler) ListPluginInstances(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	instances, err := h.store.Queries().ListPluginInstances(ctx)
-	if err != nil {
-		slog.Error("list plugin instances: DB error", "err", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
-		return
-	}
-
-	dtos := make([]pluginInstanceForAudienceDTO, 0, len(instances))
-	for _, inst := range instances {
-		manifest, err := h.snap.ForInstanceID(ctx, inst.ID)
-		if err != nil {
-			// Skip instances whose manifest cannot be parsed rather than failing
-			// the entire list — the operator can still use other instances.
-			slog.Warn("list plugin instances: parse manifest", "instance_id", inst.ID, "err", err)
-			continue
-		}
-
-		var implementsNotify, implementsRequest bool
-		var configSchema interface{}
-		if len(manifest.Channels) > 0 {
-			ch := manifest.Channels[0]
-			implementsNotify = ch.ImplementsNotify
-			implementsRequest = ch.ImplementsRequest
-			if ch.ConfigSchema != nil {
-				// Convert the YAML node to a plain map so it serializes as JSON.
-				var csMap interface{}
-				if err := ch.ConfigSchema.Decode(&csMap); err == nil {
-					configSchema = csMap
-				}
-			}
-		}
-
-		eventKinds := make([]pluginEventKindDTO, 0, len(manifest.EventKinds))
-		for _, ek := range manifest.EventKinds {
-			if ek.Kind == "" {
-				continue
-			}
-
-			dto := pluginEventKindDTO{
-				Kind:        ek.Kind,
-				Description: ek.Description,
-			}
-
-			// Decode binding_schema into a plain map so it serializes as JSON.
-			if ek.BindingSchema != nil {
-				var bsMap interface{}
-				if err := ek.BindingSchema.Decode(&bsMap); err == nil {
-					dto.BindingSchema = bsMap
-				} else {
-					slog.Warn("list plugin instances: decode binding_schema", "instance_id", inst.ID, "kind", ek.Kind, "err", err)
-				}
-			}
-
-			// Decode examples; skip malformed entries rather than failing the request.
-			for i, exNode := range ek.Examples {
-				var m map[string]any
-				if err := exNode.Decode(&m); err != nil {
-					slog.Warn("list plugin instances: decode example", "instance_id", inst.ID, "kind", ek.Kind, "index", i, "err", err)
-					continue
-				}
-				name, _ := m["name"].(string)
-				payload, payloadOK := m["payload"]
-				if name == "" || !payloadOK {
-					slog.Warn("list plugin instances: example missing name or payload", "instance_id", inst.ID, "kind", ek.Kind, "index", i)
-					continue
-				}
-				dto.Examples = append(dto.Examples, pluginEventExampleDTO{Name: name, Payload: payload})
-			}
-
-			eventKinds = append(eventKinds, dto)
-		}
-
-		// Decode manifest-level subscription_schema (OUTSIDE the Channels guard —
-		// this is a manifest top-level field, not a per-channel field).
-		var subscriptionSchema interface{}
-		if manifest.SubscriptionSchema != nil {
-			var ssMap interface{}
-			if err := manifest.SubscriptionSchema.Decode(&ssMap); err == nil {
-				subscriptionSchema = ssMap
-			} else {
-				slog.Warn("list plugin instances: decode subscription_schema", "instance_id", inst.ID, "err", err)
-			}
-		}
-
-		// Decode current subscription scope from the raw DB row (no extra query).
-		var subscriptionScope map[string]any
-		if inst.SubscriptionScopeJson != "" && inst.SubscriptionScopeJson != "{}" {
-			if err := json.Unmarshal([]byte(inst.SubscriptionScopeJson), &subscriptionScope); err != nil {
-				slog.Warn("list plugin instances: decode subscription_scope_json", "instance_id", inst.ID, "err", err)
-				subscriptionScope = map[string]any{}
-			}
-		} else {
-			subscriptionScope = map[string]any{}
-		}
-
-		healthDetail := ""
-		if inst.HealthDetail != nil {
-			healthDetail = *inst.HealthDetail
-		}
-
-		lastCallbackURL := ""
-		if inst.LastOauthCallbackUrl != nil {
-			lastCallbackURL = *inst.LastOauthCallbackUrl
-		}
-
-		// Derive the declared service list from the manifest Services field.
-		// All instances of the same plugin share the same manifest, so this
-		// value is identical across instances.
-		var services []string
-		if manifest.Services.Tool != "" {
-			services = append(services, "tool")
-		}
-		if manifest.Services.Trigger != "" {
-			services = append(services, "trigger")
-		}
-		if manifest.Services.Channel != "" {
-			services = append(services, "channel")
-		}
-
-		var tools []pluginToolDTO
-		for _, t := range manifest.Tools {
-			if t.Name == "" {
-				continue
-			}
-			tools = append(tools, pluginToolDTO{
-				Name:        t.Name,
-				Description: t.Description,
-			})
-		}
-
-		dtos = append(dtos, pluginInstanceForAudienceDTO{
-			ID:                   inst.ID,
-			PluginID:             inst.PluginID,
-			PluginName:           manifest.Name,
-			InstanceName:         inst.InstanceName,
-			State:                inst.HealthState,
-			ImplementsNotify:     implementsNotify,
-			ImplementsRequest:    implementsRequest,
-			ConfigSchema:         configSchema,
-			EventKinds:           eventKinds,
-			SubscriptionSchema:   subscriptionSchema,
-			SubscriptionScope:    subscriptionScope,
-			Version:              inst.Version,
-			AuthStrategy:         string(manifest.Auth.Strategy),
-			HealthDetail:         healthDetail,
-			LastOauthCallbackUrl: lastCallbackURL,
-			PluginVersion:        manifest.Version,
-			Services:             services,
-			Tools:                tools,
-		})
-	}
-
-	httputil.WriteJSON(w, http.StatusOK, dtos)
-}
+// The GET /api/v1/admin/plugin-instances endpoint and its DTOs live in
+// plugin_instance_handler.go — it is a general plugin-instance projection, not
+// audience-specific, even though it hangs off AudienceHandler for its deps.
 
 // List handles GET /api/v1/admin/audiences.
 func (h *AudienceHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -381,7 +158,7 @@ func (h *AudienceHandler) List(w http.ResponseWriter, r *http.Request) {
 			EntryCount:              entryCountByID[a.ID],
 			ReferencedByPolicyCount: refCounts[a.Name],
 			HasInFlightRuns:         inFlight[a.ID],
-			DisableInAppFallback:    a.DisableInAppFallback != 0,
+			DisableInAppFallback:    int64ToBool(a.DisableInAppFallback),
 			Version:                 a.Version,
 			CreatedAt:               a.CreatedAt,
 			UpdatedAt:               a.UpdatedAt,
@@ -466,18 +243,13 @@ func (h *AudienceHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	q := db.New(tx)
 
-	disableFlag := int64(0)
-	if req.DisableInAppFallback {
-		disableFlag = 1
-	}
-
 	audience, err := q.CreatePluginAudience(ctx, db.CreatePluginAudienceParams{
 		ID:                   id,
 		Name:                 req.Name,
 		CreatedByUserID:      createdByUserID,
 		CreatedAt:            now,
 		UpdatedAt:            now,
-		DisableInAppFallback: disableFlag,
+		DisableInAppFallback: boolToInt64(req.DisableInAppFallback),
 	})
 	if err != nil {
 		if isAudienceUniqueConstraintError(err) {
@@ -558,15 +330,10 @@ func (h *AudienceHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	q := db.New(tx)
 
-	disableFlag := int64(0)
-	if req.DisableInAppFallback {
-		disableFlag = 1
-	}
-
 	rows, err := q.UpdatePluginAudience(ctx, db.UpdatePluginAudienceParams{
 		ID:                   id,
 		Name:                 req.Name,
-		DisableInAppFallback: disableFlag,
+		DisableInAppFallback: boolToInt64(req.DisableInAppFallback),
 		UpdatedAt:            now,
 		ExpectedVersion:      *req.ExpectedVersion,
 	})
@@ -587,7 +354,7 @@ func (h *AudienceHandler) Update(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Stale version — mirror ADR-038 conflict shape.
-		httputil.WriteError(w, http.StatusConflict, "run status transition lost to concurrent writer", "")
+		httputil.WriteError(w, http.StatusConflict, "audience was modified by another writer; reload and retry", "")
 		return
 	}
 
@@ -858,21 +625,13 @@ func insertAudienceEntries(ctx context.Context, q *db.Queries, audienceID string
 		if len(e.Config) > 0 {
 			configStr = string(e.Config)
 		}
-		notifyVal := int64(0)
-		if e.Notify {
-			notifyVal = 1
-		}
-		requestVal := int64(0)
-		if e.Request {
-			requestVal = 1
-		}
 		if _, err := q.CreateAudienceEntry(ctx, db.CreateAudienceEntryParams{
 			ID:               model.NewULID(),
 			AudienceID:       audienceID,
 			PluginInstanceID: e.PluginInstanceID,
 			Position:         int64(i),
-			Notify:           notifyVal,
-			Request:          requestVal,
+			Notify:           boolToInt64(e.Notify),
+			Request:          boolToInt64(e.Request),
 			ConfigJson:       configStr,
 		}); err != nil {
 			return err
@@ -906,7 +665,7 @@ func (h *AudienceHandler) buildAudienceDTO(a db.PluginAudience, entries []audien
 	return audienceDTO{
 		ID:                   a.ID,
 		Name:                 a.Name,
-		DisableInAppFallback: a.DisableInAppFallback != 0,
+		DisableInAppFallback: int64ToBool(a.DisableInAppFallback),
 		Version:              a.Version,
 		CreatedAt:            a.CreatedAt,
 		UpdatedAt:            a.UpdatedAt,
@@ -919,3 +678,15 @@ func (h *AudienceHandler) buildAudienceDTO(a db.PluginAudience, entries []audien
 func isAudienceUniqueConstraintError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
 }
+
+// SQLite stores booleans as INTEGER 0/1. boolToInt64 / int64ToBool centralize
+// that convention at the handler boundary so the conversions are not scattered
+// inline across Create, Update, and the DTO builders.
+func boolToInt64(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func int64ToBool(i int64) bool { return i != 0 }

--- a/internal/http/api/plugin_instance_handler.go
+++ b/internal/http/api/plugin_instance_handler.go
@@ -1,0 +1,247 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+)
+
+// This file owns the GET /api/v1/admin/plugin-instances endpoint and its
+// manifest-derived DTOs. The endpoint is a general plugin-instance projection
+// consumed by several surfaces (the audience editor, the trigger picker #219,
+// the admin/plugins service badges, and the OAuth re-authorize banner #228/#230)
+// — it is not specific to audiences. The method receiver is *AudienceHandler
+// because that handler already owns the (store, snap) dependencies this
+// projection needs; the route is wired through it in router.go.
+
+// pluginEventExampleDTO is a single named example payload for a plugin event kind.
+// Used by the "Test against sample" feature in the policy editor (spec §7.5).
+type pluginEventExampleDTO struct {
+	Name    string      `json:"name"`
+	Payload interface{} `json:"payload"`
+}
+
+// pluginToolDTO describes a single tool declared by a plugin's manifest.
+// Used by the admin UI detail pane to list what tools the plugin provides.
+type pluginToolDTO struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// pluginEventKindDTO is a single event kind from an installed plugin instance's
+// manifest — used by the trigger picker to show plugin-sourced trigger options.
+type pluginEventKindDTO struct {
+	Kind          string                  `json:"kind"`
+	Description   string                  `json:"description"`
+	BindingSchema interface{}             `json:"binding_schema,omitempty"`
+	Examples      []pluginEventExampleDTO `json:"examples,omitempty"`
+}
+
+// pluginInstanceDTO describes one installed plugin instance with its
+// manifest-derived capabilities. It is the response shape for
+// GET /api/v1/admin/plugin-instances and is shared across the audience editor,
+// the trigger picker (#219) which reads event_kinds, the admin/plugins page
+// service badges, and the OAuth re-authorize banner (#228/#230). Fields added
+// here are observed by all of those surfaces — change with care.
+type pluginInstanceDTO struct {
+	ID                 string               `json:"id"`
+	PluginID           string               `json:"plugin_id"`
+	PluginName         string               `json:"plugin_name"`
+	InstanceName       string               `json:"instance_name"`
+	State              string               `json:"state"`
+	ImplementsNotify   bool                 `json:"implements_notify"`
+	ImplementsRequest  bool                 `json:"implements_request"`
+	ConfigSchema       interface{}          `json:"config_schema"`
+	EventKinds         []pluginEventKindDTO `json:"event_kinds"`
+	SubscriptionSchema interface{}          `json:"subscription_schema"`
+	SubscriptionScope  map[string]any       `json:"subscription_scope"`
+	Version            int64                `json:"version"`
+	// AuthStrategy is the auth strategy declared in the manifest (e.g.
+	// "oauth2_authcode", "oauth2_clientcred", "static_api_key"). Used by the
+	// admin UI to decide whether to show the Re-authorize button (#228).
+	AuthStrategy string `json:"auth_strategy"`
+	// HealthDetail is the detail string from the most recent health transition.
+	// Omitted when empty. Used together with AuthStrategy to gate the
+	// Re-authorize banner: detail prefix "oauth refresh failed" + oauth strategy
+	// → show the button.
+	HealthDetail string `json:"health_detail,omitempty"`
+	// LastOauthCallbackUrl is the OAuth callback URL recorded the last time this
+	// instance completed an OAuth flow. Omitted when nil (never authorized). Used
+	// by the admin/plugins page to help operators understand which URL needs to be
+	// updated in the provider after a public_url change (#230).
+	LastOauthCallbackUrl string `json:"last_oauth_callback_url,omitempty"`
+	// PluginVersion is the SemVer version string from the manifest (e.g. "1.0.0").
+	// Used by the admin/plugins page to display the version on each plugin card.
+	PluginVersion string `json:"plugin_version"`
+	// Services lists the gRPC services declared by the plugin manifest.
+	// Possible values: "tool", "trigger", "channel". Omitted when empty.
+	// Used by the admin/plugins page to render service badges on plugin cards.
+	Services []string `json:"services,omitempty"`
+	// Tools lists tool declarations from the plugin manifest (ToolService plugins
+	// only). Each entry carries the tool name and description for the admin UI
+	// detail pane. Omitted when the plugin declares no tools.
+	Tools []pluginToolDTO `json:"tools,omitempty"`
+}
+
+// ListPluginInstances handles GET /api/v1/admin/plugin-instances.
+// Returns all installed plugin instances with their manifest-derived
+// capabilities for use in the audience editor and trigger picker.
+func (h *AudienceHandler) ListPluginInstances(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	instances, err := h.store.Queries().ListPluginInstances(ctx)
+	if err != nil {
+		slog.Error("list plugin instances: DB error", "err", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	dtos := make([]pluginInstanceDTO, 0, len(instances))
+	for _, inst := range instances {
+		manifest, err := h.snap.ForInstanceID(ctx, inst.ID)
+		if err != nil {
+			// Skip instances whose manifest cannot be parsed rather than failing
+			// the entire list — the operator can still use other instances.
+			slog.Warn("list plugin instances: parse manifest", "instance_id", inst.ID, "err", err)
+			continue
+		}
+
+		var implementsNotify, implementsRequest bool
+		var configSchema interface{}
+		if len(manifest.Channels) > 0 {
+			ch := manifest.Channels[0]
+			implementsNotify = ch.ImplementsNotify
+			implementsRequest = ch.ImplementsRequest
+			if ch.ConfigSchema != nil {
+				// Convert the YAML node to a plain map so it serializes as JSON.
+				var csMap interface{}
+				if err := ch.ConfigSchema.Decode(&csMap); err == nil {
+					configSchema = csMap
+				}
+			}
+		}
+
+		eventKinds := make([]pluginEventKindDTO, 0, len(manifest.EventKinds))
+		for _, ek := range manifest.EventKinds {
+			if ek.Kind == "" {
+				continue
+			}
+
+			dto := pluginEventKindDTO{
+				Kind:        ek.Kind,
+				Description: ek.Description,
+			}
+
+			// Decode binding_schema into a plain map so it serializes as JSON.
+			if ek.BindingSchema != nil {
+				var bsMap interface{}
+				if err := ek.BindingSchema.Decode(&bsMap); err == nil {
+					dto.BindingSchema = bsMap
+				} else {
+					slog.Warn("list plugin instances: decode binding_schema", "instance_id", inst.ID, "kind", ek.Kind, "err", err)
+				}
+			}
+
+			// Decode examples; skip malformed entries rather than failing the request.
+			for i, exNode := range ek.Examples {
+				var m map[string]any
+				if err := exNode.Decode(&m); err != nil {
+					slog.Warn("list plugin instances: decode example", "instance_id", inst.ID, "kind", ek.Kind, "index", i, "err", err)
+					continue
+				}
+				name, _ := m["name"].(string)
+				payload, payloadOK := m["payload"]
+				if name == "" || !payloadOK {
+					slog.Warn("list plugin instances: example missing name or payload", "instance_id", inst.ID, "kind", ek.Kind, "index", i)
+					continue
+				}
+				dto.Examples = append(dto.Examples, pluginEventExampleDTO{Name: name, Payload: payload})
+			}
+
+			eventKinds = append(eventKinds, dto)
+		}
+
+		// Decode manifest-level subscription_schema (OUTSIDE the Channels guard —
+		// this is a manifest top-level field, not a per-channel field).
+		var subscriptionSchema interface{}
+		if manifest.SubscriptionSchema != nil {
+			var ssMap interface{}
+			if err := manifest.SubscriptionSchema.Decode(&ssMap); err == nil {
+				subscriptionSchema = ssMap
+			} else {
+				slog.Warn("list plugin instances: decode subscription_schema", "instance_id", inst.ID, "err", err)
+			}
+		}
+
+		// Decode current subscription scope from the raw DB row (no extra query).
+		var subscriptionScope map[string]any
+		if inst.SubscriptionScopeJson != "" && inst.SubscriptionScopeJson != "{}" {
+			if err := json.Unmarshal([]byte(inst.SubscriptionScopeJson), &subscriptionScope); err != nil {
+				slog.Warn("list plugin instances: decode subscription_scope_json", "instance_id", inst.ID, "err", err)
+				subscriptionScope = map[string]any{}
+			}
+		} else {
+			subscriptionScope = map[string]any{}
+		}
+
+		healthDetail := ""
+		if inst.HealthDetail != nil {
+			healthDetail = *inst.HealthDetail
+		}
+
+		lastCallbackURL := ""
+		if inst.LastOauthCallbackUrl != nil {
+			lastCallbackURL = *inst.LastOauthCallbackUrl
+		}
+
+		// Derive the declared service list from the manifest Services field.
+		// All instances of the same plugin share the same manifest, so this
+		// value is identical across instances.
+		var services []string
+		if manifest.Services.Tool != "" {
+			services = append(services, "tool")
+		}
+		if manifest.Services.Trigger != "" {
+			services = append(services, "trigger")
+		}
+		if manifest.Services.Channel != "" {
+			services = append(services, "channel")
+		}
+
+		var tools []pluginToolDTO
+		for _, t := range manifest.Tools {
+			if t.Name == "" {
+				continue
+			}
+			tools = append(tools, pluginToolDTO{
+				Name:        t.Name,
+				Description: t.Description,
+			})
+		}
+
+		dtos = append(dtos, pluginInstanceDTO{
+			ID:                   inst.ID,
+			PluginID:             inst.PluginID,
+			PluginName:           manifest.Name,
+			InstanceName:         inst.InstanceName,
+			State:                inst.HealthState,
+			ImplementsNotify:     implementsNotify,
+			ImplementsRequest:    implementsRequest,
+			ConfigSchema:         configSchema,
+			EventKinds:           eventKinds,
+			SubscriptionSchema:   subscriptionSchema,
+			SubscriptionScope:    subscriptionScope,
+			Version:              inst.Version,
+			AuthStrategy:         string(manifest.Auth.Strategy),
+			HealthDetail:         healthDetail,
+			LastOauthCallbackUrl: lastCallbackURL,
+			PluginVersion:        manifest.Version,
+			Services:             services,
+			Tools:                tools,
+		})
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, dtos)
+}


### PR DESCRIPTION
## Why

Asked to assess the audience feature for maintainer-friendliness. The domain package (`internal/plugin/audience`), the dispatcher (`channel.go`), and the policy-ref scanner are all clean and well-bounded. The one real structural wart was the HTTP layer: `audience_handler.go` had grown to 922 lines because the general-purpose `GET /api/v1/admin/plugin-instances` endpoint had been parked inside it.

That endpoint is **not** audience-specific — it's a manifest→DTO projection consumed by four surfaces:
- the audience editor
- the trigger picker (#219, reads `event_kinds`)
- the admin/plugins service badges
- the OAuth re-authorize banner (#228/#230)

…yet its DTO was named `pluginInstanceForAudienceDTO`, actively misleading anyone editing the audience editor into thinking they could change it freely.

## What changed

- **Relocated** `ListPluginInstances` + its four DTOs into a new `plugin_instance_handler.go`. The method receiver stays `*AudienceHandler` (it already owns the `store`+`snap` deps and the route wiring), so **router/main/tests are untouched — pure relocation, zero behavior change.**
- **Renamed** `pluginInstanceForAudienceDTO` → `pluginInstanceDTO`, with a doc comment naming all four consumers so future field changes account for the shared surface.
- **Fixed a misleading error message** on audience `Update`: the CAS-conflict path reused `runstate`'s `"run status transition lost to concurrent writer"` string, telling operators editing an audience about "run status transitions." Now `"audience was modified by another writer; reload and retry"`.
- **Centralized the SQLite bool↔int64 convention** in `boolToInt64`/`int64ToBool` helpers, replacing five scattered inline conversions.

`audience_handler.go` drops from 922 → ~660 lines, now focused purely on audience CRUD.

## Deferred

Follow-up cleanups (Create/Update save-skeleton dedup; an audit of the half-wired `RouteToInApp` `TODO(#209)` seam) are tracked in #548.

## Testing

- `go build ./...` clean
- `gofmt` clean on both files
- `go test ./internal/http/api/ ./internal/plugin/audience/ ./internal/plugin/dispatch/ ./internal/policy/` all pass

No new tests: this is a relocation + rename + message/helper change with no behavior delta; the existing `ListPluginInstances` suite (which still constructs `AudienceHandler` and calls the moved method) exercises it unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)