### PR TITLE
fix: start the plugin_pending_requests reclaim scanner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,6 @@ GLEIPNIR_LOG_LEVEL=info
 
 # How often to scan for feedback requests that have timed out.
 # GLEIPNIR_FEEDBACK_SCAN_INTERVAL=30s
+
+# How often to scan for plugin channel requests that have timed out.
+# GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL=30s

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ npm run storybook        # Storybook on port 6006
 | `GLEIPNIR_APPROVAL_SCAN_INTERVAL` | `30s` | How often to check for timed-out approvals |
 | `GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT` | `30m` | Default timeout for feedback requests |
 | `GLEIPNIR_FEEDBACK_SCAN_INTERVAL` | `30s` | How often to check for timed-out feedback |
-| `GLEIPNIR_DRAIN_TIMEOUT` | `5m` | Graceful-shutdown drain timeout for in-flight runs and background loops. Bounds the concurrent drain of the poller, cron runner, scheduler (in-flight `fire()`), and the approval/feedback timeout scanners (in-flight `resolveTimeout()`), plus the run manager — all joined in one timeout-raced goroutine (#487). |
+| `GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL` | `30s` | How often to check for timed-out plugin channel requests (reclaims stranded `plugin_pending_requests` rows whose in-memory waiter died on host restart) |
+| `GLEIPNIR_DRAIN_TIMEOUT` | `5m` | Graceful-shutdown drain timeout for in-flight runs and background loops. Bounds the concurrent drain of the poller, cron runner, scheduler (in-flight `fire()`), the approval/feedback/plugin-request timeout scanners (in-flight `resolveTimeout()`), plus the run manager — all joined in one timeout-raced goroutine (#487). |
 | `GLEIPNIR_PID_FILE` | `/var/run/gleipnir.pid` | Path the server writes its PID to on startup |
 | `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS` | `false` | When `true`, the loader accepts plugins lacking a Minisign `.minisig`/`signing.pub` pair (instance health = `unsigned_permissive`). Every load emits a high-severity audit event; admin UI shows a non-dismissible red banner; `/api/v1/health` reports `signature_verification: disabled`. **Signed plugins are still fully verified even in permissive mode.** Scope is global, not per-plugin. Read once at startup. See ADR-045 §6. |
 | `GLEIPNIR_PLUGINS_DIR` | `/plugins` | Directory watched by the fsnotify watcher for plugin tarballs (`.tar.gz`/`.tgz`). |

--- a/internal/infra/config/config.go
+++ b/internal/infra/config/config.go
@@ -28,10 +28,11 @@ type Config struct {
 	ReadTimeout            time.Duration
 	WriteTimeout           time.Duration
 	IdleTimeout            time.Duration
-	ApprovalScanInterval   time.Duration
-	DefaultFeedbackTimeout time.Duration
-	FeedbackScanInterval   time.Duration
-	DrainTimeout           time.Duration
+	ApprovalScanInterval      time.Duration
+	DefaultFeedbackTimeout    time.Duration
+	FeedbackScanInterval      time.Duration
+	PluginRequestScanInterval time.Duration
+	DrainTimeout              time.Duration
 	PIDFile                string
 	EncryptionKey          string
 	AllowUnsignedPlugins   bool
@@ -68,10 +69,11 @@ func Load() (Config, error) {
 		ReadTimeout:            envDuration("GLEIPNIR_HTTP_READ_TIMEOUT", 15*time.Second),
 		WriteTimeout:           envDuration("GLEIPNIR_HTTP_WRITE_TIMEOUT", 15*time.Second),
 		IdleTimeout:            envDuration("GLEIPNIR_HTTP_IDLE_TIMEOUT", 60*time.Second),
-		ApprovalScanInterval:   envDuration("GLEIPNIR_APPROVAL_SCAN_INTERVAL", 30*time.Second),
-		DefaultFeedbackTimeout: envDuration("GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT", 30*time.Minute),
-		FeedbackScanInterval:   envDuration("GLEIPNIR_FEEDBACK_SCAN_INTERVAL", 30*time.Second),
-		DrainTimeout:           envDuration("GLEIPNIR_DRAIN_TIMEOUT", 5*time.Minute),
+		ApprovalScanInterval:      envDuration("GLEIPNIR_APPROVAL_SCAN_INTERVAL", 30*time.Second),
+		DefaultFeedbackTimeout:    envDuration("GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT", 30*time.Minute),
+		FeedbackScanInterval:      envDuration("GLEIPNIR_FEEDBACK_SCAN_INTERVAL", 30*time.Second),
+		PluginRequestScanInterval: envDuration("GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL", 30*time.Second),
+		DrainTimeout:              envDuration("GLEIPNIR_DRAIN_TIMEOUT", 5*time.Minute),
 		PIDFile:                envOrDefault("GLEIPNIR_PID_FILE", "/var/run/gleipnir.pid"),
 		EncryptionKey:          raw,
 		AllowUnsignedPlugins:   envBool("GLEIPNIR_ALLOW_UNSIGNED_PLUGINS", false),

--- a/internal/infra/config/config.go
+++ b/internal/infra/config/config.go
@@ -21,24 +21,24 @@ const DefaultPerCallMaxTokens = 8192
 
 // Config holds all runtime configuration for the Gleipnir server.
 type Config struct {
-	DBPath                 string
-	ListenAddr             string
-	LogLevel               slog.Level
-	MCPTimeout             time.Duration
-	ReadTimeout            time.Duration
-	WriteTimeout           time.Duration
-	IdleTimeout            time.Duration
+	DBPath                    string
+	ListenAddr                string
+	LogLevel                  slog.Level
+	MCPTimeout                time.Duration
+	ReadTimeout               time.Duration
+	WriteTimeout              time.Duration
+	IdleTimeout               time.Duration
 	ApprovalScanInterval      time.Duration
 	DefaultFeedbackTimeout    time.Duration
 	FeedbackScanInterval      time.Duration
 	PluginRequestScanInterval time.Duration
 	DrainTimeout              time.Duration
-	PIDFile                string
-	EncryptionKey          string
-	AllowUnsignedPlugins   bool
-	PluginsDir             string
-	OAuthRefreshInterval   time.Duration // GLEIPNIR_OAUTH_REFRESH_INTERVAL, default 5m
-	OAuthRefreshLead       time.Duration // GLEIPNIR_OAUTH_REFRESH_LEAD, default 15m
+	PIDFile                   string
+	EncryptionKey             string
+	AllowUnsignedPlugins      bool
+	PluginsDir                string
+	OAuthRefreshInterval      time.Duration // GLEIPNIR_OAUTH_REFRESH_INTERVAL, default 5m
+	OAuthRefreshLead          time.Duration // GLEIPNIR_OAUTH_REFRESH_LEAD, default 15m
 
 	// LLM transient-failure retry. A 429 (TPM/RPM rate limit) or 5xx response
 	// from a provider is retried up to LLMRetryMaxAttempts times, honoring the
@@ -62,27 +62,27 @@ func Load() (Config, error) {
 	}
 
 	return Config{
-		DBPath:                 envOrDefault("GLEIPNIR_DB_PATH", "/data/gleipnir.db"),
-		ListenAddr:             envOrDefault("GLEIPNIR_LISTEN_ADDR", ":8080"),
-		LogLevel:               envLogLevel("GLEIPNIR_LOG_LEVEL", slog.LevelInfo),
-		MCPTimeout:             envDuration("GLEIPNIR_MCP_TIMEOUT", 30*time.Second),
-		ReadTimeout:            envDuration("GLEIPNIR_HTTP_READ_TIMEOUT", 15*time.Second),
-		WriteTimeout:           envDuration("GLEIPNIR_HTTP_WRITE_TIMEOUT", 15*time.Second),
-		IdleTimeout:            envDuration("GLEIPNIR_HTTP_IDLE_TIMEOUT", 60*time.Second),
+		DBPath:                    envOrDefault("GLEIPNIR_DB_PATH", "/data/gleipnir.db"),
+		ListenAddr:                envOrDefault("GLEIPNIR_LISTEN_ADDR", ":8080"),
+		LogLevel:                  envLogLevel("GLEIPNIR_LOG_LEVEL", slog.LevelInfo),
+		MCPTimeout:                envDuration("GLEIPNIR_MCP_TIMEOUT", 30*time.Second),
+		ReadTimeout:               envDuration("GLEIPNIR_HTTP_READ_TIMEOUT", 15*time.Second),
+		WriteTimeout:              envDuration("GLEIPNIR_HTTP_WRITE_TIMEOUT", 15*time.Second),
+		IdleTimeout:               envDuration("GLEIPNIR_HTTP_IDLE_TIMEOUT", 60*time.Second),
 		ApprovalScanInterval:      envDuration("GLEIPNIR_APPROVAL_SCAN_INTERVAL", 30*time.Second),
 		DefaultFeedbackTimeout:    envDuration("GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT", 30*time.Minute),
 		FeedbackScanInterval:      envDuration("GLEIPNIR_FEEDBACK_SCAN_INTERVAL", 30*time.Second),
 		PluginRequestScanInterval: envDuration("GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL", 30*time.Second),
 		DrainTimeout:              envDuration("GLEIPNIR_DRAIN_TIMEOUT", 5*time.Minute),
-		PIDFile:                envOrDefault("GLEIPNIR_PID_FILE", "/var/run/gleipnir.pid"),
-		EncryptionKey:          raw,
-		AllowUnsignedPlugins:   envBool("GLEIPNIR_ALLOW_UNSIGNED_PLUGINS", false),
-		PluginsDir:             envOrDefault("GLEIPNIR_PLUGINS_DIR", "/plugins"),
-		OAuthRefreshInterval:   envDuration("GLEIPNIR_OAUTH_REFRESH_INTERVAL", 5*time.Minute),
-		OAuthRefreshLead:       envDuration("GLEIPNIR_OAUTH_REFRESH_LEAD", 15*time.Minute),
-		LLMRetryMaxAttempts:    envInt("GLEIPNIR_LLM_RETRY_MAX_ATTEMPTS", 4),
-		LLMRetryInitialBackoff: envDuration("GLEIPNIR_LLM_RETRY_INITIAL_BACKOFF", 1*time.Second),
-		LLMRetryMaxBackoff:     envDuration("GLEIPNIR_LLM_RETRY_MAX_BACKOFF", 30*time.Second),
+		PIDFile:                   envOrDefault("GLEIPNIR_PID_FILE", "/var/run/gleipnir.pid"),
+		EncryptionKey:             raw,
+		AllowUnsignedPlugins:      envBool("GLEIPNIR_ALLOW_UNSIGNED_PLUGINS", false),
+		PluginsDir:                envOrDefault("GLEIPNIR_PLUGINS_DIR", "/plugins"),
+		OAuthRefreshInterval:      envDuration("GLEIPNIR_OAUTH_REFRESH_INTERVAL", 5*time.Minute),
+		OAuthRefreshLead:          envDuration("GLEIPNIR_OAUTH_REFRESH_LEAD", 15*time.Minute),
+		LLMRetryMaxAttempts:       envInt("GLEIPNIR_LLM_RETRY_MAX_ATTEMPTS", 4),
+		LLMRetryInitialBackoff:    envDuration("GLEIPNIR_LLM_RETRY_INITIAL_BACKOFF", 1*time.Second),
+		LLMRetryMaxBackoff:        envDuration("GLEIPNIR_LLM_RETRY_MAX_BACKOFF", 30*time.Second),
 	}, nil
 }
 

--- a/internal/infra/config/config_test.go
+++ b/internal/infra/config/config_test.go
@@ -25,6 +25,7 @@ func TestLoad_Defaults(t *testing.T) {
 		"GLEIPNIR_APPROVAL_SCAN_INTERVAL",
 		"GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT",
 		"GLEIPNIR_FEEDBACK_SCAN_INTERVAL",
+		"GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL",
 		"GLEIPNIR_DRAIN_TIMEOUT",
 		"GLEIPNIR_PID_FILE",
 		"GLEIPNIR_ALLOW_UNSIGNED_PLUGINS",
@@ -68,6 +69,9 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if cfg.FeedbackScanInterval != 30*time.Second {
 		t.Errorf("FeedbackScanInterval: got %v, want 30s", cfg.FeedbackScanInterval)
+	}
+	if cfg.PluginRequestScanInterval != 30*time.Second {
+		t.Errorf("PluginRequestScanInterval: got %v, want 30s", cfg.PluginRequestScanInterval)
 	}
 	if cfg.DrainTimeout != 5*time.Minute {
 		t.Errorf("DrainTimeout: got %v, want 5m", cfg.DrainTimeout)
@@ -174,6 +178,15 @@ func TestLoad_Overrides(t *testing.T) {
 			},
 		},
 		{
+			name: "plugin request scan interval",
+			env:  map[string]string{"GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL": "1m"},
+			check: func(t *testing.T, cfg Config) {
+				if cfg.PluginRequestScanInterval != time.Minute {
+					t.Errorf("got %v, want 1m", cfg.PluginRequestScanInterval)
+				}
+			},
+		},
+		{
 			name: "drain timeout",
 			env:  map[string]string{"GLEIPNIR_DRAIN_TIMEOUT": "10m"},
 			check: func(t *testing.T, cfg Config) {
@@ -221,6 +234,7 @@ func TestLoad_Overrides(t *testing.T) {
 				"GLEIPNIR_HTTP_WRITE_TIMEOUT", "GLEIPNIR_HTTP_IDLE_TIMEOUT",
 				"GLEIPNIR_APPROVAL_SCAN_INTERVAL",
 				"GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT", "GLEIPNIR_FEEDBACK_SCAN_INTERVAL",
+				"GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL",
 				"GLEIPNIR_DRAIN_TIMEOUT", "GLEIPNIR_PID_FILE",
 				"GLEIPNIR_ALLOW_UNSIGNED_PLUGINS", "GLEIPNIR_PLUGINS_DIR",
 			} {
@@ -285,6 +299,7 @@ func TestLoad_InvalidDuration(t *testing.T) {
 		{"invalid approval scan interval falls back", "GLEIPNIR_APPROVAL_SCAN_INTERVAL", 30 * time.Second},
 		{"invalid default feedback timeout falls back", "GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT", 30 * time.Minute},
 		{"invalid feedback scan interval falls back", "GLEIPNIR_FEEDBACK_SCAN_INTERVAL", 30 * time.Second},
+		{"invalid plugin request scan interval falls back", "GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL", 30 * time.Second},
 		{"invalid drain timeout falls back", "GLEIPNIR_DRAIN_TIMEOUT", 5 * time.Minute},
 	}
 
@@ -312,6 +327,8 @@ func TestLoad_InvalidDuration(t *testing.T) {
 				got = cfg.DefaultFeedbackTimeout
 			case "GLEIPNIR_FEEDBACK_SCAN_INTERVAL":
 				got = cfg.FeedbackScanInterval
+			case "GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL":
+				got = cfg.PluginRequestScanInterval
 			case "GLEIPNIR_DRAIN_TIMEOUT":
 				got = cfg.DrainTimeout
 			}

--- a/internal/timeout/scanner_test.go
+++ b/internal/timeout/scanner_test.go
@@ -890,6 +890,36 @@ func TestPluginRequestScanner_NoExpiry_NotCollected(t *testing.T) {
 	}
 }
 
+// TestPluginRequestScanner_StartStop verifies the Start(ctx) -> cancel -> Wait()
+// lifecycle: a pre-seeded expired plugin_pending_requests row is resolved to
+// timed_out by the background goroutine, and Wait() returns cleanly after cancel.
+// This directly exercises the start-at-boot / drain-at-shutdown wiring.
+func TestPluginRequestScanner_StartStop(t *testing.T) {
+	s := testutil.NewTestStore(t)
+	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
+	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusWaitingForFeedback)
+	instID := insertPluginForScanner(t, s)
+	insertPluginPendingRequest(t, s, "req1", instID, "r1", "ask_tool", pastTimestamp())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Short interval so the scan fires quickly in the test.
+	scanner := timeout.NewPluginRequestScanner(s, 20*time.Millisecond)
+	scanner.Start(ctx)
+
+	// Wait long enough for at least one scan tick.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	scanner.Wait()
+
+	var status string
+	if err := s.DB().QueryRow(`SELECT status FROM plugin_pending_requests WHERE id = 'req1'`).Scan(&status); err != nil {
+		t.Fatalf("query request: %v", err)
+	}
+	if status != "timed_out" {
+		t.Errorf("status = %q after scanner ran, want timed_out", status)
+	}
+}
+
 // TestPluginRequestScanner_RunNotWaiting_RowTimedOutNoRunStep verifies that
 // when the run is not in waiting_for_feedback (e.g. already interrupted), the
 // scanner still marks the row timed_out but does NOT write an error step or

--- a/main.go
+++ b/main.go
@@ -117,6 +117,13 @@ func run(cfg config.Config) error {
 	)
 	feedbackScanner.Start(ctx)
 
+	pluginRequestScanner := timeout.NewPluginRequestScanner(
+		store,
+		cfg.PluginRequestScanInterval,
+		timeout.WithPublisher(broadcaster),
+	)
+	pluginRequestScanner.Start(ctx)
+
 	// Apply the LLM transient-failure retry policy BEFORE any provider client is
 	// constructed. The Anthropic/OpenAI SDKs retry internally — they read
 	// MaxAttempts (via SDKMaxRetries) at construction. Google + openaicompat have
@@ -496,6 +503,7 @@ func run(cfg config.Config) error {
 		scheduler.Wait()
 		approvalScanner.Wait()
 		feedbackScanner.Wait()
+		pluginRequestScanner.Wait()
 		runManager.Wait()
 		close(runsDrained)
 	}()


### PR DESCRIPTION
Closes #564

## Summary

`timeout.NewPluginRequestScanner` was fully implemented and unit-tested but had **no production caller** — `main.go` wired the approval and feedback scanners but not this one. A `plugin_pending_requests` row whose in-memory `Wait` waiter died on a host restart was stranded `pending` forever, with no reclaim path.

This wires the scanner exactly like its siblings:
- `main.go` — construct + `Start(ctx)` the `pluginRequestScanner`, and join its `Wait()` **inside the existing single timeout-raced drain goroutine** (between `feedbackScanner.Wait()` and `runManager.Wait()`), so it stays bounded by `GLEIPNIR_DRAIN_TIMEOUT` (#487).
- `internal/infra/config/config.go` — new `PluginRequestScanInterval` field + `GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL` env var (default `30s`, matching the per-scanner convention).
- `config_test.go` — defaults, override-table, and invalid-duration coverage for the new var.
- `internal/timeout/scanner_test.go` — new `TestPluginRequestScanner_StartStop` lifecycle test (seed expired row → Start → cancel → Wait → assert `timed_out`).
- `.env.example` + `CLAUDE.md` — documented the new var; extended the drain-timeout note.

`internal/timeout/scanner.go` is unchanged — the constructor was already complete.

<details>
<summary>Architecture plan</summary>

Architect confirmed the issue's core assumption: `NewPluginRequestScanner` is not a hollow stub — it has a complete `Config` (`ListExpiredPluginPendingRequests`, `UpdatePluginPendingRequestStatus` → `timed_out`, error-code `plugin_request_timeout`, SSE `plugin.request.timed_out`) and runs through the shared `resolveTimeout` path. Decision: dedicated env var (matches one-interval-per-scanner convention), unconditional wiring (plugins are unconditional since #559), `Wait()` inside the single drain goroutine to preserve the #487 bound.
</details>

## Review
- Plan review: APPROVE (all variable names, option function, drain structure, queries, and test helpers verified against source).
- Code review: APPROVE, 1 cycle — drain-bound invariant explicitly verified.
- CLAUDE.md: updated (new env var row + drain-timeout note).
- Brainstorming: not triggered (well-specified).

🤖 Generated by the agentic dev loop.
