### PR TITLE
fix: channel-only plugin instances reach health=healthy + credential-set advances readiness

### DIFF
--- a/internal/admin/instance_config.go
+++ b/internal/admin/instance_config.go
@@ -632,13 +632,22 @@ func (m *InstanceConfig) PutConfigProperty(ctx context.Context, pluginID, instan
 	}}, nil
 }
 
-// advanceInstanceReadiness re-evaluates the instance's readiness detail and
-// writes it back through SetHealthState if it has changed. Best-effort — any
-// failure is logged but not returned to the caller because the underlying
-// config/credentials write has already succeeded. Bypasses the update entirely
-// when the instance is not currently in unhealthy (e.g. already healthy, or
-// pending some other admin action).
-func (m *InstanceConfig) advanceInstanceReadiness(ctx context.Context, inst db.PluginInstance, manifest *sdkmanifest.Manifest) {
+// AdvanceInstanceReadiness re-evaluates an instance's readiness detail and
+// writes it back through SetHealthState if it has changed. This is called after
+// the operator saves instance config or credentials so the admin UI progresses
+// through config_missing → credentials_missing → "" (fully ready) without
+// requiring a manual page refresh.
+//
+// Best-effort: any failure is logged but not returned to the caller because the
+// underlying config/credentials write has already committed. The update is
+// skipped when the instance is not currently in unhealthy (e.g. already healthy
+// or pending an admin action).
+//
+// The querier param satisfies pluginstate.Querier (GetPluginInstanceByID +
+// UpdatePluginInstanceHealth). Both InstanceConfig.q and PluginCredentialsHandler's
+// querier satisfy it, which is why this is a package-level helper rather than a
+// method — it lets both handlers share the same logic without a circular dep.
+func AdvanceInstanceReadiness(ctx context.Context, q pluginstate.Querier, pub event.Publisher, inst db.PluginInstance, manifest *sdkmanifest.Manifest) {
 	if model.PluginHealthState(inst.HealthState) != model.PluginHealthStateUnhealthy {
 		return
 	}
@@ -651,12 +660,19 @@ func (m *InstanceConfig) advanceInstanceReadiness(ctx context.Context, inst db.P
 	if wanted == currentDetail {
 		return
 	}
-	err := pluginstate.SetHealthState(ctx, m.q, m.publisher, inst.ID, pluginstate.OriginHost,
+	err := pluginstate.SetHealthState(ctx, q, pub, inst.ID, pluginstate.OriginHost,
 		model.PluginHealthStateUnhealthy, wanted)
 	if err != nil && !errors.Is(err, pluginstate.ErrTransitionConflict) {
-		slog.WarnContext(ctx, "advanceInstanceReadiness: set health detail failed",
+		slog.WarnContext(ctx, "AdvanceInstanceReadiness: set health detail failed",
 			"instance_id", inst.ID, "from", currentDetail, "to", wanted, "err", err)
 	}
+}
+
+// advanceInstanceReadiness is the method-scoped thin forward to AdvanceInstanceReadiness
+// used by PutConfig (and PutConfigProperty which calls PutConfig indirectly).
+// Keeping the method preserves the existing PutConfig call site unchanged.
+func (m *InstanceConfig) advanceInstanceReadiness(ctx context.Context, inst db.PluginInstance, manifest *sdkmanifest.Manifest) {
+	AdvanceInstanceReadiness(ctx, m.q, m.publisher, inst, manifest)
 }
 
 // computeInstanceReadinessDetail returns the appropriate health_detail string

--- a/internal/admin/plugin_credentials_handler.go
+++ b/internal/admin/plugin_credentials_handler.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
+	"github.com/felag-engineering/gleipnir/internal/infra/event"
 	"github.com/felag-engineering/gleipnir/internal/infra/headervalidate"
 	"github.com/felag-engineering/gleipnir/internal/plugin/oauth"
 	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
@@ -32,13 +34,17 @@ type PluginCredentialsHandler struct {
 	// q is used to look up instance details (belongs-to-plugin check and
 	// manifest snapshot for strategy validation). OAuthPluginQuerier is
 	// declared in plugin_oauth_handler.go — same package, no redeclaration.
-	q     OAuthPluginQuerier
-	store *oauth.DBStore
+	q         OAuthPluginQuerier
+	store     *oauth.DBStore
+	publisher event.Publisher
 }
 
 // NewPluginCredentialsHandler constructs a PluginCredentialsHandler.
-func NewPluginCredentialsHandler(q OAuthPluginQuerier, store *oauth.DBStore) *PluginCredentialsHandler {
-	return &PluginCredentialsHandler{q: q, store: store}
+// pub is used to broadcast plugin.health_changed events after a credential write
+// advances the instance readiness detail (config_missing → credentials_missing → "").
+// Pass nil when health events are not needed (e.g. tests that don't assert on them).
+func NewPluginCredentialsHandler(q OAuthPluginQuerier, store *oauth.DBStore, pub event.Publisher) *PluginCredentialsHandler {
+	return &PluginCredentialsHandler{q: q, store: store, publisher: pub}
 }
 
 // Get handles GET /api/v1/admin/plugins/{id}/instances/{iid}/credentials.
@@ -125,6 +131,7 @@ func (h *PluginCredentialsHandler) SetStaticAPIKey(w http.ResponseWriter, r *htt
 		return
 	}
 
+	h.advanceReadiness(ctx, pluginID, instanceID)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -164,6 +171,7 @@ func (h *PluginCredentialsHandler) SetHeader(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	h.advanceReadiness(ctx, pluginID, instanceID)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -188,6 +196,7 @@ func (h *PluginCredentialsHandler) DeleteHeader(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	h.advanceReadiness(ctx, pluginID, instanceID)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -231,6 +240,7 @@ func (h *PluginCredentialsHandler) SetBasicAuth(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	h.advanceReadiness(ctx, pluginID, instanceID)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -411,4 +421,33 @@ func (h *PluginCredentialsHandler) handleStoreError(w http.ResponseWriter, r *ht
 	default:
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to "+op, "")
 	}
+}
+
+// advanceReadiness re-fetches the instance row (which now reflects the
+// just-written credentials_encrypted) and calls AdvanceInstanceReadiness to
+// progress the health detail through credentials_missing → "". Best-effort:
+// any error is logged and the caller still returns 204.
+func (h *PluginCredentialsHandler) advanceReadiness(ctx context.Context, pluginID, instanceID string) {
+	inst, err := h.q.GetPluginInstanceByID(ctx, instanceID)
+	if err != nil {
+		slog.WarnContext(ctx, "credentials: advanceReadiness: failed to re-fetch instance",
+			"instance_id", instanceID, "err", err)
+		return
+	}
+
+	plugin, err := h.q.GetPluginByID(ctx, pluginID)
+	if err != nil {
+		slog.WarnContext(ctx, "credentials: advanceReadiness: failed to get plugin",
+			"plugin_id", pluginID, "err", err)
+		return
+	}
+
+	var manifest sdkmanifest.Manifest
+	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &manifest); parseErr != nil {
+		slog.WarnContext(ctx, "credentials: advanceReadiness: corrupt manifest snapshot",
+			"plugin_id", pluginID, "err", parseErr)
+		return
+	}
+
+	AdvanceInstanceReadiness(ctx, h.q, h.publisher, inst, &manifest)
 }

--- a/internal/admin/plugin_credentials_handler_test.go
+++ b/internal/admin/plugin_credentials_handler_test.go
@@ -30,7 +30,7 @@ func buildCredHandlerWithStore(t *testing.T, q OAuthPluginQuerier, fakeStore *fa
 		return "", nil
 	}
 	store := oauth.NewDBStore(fakeStore, enc, dec, fakeStore, clock)
-	return NewPluginCredentialsHandler(q, store), store
+	return NewPluginCredentialsHandler(q, store, nil), store
 }
 
 // buildCredHandler builds a PluginCredentialsHandler backed by the given fake
@@ -47,13 +47,15 @@ func buildCredHandler(t *testing.T, q OAuthPluginQuerier, fakeStore *fakeCredQue
 		return "", nil
 	}
 	store := oauth.NewDBStore(fakeStore, enc, dec, fakeStore, clock)
-	return NewPluginCredentialsHandler(q, store)
+	return NewPluginCredentialsHandler(q, store, nil)
 }
 
-// fakeCredQuerier satisfies both oauth.OAuthQuerier and pluginstate.Querier for
-// the credential handler tests. It stores a single instance in memory.
+// fakeCredQuerier satisfies oauth.OAuthQuerier, OAuthPluginQuerier, and
+// pluginstate.Querier for the credential handler tests. It stores a single
+// instance and plugin in memory.
 type fakeCredQuerier struct {
 	instance      db.PluginInstance
+	plugin        db.Plugin
 	casFailTimes  int
 	auditEvents   []db.InsertPluginAuditEventParams
 	healthUpdates []db.UpdatePluginInstanceHealthParams
@@ -64,6 +66,13 @@ func (f *fakeCredQuerier) GetPluginInstanceByID(_ context.Context, id string) (d
 		return f.instance, nil
 	}
 	return db.PluginInstance{}, ErrNotFound
+}
+
+func (f *fakeCredQuerier) GetPluginByID(_ context.Context, id string) (db.Plugin, error) {
+	if f.plugin.ID == id {
+		return f.plugin, nil
+	}
+	return db.Plugin{}, ErrNotFound
 }
 
 func (f *fakeCredQuerier) UpdatePluginInstanceCredentials(_ context.Context, arg db.UpdatePluginInstanceCredentialsParams) (int64, error) {
@@ -619,6 +628,303 @@ func TestPluginCredentialsHandler_SetOAuthToken_PluginIDMismatch_404(t *testing.
 }
 
 // --- Write-only assertion: GET must never expose raw secrets ---
+
+// buildReadinessCredHandler builds a handler for readiness-advancement tests.
+// It uses sq as BOTH the h.q querier and the backing store for oauth.DBStore,
+// so health writes land in sq.healthUpdates where tests can assert them.
+func buildReadinessCredHandler(t *testing.T, sq *fakeCredQuerier) *PluginCredentialsHandler {
+	t.Helper()
+	clock := func() time.Time { return time.Unix(1000000, 0) }
+	enc := func(p string) (string, error) { return "enc:" + p, nil }
+	dec := func(c string) (string, error) {
+		if strings.HasPrefix(c, "enc:") {
+			return c[4:], nil
+		}
+		return "", nil
+	}
+	store := oauth.NewDBStore(sq, enc, dec, sq, clock)
+	return NewPluginCredentialsHandler(sq, store, nil)
+}
+
+// --- Readiness advancement tests (#576 Gap A) ---
+
+// TestPluginCredentialsHandler_SetStaticAPIKey_AdvancesReadiness verifies that
+// SetStaticAPIKey on an instance at unhealthy/credentials_missing advances the
+// health detail to "" (fully ready) via AdvanceInstanceReadiness.
+func TestPluginCredentialsHandler_SetStaticAPIKey_AdvancesReadiness(t *testing.T) {
+	credsMissing := "credentials_missing"
+	sq := &fakeCredQuerier{
+		instance: db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			HealthState:  "unhealthy",
+			HealthDetail: &credsMissing,
+			// Non-empty config so computeInstanceReadinessDetail passes config gate.
+			ConfigJson: `{"server_url":"https://ntfy.sh"}`,
+			Version:    1,
+		},
+		plugin: db.Plugin{
+			ID:               "plugin-1",
+			ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyStaticAPIKey),
+		},
+	}
+	// Seed initial credentials blob so UpdatePluginInstanceCredentials succeeds.
+	seedCredentials(t, sq, oauth.StoredCredentials{Strategy: sdkmanifest.AuthStrategyStaticAPIKey})
+
+	h := buildReadinessCredHandler(t, sq)
+	body := map[string]string{"header_name": "X-API-Key", "scheme": "Bearer", "api_key": "sk-123"}
+	r := newCredRequest(http.MethodPut, "/credentials/static-api-key", body, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+	w := httptest.NewRecorder()
+	h.SetStaticAPIKey(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	// advanceReadiness must have written a health update advancing the detail to "".
+	if len(sq.healthUpdates) == 0 {
+		t.Fatal("expected a health update (readiness advancement), got none")
+	}
+	last := sq.healthUpdates[len(sq.healthUpdates)-1]
+	if last.HealthState != "unhealthy" {
+		t.Errorf("health state = %q, want unhealthy", last.HealthState)
+	}
+	if last.HealthDetail != nil {
+		t.Errorf("health detail = %q, want nil (empty string → nil ptr)", *last.HealthDetail)
+	}
+}
+
+// TestPluginCredentialsHandler_SetBasicAuth_AdvancesReadiness mirrors the
+// SetStaticAPIKey readiness test for the basic_auth strategy.
+func TestPluginCredentialsHandler_SetBasicAuth_AdvancesReadiness(t *testing.T) {
+	credsMissing := "credentials_missing"
+	sq := &fakeCredQuerier{
+		instance: db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			HealthState:  "unhealthy",
+			HealthDetail: &credsMissing,
+			ConfigJson:   `{"endpoint":"https://api.example.com"}`,
+			Version:      1,
+		},
+		plugin: db.Plugin{
+			ID:               "plugin-1",
+			ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyBasicAuth),
+		},
+	}
+	seedCredentials(t, sq, oauth.StoredCredentials{Strategy: sdkmanifest.AuthStrategyBasicAuth})
+
+	h := buildReadinessCredHandler(t, sq)
+	body := map[string]string{"username": "alice", "password": "s3cr3t"}
+	r := newCredRequest(http.MethodPut, "/credentials/basic-auth", body, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+	w := httptest.NewRecorder()
+	h.SetBasicAuth(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(sq.healthUpdates) == 0 {
+		t.Fatal("expected a health update (readiness advancement), got none")
+	}
+	last := sq.healthUpdates[len(sq.healthUpdates)-1]
+	if last.HealthState != "unhealthy" {
+		t.Errorf("health state = %q, want unhealthy", last.HealthState)
+	}
+	if last.HealthDetail != nil {
+		t.Errorf("health detail = %q, want nil (empty → nil ptr)", *last.HealthDetail)
+	}
+}
+
+// TestPluginCredentialsHandler_SetHeader_AdvancesReadiness mirrors the
+// SetStaticAPIKey readiness test for the header_set strategy.
+func TestPluginCredentialsHandler_SetHeader_AdvancesReadiness(t *testing.T) {
+	credsMissing := "credentials_missing"
+	sq := &fakeCredQuerier{
+		instance: db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			HealthState:  "unhealthy",
+			HealthDetail: &credsMissing,
+			ConfigJson:   `{"org":"my-org"}`,
+			Version:      1,
+		},
+		plugin: db.Plugin{
+			ID:               "plugin-1",
+			ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyHeaderSet),
+		},
+	}
+	seedCredentials(t, sq, oauth.StoredCredentials{
+		Strategy:  sdkmanifest.AuthStrategyHeaderSet,
+		HeaderSet: &oauth.HeaderSetCreds{Headers: []oauth.NamedHeader{}},
+	})
+
+	h := buildReadinessCredHandler(t, sq)
+	body := map[string]string{"value": "org-123"}
+	params := map[string]string{"id": "plugin-1", "iid": "inst-1", "name": "X-Org-ID"}
+	r := newCredRequest(http.MethodPut, "/credentials/headers/X-Org-ID", body, params)
+	w := httptest.NewRecorder()
+	h.SetHeader(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(sq.healthUpdates) == 0 {
+		t.Fatal("expected a health update (readiness advancement), got none")
+	}
+	last := sq.healthUpdates[len(sq.healthUpdates)-1]
+	if last.HealthDetail != nil {
+		t.Errorf("health detail = %q, want nil (empty → nil ptr)", *last.HealthDetail)
+	}
+}
+
+// TestPluginCredentialsHandler_DeleteHeader_AdvancesReadiness_NoHealthWrite verifies
+// that DeleteHeaderSetEntry — which always leaves a non-empty StoredCredentials blob
+// (Strategy + empty HeaderSet{}) — does NOT cause a health write when the current
+// detail is already "". The unhealthy-only gate plus the wanted==current no-op keep
+// the call safe.
+func TestPluginCredentialsHandler_DeleteHeader_AdvancesReadiness_NoHealthWrite(t *testing.T) {
+	// Detail is already "" — fully configured. Deleting a header should be a no-op
+	// for the readiness state machine.
+	emptyDetail := ""
+	sq := &fakeCredQuerier{
+		instance: db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			HealthState:  "unhealthy",
+			HealthDetail: &emptyDetail,
+			ConfigJson:   `{"org":"my-org"}`,
+			Version:      1,
+		},
+		plugin: db.Plugin{
+			ID:               "plugin-1",
+			ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyHeaderSet),
+		},
+	}
+	seedCredentials(t, sq, oauth.StoredCredentials{
+		Strategy:  sdkmanifest.AuthStrategyHeaderSet,
+		HeaderSet: &oauth.HeaderSetCreds{Headers: []oauth.NamedHeader{{Name: "X-Org-ID", Value: "org-123"}}},
+	})
+
+	h := buildReadinessCredHandler(t, sq)
+	params := map[string]string{"id": "plugin-1", "iid": "inst-1", "name": "X-Org-ID"}
+	r := newCredRequest(http.MethodDelete, "/credentials/headers/X-Org-ID", nil, params)
+	w := httptest.NewRecorder()
+	h.DeleteHeader(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	// Deleting a header from a non-empty StoredCredentials leaves credentials_encrypted
+	// non-nil (Strategy + empty HeaderSet), so credentialsPresent stays true and
+	// computeInstanceReadinessDetail returns "" == currentDetail → no health write.
+	if len(sq.healthUpdates) != 0 {
+		t.Errorf("expected no health write for DeleteHeader when detail is already empty, got %d writes", len(sq.healthUpdates))
+	}
+}
+
+// secondCallFailQuerier wraps fakeCredQuerier and returns a corrupt manifest
+// on the SECOND call to GetPluginByID (the first call is requireOneOfStrategies;
+// the second is advanceReadiness). This lets us verify that advanceReadiness
+// handles a corrupt manifest gracefully without a panic or extra HTTP error.
+type secondCallFailQuerier struct {
+	fakeCredQuerier
+	pluginCallCount int
+}
+
+func (q *secondCallFailQuerier) GetPluginByID(ctx context.Context, id string) (db.Plugin, error) {
+	q.pluginCallCount++
+	if q.pluginCallCount >= 2 {
+		// Return a corrupt manifest on the advanceReadiness call.
+		return db.Plugin{
+			ID:               id,
+			ManifestSnapshot: "not valid yaml {{{",
+		}, nil
+	}
+	return q.fakeCredQuerier.GetPluginByID(ctx, id)
+}
+
+// TestPluginCredentialsHandler_AdvancesReadiness_CorruptManifest verifies that
+// when advanceReadiness encounters a corrupt manifest snapshot on the re-fetch
+// it logs and returns without writing a health update and without panicking.
+// The credential write has already returned 204.
+func TestPluginCredentialsHandler_AdvancesReadiness_CorruptManifest(t *testing.T) {
+	credsMissing := "credentials_missing"
+	inner := &fakeCredQuerier{
+		instance: db.PluginInstance{
+			ID:           "inst-1",
+			PluginID:     "plugin-1",
+			HealthState:  "unhealthy",
+			HealthDetail: &credsMissing,
+			ConfigJson:   `{"x":"y"}`,
+			Version:      1,
+		},
+		plugin: db.Plugin{
+			ID:               "plugin-1",
+			ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyStaticAPIKey),
+		},
+	}
+	seedCredentials(t, inner, oauth.StoredCredentials{Strategy: sdkmanifest.AuthStrategyStaticAPIKey})
+	sq := &secondCallFailQuerier{fakeCredQuerier: *inner}
+
+	clock := func() time.Time { return time.Unix(1000000, 0) }
+	enc := func(p string) (string, error) { return "enc:" + p, nil }
+	dec := func(c string) (string, error) {
+		if strings.HasPrefix(c, "enc:") {
+			return c[4:], nil
+		}
+		return "", nil
+	}
+	store := oauth.NewDBStore(sq, enc, dec, sq, clock)
+	h := NewPluginCredentialsHandler(sq, store, nil)
+
+	body := map[string]string{"header_name": "X-Key", "scheme": "", "api_key": "val"}
+	r := newCredRequest(http.MethodPut, "/credentials/static-api-key", body, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+	w := httptest.NewRecorder()
+	h.SetStaticAPIKey(w, r)
+
+	// Despite the corrupt manifest on the second GetPluginByID call, the handler
+	// still returns 204 — the credential write already committed.
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 even with corrupt manifest in advanceReadiness, got %d: %s", w.Code, w.Body.String())
+	}
+	// No health write because advanceReadiness returns early on parse failure.
+	if len(sq.fakeCredQuerier.healthUpdates) != 0 {
+		t.Errorf("expected no health write on corrupt manifest, got %d writes", len(sq.fakeCredQuerier.healthUpdates))
+	}
+}
+
+// TestPluginCredentialsHandler_AdvancesReadiness_AlreadyHealthy verifies that
+// when an instance is already healthy, advanceReadiness is a no-op (the
+// unhealthy-only gate fires and no UpdatePluginInstanceHealth is called).
+func TestPluginCredentialsHandler_AdvancesReadiness_AlreadyHealthy(t *testing.T) {
+	sq := &fakeCredQuerier{
+		instance: db.PluginInstance{
+			ID:          "inst-1",
+			PluginID:    "plugin-1",
+			HealthState: "healthy",
+			ConfigJson:  `{"x":"y"}`,
+			Version:     1,
+		},
+		plugin: db.Plugin{
+			ID:               "plugin-1",
+			ManifestSnapshot: buildTestManifest(t, sdkmanifest.AuthStrategyStaticAPIKey),
+		},
+	}
+	seedCredentials(t, sq, oauth.StoredCredentials{Strategy: sdkmanifest.AuthStrategyStaticAPIKey})
+
+	h := buildReadinessCredHandler(t, sq)
+	body := map[string]string{"header_name": "X-Key", "scheme": "", "api_key": "val"}
+	r := newCredRequest(http.MethodPut, "/credentials/static-api-key", body, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+	w := httptest.NewRecorder()
+	h.SetStaticAPIKey(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	// Already healthy → AdvanceInstanceReadiness returns immediately; no health write.
+	if len(sq.healthUpdates) != 0 {
+		t.Errorf("expected no health write for already-healthy instance, got %d writes", len(sq.healthUpdates))
+	}
+}
 
 func TestPluginCredentialsHandler_Get_NoRawSecretFields(t *testing.T) {
 	tests := []struct {

--- a/internal/admin/plugin_oauth_handler.go
+++ b/internal/admin/plugin_oauth_handler.go
@@ -19,10 +19,13 @@ import (
 )
 
 // OAuthPluginQuerier is the narrow DB interface required by PluginOAuthHandler
-// to look up instance details needed for strategy validation.
+// and PluginCredentialsHandler to look up instance details and write health
+// transitions. UpdatePluginInstanceHealth is needed by AdvanceInstanceReadiness
+// (called after credential writes) to progress config_missing → credentials_missing → "".
 type OAuthPluginQuerier interface {
 	GetPluginInstanceByID(ctx context.Context, id string) (db.PluginInstance, error)
 	GetPluginByID(ctx context.Context, id string) (db.Plugin, error)
+	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
 }
 
 // PluginOAuthHandler handles the admin OAuth2 endpoints for plugin instances.

--- a/internal/admin/plugin_oauth_handler_test.go
+++ b/internal/admin/plugin_oauth_handler_test.go
@@ -45,6 +45,10 @@ func (f *fakeOAuthPluginQuerier) GetPluginByID(_ context.Context, id string) (db
 	return row, nil
 }
 
+func (f *fakeOAuthPluginQuerier) UpdatePluginInstanceHealth(_ context.Context, _ db.UpdatePluginInstanceHealthParams) (int64, error) {
+	return 1, nil
+}
+
 // fakeOAuthQuerier from store_test.go also satisfies oauth.OAuthQuerier and
 // oauth.HealthSetter, but it is in the same package (admin), so we build a
 // minimal one here that satisfies oauth.OAuthQuerier.

--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -250,34 +250,63 @@ func (m *Manager) Start(ctx context.Context, plugin db.Plugin, instance db.Plugi
 	m.instances[instance.ID] = inst
 	m.mu.Unlock()
 
+	// Parse the manifest once for both tool registration and the Gap B healthy
+	// transition below. A parse failure skips both (fail-closed per ADR-001).
+	var mfst sdkmanifest.Manifest
+	manifestOK := false
+	if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &mfst); parseErr != nil {
+		m.logger().Warn("could not parse manifest after spawn",
+			"instance_id", instance.ID,
+			"err", parseErr,
+		)
+	} else {
+		manifestOK = true
+	}
+
 	// Register the plugin's manifest-declared tools in the shared namespace
 	// arbiter. Parsing the manifest here (rather than in the caller) keeps
 	// tool registration tightly coupled to the spawn lifecycle. On conflict,
 	// the Registrar already drives the instance to unhealthy and writes an audit
 	// event (#194); we surface the error to the caller so the subsystem can
 	// decide how to handle it.
-	if m.cfg.ToolRegistrar != nil {
-		var mfst sdkmanifest.Manifest
-		if parseErr := sdkmanifest.Unmarshal([]byte(plugin.ManifestSnapshot), &mfst); parseErr != nil {
-			m.logger().Warn("could not parse manifest for tool registration",
+	if m.cfg.ToolRegistrar != nil && manifestOK && len(mfst.Tools) > 0 {
+		toolNames := make([]string, len(mfst.Tools))
+		for i, td := range mfst.Tools {
+			toolNames[i] = td.Name
+		}
+		gen := m.nextToolGeneration(instance.ID)
+		if regErr := m.cfg.ToolRegistrar.RegisterInstanceTools(
+			ctx, instance.ID, instance.InstanceName, toolNames, gen,
+		); regErr != nil {
+			m.logger().Warn("plugin tool registration failed",
 				"instance_id", instance.ID,
-				"err", parseErr,
+				"instance_name", instance.InstanceName,
+				"err", regErr,
 			)
-		} else if len(mfst.Tools) > 0 {
-			toolNames := make([]string, len(mfst.Tools))
-			for i, td := range mfst.Tools {
-				toolNames[i] = td.Name
-			}
-			gen := m.nextToolGeneration(instance.ID)
-			if regErr := m.cfg.ToolRegistrar.RegisterInstanceTools(
-				ctx, instance.ID, instance.InstanceName, toolNames, gen,
-			); regErr != nil {
-				m.logger().Warn("plugin tool registration failed",
-					"instance_id", instance.ID,
-					"instance_name", instance.InstanceName,
-					"err", regErr,
-				)
-				return fmt.Errorf("manager: register tools for instance %s: %w", instance.ID, regErr)
+			return fmt.Errorf("manager: register tools for instance %s: %w", instance.ID, regErr)
+		}
+	}
+
+	// Gap B (#576): a channel-only or tool-only instance has no TriggerService stream
+	// to drive the healthy transition (trigger/supervisor.go owns that path for trigger
+	// plugins). When the manifest declares no TriggerService and the instance is
+	// unhealthy with an empty readiness detail — meaning config + credentials are
+	// present and we just successfully spawned the subprocess — mark it healthy here.
+	// Trigger plugins are explicitly excluded: Services.Trigger != "" means the
+	// supervisor will drive the transition when the TriggerService stream connects.
+	if manifestOK && mfst.Services.Trigger == "" {
+		// Re-fetch the row: the `instance` arg passed to Start may be stale (it
+		// carries the health state at dispatch time, not the current DB value).
+		fresh, fetchErr := m.cfg.Querier.GetPluginInstanceByID(ctx, instance.ID)
+		if fetchErr != nil {
+			m.logger().Warn("Gap B: failed to re-fetch instance for healthy transition",
+				"instance_id", instance.ID, "err", fetchErr)
+		} else if model.PluginHealthState(fresh.HealthState) == model.PluginHealthStateUnhealthy &&
+			(fresh.HealthDetail == nil || *fresh.HealthDetail == "") {
+			// Config and credentials are in place (empty detail = fully ready).
+			// Subprocess handshake succeeded. Transition to healthy.
+			if healthSetter := m.HealthSetter(); healthSetter != nil {
+				healthSetter(ctx, instance.ID, model.PluginHealthStateHealthy, "")
 			}
 		}
 	}

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -1160,3 +1160,299 @@ func (a *dbQuerierAdapter) UpdatePluginInstanceHealth(ctx context.Context, arg d
 func (a *dbQuerierAdapter) InsertPluginAuditEvent(ctx context.Context, arg db.InsertPluginAuditEventParams) (db.PluginAuditEvent, error) {
 	return a.q.InsertPluginAuditEvent(ctx, arg)
 }
+
+// ── Gap B tests (#576) ───────────────────────────────────────────────────────
+
+// healthCapturingQuerier extends fakeQuerier with instance tracking: it holds
+// a map of instance rows by ID so GetPluginInstanceByID returns the right row
+// (needed for the Gap B healthy-transition gate that re-fetches the instance),
+// and it records UpdatePluginInstanceHealth calls for assertion.
+type healthCapturingQuerier struct {
+	fakeQuerier
+	mu            sync.Mutex
+	instancesByID map[string]db.PluginInstance
+	healthCalls   []db.UpdatePluginInstanceHealthParams
+}
+
+func newHealthCapturingQuerier() *healthCapturingQuerier {
+	return &healthCapturingQuerier{
+		instancesByID: make(map[string]db.PluginInstance),
+	}
+}
+
+func (q *healthCapturingQuerier) GetPluginInstanceByID(_ context.Context, id string) (db.PluginInstance, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if inst, ok := q.instancesByID[id]; ok {
+		return inst, nil
+	}
+	// Fallback to fakeQuerier's flat instances map.
+	for _, instances := range q.fakeQuerier.instances {
+		for _, inst := range instances {
+			if inst.ID == id {
+				return inst, nil
+			}
+		}
+	}
+	return db.PluginInstance{}, errors.New("not found")
+}
+
+func (q *healthCapturingQuerier) UpdatePluginInstanceHealth(_ context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error) {
+	q.mu.Lock()
+	q.healthCalls = append(q.healthCalls, arg)
+	q.mu.Unlock()
+	return 1, nil
+}
+
+// manifestWithChannelService returns a minimal manifest YAML declaring a
+// ChannelService but no TriggerService and no tools.
+func manifestWithChannelService() string {
+	return `schema_version: "1"
+name: channel-plugin
+version: "1.0.0"
+services:
+  channel: v1
+`
+}
+
+// manifestWithTriggerService returns a minimal manifest YAML declaring a
+// TriggerService — used to verify the Gap B gate excludes trigger plugins.
+func manifestWithTriggerService() string {
+	return `schema_version: "1"
+name: trigger-plugin
+version: "1.0.0"
+services:
+  trigger: v1
+`
+}
+
+// stubSuccessStarter returns a fake starter that succeeds without spawning a
+// real subprocess. The returned *process.Instance is nil, which is sufficient
+// for Manager.Start unit tests that don't call inst.Stop().
+//
+// The TestProcessStarter field type is processStarter; the Manager stores the
+// result in m.instances. Because *Instance methods are not called in Gap B
+// tests (no Stop, no Pid), a nil *Instance is safe here.
+//
+// NOTE: process.Instance has no exported constructor; for tests that DO call
+// Stop we use the real fixture approach (see TestManager_IdempotentStart).
+// Gap B tests only assert on health writes, not on subprocess lifecycle.
+func stubSuccessStarter(t *testing.T, reg *identity.Registry) func(context.Context, process.Config) (*process.Instance, error) {
+	t.Helper()
+	return func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+		// Use a real minimal instance so m.instances[id] is non-nil and Stop
+		// can be called at cleanup time without panic. We use the fixture binary
+		// approach from other tests in this file.
+		fc := fixtureConfig(t, "serve-and-block", reg, nil)
+		fc.InstanceID = cfg.InstanceID
+		return process.Start(ctx, fc)
+	}
+}
+
+// TestManager_Start_ChannelOnly_AdvancesToHealthy verifies Gap B (#576):
+// a channel-only instance (no TriggerService) that is unhealthy with empty
+// readiness detail is marked healthy after a successful spawn.
+func TestManager_Start_ChannelOnly_AdvancesToHealthy(t *testing.T) {
+	reg := identity.New()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	q := newHealthCapturingQuerier()
+	emptyDetail := ""
+	inst := db.PluginInstance{
+		ID:           "i-channel",
+		PluginID:     "p-channel",
+		InstanceName: "channel-inst",
+		HealthState:  string(model.PluginHealthStateUnhealthy),
+		HealthDetail: &emptyDetail, // empty = config + creds present
+		Version:      1,
+	}
+	q.instancesByID[inst.ID] = inst
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:            q,
+		IdentityIssuer:     reg,
+		TestProcessStarter: stubSuccessStarter(t, reg),
+	})
+
+	plugin := db.Plugin{
+		ID:               "p-channel",
+		Status:           "active",
+		ManifestSnapshot: manifestWithChannelService(),
+	}
+
+	if err := mgr.Start(ctx, plugin, inst, os.Args[0]); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { mgr.Stop(ctx, inst.ID) }) //nolint:errcheck
+
+	// The Gap B transition is synchronous inside Start; assert directly.
+	q.mu.Lock()
+	calls := q.healthCalls
+	q.mu.Unlock()
+
+	var sawHealthy bool
+	for _, c := range calls {
+		if c.HealthState == string(model.PluginHealthStateHealthy) {
+			sawHealthy = true
+			break
+		}
+	}
+	if !sawHealthy {
+		t.Errorf("expected UpdatePluginInstanceHealth(healthy) after channel-only spawn, got calls: %+v", calls)
+	}
+}
+
+// TestManager_Start_ChannelOnly_ConfigMissing_NoHealthyTransition verifies that
+// a channel-only instance with a non-empty readiness detail (e.g. config_missing)
+// does NOT get the Gap B healthy transition — it must stay unhealthy until the
+// operator finishes configuration.
+func TestManager_Start_ChannelOnly_ConfigMissing_NoHealthyTransition(t *testing.T) {
+	reg := identity.New()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	q := newHealthCapturingQuerier()
+	configMissing := "config_missing"
+	inst := db.PluginInstance{
+		ID:           "i-channel-cfg",
+		PluginID:     "p-channel-cfg",
+		InstanceName: "channel-cfg-inst",
+		HealthState:  string(model.PluginHealthStateUnhealthy),
+		HealthDetail: &configMissing,
+		Version:      1,
+	}
+	q.instancesByID[inst.ID] = inst
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:            q,
+		IdentityIssuer:     reg,
+		TestProcessStarter: stubSuccessStarter(t, reg),
+	})
+
+	plugin := db.Plugin{
+		ID:               "p-channel-cfg",
+		Status:           "active",
+		ManifestSnapshot: manifestWithChannelService(),
+	}
+
+	if err := mgr.Start(ctx, plugin, inst, os.Args[0]); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { mgr.Stop(ctx, inst.ID) }) //nolint:errcheck
+
+	q.mu.Lock()
+	calls := q.healthCalls
+	q.mu.Unlock()
+
+	for _, c := range calls {
+		if c.HealthState == string(model.PluginHealthStateHealthy) {
+			t.Errorf("unexpected healthy transition for config_missing instance; calls: %+v", calls)
+		}
+	}
+}
+
+// TestManager_Start_TriggerPlugin_NoHealthyTransition verifies that a trigger
+// plugin (Services.Trigger != "") is excluded from the Gap B healthy transition —
+// trigger/supervisor.go owns that path when the TriggerService stream connects.
+func TestManager_Start_TriggerPlugin_NoHealthyTransition(t *testing.T) {
+	reg := identity.New()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	q := newHealthCapturingQuerier()
+	emptyDetail := ""
+	inst := db.PluginInstance{
+		ID:           "i-trigger",
+		PluginID:     "p-trigger",
+		InstanceName: "trigger-inst",
+		HealthState:  string(model.PluginHealthStateUnhealthy),
+		HealthDetail: &emptyDetail,
+		Version:      1,
+	}
+	q.instancesByID[inst.ID] = inst
+
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:            q,
+		IdentityIssuer:     reg,
+		TestProcessStarter: stubSuccessStarter(t, reg),
+	})
+
+	plugin := db.Plugin{
+		ID:               "p-trigger",
+		Status:           "active",
+		ManifestSnapshot: manifestWithTriggerService(),
+	}
+
+	if err := mgr.Start(ctx, plugin, inst, os.Args[0]); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { mgr.Stop(ctx, inst.ID) }) //nolint:errcheck
+
+	q.mu.Lock()
+	calls := q.healthCalls
+	q.mu.Unlock()
+
+	for _, c := range calls {
+		if c.HealthState == string(model.PluginHealthStateHealthy) {
+			t.Errorf("trigger plugin should NOT get Gap B healthy transition; got: %+v", calls)
+		}
+	}
+}
+
+// TestManager_Start_ToolOnly_AdvancesToHealthy verifies that a tool-only plugin
+// (no TriggerService, has tools) also receives the Gap B healthy transition.
+// The manifest is parsed before the ToolRegistrar block, so the transition runs
+// even for tool-only plugins. A non-nil ToolRegistrar is provided to mirror
+// production wiring.
+func TestManager_Start_ToolOnly_AdvancesToHealthy(t *testing.T) {
+	reg := identity.New()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	q := newHealthCapturingQuerier()
+	emptyDetail := ""
+	inst := db.PluginInstance{
+		ID:           "i-tool",
+		PluginID:     "p-tool",
+		InstanceName: "tool-inst",
+		HealthState:  string(model.PluginHealthStateUnhealthy),
+		HealthDetail: &emptyDetail,
+		Version:      1,
+	}
+	q.instancesByID[inst.ID] = inst
+
+	registrar := &fakeToolRegistrar{}
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:            q,
+		IdentityIssuer:     reg,
+		ToolRegistrar:      registrar,
+		TestProcessStarter: stubSuccessStarter(t, reg),
+	})
+
+	plugin := db.Plugin{
+		ID:               "p-tool",
+		Status:           "active",
+		ManifestSnapshot: manifestWithTools("send", "read"),
+	}
+
+	if err := mgr.Start(ctx, plugin, inst, os.Args[0]); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { mgr.Stop(ctx, inst.ID) }) //nolint:errcheck
+
+	q.mu.Lock()
+	calls := q.healthCalls
+	q.mu.Unlock()
+
+	var sawHealthy bool
+	for _, c := range calls {
+		if c.HealthState == string(model.PluginHealthStateHealthy) {
+			sawHealthy = true
+			break
+		}
+	}
+	if !sawHealthy {
+		t.Errorf("expected UpdatePluginInstanceHealth(healthy) after tool-only spawn, got calls: %+v", calls)
+	}
+}

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -266,7 +266,7 @@ func startPluginRuntime(
 			oauthScanner.Run(ctx)
 		}()
 		rt.OAuthHandler = admin.NewPluginOAuthHandler(store.Queries(), oauthMgr, getPublicURL)
-		rt.CredentialsHandler = admin.NewPluginCredentialsHandler(store.Queries(), oauthStore)
+		rt.CredentialsHandler = admin.NewPluginCredentialsHandler(store.Queries(), oauthStore, broadcaster)
 
 		callbackRescanner := pluginoauth.NewCallbackRescanner(
 			store.Queries(), store.Queries(), getPublicURL, time.Now,


### PR DESCRIPTION
Closes #576

## Summary

A channel-only plugin instance (e.g. the ntfy reference plugin — `static_api_key`, no TriggerService) could never reach `health=healthy` through the documented admin flow. Two related gaps:

- **Gap A — credential-set didn't advance readiness.** The credential handlers (`SetStaticAPIKey` / `SetHeaderSetEntry` / `SetBasicAuth`) never re-ran the readiness re-eval that the config handler does, so the detail stuck at `credentials_missing` until config was re-saved.
- **Gap B — nothing marked a channel-only instance `healthy`.** Only the trigger supervisor transitions instances to `healthy` (on TriggerService stream connect). A channel-only plugin has no TriggerService, so it stayed `unhealthy` forever even when fully working (notifications still delivered — `Notify` dispatch never gated on health — so this was operator-facing, not a functional blocker).

## What changed

**Gap A**
- Extracted `advanceInstanceReadiness` into a package-level `AdvanceInstanceReadiness(ctx, pluginstate.Querier, event.Publisher, db.PluginInstance, *Manifest)` helper; the existing method thin-forwards (config path unchanged).
- Widened `OAuthPluginQuerier` with `UpdatePluginInstanceHealth` so it satisfies `pluginstate.Querier`.
- Added an `event.Publisher` dep to `PluginCredentialsHandler` (threaded `broadcaster` in `pluginruntime.go`); call the re-eval after each of the four non-OAuth credential writes.

**Gap B** (host-side, per the issue's recommendation — doesn't depend on plugin authors)
- `process.Manager.Start` now marks a successfully-spawned **non-trigger** instance (`Services.Trigger == ""`) `healthy` when it is `unhealthy` with an empty readiness detail (config + credentials present). Trigger plugins are excluded so the trigger supervisor remains the sole owner of their `healthy` transition. The gate re-fetches a fresh DB row rather than trusting the stale `instance` arg.

All health writes route through `pluginstate.SetHealthState` (ADR-038 version-CAS); `ErrTransitionConflict` is tolerated and manifest-parse failures fail closed (skip the transition).

## Tests
- 6 credential-handler tests (each setter advances readiness; `DeleteHeader` is a correct no-op since the empty-but-present blob still reads as "credentials present"; corrupt-manifest best-effort path; already-healthy no-op).
- 4 `process.Manager.Start` Gap B tests (channel-only → healthy; `config_missing` → no transition; trigger plugin → no transition; tool-only → healthy).

## Review cycles
- Plan review: 1 REVISE → revised (fixed an incorrect `DeleteHeader` test expectation + named compile-break sites).
- Code review: APPROVE on cycle 1.

CLAUDE.md: no updates needed (no new packages, env vars, routes, or ADRs).

<details>
<summary>Architecture plan</summary>

See `.dev-loop/plan.md` on the branch. Gap A extracts a shared readiness helper and wires a publisher into the credentials handler; Gap B adds a host-side `unhealthy → healthy` transition in `Manager.Start` gated on no-TriggerService + empty readiness detail, re-using the existing CAS-guarded `HealthSetter` closure.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the agentic dev loop.
