### PR TITLE
refactor: move mcp.Registry.RegisterServer to a test helper

### DIFF
--- a/internal/execution/run/launcher_test.go
+++ b/internal/execution/run/launcher_test.go
@@ -73,8 +73,8 @@ func setupIntegrationFixture(t *testing.T) (*db.Store, *mcp.Registry) {
 	mcpSrv := newStubMCPServer(t)
 	t.Cleanup(mcpSrv.Close)
 	registry := mcp.NewRegistry(store.Queries())
-	if err := registry.RegisterServer(context.Background(), "stub-server", mcpSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := mcp.RegisterServerForTest(context.Background(), store.Queries(), registry, "stub-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 	return store, registry
 }

--- a/internal/execution/run/run_and_drain_test.go
+++ b/internal/execution/run/run_and_drain_test.go
@@ -138,8 +138,8 @@ func TestRunAndDrain_NonQueuePolicy(t *testing.T) {
 	mcpSrv := newStubMCPServerInternal(t)
 	t.Cleanup(mcpSrv.Close)
 	registry := mcp.NewRegistry(store.Queries())
-	if err := registry.RegisterServer(context.Background(), "stub-server", mcpSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := mcp.RegisterServerForTest(context.Background(), store.Queries(), registry, "stub-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	testutil.InsertPolicy(t, store, "p-parallel", "policy-p-parallel", "webhook", parallelPolicyYAML)
@@ -194,8 +194,8 @@ func TestRunAndDrain_QueuePolicy(t *testing.T) {
 	mcpSrv := newStubMCPServerInternal(t)
 	t.Cleanup(mcpSrv.Close)
 	registry := mcp.NewRegistry(store.Queries())
-	if err := registry.RegisterServer(context.Background(), "stub-server", mcpSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := mcp.RegisterServerForTest(context.Background(), store.Queries(), registry, "stub-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	testutil.InsertPolicy(t, store, "p-queue", "policy-p-queue", "webhook", queuePolicyYAML)

--- a/internal/mcp/registertest.go
+++ b/internal/mcp/registertest.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/model"
+)
+
+// RegisterServerForTest persists a new mcp_servers row and discovers its tools
+// through the real RefreshTools path (including the #194 namespace arbiter when
+// the Registry was built WithToolNamespaceArbiter). It mirrors the production
+// MCPHandler.Create flow. Test-only seam; no production code reaches it.
+// Returns the generated server ID.
+func RegisterServerForTest(ctx context.Context, q *db.Queries, reg *Registry, name, url string) (string, error) {
+	if err := ValidateServerURL(ctx, url); err != nil {
+		return "", fmt.Errorf("invalid server url: %w", err)
+	}
+	serverID := model.NewULID()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := q.CreateMCPServer(ctx, db.CreateMCPServerParams{
+		ID:        serverID,
+		Name:      name,
+		Url:       url,
+		CreatedAt: now,
+	}); err != nil {
+		return "", fmt.Errorf("create mcp server: %w", err)
+	}
+	if _, err := reg.RefreshTools(ctx, serverID); err != nil {
+		return serverID, fmt.Errorf("refresh tools: %w", err)
+	}
+	return serverID, nil
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -255,51 +255,6 @@ func (r *Registry) ProbeTools(ctx context.Context, name, urlStr string, encrypte
 	return tools, nil
 }
 
-// RegisterServer stores a new MCP server record, discovers its tools via the
-// MCP client, and upserts all discovered tools into mcp_tools.
-// last_discovered_at is intentionally left NULL here — it is set only by RefreshTools.
-func (r *Registry) RegisterServer(ctx context.Context, name, url string) error {
-	if err := ValidateServerURL(ctx, url); err != nil {
-		return fmt.Errorf("invalid server url: %w", err)
-	}
-
-	serverID := model.NewULID()
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-
-	if _, err := r.queries.CreateMCPServer(ctx, db.CreateMCPServerParams{
-		ID:        serverID,
-		Name:      name,
-		Url:       url,
-		CreatedAt: now,
-	}); err != nil {
-		return fmt.Errorf("create mcp server: %w", err)
-	}
-
-	// Build a synthetic server record so newClientForServer can apply auth headers.
-	// RegisterServer does not yet have a DB row to read from, so we construct the
-	// minimal record. auth_headers_encrypted is always nil at creation time —
-	// headers are added via the Update endpoint after the server is registered.
-	tools, err := r.newClientForServer(db.McpServer{ID: serverID, Name: name, Url: url}).DiscoverTools(ctx)
-	if err != nil {
-		return fmt.Errorf("discover tools for server %q: %w", name, err)
-	}
-
-	for _, t := range tools {
-		if _, err := r.queries.UpsertMCPTool(ctx, db.UpsertMCPToolParams{
-			ID:          model.NewULID(),
-			ServerID:    serverID,
-			Name:        t.Name,
-			Description: t.Description,
-			InputSchema: string(t.InputSchema),
-			CreatedAt:   now,
-		}); err != nil {
-			return fmt.Errorf("upsert tool %q: %w", t.Name, err)
-		}
-	}
-
-	return nil
-}
-
 // RefreshTools re-discovers tools for a registered server, computes the diff
 // against the current DB state, upserts all fresh tools, deletes tools that
 // have disappeared, and updates last_discovered_at.

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -49,7 +49,7 @@ func makeMCPServer(t *testing.T, tools []map[string]any) *httptest.Server {
 	return srv
 }
 
-func TestRegisterServer_HappyPath(t *testing.T) {
+func TestRegisterServerForTest_HappyPath(t *testing.T) {
 	reg, store := newTestRegistry(t)
 	rawDB := store.DB()
 
@@ -59,15 +59,9 @@ func TestRegisterServer_HappyPath(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "test-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
-	}
-
-	// Verify server row exists.
-	var serverID string
-	err := rawDB.QueryRow(`SELECT id FROM mcp_servers WHERE name = 'test-server'`).Scan(&serverID)
+	serverID, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "test-server", srv.URL)
 	if err != nil {
-		t.Fatalf("query server: %v", err)
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	// Verify exactly 2 tool rows.
@@ -100,17 +94,17 @@ func TestRegisterServer_HappyPath(t *testing.T) {
 		t.Errorf("tools[1].name = %q, want %q", gotNames[1], "tool-b")
 	}
 
-	// last_discovered_at must be NULL after RegisterServer — only RefreshTools sets it.
+	// last_discovered_at must be SET after discovery via RefreshTools.
 	var lastDiscovered *string
 	if err := rawDB.QueryRow(`SELECT last_discovered_at FROM mcp_servers WHERE id = ?`, serverID).Scan(&lastDiscovered); err != nil {
 		t.Fatalf("query last_discovered_at: %v", err)
 	}
-	if lastDiscovered != nil {
-		t.Errorf("last_discovered_at = %q, want NULL after RegisterServer", *lastDiscovered)
+	if lastDiscovered == nil {
+		t.Error("last_discovered_at must be SET after discovery via RefreshTools.")
 	}
 }
 
-func TestRegisterServer_MCPServerUnreachable(t *testing.T) {
+func TestRegisterServerForTest_MCPServerUnreachable(t *testing.T) {
 	reg, store := newTestRegistry(t)
 	rawDB := store.DB()
 
@@ -119,7 +113,7 @@ func TestRegisterServer_MCPServerUnreachable(t *testing.T) {
 	url := srv.URL
 	srv.Close()
 
-	err := reg.RegisterServer(context.Background(), "unreachable-server", url)
+	_, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "unreachable-server", url)
 	if err == nil {
 		t.Fatal("expected error for unreachable MCP server, got nil")
 	}
@@ -144,13 +138,9 @@ func TestRefreshTools_NoChanges(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "test-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
-	}
-
-	var serverID string
-	if err := rawDB.QueryRow(`SELECT id FROM mcp_servers WHERE name = 'test-server'`).Scan(&serverID); err != nil {
-		t.Fatalf("query server id: %v", err)
+	serverID, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "test-server", srv.URL)
+	if err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	diff, err := reg.RefreshTools(context.Background(), serverID)
@@ -196,13 +186,9 @@ func TestRefreshTools_AddedTools(t *testing.T) {
 	}
 	firstSrv := makeMCPServer(t, oneTool)
 
-	if err := reg.RegisterServer(context.Background(), "test-server", firstSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
-	}
-
-	var serverID string
-	if err := rawDB.QueryRow(`SELECT id FROM mcp_servers WHERE name = 'test-server'`).Scan(&serverID); err != nil {
-		t.Fatalf("query server id: %v", err)
+	serverID, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "test-server", firstSrv.URL)
+	if err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	// Now point the server at a handler that returns two tools.
@@ -249,13 +235,9 @@ func TestRefreshTools_RemovedTools(t *testing.T) {
 	}
 	firstSrv := makeMCPServer(t, twoTools)
 
-	if err := reg.RegisterServer(context.Background(), "test-server", firstSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
-	}
-
-	var serverID string
-	if err := rawDB.QueryRow(`SELECT id FROM mcp_servers WHERE name = 'test-server'`).Scan(&serverID); err != nil {
-		t.Fatalf("query server id: %v", err)
+	serverID, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "test-server", firstSrv.URL)
+	if err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	// Second discovery returns only tool-a.
@@ -308,13 +290,9 @@ func TestRefreshTools_ModifiedTools(t *testing.T) {
 	}
 	firstSrv := makeMCPServer(t, original)
 
-	if err := reg.RegisterServer(context.Background(), "test-server", firstSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
-	}
-
-	var serverID string
-	if err := rawDB.QueryRow(`SELECT id FROM mcp_servers WHERE name = 'test-server'`).Scan(&serverID); err != nil {
-		t.Fatalf("query server id: %v", err)
+	serverID, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "test-server", firstSrv.URL)
+	if err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	// Same name, changed description.
@@ -370,13 +348,9 @@ func TestRefreshTools_MCPServerUnreachable(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "test-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
-	}
-
-	var serverID string
-	if err := rawDB.QueryRow(`SELECT id FROM mcp_servers WHERE name = 'test-server'`).Scan(&serverID); err != nil {
-		t.Fatalf("query server id: %v", err)
+	serverID, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "test-server", srv.URL)
+	if err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	// Capture state before the failed refresh.
@@ -394,7 +368,7 @@ func TestRefreshTools_MCPServerUnreachable(t *testing.T) {
 		t.Fatalf("update server url: %v", err)
 	}
 
-	_, err := reg.RefreshTools(context.Background(), serverID)
+	_, err = reg.RefreshTools(context.Background(), serverID)
 	if err == nil {
 		t.Fatal("expected error for unreachable MCP server, got nil")
 	}
@@ -412,15 +386,15 @@ func TestRefreshTools_MCPServerUnreachable(t *testing.T) {
 // TestResolveToolByName_HappyPath verifies that a registered tool can be
 // resolved to a ready Client and bare tool name.
 func TestResolveToolByName_HappyPath(t *testing.T) {
-	reg, _ := newTestRegistry(t)
+	reg, store := newTestRegistry(t)
 
 	tools := []map[string]any{
 		{"name": "my-tool", "description": "a tool", "inputSchema": map[string]any{"type": "object"}},
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	client, toolName, err := reg.ResolveToolByName(context.Background(), "my-server.my-tool")
@@ -438,15 +412,15 @@ func TestResolveToolByName_HappyPath(t *testing.T) {
 // TestResolveToolByName_UnknownTool verifies that resolving a tool that is not
 // in the registry returns an error.
 func TestResolveToolByName_UnknownTool(t *testing.T) {
-	reg, _ := newTestRegistry(t)
+	reg, store := newTestRegistry(t)
 
 	tools := []map[string]any{
 		{"name": "real-tool", "description": "exists", "inputSchema": map[string]any{"type": "object"}},
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	_, _, err := reg.ResolveToolByName(context.Background(), "my-server.nonexistent")
@@ -614,13 +588,9 @@ func TestRefreshTools_DriftClearedOnCleanRefresh(t *testing.T) {
 	}
 	firstSrv := makeMCPServer(t, oneTool)
 
-	if err := reg.RegisterServer(context.Background(), "test-server", firstSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
-	}
-
-	var serverID string
-	if err := rawDB.QueryRow(`SELECT id FROM mcp_servers WHERE name = 'test-server'`).Scan(&serverID); err != nil {
-		t.Fatalf("query server id: %v", err)
+	serverID, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "test-server", firstSrv.URL)
+	if err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	// Point to a server that returns tool-a + tool-b: diff is non-empty, so has_drift=1.

--- a/internal/mcp/resolve_test.go
+++ b/internal/mcp/resolve_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestResolveForPolicy_AllToolsFound(t *testing.T) {
-	reg, _ := newTestRegistry(t)
+	reg, store := newTestRegistry(t)
 
 	tools := []map[string]any{
 		{"name": "read_pods", "description": "list pods", "inputSchema": map[string]any{"type": "object"}},
@@ -19,8 +19,8 @@ func TestResolveForPolicy_AllToolsFound(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	p := &model.ParsedPolicy{
@@ -80,15 +80,15 @@ func TestResolveForPolicy_AllToolsFound(t *testing.T) {
 }
 
 func TestResolveForPolicy_MissingTool(t *testing.T) {
-	reg, _ := newTestRegistry(t)
+	reg, store := newTestRegistry(t)
 
 	tools := []map[string]any{
 		{"name": "read_pods", "description": "list pods", "inputSchema": map[string]any{"type": "object"}},
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	p := &model.ParsedPolicy{
@@ -165,15 +165,15 @@ func TestResolveForPolicy_ServerNotFound(t *testing.T) {
 }
 
 func TestResolveForPolicy_ToolNotFound(t *testing.T) {
-	reg, _ := newTestRegistry(t)
+	reg, store := newTestRegistry(t)
 
 	tools := []map[string]any{
 		{"name": "read_pods", "description": "list pods", "inputSchema": map[string]any{"type": "object"}},
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	p := &model.ParsedPolicy{
@@ -195,7 +195,7 @@ func TestResolveForPolicy_ToolNotFound(t *testing.T) {
 }
 
 func TestResolveForPolicy_SharedClient(t *testing.T) {
-	reg, _ := newTestRegistry(t)
+	reg, store := newTestRegistry(t)
 
 	tools := []map[string]any{
 		{"name": "tool_a", "description": "tool a", "inputSchema": map[string]any{"type": "object"}},
@@ -204,8 +204,8 @@ func TestResolveForPolicy_SharedClient(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	p := &model.ParsedPolicy{
@@ -236,7 +236,7 @@ func TestResolveForPolicy_SharedClient(t *testing.T) {
 }
 
 func TestResolveForPolicy_ToolsOrdered(t *testing.T) {
-	reg, _ := newTestRegistry(t)
+	reg, store := newTestRegistry(t)
 
 	tools := []map[string]any{
 		{"name": "tool_a", "description": "tool a", "inputSchema": map[string]any{"type": "object"}},
@@ -245,8 +245,8 @@ func TestResolveForPolicy_ToolsOrdered(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	p := &model.ParsedPolicy{
@@ -287,8 +287,8 @@ func TestResolveForPolicy_DisabledTool(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	// Fetch the tool ID so we can disable it.
@@ -335,8 +335,8 @@ func TestResolveToolByName_DisabledTool(t *testing.T) {
 	}
 	srv := makeMCPServer(t, tools)
 
-	if err := reg.RegisterServer(context.Background(), "my-server", srv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := RegisterServerForTest(context.Background(), store.Queries(), reg, "my-server", srv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 
 	registered, err := store.Queries().GetMCPToolByServerAndName(context.Background(), db.GetMCPToolByServerAndNameParams{

--- a/internal/trigger/poll_test.go
+++ b/internal/trigger/poll_test.go
@@ -117,8 +117,8 @@ func setupPollerFixture(t *testing.T, mcpSrv *httptest.Server) (*db.Store, *mcp.
 	t.Helper()
 	store := testutil.NewTestStore(t)
 	registry := mcp.NewRegistry(store.Queries())
-	if err := registry.RegisterServer(context.Background(), "poll-server", mcpSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := mcp.RegisterServerForTest(context.Background(), store.Queries(), registry, "poll-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 	return store, registry
 }

--- a/internal/trigger/scheduled_test.go
+++ b/internal/trigger/scheduled_test.go
@@ -66,8 +66,8 @@ func setupSchedulerFixture(t *testing.T) (*db.Store, *mcp.Registry) {
 	mcpSrv := newStubMCPServer(t)
 	t.Cleanup(mcpSrv.Close)
 	registry := mcp.NewRegistry(store.Queries())
-	if err := registry.RegisterServer(context.Background(), "stub-server", mcpSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := mcp.RegisterServerForTest(context.Background(), store.Queries(), registry, "stub-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 	return store, registry
 }

--- a/internal/trigger/testhelpers_test.go
+++ b/internal/trigger/testhelpers_test.go
@@ -103,8 +103,8 @@ func setupIntegrationFixture(t *testing.T) (*db.Store, *mcp.Registry) {
 	mcpSrv := newStubMCPServer(t)
 	t.Cleanup(mcpSrv.Close)
 	registry := mcp.NewRegistry(store.Queries())
-	if err := registry.RegisterServer(context.Background(), "stub-server", mcpSrv.URL); err != nil {
-		t.Fatalf("RegisterServer: %v", err)
+	if _, err := mcp.RegisterServerForTest(context.Background(), store.Queries(), registry, "stub-server", mcpSrv.URL); err != nil {
+		t.Fatalf("RegisterServerForTest: %v", err)
 	}
 	return store, registry
 }


### PR DESCRIPTION
Closes #280

## Summary

`internal/mcp.Registry.RegisterServer` was a production-type method with **zero production callers** — it survived only as a test convenience, and (worse) it bypassed the #194 namespace arbiter that the real server-creation path (`MCPHandler.Create` → `CreateMCPServer` + `RefreshTools`) runs through. Every test using it exercised a code path that does not exist in production.

This change:
- **Deletes** `Registry.RegisterServer` from `internal/mcp/registry.go`.
- **Adds** `RegisterServerForTest` in a new non-test file `internal/mcp/registertest.go` (`package mcp`, so both internal and external test packages can reach it). It mirrors the production flow — `CreateMCPServer` then `RefreshTools` — so migrated tests now exercise the real arbiter-aware path.
- **Migrates all 23 call sites** across 7 test files (`registry_test.go`, `resolve_test.go`, `trigger/{testhelpers,poll,scheduled}_test.go`, `execution/run/{run_and_drain,launcher}_test.go`).

Net effect on coverage is positive: the arbiter-bypass gap is closed. Pure refactor — no production behavior change.

## Notable behavioral delta handled

Switching to `RefreshTools` means `last_discovered_at` is now **set** after discovery (the old method intentionally left it NULL). `TestRegisterServerForTest_HappyPath`'s assertion was flipped NULL→non-NULL to match production semantics. Redundant `SELECT id … WHERE name = …` re-queries were dropped in favor of the serverID the helper now returns.

## Review cycles

1 implementation cycle, approved on first code review. The plan went through one adversarial plan-review REVISE (caught compile-blocking `reg, _ :=` → `reg, store :=` sites that needed per-line precision) before implementation.

<details>
<summary>Architecture plan</summary>

Helper lives in `internal/mcp` as an exported non-`_test.go` file taking `(ctx, *db.Queries, *Registry, name, url)` and routing through `RefreshTools` (not a renamed direct-`UpsertMCPTool` shortcut — that was explicitly rejected as it would just relocate the arbiter-bypass behind a nicer name). `CreateMCPServer` before `RefreshTools` ordering is load-bearing (`RefreshTools` calls `GetMCPServer`). The `reg, _ :=` → `reg, store :=` change was applied at exactly the sites whose tests call the helper and nowhere else, to avoid unused-variable compile errors.
</details>

## Gates

`go build ./...`, `go test ./...` (55 packages), and `gofmt -l -s .` all pass. CLAUDE.md needed no updates (no new packages/env vars/routes/enums/ADRs).

🤖 Generated with the agentic dev loop.