### PR TITLE
docs: operator-facing plugin runbook + env vars + README plugins section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,24 @@ GLEIPNIR_LOG_LEVEL=info
 # How often to scan for feedback requests that have timed out.
 # GLEIPNIR_FEEDBACK_SCAN_INTERVAL=30s
 
+# ---------------------------------------------------------------------------
+# Plugins
+# ---------------------------------------------------------------------------
+
+# Directory watched for plugin tarballs (.tar.gz / .tgz) by the fsnotify watcher.
+# GLEIPNIR_PLUGINS_DIR=/plugins
+
+# Allow unsigned plugin bundles to load (development only).
+# WARNING: disables tamper-evidence for unsigned bundles globally; leave false
+# in any shared or production deployment. Signed bundles are still fully verified.
+# GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=false
+
+# How often the OAuth refresh scanner proactively refreshes plugin OAuth2 tokens.
+# GLEIPNIR_OAUTH_REFRESH_INTERVAL=5m
+
+# Lead-time window before OAuth token expiry within which the scanner refreshes.
+# GLEIPNIR_OAUTH_REFRESH_LEAD=15m
+
 # How often to scan for plugin channel requests that have timed out.
 # GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL=30s
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,18 @@ Once the stack is running and you're logged in, here's how to wire up your first
 
 For fully worked examples against specific services, follow one of the [playbooks](docs/playbooks/).
 
+## Plugins
+
+Gleipnir supports plugins — signed sandboxed subprocesses that add tools, notification channels, and trigger event sources. Drop a `.tar.gz` bundle into `GLEIPNIR_PLUGINS_DIR` (default: `/plugins`) or upload it via **Admin → Plugins**. Signed plugins require admin approval before any subprocess is spawned. Signature verification and TOFU key pinning are enforced by default; every signing key is pinned on first install and subsequent updates must match.
+
+See [Plugins](docs/user/plugins.md) for the full operator runbook: installing, signing, approving, and rotating keys.
+
 ## More reading
 
 - [Setup](docs/user/setup.md) — detailed first-run walkthrough.
 - [Policies](docs/user/policies.md) — trigger types, capability grants, run states.
 - [Roles](docs/user/roles.md) — what each role can and cannot do.
+- [Plugins](docs/user/plugins.md) — installing, signing, approving, and key-rotating plugins.
 - [Operations](docs/user/operations.md) — upgrading, backups, environment variables.
 - [Playbooks](docs/playbooks/) — copy-pasteable setups for the use cases above.
 - [Developer docs](docs/developer/) — architecture, building, contributing.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -7,5 +7,6 @@ For people running a Gleipnir instance. If you're looking for how to *build* Gle
 - [Setup](setup.md) — first-run walkthrough: key generation, starting the stack, adding a provider, your first policy.
 - [Policies](policies.md) — trigger types, capability grants, run states, concurrency modes.
 - [Roles](roles.md) — what each role (admin, operator, approver, auditor) can and cannot do.
+- [Plugins](plugins.md) — installing, signing, approving, and key-rotating plugins; the unsigned escape hatch.
 - [Operations](operations.md) — upgrading, environment variables, database backups, viewing logs, resetting stuck runs.
 - [Troubleshooting](troubleshooting.md) — first-run failures and known issues.

--- a/docs/user/operations.md
+++ b/docs/user/operations.md
@@ -115,8 +115,16 @@ All variables are read at startup. Changing a value requires restarting the stac
 | `GLEIPNIR_APPROVAL_SCAN_INTERVAL` | `30s` | How often to check for timed-out approval requests. |
 | `GLEIPNIR_DEFAULT_FEEDBACK_TIMEOUT` | `30m` | Default timeout for feedback requests when not set in the policy. |
 | `GLEIPNIR_FEEDBACK_SCAN_INTERVAL` | `30s` | How often to check for timed-out feedback requests. |
+| `GLEIPNIR_PLUGINS_DIR` | `/plugins` | Directory watched for plugin tarballs (`.tar.gz`/`.tgz`) by the fsnotify watcher. |
+| `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS` | `false` | When `true`, unsigned bundles load; every unsigned load emits a high-severity audit event; `GET /api/v1/health` reports `signature_verification: disabled`. Signed bundles are still fully verified. Dev-only — leave `false` in production. |
+| `GLEIPNIR_OAUTH_REFRESH_INTERVAL` | `5m` | How often the OAuth refresh scanner proactively refreshes plugin OAuth2 tokens approaching expiry. |
+| `GLEIPNIR_OAUTH_REFRESH_LEAD` | `15m` | Lead-time window before OAuth token expiry within which the scanner triggers a refresh attempt. |
+| `GLEIPNIR_PLUGIN_REQUEST_SCAN_INTERVAL` | `30s` | How often to scan for plugin channel requests that have timed out. |
+| `GLEIPNIR_PLUGIN_DEDUP_SWEEP_INTERVAL` | `10m` | How often the dedup sweeper evicts entries older than the 1-hour dedup window. |
 
 `GLEIPNIR_PORT` is a Docker Compose variable (not read by the Go server directly). It controls which host port the container exposes and defaults to `3000`.
+
+Installing and managing plugins — see [Plugins](plugins.md).
 
 ## Viewing structured logs
 

--- a/docs/user/plugins.md
+++ b/docs/user/plugins.md
@@ -1,0 +1,296 @@
+# Plugins
+
+Plugins extend Gleipnir with tools, notification channels, and trigger event sources. Each plugin runs as a sandboxed subprocess; Gleipnir enforces the same hard capability boundary for plugin tools as it does for MCP tools. This page covers how to install, sign, approve, and manage the key lifecycle for a plugin.
+
+## Installing a plugin
+
+Plugins are distributed as `.tar.gz` (or `.tgz`) tarballs. There are two ways to install one.
+
+### Filesystem drop
+
+Drop the tarball into the directory set by `GLEIPNIR_PLUGINS_DIR` (default: `/plugins`). Gleipnir's fsnotify watcher detects new files within roughly 250 ms and installs the bundle automatically. If the server was down when a tarball arrived, the restart sweep picks it up on next startup. When multiple tarballs for the same plugin name are present, only the one with the highest semver is installed.
+
+Using Docker Compose with the default volume:
+
+```bash
+docker cp my-plugin-1.2.0.tar.gz gleipnir-api:/plugins/
+```
+
+### Admin API upload
+
+Send the raw tarball as an HTTP request body to the install endpoint (admin role required):
+
+```bash
+curl -X POST https://<host>/api/v1/admin/plugins \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @my-plugin-1.2.0.tar.gz
+```
+
+Maximum body size: 100 MiB. On success the response is `{ "data": { "id": "...", "name": "...", "version": "...", "status": "..." } }`. The `status` field reflects the post-install state, which may be `pending_review` for signed plugins awaiting admin approval (see below).
+
+Both paths run the same extract → signature-verify → snapshot install pipeline.
+
+## Approving a plugin (pending\_review)
+
+Signed plugins land in `pending_review` after installation. They are present in the database but no subprocess is spawned until an admin approves them. Unsigned plugins that loaded under `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true` auto-activate and skip this step.
+
+**Review surface:**
+
+- `GET /api/v1/admin/plugins` — lists all plugins including those in `pending_review` (which have no instances yet).
+- `GET /api/v1/admin/plugins/{id}` — full plugin detail: manifest metadata, services declared, tier-2 capabilities, auth strategy, pubkey fingerprint, SBOM presence.
+
+In the UI, go to **Admin → Plugins** and open the plugin's review page at `/admin/plugins/:id/review`.
+
+**Approve:**
+
+```bash
+curl -X POST https://<host>/api/v1/admin/plugins/{id}/approve
+```
+
+Transitions status `pending_review → active`, emits a `plugin_review_approved` audit event, and unblocks instance spawning. Returns 409 if the plugin is not in `pending_review`.
+
+**Reject:**
+
+```bash
+curl -X POST https://<host>/api/v1/admin/plugins/{id}/reject
+```
+
+Deletes the database row and the bundle directory. The tarball can be re-dropped to re-install. Returns 409 if the plugin is not in `pending_review`.
+
+## Making an instance functional
+
+Each installed plugin can have one or more named instances. Instances are the running subprocesses; a plugin row without instances does nothing at runtime.
+
+### Create an instance
+
+```bash
+curl -X POST https://<host>/api/v1/admin/plugins/{id}/instances \
+  -H "Content-Type: application/json" \
+  -d '{"instance_name": "my-instance"}'
+```
+
+Status codes:
+- `201` — instance created with health `unhealthy` / detail `config_missing`.
+- `400` — `instance_name` is missing or whitespace-only.
+- `409` — `instance_name` already exists for this plugin.
+
+A freshly-created instance is immediately visible in the admin UI but shows health `unhealthy` with detail `config_missing`. This is expected — the subprocess does not start until the instance is configured. Once you set its config (and credentials, if required), the health state clears.
+
+### Configure the instance
+
+After creation, the instance needs to be configured before it becomes healthy. The exact steps depend on what the plugin's manifest declares.
+
+**Instance config** (non-secret fields):
+
+```bash
+curl -X PUT https://<host>/api/v1/admin/plugins/{id}/instances/{iid}/config \
+  -H "Content-Type: application/json" \
+  -d '{"config": {"option_key": "value"}, "expected_version": 0}'
+```
+
+**Secret config fields** (write-only; avoids round-trip clobber):
+
+```bash
+curl -X PUT https://<host>/api/v1/admin/plugins/{id}/instances/{iid}/config/{property} \
+  -H "Content-Type: application/json" \
+  -d '{"value": "secret-value", "expected_version": 1}'
+```
+
+GET responses for config redact secret fields (annotated `x-gleipnir-secret: true` in the manifest) to `"***"`.
+
+**Subscription scope** (trigger plugins; restarts the trigger stream immediately):
+
+```bash
+curl -X PUT https://<host>/api/v1/admin/plugins/{id}/instances/{iid}/subscription-scope \
+  -H "Content-Type: application/json" \
+  -d '{"scope": {...}, "expected_version": 0}'
+```
+
+**Credentials:**
+
+| Strategy | Endpoint | Body |
+|---|---|---|
+| Static API key | `PUT .../credentials/static-api-key` | `{"header_name": "X-Api-Key", "scheme": "Bearer", "api_key": "..."}` |
+| Individual headers | `PUT .../credentials/headers/{name}` | `{"value": "..."}` |
+| Basic auth | `PUT .../credentials/basic-auth` | `{"username": "...", "password": "..."}` |
+| OAuth2 — step 1: store client creds | `PUT .../credentials/oauth-client` | `{"client_id": "...", "client_secret": "..."}` |
+| OAuth2 — step 2: start flow | `POST .../oauth/begin` | starts the OAuth2 flow |
+| Direct OAuth token seed | `PUT .../credentials/oauth-token` | `{"access_token": "...", "refresh_token": "...", "expires_at": "2026-06-19T00:00:00Z"}` |
+
+For `oauth2_authcode` and `oauth2_clientcred` strategies, you must call `PUT .../credentials/oauth-client` first — `BeginAuthcode` reads the client ID and secret from the stored credentials and fails with a config error if they are absent. Only after storing the client credentials should you call `POST .../oauth/begin` to start the authorization flow.
+
+All `PUT .../credentials/*` calls reject `"***"` as a value. Header names are validated against the RFC 7230 header-name rules and the reserved-name blocklist.
+
+### Deactivate and reactivate
+
+```bash
+# Soft-stop subprocess, transition health to inactive
+curl -X POST https://<host>/api/v1/admin/plugins/{id}/instances/{iid}/deactivate
+
+# Restart subprocess from inactive
+curl -X POST https://<host>/api/v1/admin/plugins/{id}/instances/{iid}/activate
+```
+
+## Signing a plugin with the gleipnir-plugin CLI
+
+Install the CLI from the plugin SDK, then use the `keygen`, `sign`, and `package` subcommands to produce a signed bundle. Signed bundles are verified by the host on every install and hot-reload.
+
+### Generate a signing keypair
+
+```bash
+gleipnir-plugin keygen \
+  --out-dir ~/.config/gleipnir-plugin/keys \
+  --name signing \
+  --kdf scrypt
+```
+
+This writes `~/.config/gleipnir-plugin/keys/signing.key` (mode 0600, passphrase-encrypted) and `signing.pub` (mode 0644).
+
+**Key flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--out-dir` | `~/.config/gleipnir-plugin/keys` | Directory for key files |
+| `--name` | `signing` | Base name → `<name>.key` / `<name>.pub` |
+| `--kdf` | `scrypt` | KDF for passphrase encryption: `scrypt` (broadest compatibility) or `argon2` (requires minisign ≥ 0.11) |
+| `--force` | false | Overwrite existing key files |
+| `--passphrase-stdin` | false | Read passphrase from stdin (CI) |
+| `--unencrypted` | false | Skip passphrase encryption — **testing only** |
+
+In CI, set `GLEIPNIR_PLUGIN_SIGNING_KEY_PASSPHRASE` to avoid interactive prompts.
+
+**Back up `signing.pub` separately from `signing.key`.** The public key is what gets TOFU-pinned on the host at first install; you need it to perform key rotation (see below).
+
+### Sign a binary and manifest
+
+`sign` produces a standalone `.minisig` file. Use it when you want to sign independently of packaging.
+
+```bash
+gleipnir-plugin sign \
+  --binary ./my-plugin \
+  --manifest manifest.yaml
+```
+
+Output: `my-plugin.minisig` in the current directory.
+
+**Key flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--binary` | *(required)* | Path to the plugin binary |
+| `--manifest` | `manifest.yaml` | Path to `manifest.yaml` |
+| `--key` | `~/.config/gleipnir-plugin/keys/signing.key` | Path to `.key` file |
+| `--key-stdin` | false | Read `.key` file from stdin (CI) |
+| `--out` | `<binary-basename>.minisig` | Output `.minisig` path |
+| `--trusted-comment` | *(auto)* | Trusted comment embedded in the signature (default: timestamp + manifest name/version) |
+
+Key resolution order: `--key-stdin` → env `GLEIPNIR_PLUGIN_SIGNING_KEY` → `--key` → default path.
+
+### Package a signed release bundle
+
+`package` builds the complete `.tar.gz` ready for installation:
+
+```bash
+gleipnir-plugin package \
+  --binary ./my-plugin \
+  --manifest manifest.yaml \
+  --out-dir dist
+```
+
+Output: `dist/my-plugin-1.2.0.tar.gz` containing:
+```
+my-plugin-1.2.0/
+  my-plugin           (mode 0755)
+  manifest.yaml       (mode 0644)
+  my-plugin.minisig   (mode 0644)  ← filename is <manifest.name>.minisig, not the binary basename
+  signing.pub         (mode 0644)
+```
+
+An optional SBOM is included when you pass `--sbom`:
+
+```bash
+gleipnir-plugin package \
+  --binary ./my-plugin \
+  --manifest manifest.yaml \
+  --sbom sbom.cyclonedx.json \
+  --out-dir dist
+```
+
+**Key flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--binary` | *(required)* | Path to the plugin binary |
+| `--manifest` | `manifest.yaml` | Path to `manifest.yaml` |
+| `--key` | `~/.config/gleipnir-plugin/keys/signing.key` | Path to `.key` file |
+| `--key-stdin` | false | Read `.key` from stdin (CI) |
+| `--pubkey` | sibling `.pub` of the `.key` | Path to `.pub` file |
+| `--out-dir` | `dist` | Output directory for the tarball |
+| `--sbom` | *(none)* | Optional CycloneDX SBOM JSON path |
+| `--unsigned` | false | Produce an unsigned bundle — only loads on hosts with `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true` |
+
+Key resolution order for `package`: same as `sign` (`--key-stdin` → env `GLEIPNIR_PLUGIN_SIGNING_KEY` → `--key` → default path).
+
+### CI signing example
+
+```bash
+# Key and passphrase available as CI secrets:
+export GLEIPNIR_PLUGIN_SIGNING_KEY=/path/to/signing.key
+export GLEIPNIR_PLUGIN_SIGNING_KEY_PASSPHRASE=<secret>
+
+gleipnir-plugin package \
+  --binary ./dist/my-plugin \
+  --manifest manifest.yaml \
+  --out-dir release
+```
+
+## TOFU key trust and rotation
+
+Gleipnir uses trust-on-first-use (TOFU) pinning for plugin signing keys.
+
+### First install pins the key
+
+When a signed plugin is installed for the first time, its public key is pinned in the database (`plugins.trusted_pubkey`). Every subsequent install or hot-reload of that plugin must be signed by the same key. This is the tamper-evidence guarantee.
+
+### Update signed by a different key
+
+If you drop in a bundle signed by a key that does not match the pinned key, Gleipnir does not auto-install it. Affected instances transition to `pending_key_approval` and a high-severity `plugin_pubkey_mismatch` audit event is emitted. The audit event payload includes the field `new_pubkey_b64` — the base64-encoded Minisign `signing.pub` bytes of the new key.
+
+To approve the new key, post that value to the accept-new-key endpoint:
+
+```bash
+# Extract new_pubkey_b64 from the audit log, then:
+curl -X POST https://<host>/api/v1/admin/plugins/{id}/accept-new-key \
+  -H "Content-Type: application/json" \
+  -d '{"candidate_pubkey": "<value of new_pubkey_b64 from audit event>"}'
+```
+
+This CAS-rotates `plugins.trusted_pubkey`, unblocks the `pending_key_approval` instances back to healthy, and emits a `plugin_pubkey_rotated` audit event. In the admin UI, the **AcceptNewKeyModal** extracts `new_pubkey_b64` automatically — you only need the manual API path when scripting.
+
+### Material manifest changes on hot-reload
+
+When a plugin update changes the manifest in a material way (schema shape changes, not just description/default edits), the hot-reload is blocked: affected instances transition to `pending_manifest_approval` and a high-severity `plugin_manifest_material_change` audit event is emitted.
+
+To commit the new manifest:
+
+```bash
+curl -X POST https://<host>/api/v1/admin/plugins/{id}/accept-manifest
+```
+
+Depending on whether the new manifest introduces newly-required config fields, instances transition to `healthy` (no new required fields) or `pending_config_migration` (new required fields that need filling). The admin UI provides a review surface at **Admin → Plugins → {plugin}**.
+
+## Unsigned plugin escape hatch
+
+`GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=false` is the default and should stay that way in any shared or production deployment. Setting it to `true` is a development convenience that disables tamper-evidence for unsigned bundles globally — **signed bundles are still fully verified even in permissive mode**.
+
+When `GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true`:
+
+- The server emits a loud `WARN` log line at startup:
+  ```
+  GLEIPNIR_ALLOW_UNSIGNED_PLUGINS=true: unsigned plugins will load; every load emits a high-severity audit event. Signed plugins are still fully verified. See ADR-045.
+  ```
+- `GET /api/v1/health` includes an additional field: `"signature_verification": "disabled"`.
+- Every unsigned plugin load emits a high-severity audit event.
+- Each instance spawned from an unsigned bundle shows an **`unsigned_permissive`** (yellow) health chip labelled **"Unsigned (permissive)"** on its row in **Admin → Plugins**. This is a per-instance indicator — there is no persistent global banner.
+
+This flag is read once at startup. To change it, update the value in `.env` and restart the stack.


### PR DESCRIPTION
Closes #565

## Summary

Operator-facing plugin documentation was essentially absent (`operations.md` had zero plugin content; `.env.example` and the README didn't mention plugins). This adds it, with every cited command/route/default verified against source.

### New `docs/user/plugins.md` — operator runbook
- **Installing**: filesystem drop into `GLEIPNIR_PLUGINS_DIR` (fsnotify watcher, highest-semver wins) or `POST /api/v1/admin/plugins` (100 MiB upload).
- **Approving**: signed installs land in `pending_review` (approve/reject); unsigned-permissive auto-activate.
- **Instances**: create + configure (config/secrets, subscription-scope, credentials, OAuth). Notes that a fresh instance starts `unhealthy`/`config_missing` until configured.
- **Signing** with `gleipnir-plugin keygen`/`sign`/`package` — exact verified flags (no `--sig`, no `package --out`; `package` uses `--out-dir`).
- **TOFU key trust & rotation**: pinning, `pending_key_approval`, `accept-new-key` (with where to source `candidate_pubkey` — the `new_pubkey_b64` audit field), material-manifest `accept-manifest`.
- **OAuth2**: documents the required `PUT .../credentials/oauth-client` step *before* `oauth/begin`.
- **Unsigned escape hatch**: only the real surfaces (startup WARN, `/api/v1/health` `signature_verification: disabled`, high-severity audits, per-instance yellow health chip) — deliberately does **not** claim the non-existent "global red banner."

### Other
- `.env.example` — added the four missing plugin vars under a "Plugins" header (didn't duplicate the two already present).
- `docs/user/operations.md` — six plugin env-var rows + a pointer to the runbook.
- `docs/user/README.md` + top-level `README.md` — Plugins entries / "More reading" links.

<details>
<summary>Architecture plan</summary>

The architect grounded every cited flag/route/env-var in source and caught that CLAUDE.md overstates the unsigned-plugin UI surface (claims a global red banner that doesn't exist) — the docs describe only the real surfaces. Plan review fact-checked all CLI flags and routes; code review (2 cycles) caught a missing OAuth client-credentials prerequisite step, now fixed.
</details>

## Review
- Plan review: 1 revision (operator-context refinements), fully fact-checked.
- Code review: 2 cycles — APPROVE after adding the `oauth-client` prerequisite.
- CLAUDE.md: no updates needed (docs-only; env vars already documented).
- Brainstorming: not triggered.

🤖 Generated by the agentic dev loop.
