### PR TITLE
fix: TOFU pubkey pin bypassed on same-version binary backfill path

### DIFF
--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -399,10 +399,30 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 		// If the row has no binary_path yet (legacy row from before #386), backfill it
 		// so a re-deploy of the same tarball repairs the gap without a version bump.
 		if in.pluginsDir != "" && (existing.BinaryPath == nil || *existing.BinaryPath == "") {
+			// Run the TOFU pin check before publishing — a same-version tarball signed by
+			// a different key must not be allowed to publish its binary to disk.
+			refreshed, mismatch, pinErr := in.checkPubkeyPin(ctx, existing, result, nowStr)
+			if pinErr != nil {
+				return "", false, "", fmt.Errorf("pubkey pin check for %q (backfill): %w", m.Name, pinErr)
+			}
+			if mismatch {
+				id, mErr := in.handlePubkeyMismatch(ctx, existing, result, m.Version, nowStr)
+				return id, false, existing.Status, mErr // BLOCK: no publishBundle
+			}
+			// Pick up the delayed-TOFU re-read. UpdatePluginTrustedPubkey bumps the row
+			// version, so updateBinaryPath's CAS must run against the refreshed version
+			// or it silently no-ops (rows==0 → logged warning, binary_path not written).
+			existing = refreshed
 			publishedPath, pubErr := in.publishBundle(ctx, tmpDir, m.Name)
 			if pubErr != nil {
 				return "", false, "", fmt.Errorf("publish bundle for %q (backfill): %w", m.Name, pubErr)
 			}
+			// INTENTIONALLY non-transactional: the backfill branch has never been wrapped
+			// in a tx (mirroring the pre-fix behavior); a crash between publishBundle and
+			// updateBinaryPath leaves the bundle on disk but binary_path unwritten — a
+			// subsequent re-drop of the tarball repairs it. Wrapping in a tx would require
+			// re-reading the version after the TOFU capture inside the tx, which is out
+			// of scope for this targeted security fix.
 			if err := in.updateBinaryPath(ctx, existing.ID, existing.Version, &publishedPath, nowStr); err != nil {
 				return "", false, "", fmt.Errorf("backfill binary_path for %q: %w", m.Name, err)
 			}
@@ -436,34 +456,13 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 	}
 
 	// TOFU pubkey trust check: only applies to verified (signed) bundles.
-	if result.Outcome == OutcomeVerified {
-		if existing.TrustedPubkey == "" {
-			// Delayed TOFU: plugin was first installed under GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true
-			// and a signed update has now arrived. Capture the pubkey silently — no mismatch event.
-			rows, updateErr := in.q.UpdatePluginTrustedPubkey(ctx, db.UpdatePluginTrustedPubkeyParams{
-				TrustedPubkey:   string(result.Pubkey),
-				UpdatedAt:       nowStr,
-				ID:              existing.ID,
-				ExpectedVersion: existing.Version,
-			})
-			if updateErr != nil {
-				return "", false, "", fmt.Errorf("capture trusted pubkey for %q (delayed TOFU): %w", m.Name, updateErr)
-			}
-			if rows == 0 {
-				return "", false, "", fmt.Errorf("capture trusted pubkey for %q: CAS conflict (version mismatch)", m.Name)
-			}
-			// Re-read so updatePlugin sees the bumped version.
-			existing, err = in.q.GetPluginByName(ctx, m.Name)
-			if err != nil {
-				return "", false, "", fmt.Errorf("re-read plugin %q after TOFU capture: %w", m.Name, err)
-			}
-		} else if !bytes.Equal(result.Pubkey, []byte(existing.TrustedPubkey)) {
-			// Key mismatch: a different signing key was used for this update.
-			// Block the update and transition all instances to pending_key_approval
-			// so admins are alerted. Do not publish the bundle.
-			id, mismatchErr := in.handlePubkeyMismatch(ctx, existing, result, m.Version, nowStr)
-			return id, false, existing.Status, mismatchErr
-		}
+	existing, mismatch, pinErr := in.checkPubkeyPin(ctx, existing, result, nowStr)
+	if pinErr != nil {
+		return "", false, "", pinErr
+	}
+	if mismatch {
+		id, mismatchErr := in.handlePubkeyMismatch(ctx, existing, result, m.Version, nowStr)
+		return id, false, existing.Status, mismatchErr
 	}
 
 	// Diff the incoming manifest against the stored snapshot before calling
@@ -487,6 +486,57 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 
 	id, upErr := in.updatePlugin(ctx, existing, m, manifestBytes, result, tmpDir, nowStr)
 	return id, upErr == nil && id != "", existing.Status, upErr
+}
+
+// checkPubkeyPin runs the TOFU pubkey pin check for a verified bundle against
+// the existing plugin row. It is the single implementation shared by the
+// version-bump path and the same-version backfill path.
+//
+// Four sub-cases:
+//
+//	(a) result.Outcome != OutcomeVerified  →  no-op; (existing, false, nil)
+//	(b) Verified && TrustedPubkey==""      →  delayed-TOFU capture via UpdatePluginTrustedPubkey,
+//	    re-read row; (refreshed, false, nil)
+//	(c) Verified && keys match             →  (existing, false, nil)
+//	(d) Verified && keys differ            →  (existing, true, nil)  — mismatch
+//
+// handlePubkeyMismatch is NOT called here; callers invoke it when mismatch==true
+// so the return values stay explicit and testable.
+func (in *Installer) checkPubkeyPin(ctx context.Context, existing db.Plugin, result VerifyResult, nowStr string) (refreshed db.Plugin, mismatch bool, err error) {
+	if result.Outcome != OutcomeVerified {
+		// Unsigned-permissive or rejected — no pin to check.
+		return existing, false, nil
+	}
+
+	if existing.TrustedPubkey == "" {
+		// Delayed TOFU: the plugin was first installed under GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true
+		// and a signed bundle has now arrived. Capture the pubkey silently — no mismatch event.
+		rows, updateErr := in.q.UpdatePluginTrustedPubkey(ctx, db.UpdatePluginTrustedPubkeyParams{
+			TrustedPubkey:   string(result.Pubkey),
+			UpdatedAt:       nowStr,
+			ID:              existing.ID,
+			ExpectedVersion: existing.Version,
+		})
+		if updateErr != nil {
+			return existing, false, fmt.Errorf("capture trusted pubkey for %q (delayed TOFU): %w", existing.Name, updateErr)
+		}
+		if rows == 0 {
+			return existing, false, fmt.Errorf("capture trusted pubkey for %q: CAS conflict (version mismatch)", existing.Name)
+		}
+		// Re-read so the caller sees the bumped version for subsequent CAS operations
+		// (UpdatePluginManifest in the version-bump path; UpdatePluginBinaryPath in backfill).
+		reread, rereadErr := in.q.GetPluginByName(ctx, existing.Name)
+		if rereadErr != nil {
+			return existing, false, fmt.Errorf("re-read plugin %q after TOFU capture: %w", existing.Name, rereadErr)
+		}
+		return reread, false, nil
+	}
+
+	if !bytes.Equal(result.Pubkey, []byte(existing.TrustedPubkey)) {
+		return existing, true, nil
+	}
+
+	return existing, false, nil
 }
 
 // handlePubkeyMismatch transitions all instances of the plugin to

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -2246,6 +2246,233 @@ func TestInstall_Downgrade_Refused(t *testing.T) {
 	}
 }
 
+// TestInstall_LegacyRowBackfill_NoMismatchEvent_MatchingKey extends
+// TestInstall_LegacyRowBackfill with assertions that the matching-key backfill
+// path does NOT emit a pubkey_mismatch event and does NOT move the instance out
+// of healthy state — confirming that the new pin check is a no-op when keys match.
+func TestInstall_LegacyRowBackfill_NoMismatchEvent_MatchingKey(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	tarPath, _ := signedPluginTarball(t, "backfill-nomatch-plugin", "1.0.0")
+
+	// First install to create the row.
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "backfill-nomatch-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName: %v", err)
+	}
+
+	// Seed a healthy instance.
+	seedPluginInstance(t, q, row.ID, "inst-nomatch", model.PluginHealthStateHealthy)
+
+	// Clear binary_path to simulate a legacy row.
+	if _, err := q.UpdatePluginBinaryPath(context.Background(), db.UpdatePluginBinaryPathParams{
+		BinaryPath:      nil,
+		UpdatedAt:       row.UpdatedAt,
+		ID:              row.ID,
+		ExpectedVersion: row.Version,
+	}); err != nil {
+		t.Fatalf("clear binary_path: %v", err)
+	}
+
+	// Re-install the same tarball (same key) — should backfill binary_path.
+	if _, err := inst.Install(context.Background(), tarPath); err != nil {
+		t.Fatalf("Install (same version, matching key, backfill): %v", err)
+	}
+
+	// binary_path must now be set.
+	row2, err := q.GetPluginByName(context.Background(), "backfill-nomatch-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after backfill: %v", err)
+	}
+	if row2.BinaryPath == nil || *row2.BinaryPath == "" {
+		t.Error("binary_path: still nil after matching-key backfill, expected non-empty")
+	}
+
+	// No pubkey_mismatch event should have been emitted.
+	events, evErr := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditPubkeyMismatch,
+		Offset:    0,
+		Limit:     10,
+	})
+	if evErr != nil {
+		t.Fatalf("list mismatch events: %v", evErr)
+	}
+	if len(events) > 0 {
+		t.Errorf("got %d pubkey_mismatch events after matching-key backfill, want 0", len(events))
+	}
+
+	// Instance must still be healthy.
+	inst1, instErr := q.GetPluginInstanceByID(context.Background(), "inst-nomatch")
+	if instErr != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", instErr)
+	}
+	if inst1.HealthState != string(model.PluginHealthStateHealthy) {
+		t.Errorf("instance health_state = %q, want healthy after matching-key backfill", inst1.HealthState)
+	}
+}
+
+// TestInstall_SameVersionBackfill_MismatchedKey_Blocks verifies the security fix:
+// when a same-version tarball with a DIFFERENT signing key is dropped and the
+// existing row has no binary_path, the publish is blocked entirely — binary_path
+// stays nil, a high-severity plugin_pubkey_mismatch audit event is emitted, and
+// the instance transitions to pending_key_approval. No .new/.old artefact must
+// appear on disk.
+func TestInstall_SameVersionBackfill_MismatchedKey_Blocks(t *testing.T) {
+	q := openTestDB(t)
+	inst := newTestInstaller(t, q, false)
+
+	// Install v1.0.0 with key A (signedPluginTarball generates a fresh keypair each call).
+	tarPath1, _ := signedPluginTarball(t, "backfill-mismatch-plugin", "1.0.0")
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1 (key A): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "backfill-mismatch-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after first install: %v", err)
+	}
+
+	// Seed a healthy instance.
+	seedPluginInstance(t, q, row.ID, "bm-inst-1", model.PluginHealthStateHealthy)
+
+	// Clear binary_path to simulate the vulnerable backfill scenario.
+	if _, err := q.UpdatePluginBinaryPath(context.Background(), db.UpdatePluginBinaryPathParams{
+		BinaryPath:      nil,
+		UpdatedAt:       row.UpdatedAt,
+		ID:              row.ID,
+		ExpectedVersion: row.Version,
+	}); err != nil {
+		t.Fatalf("clear binary_path: %v", err)
+	}
+
+	// Install a SECOND same-name same-version tarball signed by a DIFFERENT key B.
+	// signedPluginTarball generates a fresh keypair each call, so this is key B.
+	tarPath2, _ := signedPluginTarball(t, "backfill-mismatch-plugin", "1.0.0")
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v1 (key B, same version): %v", err)
+	}
+
+	// binary_path must still be nil — publishBundle must not have run.
+	row2, err := q.GetPluginByName(context.Background(), "backfill-mismatch-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after mismatch install: %v", err)
+	}
+	if row2.BinaryPath != nil && *row2.BinaryPath != "" {
+		t.Errorf("binary_path = %q after mismatch backfill install; want nil/empty (publish must be blocked)", *row2.BinaryPath)
+	}
+
+	// A high-severity plugin_pubkey_mismatch audit event must exist.
+	events, evErr := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditPubkeyMismatch,
+		Offset:    0,
+		Limit:     10,
+	})
+	if evErr != nil {
+		t.Fatalf("list mismatch events: %v", evErr)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected a plugin_pubkey_mismatch audit event, got none")
+	}
+	if events[0].Severity != severityHigh {
+		t.Errorf("audit severity = %q, want %q", events[0].Severity, severityHigh)
+	}
+
+	// The seeded instance must be in pending_key_approval.
+	instRow, instErr := q.GetPluginInstanceByID(context.Background(), "bm-inst-1")
+	if instErr != nil {
+		t.Fatalf("GetPluginInstanceByID: %v", instErr)
+	}
+	if instRow.HealthState != string(model.PluginHealthStatePendingKeyApproval) {
+		t.Errorf("instance health_state = %q, want pending_key_approval", instRow.HealthState)
+	}
+
+	// No .new or .old artefact must exist under the installed dir (no partial publish).
+	installedDir := filepath.Join(inst.pluginsDir, "installed", "backfill-mismatch-plugin")
+	for _, suffix := range []string{".new", ".old"} {
+		if _, statErr := os.Stat(installedDir + suffix); statErr == nil {
+			t.Errorf("unexpected artefact %s after mismatch backfill install", installedDir+suffix)
+		}
+	}
+}
+
+// TestInstall_SameVersionBackfill_DelayedTOFU verifies the load-bearing
+// `existing = refreshed` line: when the existing row has an empty trusted_pubkey
+// (installed unsigned) and binary_path is nil, a signed re-install of the same
+// version must capture the pubkey AND successfully backfill binary_path. Without
+// `existing = refreshed`, the updateBinaryPath CAS would run against the pre-capture
+// version, get rows==0 (non-fatal warning), and silently leave binary_path unset.
+func TestInstall_SameVersionBackfill_DelayedTOFU(t *testing.T) {
+	q := openTestDB(t)
+
+	// First install: unsigned so trusted_pubkey="" but binary_path gets set.
+	instUnsigned := newTestInstaller(t, q, true) // allowUnsigned=true
+	tarPathUnsigned := unsignedPluginTarball(t, "backfill-tofu-plugin", "1.0.0")
+	if _, err := instUnsigned.Install(context.Background(), tarPathUnsigned); err != nil {
+		t.Fatalf("Install v1 (unsigned): %v", err)
+	}
+
+	row, err := q.GetPluginByName(context.Background(), "backfill-tofu-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after unsigned install: %v", err)
+	}
+	if row.TrustedPubkey != "" {
+		t.Fatalf("trusted_pubkey after unsigned install = %q, want empty", row.TrustedPubkey)
+	}
+
+	// Clear binary_path to enter the backfill branch on re-install.
+	if _, err := q.UpdatePluginBinaryPath(context.Background(), db.UpdatePluginBinaryPathParams{
+		BinaryPath:      nil,
+		UpdatedAt:       row.UpdatedAt,
+		ID:              row.ID,
+		ExpectedVersion: row.Version,
+	}); err != nil {
+		t.Fatalf("clear binary_path: %v", err)
+	}
+
+	// Second install: signed same-version tarball. The installer must:
+	//   1. Run delayed-TOFU capture (trusted_pubkey="" → capture key, bump version)
+	//   2. Re-read the row (existing = refreshed) to pick up the bumped version
+	//   3. Successfully backfill binary_path via updateBinaryPath CAS
+	instSigned := newTestInstaller(t, q, false) // allowUnsigned=false
+	tarPathSigned, _ := signedPluginTarball(t, "backfill-tofu-plugin", "1.0.0")
+	if _, err := instSigned.Install(context.Background(), tarPathSigned); err != nil {
+		t.Fatalf("Install v1 (signed, backfill): %v", err)
+	}
+
+	row2, err := q.GetPluginByName(context.Background(), "backfill-tofu-plugin")
+	if err != nil {
+		t.Fatalf("GetPluginByName after signed backfill: %v", err)
+	}
+
+	// trusted_pubkey must now be captured.
+	if row2.TrustedPubkey == "" {
+		t.Error("trusted_pubkey: want non-empty after delayed TOFU capture via backfill")
+	}
+
+	// binary_path must be backfilled — proves `existing = refreshed` made the CAS succeed.
+	if row2.BinaryPath == nil || *row2.BinaryPath == "" {
+		t.Error("binary_path: still nil after delayed-TOFU backfill; `existing = refreshed` may be missing")
+	}
+
+	// No mismatch event — delayed TOFU is a capture, not a mismatch.
+	events, evErr := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditPubkeyMismatch,
+		Offset:    0,
+		Limit:     10,
+	})
+	if evErr != nil {
+		t.Fatalf("list mismatch events: %v", evErr)
+	}
+	if len(events) > 0 {
+		t.Errorf("got %d pubkey_mismatch events after delayed TOFU backfill, want 0", len(events))
+	}
+}
+
 // TestInstall_NonSemver_FallsThrough verifies that when either of the installed
 // or incoming version strings is not valid semver, the downgrade guard does not
 // fire and the install proceeds normally through the existing update path.


### PR DESCRIPTION
Closes #563

## Summary (security — trust-path fail-open)

The idempotent same-version re-install branch in `upsertPlugin` backfilled an empty `binary_path` via `publishBundle` after only a self-consistent signature check — it skipped the TOFU pubkey-pin comparison that the version-bump path enforces. A same-version tarball signed by a **different key** could therefore publish its binary to disk and defeat key-pinning (gated on `binary_path` being empty: legacy pre-#386 rows, or a row whose first publish failed).

### Fix
- Extracted the version-bump path's TOFU pin logic into a shared `checkPubkeyPin` helper (`*Installer`) so the check **cannot drift** between the two paths. Four sub-cases: non-Verified no-op, empty-`trusted_pubkey` delayed-TOFU capture+re-read, matching key, mismatch.
- The same-version backfill branch now runs `checkPubkeyPin` **before** `publishBundle`. On mismatch it routes to `handlePubkeyMismatch` (instances → `pending_key_approval`, high-severity audit) and **returns before any publish**. On success it adopts the re-read row (`existing = refreshed`) before backfilling.
- Version-bump path refactored to call the same helper — behavior-preserving (existing suite is the regression gate).
- **No** material-manifest diff added to the backfill branch (out of scope; see plan) — the snapshot is never rewritten there.

### The load-bearing line
`existing = refreshed` is essential: a delayed-TOFU capture does `version = version + 1`, and `UpdatePluginBinaryPath`'s CAS treats `rows==0` as a **non-fatal warning** — so without the re-read the backfill would *silently* no-op. `TestInstall_SameVersionBackfill_DelayedTOFU` exists specifically to prove this.

### Tests (all new, internal/plugin/loader/install_test.go)
- `TestInstall_SameVersionBackfill_MismatchedKey_Blocks` — different key at same version → `binary_path` stays empty, high-severity `plugin_pubkey_mismatch` event, instance → `pending_key_approval`, no `.new`/`.old` artefact.
- `TestInstall_SameVersionBackfill_DelayedTOFU` — proves the re-read line.
- `TestInstall_LegacyRowBackfill_NoMismatchEvent_MatchingKey` — no-regression guard for the #386 matching-key backfill.

All loader tests pass under `-race`.

<details>
<summary>Architecture plan</summary>

Plan-reviewer independently verified the highest-risk claim against the SQL: both `UpdatePluginTrustedPubkey` and `UpdatePluginBinaryPath` bump `version`, and a CAS miss is a non-fatal warning — confirming the delayed-TOFU re-read is load-bearing. Decision to skip the manifest diff was reviewed as sound (the snapshot isn't rewritten on backfill; a same-*key* manifest mismatch is a pre-existing logic inconsistency, not a trust bypass). The backfill write is intentionally non-transactional (matches pre-fix behavior), documented in a code comment.
</details>

## Review
- Plan review: APPROVE (verified the CAS/version-bump facts and all test fixtures against source).
- Code review: APPROVE, 1 cycle — security invariant traced line-by-line (mismatch returns before `publishBundle`). Applied the one non-blocking suggestion (dropped an unused helper parameter).
- CLAUDE.md: current — no updates needed (bug fix to existing ADR-045 behavior).
- Brainstorming: not triggered (well-specified).

🤖 Generated by the agentic dev loop.
