### PR TITLE
fix: wire plugin dispatcher WriteRunStep for audit-trail completeness

### DIFF
--- a/audit_writestep_adapter_test.go
+++ b/audit_writestep_adapter_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/execution/agent"
+	"github.com/felag-engineering/gleipnir/internal/model"
+	"github.com/felag-engineering/gleipnir/internal/testutil"
+)
+
+// TestNewDispatchStepWriter asserts the production WriteRunStep adapter (#573)
+// persists a dispatcher error step into the run reasoning trace. The dispatcher
+// emits non-canonical step strings ("feedback_dispatch_error",
+// "plugin_request_timeout") that the run_steps.type CHECK constraint rejects, so
+// the adapter records them as the canonical "error" step type while preserving
+// the original kind in payload["kind"] (ADR-046 audit completeness).
+func TestNewDispatchStepWriter(t *testing.T) {
+	cases := []struct {
+		name     string
+		stepType string
+		payload  map[string]interface{}
+	}{
+		{
+			name:     "feedback dispatch error",
+			stepType: "feedback_dispatch_error",
+			payload:  map[string]interface{}{"reason": "no route", "instance": "slack-prod"},
+		},
+		{
+			name:     "plugin request timeout",
+			stepType: "plugin_request_timeout",
+			payload:  map[string]interface{}{"request_id": "req-123"},
+		},
+		{
+			name:     "standard error type control",
+			stepType: "error",
+			payload:  map[string]interface{}{"message": "boom"},
+		},
+		{
+			name:     "nil payload still records kind",
+			stepType: "feedback_dispatch_error",
+			payload:  nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := testutil.NewTestStore(t)
+			const policyID, runID = "pol-1", "run-1"
+			testutil.InsertPolicy(t, store, policyID, "p", "webhook", testutil.MinimalWebhookPolicy)
+			testutil.InsertRun(t, store, runID, policyID, model.RunStatusRunning)
+
+			// Build the EXACT production adapter, not a copy, so the test guards
+			// against drift in the conversion shape.
+			aw := agent.NewAuditWriter(store.Queries())
+			write := newDispatchStepWriter(aw)
+
+			if err := write(context.Background(), runID, tc.stepType, tc.payload); err != nil {
+				t.Fatalf("write step: %v", err)
+			}
+			// Close flushes the serialised queue and joins the writer goroutine.
+			if err := aw.Close(); err != nil {
+				t.Fatalf("audit writer close: %v", err)
+			}
+
+			steps, err := store.ListRunSteps(context.Background(), db.ListRunStepsParams{
+				RunID: runID,
+				After: -1,
+				Limit: 10,
+			})
+			if err != nil {
+				t.Fatalf("list run steps: %v", err)
+			}
+			if len(steps) != 1 {
+				t.Fatalf("expected exactly 1 run step, got %d", len(steps))
+			}
+
+			got := steps[0]
+			// Every dispatcher error is recorded as the canonical "error" step
+			// type (the run_steps CHECK constraint rejects the raw dispatcher
+			// strings); the original kind survives in payload["kind"].
+			if got.Type != model.StepTypeError.String() {
+				t.Errorf("step type = %q, want %q", got.Type, model.StepTypeError.String())
+			}
+
+			// Content must round-trip the payload JSON the dispatcher handed us,
+			// plus the injected "kind" carrying the original dispatcher step type.
+			var content map[string]interface{}
+			if err := json.Unmarshal([]byte(got.Content), &content); err != nil {
+				t.Fatalf("unmarshal step content %q: %v", got.Content, err)
+			}
+			if content["kind"] != tc.stepType {
+				t.Errorf("content[kind] = %v, want %q", content["kind"], tc.stepType)
+			}
+			for k, want := range tc.payload {
+				if content[k] != want {
+					t.Errorf("content[%q] = %v, want %v", k, content[k], want)
+				}
+			}
+		})
+	}
+}

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/infra/config"
 	"github.com/felag-engineering/gleipnir/internal/infra/crypto"
 	"github.com/felag-engineering/gleipnir/internal/infra/event"
+	"github.com/felag-engineering/gleipnir/internal/model"
 	pluginpkg "github.com/felag-engineering/gleipnir/internal/plugin"
 	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
 	"github.com/felag-engineering/gleipnir/internal/plugin/dedup"
@@ -48,6 +49,14 @@ type pluginRuntime struct {
 	// ChannelDispatcher routes channel Notify/Request RPCs. shutdown() closes its
 	// cached gRPC connections (channel-path analogue of Pool.Close).
 	ChannelDispatcher *dispatch.Dispatcher
+
+	// auditWriter is the long-lived AuditWriter that backs the channel
+	// dispatcher's WriteRunStep callback (#573). It records dispatcher-level
+	// error steps (feedback_dispatch_error, plugin_request_timeout) into the run
+	// reasoning trace so the audit trail stays complete (ADR-046). shutdown()
+	// closes it LAST, after ChannelDispatcher.Close(), so any final dispatch-error
+	// step is flushed before the write queue closes.
+	auditWriter *agent.AuditWriter
 
 	// DispatchAdapter satisfies agent.PluginToolDispatcher for RunLauncherConfig.
 	DispatchAdapter agent.PluginToolDispatcher
@@ -110,6 +119,43 @@ func (rt *pluginRuntime) Manager() *process.Manager { return rt.loader.Manager()
 // Manager() from it via the Loader's own accessor methods.
 func (rt *pluginRuntime) Loader() *pluginpkg.Loader { return rt.loader }
 
+// newDispatchStepWriter adapts an AuditWriter into the dispatcher's narrow
+// WriteRunStep callback (#573). The dispatch package must not import
+// internal/execution/agent (package boundary), so the conversion lives here in
+// package main where agent is already imported.
+//
+// The dispatcher emits non-canonical step strings ("feedback_dispatch_error",
+// "plugin_request_timeout"). Those are NOT members of model.StepType's valid
+// set, and the run_steps.type column carries a CHECK constraint that rejects
+// them outright — so they cannot be written verbatim. We therefore record every
+// dispatcher error as the canonical model.StepTypeError step and fold the
+// original kind into the JSON payload under "kind", preserving full fidelity in
+// the run reasoning trace (ADR-046) without a schema migration. The dispatcher
+// already echoes the kind in payload["code"]; "kind" is the structural
+// guarantee that survives even if a future caller omits "code".
+//
+// Extracted (rather than inlined at the construction site) so the exact
+// production wiring is unit-testable from package main.
+func newDispatchStepWriter(w *agent.AuditWriter) func(ctx context.Context, runID, stepType string, payload map[string]interface{}) error {
+	return func(ctx context.Context, runID, stepType string, payload map[string]interface{}) error {
+		// Copy so we never mutate the dispatcher's caller-owned map.
+		content := make(map[string]interface{}, len(payload)+1)
+		for k, v := range payload {
+			content[k] = v
+		}
+		// "kind" is reserved for the dispatcher's original step type and always
+		// wins over a caller-supplied value of the same key — it is the canonical
+		// discriminator for an "error" step that originated in the dispatcher.
+		content["kind"] = stepType
+
+		return w.Write(ctx, agent.Step{
+			RunID:   runID,
+			Type:    model.StepTypeError,
+			Content: content,
+		})
+	}
+}
+
 // startPluginRuntime brings up the plugin subsystem and returns a populated
 // *pluginRuntime. On success the returned value is always non-nil; a nil return
 // is always paired with a non-nil error.
@@ -159,12 +205,18 @@ func startPluginRuntime(
 	identityReg := identity.New()
 	genCtrl := generation.New()
 
+	// auditWriter backs the dispatcher's WriteRunStep callback (#573). It shares
+	// the run_steps write path with the agent runtime via the same serialised
+	// AuditWriter queue (ADR-003) and publishes run.step_added so the UI sees
+	// dispatcher-error steps in real time.
+	auditWriter := agent.NewAuditWriter(store.Queries(), agent.WithPublisher(broadcaster))
+
 	pluginDispatcher := dispatch.NewDispatcher(dispatch.DispatcherConfig{
 		Queries: store.Queries(),
 		Connect: connFactory.Connect,
-		// TODO(#NNN): Wire WriteRunStep here for audit trail completeness.
-		// Requires constructing an AuditWriter outside the agent package,
-		// which is deferred to a follow-up issue.
+		// Wire WriteRunStep so dispatcher-level error steps reach the run
+		// reasoning trace (ADR-046 audit completeness, #573).
+		WriteRunStep: newDispatchStepWriter(auditWriter),
 	})
 
 	approvalAdapter := runpkg.NewApprovalChannelAdapter(pluginDispatcher)
@@ -217,6 +269,7 @@ func startPluginRuntime(
 	rt := &pluginRuntime{
 		Pool:              pool,
 		ChannelDispatcher: pluginDispatcher,
+		auditWriter:       auditWriter,
 		DispatchAdapter:   dispatchAdapter,
 		ApprovalAdapter:   approvalAdapter,
 		FeedbackAdapter:   feedbackAdapter,
@@ -432,6 +485,15 @@ func (rt *pluginRuntime) shutdown() {
 	if rt.ChannelDispatcher != nil {
 		if err := rt.ChannelDispatcher.Close(); err != nil {
 			slog.Warn("plugin channel dispatcher close error", "err", err)
+		}
+	}
+
+	// Close the audit writer LAST so any dispatch-error step enqueued during the
+	// teardown above is flushed before the write queue closes (#573). Close()
+	// synchronously joins the writer's loop goroutine and is idempotent.
+	if rt.auditWriter != nil {
+		if err := rt.auditWriter.Close(); err != nil {
+			slog.Warn("plugin audit writer close error", "err", err)
 		}
 	}
 }


### PR DESCRIPTION
Closes #573

## Summary

The plugin channel/tool dispatcher was constructed in production (`pluginruntime.go`) **without** a `WriteRunStep` callback, so dispatcher-level error steps (`feedback_dispatch_error`, `plugin_request_timeout`) were silently dropped instead of being written to the run reasoning trace. This was a gap in the audit-completeness guarantee of **ADR-046** (error-path only — successful tool calls/feedback are audited through the normal agent path).

This PR constructs a long-lived `agent.AuditWriter` in `pluginruntime.go` and wires it into `DispatcherConfig.WriteRunStep` via a small `newDispatchStepWriter` adapter. The `TODO(#NNN)` placeholder is replaced with the real wiring.

## Notable implementation detail

The `run_steps.type` column carries a **CHECK constraint** allowing only the 10 canonical step types. The dispatcher's strings `feedback_dispatch_error` / `plugin_request_timeout` are **not** in that set and are rejected by SQLite. Rather than migrate the constraint (a non-trivial table-recreation on a hot table, and these are not LLM-visible reasoning steps), the adapter records every dispatcher error as the canonical `model.StepTypeError` step and folds the original kind into `payload["kind"]`, preserving full fidelity in the trace. The dispatcher already echoes the kind in `payload["code"]`; `"kind"` is the structural guarantee that survives even if a caller omits `"code"`.

## Package boundary

`internal/plugin/dispatch` must not import `internal/execution/agent`. That boundary is preserved: the adapter and `AuditWriter` live in `package main` (which already imports `agent`), and the dispatch package only ever sees the narrow injected `WriteRunStep` function signature.

<details>
<summary>Architecture plan</summary>

1. In `startPluginRuntime`, construct `agent.NewAuditWriter(store.Queries(), agent.WithPublisher(broadcaster))` before the dispatcher.
2. Set `DispatcherConfig.WriteRunStep` to `newDispatchStepWriter(auditWriter)` — an extracted (unit-testable) adapter that:
   - copies the dispatcher's caller-owned payload map (never mutates it),
   - injects `content["kind"] = stepType`,
   - writes an `agent.Step` of canonical type `model.StepTypeError`.
3. Store the `AuditWriter` on `pluginRuntime` and `Close()` it **last** in `shutdown()`, after `ChannelDispatcher.Close()`, so a final dispatch-error step is flushed before the write queue closes. `Close()` synchronously joins the writer goroutine and is idempotent.
4. Replace the `TODO(#NNN)` comment with the #573 reference.
5. Add a table-driven `package main` test (`audit_writestep_adapter_test.go`) that drives the **exact production adapter** against a real migrated SQLite DB — so the CHECK constraint is enforced and the test genuinely exercises the error path being fixed.

The plan was produced by an `architect` subagent and validated by a `code-reviewer` subagent (verdict: APPROVE); the CHECK-constraint mapping decision emerged during implementation and was reviewed.

</details>

References **ADR-046** (audit-table split / audit completeness).

## Testing

- New table-driven test covers `feedback_dispatch_error`, `plugin_request_timeout`, a standard `error` control, and a nil-payload case — asserting the step lands as `error` with the original kind preserved in `payload["kind"]`.
- `gofmt -l -s .` clean, `go build ./...`, `go vet ./...`, `go test ./...` all pass; affected packages run with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
