### PR TITLE
fix: plugin loader/hostsvc hardening — cosmetic audit severity + WriteAuditStep request-id oracle

### DIFF
--- a/internal/plugin/hostsvc/handlers_feedback.go
+++ b/internal/plugin/hostsvc/handlers_feedback.go
@@ -29,6 +29,11 @@ const maxPayloadJSONBytes = 64 * 1024
 // matching `<instance_name>.` (native path) must match the calling instance.
 // The detached-context check does not apply — request-ownership is the §8.5
 // alternative auth primitive.
+//
+// NATIVE PATH ORDERING: ownership is resolved BEFORE the fr.Status check so a
+// non-owner cannot probe whether a request_id exists or what state it is in —
+// nonexistent, foreign-pending, and foreign-resolved all collapse to a single
+// codes.PermissionDenied "unauthorized_request_id".
 func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepRequest) (*hostv1.WriteAuditStepResponse, error) {
 	inst, err := s.resolveInstance(ctx)
 	if err != nil {
@@ -137,35 +142,29 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 	}
 	// sql.ErrNoRows: not a plugin-substrate request — fall through to native path.
 
-	// Look up the feedback request; reject late responses without mutating state.
+	// Look up the feedback request. Ownership is resolved before the status
+	// check so a non-owner cannot probe whether a request_id exists or what
+	// state it is in (existence oracle / state oracle closure).
 	fr, err := s.q.GetFeedbackRequest(ctx, requestID)
 	if err != nil {
-		// sql.ErrNoRows means neither substrate recognized this request_id — it was
-		// never issued or has already been purged. NotFound is more accurate than
-		// Internal and lets callers distinguish "bad ID" from "unexpected DB error".
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, status.Errorf(codes.NotFound, "unknown request_id %q", requestID)
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, status.Errorf(codes.Internal, "get feedback request: %v", err)
 		}
-		return nil, status.Errorf(codes.Internal, "get feedback request: %v", err)
-	}
-	if fr.Status != "pending" {
-		// Spec §4.2 line 106: record the late attempt and return ok=false.
-		s.writeAuditEvent(ctx, inst.ID, EventTypeFeedbackResponseLate, "warning", map[string]string{
-			"request_id": requestID,
-			"status":     fr.Status,
-		})
-		return &hostv1.WriteAuditStepResponse{
-			Ok: false,
-			Error: &commonv1.ErrorEnvelope{
-				Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
-				Message: EventTypeFeedbackResponseLate,
-			},
-		}, nil
+		// Unknown request_id: ownership is undeterminable — deny by default
+		// (ADR-001). Return the same codes.PermissionDenied a foreign request
+		// would get so the response is identical and the request_id existence is
+		// not revealed.
+		//
+		// No audit event is written here: there is no run_id to attribute it to,
+		// and writing a high-severity event on every probe of a nonexistent id
+		// would flood plugin_audit_events. The foreign-but-existing case below
+		// DOES write an audit event — that asymmetry is intentional and must be
+		// preserved (do not add an unconditional audit write to this branch).
+		return nil, status.Error(codes.PermissionDenied, "unauthorized_request_id")
 	}
 
-	// Verify that the feedback_request's run belongs to a policy that grants
-	// tools to the calling instance (i.e. has at least one capabilities.tools
-	// entry with the prefix "<instanceName>."). This is the heuristic available
+	// Verify ownership BEFORE the status check so a non-owner cannot distinguish
+	// a pending request from a resolved one. This is the heuristic available
 	// today; audience-based routing (audiences.plugin_instance per spec §4.2/§6)
 	// is a follow-up — no audiences DB schema exists yet.
 	run, err := s.q.GetRun(ctx, fr.RunID)
@@ -183,6 +182,22 @@ func (s *Server) WriteAuditStep(ctx context.Context, req *hostv1.WriteAuditStepR
 			"rpc_method": rpcMethod,
 		})
 		return nil, status.Error(codes.PermissionDenied, "unauthorized_request_id")
+	}
+
+	// Ownership confirmed. Now check whether the request is still actionable.
+	if fr.Status != "pending" {
+		// Spec §4.2 line 106: record the late attempt and return ok=false.
+		s.writeAuditEvent(ctx, inst.ID, EventTypeFeedbackResponseLate, "warning", map[string]string{
+			"request_id": requestID,
+			"status":     fr.Status,
+		})
+		return &hostv1.WriteAuditStepResponse{
+			Ok: false,
+			Error: &commonv1.ErrorEnvelope{
+				Code:    commonv1.ErrorCode_ERROR_CODE_INVALID_ARG,
+				Message: EventTypeFeedbackResponseLate,
+			},
+		}, nil
 	}
 
 	// Insert the run step and resolve the feedback request atomically.

--- a/internal/plugin/hostsvc/server_test.go
+++ b/internal/plugin/hostsvc/server_test.go
@@ -736,8 +736,8 @@ func TestWriteAuditStep_NoCallID_CrossInstanceEscalation(t *testing.T) {
 
 // TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss verifies that when
 // neither the substrate (plugin_pending_requests) nor the native (feedback_requests)
-// row exists, the handler returns codes.NotFound (not codes.Internal — the request_id
-// is simply unknown, which is a caller error, not a server error).
+// row exists, the handler returns codes.PermissionDenied — oracle-closed: an
+// unknown id is indistinguishable from a foreign id so both return the same error.
 func TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss(t *testing.T) {
 	t.Parallel()
 
@@ -753,18 +753,100 @@ func TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss(t *testing.T) {
 		RequestId: "req-unknown",
 	})
 	st, ok := status.FromError(err)
-	if !ok || st.Code() != codes.NotFound {
-		t.Errorf("expected codes.NotFound for unknown request_id, got %v", err)
+	if !ok || st.Code() != codes.PermissionDenied {
+		t.Errorf("expected codes.PermissionDenied for unknown request_id, got %v", err)
+	}
+	if st.Message() != "unauthorized_request_id" {
+		t.Errorf("message = %q, want unauthorized_request_id", st.Message())
+	}
+}
+
+// TestWriteAuditStep_Native_OwnershipOracleClosed verifies that the native
+// feedback path returns an identical codes.PermissionDenied/"unauthorized_request_id"
+// for all three non-owner scenarios, closing the request_id probing oracle:
+//
+//   - nonexistent: the request_id does not exist in either table.
+//   - foreign-pending: the request exists but belongs to a different policy.
+//   - foreign-resolved: same as foreign-pending but with Status="responded" —
+//     CRITICAL: must return PermissionDenied, not the late ok=false envelope,
+//     proving ownership is checked before the status branch.
+func TestWriteAuditStep_Native_OwnershipOracleClosed(t *testing.T) {
+	t.Parallel()
+
+	// foreignPolicy grants "otherplugin.*" but the caller is "myplugin".
+	foreignPolicyYAML := policyYAMLWithTool("otherplugin.do_thing")
+
+	tests := []struct {
+		name        string
+		feedbackReq db.FeedbackRequest
+		feedbackErr error
+		run         db.Run
+		policy      db.Policy
+	}{
+		{
+			name:        "nonexistent",
+			feedbackErr: sql.ErrNoRows,
+		},
+		{
+			name:        "foreign-pending",
+			feedbackReq: db.FeedbackRequest{ID: "fr-foreign", RunID: "run-foreign", Status: "pending"},
+			run:         db.Run{ID: "run-foreign", PolicyID: "pol-other"},
+			policy:      db.Policy{ID: "pol-other", Yaml: foreignPolicyYAML},
+		},
+		{
+			// This is the critical guard: a resolved request must still return
+			// PermissionDenied — the status branch must not precede ownership.
+			name:        "foreign-resolved",
+			feedbackReq: db.FeedbackRequest{ID: "fr-foreign", RunID: "run-foreign", Status: "responded"},
+			run:         db.Run{ID: "run-foreign", PolicyID: "pol-other"},
+			policy:      db.Policy{ID: "pol-other", Yaml: foreignPolicyYAML},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &fakeQuerier{
+				instance:                db.PluginInstance{ID: "iid-probe", PluginID: "plug-probe", InstanceName: "myplugin"},
+				feedbackRequest:         tt.feedbackReq,
+				feedbackErr:             tt.feedbackErr,
+				run:                     tt.run,
+				policy:                  tt.policy,
+				pluginPendingRequestErr: sql.ErrNoRows, // native path
+			}
+			srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
+
+			_, err := srv.WriteAuditStep(context.Background(), &hostv1.WriteAuditStepRequest{
+				StepType:  "feedback_response",
+				RequestId: "fr-foreign",
+			})
+			st, ok := status.FromError(err)
+			if !ok || st.Code() != codes.PermissionDenied {
+				t.Errorf("[%s] expected codes.PermissionDenied, got %v", tt.name, err)
+			}
+			if st.Message() != "unauthorized_request_id" {
+				t.Errorf("[%s] message = %q, want unauthorized_request_id", tt.name, st.Message())
+			}
+		})
 	}
 }
 
 func TestWriteAuditStep_LateFeedback(t *testing.T) {
 	t.Parallel()
 
+	// The caller must be an owner of the request so the ownership check passes
+	// and the late-feedback branch is reached. Without the owner fixture the
+	// restructured handler would return PermissionDenied before the status check.
 	q := &fakeQuerier{
-		instance:                db.PluginInstance{ID: "iid-1", PluginID: "plug-1"},
+		instance:                db.PluginInstance{ID: "iid-1", PluginID: "plug-1", InstanceName: "myplugin"},
 		feedbackRequest:         db.FeedbackRequest{ID: "fr-1", RunID: "run-1", Status: "responded"},
+		run:                     db.Run{ID: "run-1", PolicyID: "pol-1"},
+		policy:                  db.Policy{ID: "pol-1", Yaml: policyYAMLWithTool("myplugin.do_thing")},
 		pluginPendingRequestErr: sql.ErrNoRows, // native path
+		// updateFeedbackStatusRows is intentionally unset: the late-feedback path
+		// returns ok=false before reaching writeFeedbackResponseStep.
 	}
 	srv := newTestServer(t, q, &fakeResolver{}, &fakePublisher{})
 

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -480,7 +480,7 @@ func (in *Installer) upsertPlugin(ctx context.Context, m *manifest.Manifest, man
 		return id, false, existing.Status, matErr
 	}
 	if len(changes) > 0 {
-		id, cosErr := in.updatePluginCosmetic(ctx, existing, m, manifestBytes, changes, tmpDir, nowStr)
+		id, cosErr := in.updatePluginCosmetic(ctx, existing, m, manifestBytes, result, changes, tmpDir, nowStr)
 		return id, cosErr == nil && id != "", existing.Status, cosErr
 	}
 
@@ -718,7 +718,7 @@ func updateBinaryPathTx(ctx context.Context, q *db.Queries, pluginID string, ver
 //
 // The manifest update and the audit event are committed atomically so a
 // mid-update failure cannot leave the plugins row advanced without an audit row.
-func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, changes []pluginmanifest.Change, tmpDir string, nowStr string) (string, error) {
+func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugin, m *manifest.Manifest, manifestBytes []byte, result VerifyResult, changes []pluginmanifest.Change, tmpDir string, nowStr string) (string, error) {
 	// Publish the verified bundle before touching the DB so the subprocess can
 	// be re-spawned with the correct binary on the next restart.
 	var binaryPathPtr *string
@@ -758,7 +758,13 @@ func (in *Installer) updatePluginCosmetic(ctx context.Context, existing db.Plugi
 			}
 		}
 
-		if auditErr := insertAuditRow(ctx, q, auditManifestCosmeticChange, severityInfo, nowStr, map[string]any{
+		// ADR-045 §6: unsigned-permissive loads must emit a high-severity audit event
+		// so severity-based alerting catches every load that bypassed signature verification.
+		cosmeticSeverity := severityInfo
+		if result.Outcome == OutcomeUnsignedPermissive {
+			cosmeticSeverity = severityHigh
+		}
+		if auditErr := insertAuditRow(ctx, q, auditManifestCosmeticChange, cosmeticSeverity, nowStr, map[string]any{
 			"plugin_id":       existing.ID,
 			"name":            existing.Name,
 			"old_version":     existing.PluginVersion,

--- a/internal/plugin/loader/install_test.go
+++ b/internal/plugin/loader/install_test.go
@@ -1538,6 +1538,46 @@ func TestInstall_HotReload_CosmeticChange_UpdatesSnapshot_EmitsInfoAuditEvent(t 
 	}
 }
 
+// TestInstall_HotReload_CosmeticChange_UnsignedPermissive_EmitsHighSeverityAuditEvent
+// verifies that a cosmetic update of an unsigned-permissive plugin emits a
+// plugin_manifest_cosmetic_change audit event with high severity (ADR-045 §6).
+// A version-only bump is used because it is cosmetic per the manifest diff logic
+// and routes through updatePluginCosmetic without triggering a same-version
+// idempotency early-return.
+func TestInstall_HotReload_CosmeticChange_UnsignedPermissive_EmitsHighSeverityAuditEvent(t *testing.T) {
+	q := openTestDB(t)
+	// allowUnsigned=true so unsigned bundles are accepted.
+	inst := newTestInstaller(t, q, true)
+
+	// First install: v1.0.0 — seeds the plugin row.
+	tarPath1 := unsignedPluginTarball(t, "unsigned-cosm-plugin", "1.0.0")
+	if _, err := inst.Install(context.Background(), tarPath1); err != nil {
+		t.Fatalf("Install v1.0.0: %v", err)
+	}
+
+	// Second install: v1.0.1 — version-only bump, cosmetic diff, routes through
+	// updatePluginCosmetic. Must emit high-severity audit event (ADR-045 §6).
+	tarPath2 := unsignedPluginTarball(t, "unsigned-cosm-plugin", "1.0.1")
+	if _, err := inst.Install(context.Background(), tarPath2); err != nil {
+		t.Fatalf("Install v1.0.1 (unsigned cosmetic): %v", err)
+	}
+
+	events, err := q.ListPluginAuditEventsByType(context.Background(), db.ListPluginAuditEventsByTypeParams{
+		EventType: auditManifestCosmeticChange,
+		Offset:    0,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list cosmetic audit events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected a plugin_manifest_cosmetic_change audit event, got none")
+	}
+	if events[0].Severity != severityHigh {
+		t.Errorf("audit severity = %q, want %q (ADR-045 §6: unsigned-permissive load must emit high severity)", events[0].Severity, severityHigh)
+	}
+}
+
 // TestInstall_HotReload_NoChange_NoOp verifies that a tarball with a new version but
 // structurally identical manifest content (differing only in version field) uses the
 // cosmetic path and does not emit a material-change event.


### PR DESCRIPTION
Closes #557

Two deferred low-severity hardening gaps from the #483 post-merge pass, shipped together.

## FIX 1 — cosmetic-update audit severity (ADR-045 §6)
`updatePluginCosmetic` hardcoded `severityInfo` for its `plugin_manifest_cosmetic_change` audit row, so an **unsigned-permissive** cosmetic hot-reload escaped the high-severity escalation that the install and version-bump paths already apply. It now threads the verification `result` and computes severity with the exact same pattern as `createPlugin`/`updatePlugin` (`severityHigh` when `OutcomeUnsignedPermissive`). New test installs an unsigned v1.0.0 → v1.0.1 (a version-only bump is cosmetic) and asserts the audit row is high-severity; the existing signed-cosmetic test remains the `info` regression guard.

## FIX 2 — WriteAuditStep request_id probing oracle
The **native** feedback path checked existence (`NotFound`) and status (late-feedback envelope) **before** verifying ownership, letting an unauthorized plugin distinguish whether a foreign `request_id` exists and its state. Ownership is now resolved **before** any existence/status branch:
- Unknown `request_id` (`sql.ErrNoRows`) returns the **same** `PermissionDenied`/`"unauthorized_request_id"` as a foreign request — no existence oracle. No audit event is written on this branch (no `run_id` to attribute; avoids audit-log flooding from probes) — documented inline so it isn't "fixed" later.
- Foreign-but-existing requests still write the high-severity `unauthorized_request_id` audit event.
- Non-owner outcomes for **nonexistent / foreign-pending / foreign-resolved** now collapse to one identical response.
- Legitimate owners retain correct `pending` (normal CAS write) and `resolved` (late-feedback `ok=false` envelope) semantics.

The **plugin-substrate path is untouched** — it already checks ownership before any status branch, so the **Slack reference plugin is unaffected** (it always owns its `plugin_pending_requests` row).

Trade-off (intended): a legitimate owner no longer receives `NotFound` for a genuinely-unknown `request_id` — an owner cannot have a nonexistent feedback request, so this is anomalous anyway. One existing test assertion flips accordingly.

### Tests
- New `TestWriteAuditStep_Native_OwnershipOracleClosed` — three sub-cases assert byte-identical `PermissionDenied`/`"unauthorized_request_id"` (the foreign-**resolved** case is the guard proving status no longer precedes ownership).
- `TestWriteAuditStep_LateFeedback` upgraded to an owner fixture (so it still exercises the late path post-reorder).
- `TestWriteAuditStep_NoCallID_UnknownRequestID_NativeMiss` assertion flipped `NotFound` → `PermissionDenied`.

All loader + hostsvc tests pass, including `-race` on hostsvc.

<details>
<summary>Architecture plan</summary>

Plan-reviewer verified no production caller branches on `codes.NotFound` from this RPC (Slack uses the substrate path; the agent never calls it at runtime), making the `NotFound`→`PermissionDenied` flip safe. It also caught two test-spec gaps in the first draft (the unsigned helper has no description param → use a version-only cosmetic bump; the `LateFeedback` fixture must be upgraded to an owner because the reorder moves ownership ahead of status). Decision to skip the audit event on the nonexistent branch is per ADR-046 (avoid flooding) and documented in code.
</details>

## Review
- Plan review: 1 revision cycle (two test-spec corrections), then verified.
- Code review: APPROVE, 1 cycle — oracle closure confirmed structurally enforced.
- CLAUDE.md: current — no updates needed.
- Brainstorming: not triggered.

🤖 Generated by the agentic dev loop.
