### PR TITLE
feat: gleipnirctl create-user subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ schemas/
   sql_schemas.sql     — human-readable reference snapshot of the full datastore. NOT consumed by sqlc or the migration runner (sqlc reads internal/db/migrations/0001_initial.sql + the two .sql migrations listed in sqlc.yaml); keep it in sync by hand with the post-migration schema. The migration NNNN_ filename prefix is a hint only — Version() (via the All() slice in registry.go) is authoritative for apply order; prefixes may carry a suffix (e.g. 0025b_) to avoid collisions (#492).
 
 cmd/
-  gleipnirctl/        — local admin CLI; direct DB-level maintenance operations (rotate-key, reset-password). Run via `docker compose run --rm api gleipnirctl <command>`.
+  gleipnirctl/        — local admin CLI; direct DB-level maintenance operations (rotate-key, reset-password, create-user). Run via `docker compose run --rm api gleipnirctl <command>`.
 
 internal/
   admin/              — admin HTTP handlers (provider/model API keys, OpenAI-compat backends, system settings) + AES-256-GCM helpers for at-rest secret encryption

--- a/cmd/gleipnirctl/README.md
+++ b/cmd/gleipnirctl/README.md
@@ -18,6 +18,7 @@ The web UI handles day-to-day operations: managing policies, reviewing runs, app
 |---|---|
 | `rotate-key` | Re-encrypt all at-rest secrets under a new encryption key |
 | `reset-password` | Reset a user's password directly in the database |
+| `create-user` | Create a new user with an assigned role directly in the database |
 
 ---
 
@@ -182,3 +183,61 @@ The server does not need to be stopped. This command performs a single short UPD
 - **Generated password is secret material.** It is printed to stdout so it can be captured by downstream tools (`... | tee password.txt`). Do not share terminal output containing this line.
 - **Rotate via the UI after logging in.** Once access is restored, change the password through the settings page so it is set according to your organization's password policy.
 - **Deactivated users.** This command resets the password hash only. It does not reactivate a deactivated account. Use the web UI (admin role) to reactivate a user.
+
+---
+
+## create-user
+
+Creates a new Gleipnir user with the specified role, writing the account directly to the database. Useful for bootstrapping a second admin account or automating user provisioning without going through the web UI.
+
+### When to use this
+
+- You need a second admin account and have only database access (no working admin session in the UI)
+- You are provisioning users in a CI/CD pipeline or automated setup script
+
+### Full workflow
+
+**With auto-generated password** (recommended):
+
+```bash
+docker compose run --rm api gleipnirctl create-user <username> --role admin
+```
+
+Example output:
+```
+generated password: dGhpcyBpcyBhIHRlc3Q
+created user alice with role admin
+```
+
+The generated password is printed to stdout before the confirmation line. Store it immediately — it is shown only once.
+
+**With an explicit password:**
+
+```bash
+docker compose run --rm api gleipnirctl create-user <username> --role operator --password <password>
+```
+
+The server does not need to be stopped. This command performs a short INSERT that does not require holding the database write lock across long operations.
+
+### Flags
+
+| Flag / Argument | Default | Description |
+|---|---|---|
+| `<username>` | *(required positional)* | Username for the new account |
+| `--role` | `operator` | Role to assign (`admin`, `operator`, `approver`, `auditor`) |
+| `--password` | *(auto-generated if omitted)* | Password for the new account. Must be at least 8 characters. |
+| `--db-path` | `$GLEIPNIR_DB_PATH` or `/data/gleipnir.db` | Path to the SQLite database file. |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Unexpected error (I/O failure, DB error, hashing failure) |
+| 2 | Bad input (invalid role, password shorter than 8 characters) |
+| 4 | Username already exists |
+
+### Security notes
+
+- **Generated password is secret material.** It is printed to stdout so it can be captured by downstream tools (`... | tee password.txt`). Do not share terminal output containing this line.
+- **Role validation happens before the database is opened.** Supplying an unrecognised role exits with code 2 without writing anything to the database.

--- a/cmd/gleipnirctl/create_user.go
+++ b/cmd/gleipnirctl/create_user.go
@@ -1,0 +1,107 @@
+// Package main implements the gleipnirctl local admin CLI.
+//
+// create_user.go contains the core user-creation logic: CreateUser inserts a new
+// user row and assigns a role in a single transaction. The Cobra command wiring
+// lives in createuser.go.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/http/auth"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// CreateUser creates a new user with username, role, and password in the database
+// at dbPath. If password is empty the caller is responsible for generating one
+// before calling this function. Returns a shell exit code:
+//
+//	0 — success
+//	1 — unexpected error (I/O, DB error, hashing failure)
+//	2 — bad input (empty username, invalid role, password shorter than 8 chars)
+//	4 — username already exists
+func CreateUser(ctx context.Context, dbPath, username, role, password string, out, errOut io.Writer) int {
+	if username == "" {
+		fmt.Fprintln(errOut, "error: username must not be empty")
+		return 2
+	}
+	if !model.Role(role).Valid() {
+		fmt.Fprintf(errOut, "error: invalid role %q; must be one of: admin, operator, approver, auditor\n", role)
+		return 2
+	}
+	if len(password) < 8 {
+		fmt.Fprintln(errOut, "error: password must be at least 8 characters")
+		return 2
+	}
+
+	store, err := db.Open(dbPath)
+	if err != nil {
+		fmt.Fprintf(errOut, "error: open db: %v\n", err)
+		return 1
+	}
+	defer store.Close()
+
+	// Migration is idempotent; ensures the command works against a restored
+	// backup that may be on an older schema version.
+	if err := store.Migrate(ctx); err != nil {
+		fmt.Fprintf(errOut, "error: migrate db: %v\n", err)
+		return 1
+	}
+
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		fmt.Fprintf(errOut, "error: hash password: %v\n", err)
+		return 1
+	}
+
+	// CreateUser + AssignRole in a single transaction so a failed role assignment
+	// cannot leave an orphaned user row.
+	tx, err := store.DB().BeginTx(ctx, nil)
+	if err != nil {
+		fmt.Fprintf(errOut, "error: begin transaction: %v\n", err)
+		return 1
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	q := store.Queries().WithTx(tx)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	user, err := q.CreateUser(ctx, db.CreateUserParams{
+		ID:           model.NewULID(),
+		Username:     username,
+		PasswordHash: hash,
+		CreatedAt:    now,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			fmt.Fprintf(errOut, "error: user %q already exists\n", username)
+			return 4
+		}
+		fmt.Fprintf(errOut, "error: create user %q: %v\n", username, err)
+		return 1
+	}
+
+	// AssignRole is INSERT OR IGNORE; the IGNORE path is unreachable here because
+	// user.ID is freshly generated and cannot already have a role row.
+	if err := q.AssignRole(ctx, db.AssignRoleParams{
+		UserID:    user.ID,
+		Role:      role,
+		CreatedAt: now,
+	}); err != nil {
+		fmt.Fprintf(errOut, "error: assign role %q to %q: %v\n", role, username, err)
+		return 1
+	}
+
+	if err := tx.Commit(); err != nil {
+		fmt.Fprintf(errOut, "error: commit transaction: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(out, "created user %s with role %s\n", username, role)
+	return 0
+}

--- a/cmd/gleipnirctl/createuser.go
+++ b/cmd/gleipnirctl/createuser.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newCreateUserCmd() *cobra.Command {
+	var password, role, dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "create-user <username>",
+		Short: "Create a new Gleipnir user directly in the database",
+		Long: `Creates a new Gleipnir user with the specified role, writing the account
+directly to the database. This is useful for bootstrapping a second admin account
+or automating user provisioning in CI/CD without going through the web UI.
+
+The server does not need to be stopped — this command performs a short INSERT
+that resolves any write contention on its own via SQLite's busy retry.
+
+If --password is not provided, a cryptographically random 24-character password
+is generated and printed to stdout before the confirmation line. Store it
+immediately; it is printed only once.`,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			username := args[0]
+			out := cmd.OutOrStdout()
+			errOut := cmd.ErrOrStderr()
+
+			if password == "" {
+				generated, err := generateRandomPassword()
+				if err != nil {
+					fmt.Fprintf(errOut, "error: %v\n", err)
+					os.Exit(1)
+				}
+				password = generated
+				fmt.Fprintf(out, "generated password: %s\n", password)
+			}
+
+			code := CreateUser(context.Background(), dbPath, username, role, password, out, errOut)
+			if code != 0 {
+				os.Exit(code)
+			}
+			return nil
+		},
+	}
+
+	// Resolve default DB path from env var, falling back to the hardcoded default.
+	envDBPath := os.Getenv("GLEIPNIR_DB_PATH")
+	if envDBPath == "" {
+		envDBPath = defaultDBPath
+	}
+
+	cmd.Flags().StringVar(&role, "role", "operator", "role to assign (admin, operator, approver, auditor)")
+	cmd.Flags().StringVar(&password, "password", "", "password for the new user; if omitted a random password is generated and printed to stdout")
+	cmd.Flags().StringVar(&dbPath, "db-path", envDBPath, "path to the SQLite database file")
+
+	return cmd
+}

--- a/cmd/gleipnirctl/createuser_test.go
+++ b/cmd/gleipnirctl/createuser_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/http/auth"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+)
+
+func TestCreateUser_SuccessWithExplicitPassword(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	path := storePath(t, s)
+	s.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := CreateUser(context.Background(), path, "bob", "operator", "explicit-password-1234", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "created user bob with role operator") {
+		t.Errorf("stdout missing confirmation: %q", stdout.String())
+	}
+
+	// Verify the password hash and role assignment.
+	s2 := openForVerify(t, path)
+	defer s2.Close()
+
+	ctx := context.Background()
+	user, err := s2.Queries().GetUserByUsername(ctx, "bob")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if err := auth.CheckPassword(user.PasswordHash, "explicit-password-1234"); err != nil {
+		t.Errorf("CheckPassword failed after create: %v", err)
+	}
+	roles, err := s2.Queries().ListRolesByUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("list roles: %v", err)
+	}
+	if len(roles) != 1 || roles[0] != "operator" {
+		t.Errorf("expected roles [operator], got %v", roles)
+	}
+}
+
+func TestCreateUser_DuplicateUsernameReturns4(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	seedUser(t, s, "alice")
+	path := storePath(t, s)
+	s.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := CreateUser(context.Background(), path, "alice", "admin", "some-password-1234", &stdout, &stderr)
+	if code != 4 {
+		t.Fatalf("expected exit 4, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `user "alice" already exists`) {
+		t.Errorf("stderr missing already-exists message: %q", stderr.String())
+	}
+}
+
+func TestCreateUser_InvalidRoleReturns2(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	path := storePath(t, s)
+	s.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := CreateUser(context.Background(), path, "carol", "superuser", "valid-password-1234", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("expected exit 2, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid role") {
+		t.Errorf("stderr missing invalid-role message: %q", stderr.String())
+	}
+
+	// Verify role validation short-circuits before any DB write.
+	s2 := openForVerify(t, path)
+	defer s2.Close()
+	users, err := s2.Queries().ListUsers(context.Background())
+	if err != nil {
+		t.Fatalf("list users: %v", err)
+	}
+	if len(users) != 0 {
+		t.Errorf("expected no users written on invalid role, got %d", len(users))
+	}
+}
+
+// TestCreateUser_GeneratedPasswordRoundtrip drives the full Cobra command with
+// no --password flag, parses the "generated password: " line from stdout, and
+// verifies the stored hash accepts that password.
+func TestCreateUser_GeneratedPasswordRoundtrip(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	path := storePath(t, s)
+	s.Close()
+
+	cmd := newCreateUserCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"dave", "--role", "admin", "--db-path", path})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command failed: %v; stderr: %s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	// Extract the generated password from the "generated password: <pwd>" line.
+	var generatedPwd string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "generated password: ") {
+			generatedPwd = strings.TrimPrefix(line, "generated password: ")
+			break
+		}
+	}
+	if generatedPwd == "" {
+		t.Fatalf("generated password line not found in stdout: %q", out)
+	}
+	if !strings.Contains(out, "created user dave with role admin") {
+		t.Errorf("confirmation line missing from stdout: %q", out)
+	}
+
+	// Verify the generated password hash stored in DB.
+	s2 := openForVerify(t, path)
+	defer s2.Close()
+	user, err := s2.Queries().GetUserByUsername(context.Background(), "dave")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if err := auth.CheckPassword(user.PasswordHash, generatedPwd); err != nil {
+		t.Errorf("CheckPassword rejected generated password: %v", err)
+	}
+}

--- a/cmd/gleipnirctl/main.go
+++ b/cmd/gleipnirctl/main.go
@@ -23,6 +23,7 @@ func main() {
 	root := newRootCmd()
 	root.AddCommand(newRotateKeyCmd())
 	root.AddCommand(newResetPasswordCmd())
+	root.AddCommand(newCreateUserCmd())
 	if err := root.Execute(); err != nil {
 		root.PrintErrln("error:", err)
 		os.Exit(1)


### PR DESCRIPTION
Closes #87

## Summary

Adds `gleipnirctl create-user <username> --role <role> [--password <pwd>]` — a companion to `reset-password` for bootstrapping a second admin or recovering from an accidentally deleted admin account.

The command mirrors the existing `reset-password` structure exactly:
- **Reuses the server's hashing** — `auth.HashPassword` (bcrypt, same cost as the server), not a reimplementation.
- **Reuses existing sqlc queries** — `CreateUser` + `AssignRole`. No new query, no `sqlc generate`, no schema change.
- **Reuses the in-package** `generateRandomPassword()` helper and `model.Role.Valid()` role validation.

### Behavior
- Role is validated **before** the DB is opened — an invalid `--role` exits `2` and never touches the database.
- If `--password` is omitted, a random password is generated and printed once.
- User-row insert + role assignment run in a **single transaction**, so a failed role assignment cannot orphan a passwordless user.
- A duplicate username surfaces a clear `user "x" already exists` error and exits `4`.
- Success prints exactly `created user <username> with role <role>`.

### Exit codes
| Code | Meaning |
|------|---------|
| 0 | success |
| 1 | unexpected error (DB open, hash, commit) |
| 2 | bad input (empty username, short password, invalid role) |
| 4 | username already exists |

## Tests
`cmd/gleipnirctl/createuser_test.go` covers all four mandated paths:
- success with explicit password (hash verified via `auth.CheckPassword`, role via `ListRolesByUser`)
- duplicate username → exit 4
- invalid role → exit 2 with no DB write
- generated-password roundtrip driven through the full Cobra command

All new + existing `cmd/gleipnirctl` tests pass; `go build ./...` clean.

## Docs
- `cmd/gleipnirctl/README.md`: added `create-user` to the commands table + a full section (usage, flags, exit codes, correct `docker compose run --rm api gleipnirctl ...` invocation — the issue's example omitted the `api` service name).
- `CLAUDE.md`: added `create-user` to the `gleipnirctl` key-packages entry.

## Review cycles
2 code-review cycles (cycle 1 flagged a missing package-doc opener + two clarity comments; all addressed in cycle 2). Architect plan was adversarially reviewed and approved before implementation.

<details>
<summary>Architecture plan</summary>

- New `cmd/gleipnirctl/create_user.go`: `CreateUser(ctx, dbPath, username, password, role string, out, errOut io.Writer) int` — validation → `auth.HashPassword` → single-tx `CreateUser` + `AssignRole` → confirmation. Exit-code contract mirrors `ResetPassword`.
- New `cmd/gleipnirctl/createuser.go`: Cobra wiring (`newCreateUserCmd`) mirroring `resetpassword.go` — `--role` (required), `--password` (auto-generated if absent), `--db-path`.
- `main.go`: `root.AddCommand(newCreateUserCmd())`.
- New `cmd/gleipnirctl/createuser_test.go`: four integration tests reusing `testutil.NewTestStore`, `storePath`, `openForVerify`, `seedUser`.
- `README.md` + `CLAUDE.md` doc updates.
- Roles live in a separate `user_roles` table → two-statement creation wrapped in one transaction (load-bearing atomicity).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.

https://claude.ai/code/session_012biTWnjcc6todBdMeLaSP5

---
_Generated by [Claude Code](https://claude.ai/code/session_012biTWnjcc6todBdMeLaSP5)_