### PR TITLE
refactor: RouterConfig.AdminHandler should be an interface, not a concrete type

### DIFF
--- a/internal/http/api/router.go
+++ b/internal/http/api/router.go
@@ -33,12 +33,32 @@ type PolicyNotifier interface {
 	Notify(ctx context.Context, policyID string)
 }
 
-// HandlerBundle groups all pre-constructed HTTP handler structs. Every field is
-// a concrete handler type — BuildRouter never constructs handlers itself.
+// AdminHandler is the subset of *admin.Handler's HTTP-handler surface that
+// BuildRouter wires into routes. Defining it here (rather than importing the
+// concrete type) lets BuildRouter be exercised with a stub in tests, and is
+// consistent with how every other handler dependency in RouterConfig is
+// expressed as an interface rather than a concrete type.
+type AdminHandler interface {
+	GetPublicConfig(w http.ResponseWriter, r *http.Request)
+	ListProviders(w http.ResponseWriter, r *http.Request)
+	SetProviderKey(w http.ResponseWriter, r *http.Request)
+	DeleteProviderKey(w http.ResponseWriter, r *http.Request)
+	GetSettings(w http.ResponseWriter, r *http.Request)
+	UpdateSettings(w http.ResponseWriter, r *http.Request)
+	SetDefaultModel(w http.ResponseWriter, r *http.Request)
+	ListModelsAdmin(w http.ResponseWriter, r *http.Request)
+	ListAllModels(lister llm.ModelLister) http.HandlerFunc
+	SetModelEnabled(w http.ResponseWriter, r *http.Request)
+}
+
+// HandlerBundle groups all pre-constructed HTTP handlers. Each field is a
+// handler ready to wire into routes — either a concrete handler pointer or a
+// consumer-defined interface (AdminHandler). BuildRouter never constructs
+// handlers itself.
 type HandlerBundle struct {
 	AuthHandler              *auth.Handler
 	SettingsHandler          *auth.SettingsHandler
-	AdminHandler             *admin.Handler
+	AdminHandler             AdminHandler
 	OpenAICompatHandler      *admin.OpenAICompatHandler
 	PluginAdminHandler       *admin.PluginHandler
 	PluginOAuthHandler       *admin.PluginOAuthHandler

--- a/internal/http/api/router_test.go
+++ b/internal/http/api/router_test.go
@@ -22,9 +22,87 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/trigger"
 )
 
-// buildTestRouterWithStore is the shared core: it lets callers inject the store
-// so they can seed rows before the router is built.
-func buildTestRouterWithStore(t *testing.T, store *db.Store) http.Handler {
+// Compile-time checks: the stub must satisfy the interface, and the real
+// *admin.Handler must still satisfy it (guards against future signature drift).
+var _ api.AdminHandler = (*stubAdminHandler)(nil)
+var _ api.AdminHandler = (*admin.Handler)(nil)
+
+// stubAdminHandler implements api.AdminHandler with a sentinel response so
+// tests can verify that BuildRouter dispatches to the injected implementation
+// rather than requiring a real *admin.Handler.
+type stubAdminHandler struct{}
+
+const stubSentinelBody = `{"stub":"admin"}`
+const stubSentinelStatus = http.StatusTeapot
+
+func (s *stubAdminHandler) respond(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(stubSentinelStatus)
+	_, _ = w.Write([]byte(stubSentinelBody))
+}
+
+func (s *stubAdminHandler) GetPublicConfig(w http.ResponseWriter, r *http.Request) { s.respond(w) }
+func (s *stubAdminHandler) ListProviders(w http.ResponseWriter, r *http.Request)   { s.respond(w) }
+func (s *stubAdminHandler) SetProviderKey(w http.ResponseWriter, r *http.Request)  { s.respond(w) }
+func (s *stubAdminHandler) DeleteProviderKey(w http.ResponseWriter, r *http.Request) {
+	s.respond(w)
+}
+func (s *stubAdminHandler) GetSettings(w http.ResponseWriter, r *http.Request)    { s.respond(w) }
+func (s *stubAdminHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) { s.respond(w) }
+func (s *stubAdminHandler) SetDefaultModel(w http.ResponseWriter, r *http.Request) {
+	s.respond(w)
+}
+func (s *stubAdminHandler) ListModelsAdmin(w http.ResponseWriter, r *http.Request) { s.respond(w) }
+func (s *stubAdminHandler) ListAllModels(lister llm.ModelLister) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) { s.respond(w) }
+}
+func (s *stubAdminHandler) SetModelEnabled(w http.ResponseWriter, r *http.Request) { s.respond(w) }
+
+// TestBuildRouter_AdminHandlerStub verifies that BuildRouter wires the injected
+// AdminHandler into routes rather than requiring a concrete *admin.Handler. It
+// builds the router with a stubAdminHandler and asserts the stub's sentinel
+// response is returned for the public-config route (all authenticated users)
+// and the admin-gated settings route (admin role required).
+func TestBuildRouter_AdminHandlerStub(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	stub := &stubAdminHandler{}
+	router := buildTestRouterWithStoreAndAdmin(t, store, stub)
+
+	adminToken := insertUserWithSession(t, store, "stub-admin", "admin")
+
+	t.Run("GET /api/v1/config dispatches to stub", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+		req.AddCookie(&http.Cookie{Name: "gleipnir_session", Value: adminToken})
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != stubSentinelStatus {
+			t.Errorf("status = %d, want %d (stub sentinel); body: %s", w.Code, stubSentinelStatus, w.Body.String())
+		}
+		if got := w.Body.String(); got != stubSentinelBody {
+			t.Errorf("body = %q, want %q", got, stubSentinelBody)
+		}
+	})
+
+	t.Run("GET /api/v1/admin/settings dispatches to stub", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/settings", nil)
+		req.AddCookie(&http.Cookie{Name: "gleipnir_session", Value: adminToken})
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != stubSentinelStatus {
+			t.Errorf("status = %d, want %d (stub sentinel); body: %s", w.Code, stubSentinelStatus, w.Body.String())
+		}
+		if got := w.Body.String(); got != stubSentinelBody {
+			t.Errorf("body = %q, want %q", got, stubSentinelBody)
+		}
+	})
+}
+
+// buildTestRouterWithStoreAndAdmin is the shared core: it lets callers inject
+// the store (so they can seed rows before the router is built) and the
+// AdminHandler implementation (so tests can substitute a stub).
+func buildTestRouterWithStoreAndAdmin(t *testing.T, store *db.Store, adminHandler api.AdminHandler) http.Handler {
 	t.Helper()
 
 	broadcaster := sse.NewBroadcaster()
@@ -37,9 +115,7 @@ func buildTestRouterWithStore(t *testing.T, store *db.Store) http.Handler {
 	providerRegistry := llm.NewProviderRegistry()
 	providerRegistry.Register("anthropic", noopClient)
 
-	adminQuerier := admin.NewQuerierAdapter(store.Queries())
 	systemSettings := settings.NewService(store.Queries())
-	adminHandler := admin.NewHandler(adminQuerier, systemSettings, nil, []string{"anthropic"}, nil, nil, nil)
 
 	launcher := run.NewRunLauncher(run.RunLauncherConfig{
 		Store:                  store,
@@ -87,6 +163,17 @@ func buildTestRouterWithStore(t *testing.T, store *db.Store) http.Handler {
 			DBPath:    "",
 		},
 	})
+}
+
+// buildTestRouterWithStore builds the router with the real *admin.Handler backed
+// by the given store. Callers that need a different AdminHandler implementation
+// should use buildTestRouterWithStoreAndAdmin directly.
+func buildTestRouterWithStore(t *testing.T, store *db.Store) http.Handler {
+	t.Helper()
+	adminQuerier := admin.NewQuerierAdapter(store.Queries())
+	systemSettings := settings.NewService(store.Queries())
+	adminHandler := admin.NewHandler(adminQuerier, systemSettings, nil, []string{"anthropic"}, nil, nil, nil)
+	return buildTestRouterWithStoreAndAdmin(t, store, adminHandler)
 }
 
 // buildTestRouter constructs a minimal RouterConfig backed by a real in-memory


### PR DESCRIPTION
Closes #57

## Summary

`HandlerBundle.AdminHandler` (in `internal/http/api/router.go`) was the one handler field that crossed a package boundary as a concrete type (`*admin.Handler`). This change replaces it with an `AdminHandler` **interface** defined in the router's own package, covering exactly the 10 HTTP-handler methods `BuildRouter` actually wires:

`GetPublicConfig`, `ListProviders`, `SetProviderKey`, `DeleteProviderKey`, `GetSettings`, `UpdateSettings`, `SetDefaultModel`, `ListModelsAdmin`, `ListAllModels(llm.ModelLister) http.HandlerFunc`, `SetModelEnabled`.

`*admin.Handler` satisfies the interface implicitly, so `main.go` and existing test helpers compile unchanged. The router now depends on behavior rather than a concrete type, and `BuildRouter` is exercisable with a stub.

### Notable corrections to the original issue
- **`GetSystemDefault` is excluded.** The #53 settings extraction already moved the model-resolver/settings dependency to `*settings.Service`, so the router never calls `GetSystemDefault`. Including it would over-constrain the seam.
- **`SetDefaultModel` is included** (the issue's proposed interface omitted it, but the router calls it).
- **The `internal/admin` import is retained.** It's still needed for `admin.GetSystemInfo`/`admin.SystemInfoDeps` and four other concrete `*admin.*Handler` fields. The decoupling delivered here is the stub-testable seam + interface consistency — **not** removal of the compile-time package dependency (which would be out of scope).

## Tests
- Compile-time assertions for both the stub (`*stubAdminHandler`) and the real `*admin.Handler` — the latter guards against future signature drift.
- `TestBuildRouter_AdminHandlerStub` builds the router with a stub admin handler and asserts the stub's sentinel (HTTP 418) is returned for `GET /api/v1/config` and `GET /api/v1/admin/settings` — proving `BuildRouter` no longer needs a real `admin.Handler`.
- Extracted a shared `buildTestRouterWithStoreAndAdmin(t, store, adminHandler)` helper so the stub test and the existing real-handler tests share wiring.

`go build ./...` clean; `go test ./internal/http/api/...` passes.

## Review cycles
2 code-review cycles (cycle 1 flagged a stale `HandlerBundle` doc comment + suggested test dedup; both addressed in cycle 2). Architect plan was reviewed adversarially and approved before implementation.

## Docs
No CLAUDE.md update needed — Go type-level seam in an existing package; no new packages, env vars, routes, or ADRs.

<details>
<summary>Architecture plan</summary>

- Add `AdminHandler` interface in `internal/http/api/router.go` (10 methods, consumer-defined seam; doc comment explains why).
- Change `HandlerBundle.AdminHandler` field from `*admin.Handler` to the interface.
- Exclude `GetSystemDefault`; include `SetDefaultModel`; keep `ListAllModels(lister llm.ModelLister) http.HandlerFunc` signature exactly.
- Retain `internal/admin` import (other concrete fields + free functions still use it) — partial decoupling by design.
- Tests: compile-time satisfaction assertions for stub + real type; stub-dispatch test via observable sentinel; shared router-wiring helper.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.

https://claude.ai/code/session_012biTWnjcc6todBdMeLaSP5

---
_Generated by [Claude Code](https://claude.ai/code/session_012biTWnjcc6todBdMeLaSP5)_