### PR TITLE
feat: openaicompat: drop the model-name reasoning heuristic

### DIFF
--- a/internal/llm/model_cache.go
+++ b/internal/llm/model_cache.go
@@ -30,10 +30,10 @@ func NewModelCache(providerName string) ModelCache {
 
 // NewModelCacheWithReasoning returns a ModelCache that classifies each model's
 // IsReasoning flag via the isReasoning predicate when building ListModels output.
-// Providers (e.g. openaicompat) that fetch a flat model list and infer reasoning
-// support from the model ID supply their heuristic here so the admin model picker
-// flags reasoning-capable backends correctly. A nil predicate behaves exactly
-// like NewModelCache.
+// Providers that fetch a flat model list and infer reasoning support from the
+// model ID supply their heuristic here so the admin model picker flags
+// reasoning-capable backends correctly. A nil predicate behaves exactly like
+// NewModelCache.
 func NewModelCacheWithReasoning(providerName string, isReasoning func(modelName string) bool) ModelCache {
 	return ModelCache{providerName: providerName, isReasoning: isReasoning}
 }

--- a/internal/llm/openaicompat/client.go
+++ b/internal/llm/openaicompat/client.go
@@ -92,10 +92,7 @@ func NewClient(baseURL, apiKey string, opts ...Option) *Client {
 	w := &compatWire{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		apiKey:  apiKey,
-		// isReasoningModel is the same heuristic the translator uses to route
-		// max_completion_tokens / reasoning_effort, reused here so reasoning models
-		// served by a compat backend surface IsReasoning=true in the model picker.
-		models: llm.NewModelCacheWithReasoning("OpenAI-compatible", isReasoningModel),
+		models:  llm.NewModelCache("OpenAI-compatible"),
 	}
 	for _, opt := range opts {
 		opt(w)

--- a/internal/llm/openaicompat/client_test.go
+++ b/internal/llm/openaicompat/client_test.go
@@ -220,10 +220,10 @@ func TestListModels_HappyPathAndCache(t *testing.T) {
 	}
 }
 
-// TestListModels_ClassifiesReasoning confirms compat-backend models are flagged
-// IsReasoning via the same o-series heuristic the translator uses for token-field
-// routing: o3-mini is reasoning; the gpt-4o family is not.
-func TestListModels_ClassifiesReasoning(t *testing.T) {
+// TestListModels_NoReasoningBadge confirms that all compat-backend models report
+// IsReasoning=false — the picker lists models without a reasoning badge and lets
+// the admin decide which to enable (the heuristic was removed in issue #539).
+func TestListModels_NoReasoningBadge(t *testing.T) {
 	fixture := loadFixture(t, "models_response.json")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -236,14 +236,9 @@ func TestListModels_ClassifiesReasoning(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := map[string]bool{"gpt-4o": false, "gpt-4o-mini": false, "o3-mini": true}
-	got := make(map[string]bool, len(models))
 	for _, m := range models {
-		got[m.Name] = m.IsReasoning
-	}
-	for name, wantReasoning := range want {
-		if got[name] != wantReasoning {
-			t.Errorf("model %q IsReasoning = %v; want %v", name, got[name], wantReasoning)
+		if m.IsReasoning {
+			t.Errorf("model %q IsReasoning = true; want false (no badge for compat models)", m.Name)
 		}
 	}
 }

--- a/internal/llm/openaicompat/translate.go
+++ b/internal/llm/openaicompat/translate.go
@@ -52,7 +52,12 @@ func BuildChatCompletionRequest(req llm.MessageRequest, stream bool, names llm.T
 		})
 	}
 
-	// MaxTokens: route to the right field depending on the model family.
+	// The token cap always goes to max_tokens. We do not attempt to detect models
+	// that require max_completion_tokens (e.g. o-series or gpt-5 hosted directly on
+	// OpenAI). If this compat client is ever pointed at those models, those requests
+	// will get a 400 — but the dedicated internal/llm/openai client handles OpenAI
+	// proper correctly and is the right path for those models. The tradeoff is
+	// intentional (see issue #539).
 	hints, _ := req.Hints.(*OpenAIHints)
 	effectiveMax := req.MaxTokens
 	if hints != nil {
@@ -67,20 +72,15 @@ func BuildChatCompletionRequest(req llm.MessageRequest, stream bool, names llm.T
 			p := *hints.TopP
 			out.TopP = &p
 		}
-		// reasoning_effort is a reasoning-model-only parameter; sending it to a
-		// non-reasoning model causes a 400 error from OpenAI.
-		if hints.ReasoningEffort != nil && isReasoningModel(req.Model) {
+		// Admin setting reasoning_effort is their assertion that the model supports it.
+		if hints.ReasoningEffort != nil {
 			e := *hints.ReasoningEffort
 			out.ReasoningEffort = &e
 		}
 	}
 	if effectiveMax > 0 {
 		v := effectiveMax
-		if isReasoningModel(req.Model) {
-			out.MaxCompletionTokens = &v
-		} else {
-			out.MaxTokens = &v
-		}
+		out.MaxTokens = &v
 	}
 
 	return out
@@ -247,29 +247,3 @@ func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping, 
 	return out, nil
 }
 
-// isReasoningModel reports whether model is an OpenAI-style reasoning model: the
-// o-series (o1/o3/o4…), the gpt-5 family, or any name containing "reasoning". It
-// is the single signal behind three request-shaping decisions for OpenAI-style
-// backends — routing the token cap to max_completion_tokens (which OpenAI requires
-// for these models and rejects max_tokens for), gating reasoning_effort, and the
-// IsReasoning model-picker badge.
-//
-// This is a name-based heuristic because the standard OpenAI-compat /models
-// endpoint advertises no per-model capabilities. Backends that DO advertise them
-// (e.g. OpenRouter's per-model supported_parameters / max_completion_tokens) are a
-// deferred follow-up (#539): parse those fields opportunistically and let real
-// capability data override this heuristic when present, falling back here only when
-// absent.
-//
-// Contained to this function; no other place in the package pattern-matches on
-// model names.
-func isReasoningModel(model string) bool {
-	if strings.Contains(model, "reasoning") {
-		return true
-	}
-	if strings.HasPrefix(model, "gpt-5") {
-		return true
-	}
-	// o-series: name starts with o<digit> (o1, o3, o4, ...).
-	return len(model) >= 2 && model[0] == 'o' && model[1] >= '0' && model[1] <= '9'
-}

--- a/internal/llm/openaicompat/translate.go
+++ b/internal/llm/openaicompat/translate.go
@@ -246,4 +246,3 @@ func ParseChatCompletionResponse(wire *chatResponse, names llm.ToolNameMapping, 
 	// here — ADR-032 §2 ("Why Chat Completions only") is unaffected.
 	return out, nil
 }
-

--- a/internal/llm/openaicompat/translate_test.go
+++ b/internal/llm/openaicompat/translate_test.go
@@ -266,38 +266,29 @@ func TestBuildChatCompletionRequest(t *testing.T) {
 				if req.MaxTokens == nil || *req.MaxTokens != 1024 {
 					t.Errorf("MaxTokens: %+v", req.MaxTokens)
 				}
-				if req.MaxCompletionTokens != nil {
-					t.Errorf("MaxCompletionTokens should be nil, got %+v", req.MaxCompletionTokens)
-				}
 			},
 		},
 		{
-			name: "MaxTokens with o-series uses max_completion_tokens",
+			name: "MaxTokens with o-series still routes to max_tokens",
 			in: llm.MessageRequest{
 				Model:     "o3-mini",
 				MaxTokens: 1024,
 			},
 			check: func(t *testing.T, req chatRequest) {
-				if req.MaxTokens != nil {
-					t.Errorf("MaxTokens should be nil, got %+v", req.MaxTokens)
-				}
-				if req.MaxCompletionTokens == nil || *req.MaxCompletionTokens != 1024 {
-					t.Errorf("MaxCompletionTokens: %+v", req.MaxCompletionTokens)
+				if req.MaxTokens == nil || *req.MaxTokens != 1024 {
+					t.Errorf("MaxTokens: %+v", req.MaxTokens)
 				}
 			},
 		},
 		{
-			name: "MaxTokens with bare gpt-5 uses max_completion_tokens",
+			name: "MaxTokens with bare gpt-5 still routes to max_tokens",
 			in: llm.MessageRequest{
 				Model:     "gpt-5",
 				MaxTokens: 1024,
 			},
 			check: func(t *testing.T, req chatRequest) {
-				if req.MaxTokens != nil {
-					t.Errorf("MaxTokens should be nil for gpt-5, got %+v", req.MaxTokens)
-				}
-				if req.MaxCompletionTokens == nil || *req.MaxCompletionTokens != 1024 {
-					t.Errorf("MaxCompletionTokens: %+v", req.MaxCompletionTokens)
+				if req.MaxTokens == nil || *req.MaxTokens != 1024 {
+					t.Errorf("MaxTokens: %+v", req.MaxTokens)
 				}
 			},
 		},
@@ -329,14 +320,14 @@ func TestBuildChatCompletionRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "reasoning_effort only sent for o-series",
+			name: "reasoning_effort sent for non-reasoning-named model when admin-provided",
 			in: llm.MessageRequest{
 				Model: "gpt-4o",
 				Hints: &OpenAIHints{ReasoningEffort: strp("high")},
 			},
 			check: func(t *testing.T, req chatRequest) {
-				if req.ReasoningEffort != nil {
-					t.Errorf("reasoning_effort should be omitted for non-o-series, got %+v", req.ReasoningEffort)
+				if req.ReasoningEffort == nil || *req.ReasoningEffort != "high" {
+					t.Errorf("reasoning_effort: %+v", req.ReasoningEffort)
 				}
 			},
 		},
@@ -397,31 +388,6 @@ func TestBuildChatCompletionRequest_StreamFlag(t *testing.T) {
 	}
 	if req.StreamOptions == nil || !req.StreamOptions.IncludeUsage {
 		t.Errorf("want stream_options.include_usage true, got %+v", req.StreamOptions)
-	}
-}
-
-// TestIsReasoningModel locks the model-name heuristic that drives token-field
-// routing, reasoning_effort gating, and the IsReasoning picker badge.
-func TestIsReasoningModel(t *testing.T) {
-	cases := map[string]bool{
-		"o1":              true,
-		"o1-mini":         true,
-		"o3":              true,
-		"o3-mini":         true,
-		"o4-mini":         true,
-		"gpt-5":           true, // bare gpt-5 family must route to max_completion_tokens
-		"gpt-5-mini":      true,
-		"gpt-5-nano":      true,
-		"gpt-5-reasoning": true,
-		"gpt-4o":          false,
-		"gpt-4o-mini":     false,
-		"gpt-4.1":         false,
-		"llama3.1:70b":    false,
-	}
-	for model, want := range cases {
-		if got := isReasoningModel(model); got != want {
-			t.Errorf("isReasoningModel(%q) = %v, want %v", model, got, want)
-		}
 	}
 }
 

--- a/internal/llm/openaicompat/wire.go
+++ b/internal/llm/openaicompat/wire.go
@@ -15,9 +15,8 @@ type chatRequest struct {
 	Stream        bool           `json:"stream,omitempty"`
 	StreamOptions *streamOptions `json:"stream_options,omitempty"`
 
-	// Exactly one of MaxTokens or MaxCompletionTokens is set by the translator.
-	MaxTokens           *int `json:"max_tokens,omitempty"`
-	MaxCompletionTokens *int `json:"max_completion_tokens,omitempty"`
+	// MaxTokens is always set by the translator (never max_completion_tokens).
+	MaxTokens *int `json:"max_tokens,omitempty"`
 
 	Temperature     *float64 `json:"temperature,omitempty"`
 	TopP            *float64 `json:"top_p,omitempty"`


### PR DESCRIPTION
Closes #539

## Summary

Removes the `isReasoningModel` model-name heuristic from `internal/llm/openaicompat` entirely. The heuristic conflated a **backend** property (which token-cap dialect the backend speaks) with a **model** property (reasoning support), and guessed capabilities in the admin model picker. Per the maintainer decision on #539, this is a deliberate **subtraction** — we replace guessing with fixed, explicit behavior rather than building a capability-detection ladder.

### Behavior changes
- **Token cap** always routes to `max_tokens` (never `max_completion_tokens`).
- **`reasoning_effort`** is sent whenever the admin set it in the policy YAML hints — the model-name gate is gone. If the admin set it, that *is* their assertion the model supports it.
- **Picker badge** removed: compat models report `IsReasoning=false`; the picker just lists what the backend advertises and the admin decides what to enable.

### Knowingly accepted tradeoff
Hardcoding `max_tokens` means o-series / gpt-5 models reached **through the compat loader** (directly, or via a proxy like OpenRouter serving `openai/o1`) will be rejected with a 400, because those models require `max_completion_tokens`. This is acceptable: the dedicated `internal/llm/openai` client handles OpenAI proper correctly, so only models reached through the third-party compat loader are affected. Documented here per the issue's acceptance criteria rather than worked around.

Net change: **+31 / −100** — a pure subtraction.

<details>
<summary>Architecture plan</summary>

- `translate.go`: delete `isReasoningModel` + doc comment; drop the `&& isReasoningModel(req.Model)` gate so `reasoning_effort` is sent whenever admin-provided; always assign `out.MaxTokens` (delete the `max_completion_tokens` branch); rewrite the leading comment to explain the always-`max_tokens` choice and the accepted tradeoff.
- `wire.go`: remove the dead `MaxCompletionTokens` field from `chatRequest`; fix the adjacent comment.
- `client.go`: `NewModelCacheWithReasoning("OpenAI-compatible", isReasoningModel)` → `NewModelCache("OpenAI-compatible")`.
- `model_cache.go`: comment-only — the `NewModelCacheWithReasoning` doc no longer names openaicompat as the heuristic example (API/behavior unchanged; shared symbol preserved, still used by tests).
- Tests (`translate_test.go`, `client_test.go`): reasoning-named models now assert `max_tokens`; `reasoning_effort` now asserted sent for `gpt-4o` when admin-set; `IsReasoning` badge test flipped to all-false; `TestIsReasoningModel` deleted.

Scope strictly confined to `internal/llm/openaicompat` plus the one comment edit in `internal/llm/model_cache.go`; `internal/llm/contract` confirmed untouched.
</details>

## Review

- Architect plan reviewed adversarially → **APPROVE** (line numbers, blast radius, and contract-suite no-change claim verified against the codebase).
- Code review: **APPROVE** on the first cycle — **1 review cycle**, no changes requested.
- CLAUDE.md: no updates needed (no new packages/env vars/routes/ADRs).

Generated by the agentic dev loop.
