### PR TITLE
fix: ntfy wrong auth strategy literal breaks credential setup + broken README CLI examples

### DIFF
--- a/internal/plugin/manifest/diff_test.go
+++ b/internal/plugin/manifest/diff_test.go
@@ -99,7 +99,7 @@ func TestDiff_MaterialOAuthScopesChanged(t *testing.T) {
 
 func TestDiff_MaterialOAuthStrategyChanged(t *testing.T) {
 	old := baseManifest()
-	old.Auth.Strategy = "static_key"
+	old.Auth.Strategy = sdkmanifest.AuthStrategyStaticAPIKey
 
 	new := baseManifest()
 	new.Auth.Strategy = sdkmanifest.AuthStrategyOAuth2Authcode

--- a/plugin-sdk/manifest/manifest_test.go
+++ b/plugin-sdk/manifest/manifest_test.go
@@ -14,7 +14,7 @@ import (
 // manifest. Used to pin byte-identical output across code paths.
 const canonicalManifestYAML = `auth:
   mode: instance_credentials
-  strategy: static_key
+  strategy: static_api_key
 name: testplugin
 schema_version: v1
 services:
@@ -29,7 +29,7 @@ const minimalManifestJSON = `{
   "name": "testplugin",
   "schema_version": "v1",
   "services": {"tool": "v1"},
-  "auth": {"mode": "instance_credentials", "strategy": "static_key"}
+  "auth": {"mode": "instance_credentials", "strategy": "static_api_key"}
 }`
 
 // minimalManifestYAMLUnsorted is YAML with keys in non-canonical order.
@@ -40,7 +40,7 @@ services:
   tool: v1
 auth:
   mode: instance_credentials
-  strategy: static_key
+  strategy: static_api_key
 `
 
 // TestCanonicalize is a table-driven test covering the main Canonicalize paths.
@@ -76,7 +76,7 @@ services:
   tool: v1
 auth:
   mode: instance_credentials
-  strategy: static_key
+  strategy: static_api_key
 tools:
   - name: zebra_tool
     description: Does zebra things
@@ -139,7 +139,7 @@ func TestCanonicalizePreservesSchemaNodes(t *testing.T) {
 		"name": "schema-plugin",
 		"version": "1.0.0",
 		"services": {"tool": "v1"},
-		"auth": {"mode": "instance_credentials", "strategy": "static_key"},
+		"auth": {"mode": "instance_credentials", "strategy": "static_api_key"},
 		"config_schema": {
 			"type": "object",
 			"properties": {

--- a/plugin-sdk/manifest/yaml_test.go
+++ b/plugin-sdk/manifest/yaml_test.go
@@ -23,7 +23,7 @@ func sampleManifest() *manifest.Manifest {
 		},
 		Auth: manifest.AuthDecl{
 			Mode:     "instance_credentials",
-			Strategy: "static_key",
+			Strategy: "static_api_key",
 		},
 		Tools: []manifest.ToolDecl{
 			{Name: "zebra_tool", Description: "Does zebra things"},

--- a/plugins/ntfy/README.md
+++ b/plugins/ntfy/README.md
@@ -7,9 +7,9 @@ only — no `Request` surface.
 ## What this plugin demonstrates
 
 - Declaring a `ChannelService` with `implements_notify: true` only.
-- Using `static_api_key` auth strategy (`static_key` in the manifest field):
-  the host stores an optional API key that the plugin fetches at call time via
-  `GetCredentials`. No OAuth, not auth-required at install.
+- Using `static_api_key` auth strategy: the host stores an optional API key
+  that the plugin fetches at call time via `GetCredentials`. No OAuth, not
+  auth-required at install.
 - Per-audience topic override: the `channels[].config_schema` carries a single
   `topic` field that the audience editor surfaces per entry.
 - Instance config (`server_url`, `default_topic`, `auth_header_name`) fetched
@@ -50,14 +50,9 @@ The API key is optional — ntfy supports unauthenticated topics. When `api_key`
 is present the plugin sends `Bearer <key>` in the auth header (or whatever
 `auth_header_name` is set to).
 
-**This plugin uses `static_key` auth strategy** — it is not auth-required at
-install (no OAuth). An admin installs it and sets the API key once in the
+**This plugin uses `static_api_key` auth strategy** — it is not auth-required
+at install (no OAuth). An admin installs it and sets the API key once in the
 instance credentials screen.
-
-> Note: the plugin-system spec §9.1 uses the conceptual name `static_api_key`
-> for this credential strategy. The manifest validator code uses the field value
-> `static_key`. The README uses the descriptive name; the manifest uses the
-> code-level name.
 
 ## Build
 
@@ -100,18 +95,19 @@ go test ./plugins/ntfy/...
 
 2. **Generate signing keys** (not committed — keep the private key secret):
    ```sh
-   gleipnir-plugin keygen --out ntfy.key
+   gleipnir-plugin keygen --out-dir . --name ntfy --unencrypted
    # produces ntfy.key (private) and ntfy.pub (public)
    ```
 
-3. **Sign and package:**
+3. **Sign and package** (the `package` subcommand signs internally):
    ```sh
-   gleipnir-plugin sign   --binary ./ntfy-plugin --manifest manifest.yaml --key ntfy.key
-   gleipnir-plugin package --binary ./ntfy-plugin --manifest manifest.yaml --sig ntfy-plugin.sig --out ntfy.tar.gz
+   gleipnir-plugin package --binary ./ntfy-plugin --manifest manifest.yaml \
+     --key ntfy.key --pubkey ntfy.pub --out-dir dist
+   # produces dist/ntfy-0.1.0.tar.gz
    ```
 
 4. **Install** via the Gleipnir admin UI at `/admin/plugins` → "Install plugin"
-   → upload `ntfy.tar.gz`.
+   → upload `dist/ntfy-0.1.0.tar.gz`.
 
 5. **Configure the instance** in the plugin settings:
    - `server_url` — your ntfy server URL

--- a/plugins/ntfy/manifest.go
+++ b/plugins/ntfy/manifest.go
@@ -17,13 +17,11 @@ var pluginManifest = manifest.Manifest{
 	Services: manifest.Services{
 		Channel: "v1",
 	},
-	// static_key strategy: the host stores an API key that the plugin retrieves
-	// via GetCredentials. The credentials JSON shape is {"api_key":"<token>"}.
-	// Spec §9.1 uses the conceptual name "static_api_key"; the manifest validator
-	// uses the code-level name "static_key" (see plugin-sdk/manifest/manifest.go).
+	// static_api_key strategy: the host stores an API key that the plugin
+	// retrieves via GetCredentials. Credentials JSON shape: {"api_key":"<token>"}.
 	Auth: manifest.AuthDecl{
 		Mode:     "instance_credentials",
-		Strategy: "static_key",
+		Strategy: manifest.AuthStrategyStaticAPIKey,
 	},
 	Channels: []manifest.ChannelDecl{
 		{

--- a/plugins/ntfy/manifest.yaml
+++ b/plugins/ntfy/manifest.yaml
@@ -1,6 +1,6 @@
 auth:
   mode: instance_credentials
-  strategy: static_key
+  strategy: static_api_key
 channels:
   - config_schema:
       properties:

--- a/plugins/ntfy/manifest_test.go
+++ b/plugins/ntfy/manifest_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 )
 
+// TestManifestAuthStrategyIsKnownConstant verifies that the auth strategy
+// declared in the Go manifest matches manifest.AuthStrategyStaticAPIKey.
+// This catches literal-vs-constant drift that would break credential setup:
+// requireOneOfStrategies, BuildSeedCredentials, and SetStaticAPIKey all
+// compare against the SDK constant, so the manifest must match it exactly.
+func TestManifestAuthStrategyIsKnownConstant(t *testing.T) {
+	if pluginManifest.Auth.Strategy != manifest.AuthStrategyStaticAPIKey {
+		t.Errorf("Auth.Strategy = %q, want %q (manifest.AuthStrategyStaticAPIKey)",
+			pluginManifest.Auth.Strategy, manifest.AuthStrategyStaticAPIKey)
+	}
+}
+
 // TestManifestYAMLIsCanonical verifies that manifest.yaml on disk is the
 // byte-exact canonical projection of the pluginManifest Go declaration.
 //


### PR DESCRIPTION
Closes #561

## Summary

The ntfy reference plugin declared `Strategy: "static_key"` — a string that matches **no** SDK constant or validator. Because there's no install-time enum validation, ntfy installed cleanly but every credential-setup path (`requireOneOfStrategies`, `BuildSeedCredentials`, `SetStaticAPIKey`) rejected it, making authenticated ntfy **impossible**. The README's build example also used non-existent CLI flags (`keygen --out`, `package --sig/--out`), so a new author copy-pasting it could not produce a bundle.

### Changes
- `plugins/ntfy/manifest.go` — `Strategy` now uses `manifest.AuthStrategyStaticAPIKey` (the single-source-of-truth constant, `"static_api_key"`); deleted the false "code-level name is static_key" comment.
- `plugins/ntfy/manifest.yaml` — regenerated (single-line strategy change; it's a byte-canonical generated artifact).
- `plugins/ntfy/manifest_test.go` — new `TestManifestAuthStrategyIsKnownConstant` regression guard.
- `plugins/ntfy/README.md` — removed the `static_key` aliasing framing; rewrote `keygen`/`package` examples to real flags; tarball reference is now `dist/ntfy-0.1.0.tar.gz`.
- Purged the bug-reinforcing `static_key` literal from SDK/host test fixtures: `plugin-sdk/manifest/manifest_test.go` (5 occurrences), `plugin-sdk/manifest/yaml_test.go`, `internal/plugin/manifest/diff_test.go` (now uses the SDK constant).

Acceptance gate: `grep -rn "static_key"` returns zero hits repo-wide.

<details>
<summary>Architecture plan</summary>

Plan was adversarially reviewed (plan-reviewer caught a missed 5th fixture occurrence at `manifest_test.go:79` and that the `'"static_key"'` quoted grep misses unquoted YAML — the final gate uses the unquoted pattern, backstopped by `TestCanonicalize`/`TestManifestYAMLIsCanonical`). Key decision: use the exported SDK constant rather than a corrected literal (ADR-042 single source of truth), and regenerate `manifest.yaml` rather than hand-edit.
</details>

## Review
- Plan review: 1 revision cycle (added missed occurrence, fixed grep gate).
- Code review: 1 cycle — APPROVE on plan compliance; sole flagged item was an unrelated pre-existing `frontend/dist/.gitkeep` deletion, restored before commit (not part of this change).
- CLAUDE.md: current — no updates needed.
- Brainstorming: not triggered (issue well-specified).

🤖 Generated by the agentic dev loop.
