### PR TITLE
fix: release stale tool-namespace reservations on MCP server rename

### DIFF
--- a/internal/http/api/mcp_handler.go
+++ b/internal/http/api/mcp_handler.go
@@ -470,11 +470,12 @@ func (h *MCPHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // Updates the server's name and url only. Auth headers are managed separately
 // via PUT/DELETE /api/v1/mcp/servers/:id/headers/:name (ADR-039).
 //
-// TODO #194 follow-up: server rename leaves stale arbiter reservations. A rename
-// changes the server's name (and therefore the dot-name prefix for all its
-// tools), but this handler does not refresh tools, so the arbiter still holds
-// reservations under the old name. A follow-up should release the old
-// reservations and re-reserve under the new name.
+// Rename refreshes the cross-source tool-namespace arbiter (#578). A server's
+// tool dot-names are prefixed with its name ("<name>.<tool>"), so renaming
+// changes every reservation's key. This handler re-reserves the server's
+// currently-known tools under the new name and releases the old-name slots, so
+// the arbiter never holds stale reservations and a later server cannot hit a
+// false conflict against an orphaned slot. The plugin-side analog is #574.
 func (h *MCPHandler) Update(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
@@ -495,12 +496,92 @@ func (h *MCPHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Load the current row first so we know the old name. We need it both to
+	// detect a rename and to release the old arbiter reservations afterwards.
+	existing, err := h.store.GetMCPServer(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httputil.WriteError(w, http.StatusNotFound, "MCP server not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get MCP server", err.Error())
+		return
+	}
+
+	renamed := h.arbiter != nil && body.Name != existing.Name
+
+	// When renaming, reject a name already used by a *different* server before
+	// touching the arbiter. Without this guard, two MCP servers sharing tool
+	// names would expose a corruption path: if the target name already owns the
+	// same dot-names in the arbiter, ReserveBulk treats them as idempotent and
+	// succeeds, but the DB's UNIQUE(name) constraint then rejects the write —
+	// and the DB-failure rollback (ReleaseAllFor below) would delete the *other*
+	// server's legitimate reservations. Catching the name clash here keeps the
+	// arbiter logic on the path where the new name is genuinely free.
+	if renamed {
+		servers, err := h.store.ListMCPServers(r.Context())
+		if err != nil {
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to list MCP servers", err.Error())
+			return
+		}
+		for _, s := range servers {
+			if s.ID != id && s.Name == body.Name {
+				httputil.WriteError(w, http.StatusConflict, "MCP server name already exists", "")
+				return
+			}
+		}
+	}
+
+	// On rename, re-reserve the server's tools under the new name *before*
+	// touching the DB. A conflict here means another source already owns one of
+	// the new dot-names; ReserveBulk rolls back its own partial claims, so the
+	// old reservations remain intact and we can fail cleanly with a 409 without
+	// any partial apply. The old-name slots are released only after the DB write
+	// succeeds, keeping the arbiter consistent with persisted state.
+	var newSrc, oldSrc toolregistry.Source
+	if renamed {
+		newSrc = toolregistry.Source{Kind: toolregistry.KindMCP, Name: body.Name}
+		oldSrc = toolregistry.Source{Kind: toolregistry.KindMCP, Name: existing.Name}
+
+		tools, err := h.store.ListMCPToolsByServer(r.Context(), id)
+		if err != nil {
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to list MCP tools for rename", err.Error())
+			return
+		}
+		if len(tools) > 0 {
+			entries := make([]toolregistry.Reservation, len(tools))
+			for i, t := range tools {
+				entries[i] = toolregistry.Reservation{
+					DotName: toolregistry.DotName(body.Name, t.Name),
+					Owner:   newSrc,
+				}
+			}
+			if err := h.arbiter.ReserveBulk(entries); err != nil {
+				var ce *toolregistry.ConflictError
+				if errors.As(err, &ce) {
+					httputil.WriteError(w, http.StatusConflict,
+						fmt.Sprintf("tool %q is already provided by %s", ce.DotName, ce.Existing.String()),
+						"")
+					return
+				}
+				httputil.WriteError(w, http.StatusInternalServerError, "failed to reserve tool namespace", err.Error())
+				return
+			}
+		}
+	}
+
 	updated, err := h.store.UpdateMCPServer(r.Context(), db.UpdateMCPServerParams{
 		Name: body.Name,
 		Url:  body.URL,
 		ID:   id,
 	})
 	if err != nil {
+		// The DB write failed, so the name did not change. Release the new-name
+		// reservations we optimistically claimed; the old-name slots are still
+		// held and remain correct.
+		if renamed {
+			h.arbiter.ReleaseAllFor(newSrc)
+		}
 		if errors.Is(err, sql.ErrNoRows) {
 			httputil.WriteError(w, http.StatusNotFound, "MCP server not found", "")
 			return
@@ -511,6 +592,12 @@ func (h *MCPHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to update MCP server", err.Error())
 		return
+	}
+
+	// Rename committed: drop the stale old-name reservations now that the new
+	// name is the source of truth.
+	if renamed {
+		h.arbiter.ReleaseAllFor(oldSrc)
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, h.serverToResponse(updated))

--- a/internal/http/api/mcp_handler_test.go
+++ b/internal/http/api/mcp_handler_test.go
@@ -1935,3 +1935,202 @@ func TestCreate_RollbackOnDBFailure(t *testing.T) {
 		}
 	}
 }
+
+// updateMCPServer issues PUT /servers/{id} with the given name/url and returns
+// the response. Caller closes the body.
+func updateMCPServer(t *testing.T, base, id, name, url string) *http.Response {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"name": name, "url": url})
+	req, err := http.NewRequest(http.MethodPut, base+"/servers/"+id, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build PUT request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /servers/%s: %v", id, err)
+	}
+	return resp
+}
+
+// TestUpdate_RenameRefreshesArbiter exercises the #578 fix: a rename releases
+// the arbiter reservations held under the old server name and re-reserves the
+// server's tools under the new name. A rename whose new name collides with an
+// existing reservation is rejected with 409 and leaves no partial state; a PUT
+// that does not change the name leaves the arbiter untouched.
+func TestUpdate_RenameRefreshesArbiter(t *testing.T) {
+	mcpSrc := func(name string) toolregistry.Source {
+		return toolregistry.Source{Kind: toolregistry.KindMCP, Name: name}
+	}
+
+	t.Run("rename releases old and re-reserves new", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		arbiter := toolregistry.New()
+		registry := mcp.NewRegistry(store.Queries(), mcp.WithToolNamespaceArbiter(arbiter))
+
+		serverID := insertTestMCPServer(t, store, "old-name", "http://localhost:9999")
+		insertTestMCPTool(t, store, serverID, "tool-a")
+		insertTestMCPTool(t, store, serverID, "tool-b")
+		// Seed the arbiter as discovery would have: old-name owns both tools.
+		if err := arbiter.ReserveBulk([]toolregistry.Reservation{
+			{DotName: toolregistry.DotName("old-name", "tool-a"), Owner: mcpSrc("old-name")},
+			{DotName: toolregistry.DotName("old-name", "tool-b"), Owner: mcpSrc("old-name")},
+		}); err != nil {
+			t.Fatalf("seed arbiter: %v", err)
+		}
+
+		srv := httptest.NewServer(newMCPRouterWithArbiter(store, registry, arbiter))
+		t.Cleanup(srv.Close)
+
+		resp := updateMCPServer(t, srv.URL, serverID, "new-name", "http://localhost:9999")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		snap := arbiter.Snapshot()
+		// Old-name reservations must be gone.
+		for dotName, owner := range snap {
+			if owner == mcpSrc("old-name") {
+				t.Errorf("stale old-name reservation %q survives rename", dotName)
+			}
+		}
+		// New-name reservations must exist for both tools.
+		for _, tool := range []string{"tool-a", "tool-b"} {
+			dn := toolregistry.DotName("new-name", tool)
+			if owner, ok := snap[dn]; !ok || owner != mcpSrc("new-name") {
+				t.Errorf("missing new-name reservation %q (got %v, ok=%v)", dn, owner, ok)
+			}
+		}
+	})
+
+	t.Run("rename colliding with existing reservation is rejected without leaking state", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		arbiter := toolregistry.New()
+		registry := mcp.NewRegistry(store.Queries(), mcp.WithToolNamespaceArbiter(arbiter))
+
+		serverID := insertTestMCPServer(t, store, "old-name", "http://localhost:9999")
+		insertTestMCPTool(t, store, serverID, "tool-a")
+		if err := arbiter.Reserve(toolregistry.DotName("old-name", "tool-a"), mcpSrc("old-name")); err != nil {
+			t.Fatalf("seed arbiter: %v", err)
+		}
+		// A plugin already owns "taken.tool-a" — renaming our server to "taken"
+		// would collide on that dot-name.
+		if err := arbiter.Reserve(toolregistry.DotName("taken", "tool-a"),
+			toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "taken"}); err != nil {
+			t.Fatalf("seed conflicting reservation: %v", err)
+		}
+
+		srv := httptest.NewServer(newMCPRouterWithArbiter(store, registry, arbiter))
+		t.Cleanup(srv.Close)
+
+		resp := updateMCPServer(t, srv.URL, serverID, "taken", "http://localhost:9999")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("status = %d, want 409", resp.StatusCode)
+		}
+
+		// DB name must NOT have changed (no partial apply).
+		row, err := store.GetMCPServer(context.Background(), serverID)
+		if err != nil {
+			t.Fatalf("GetMCPServer: %v", err)
+		}
+		if row.Name != "old-name" {
+			t.Errorf("server name = %q after rejected rename, want old-name", row.Name)
+		}
+
+		// Arbiter: old-name reservation intact, no orphaned new-name slot.
+		snap := arbiter.Snapshot()
+		if owner, ok := snap[toolregistry.DotName("old-name", "tool-a")]; !ok || owner != mcpSrc("old-name") {
+			t.Errorf("old-name reservation lost after rejected rename (got %v, ok=%v)", owner, ok)
+		}
+		if owner, ok := snap[toolregistry.DotName("taken", "tool-a")]; !ok ||
+			owner != (toolregistry.Source{Kind: toolregistry.KindPlugin, Name: "taken"}) {
+			t.Errorf("pre-existing conflicting reservation mutated (got %v, ok=%v)", owner, ok)
+		}
+	})
+
+	t.Run("rename to a name held by another MCP server is rejected without corrupting its reservations", func(t *testing.T) {
+		// Regression for the corruption path where two MCP servers share tool
+		// names: renaming server B to server A's name must not delete A's
+		// arbiter slots, even though the dot-names would look idempotent to the
+		// arbiter. The DB-name pre-check rejects the rename before reservation.
+		store := testutil.NewTestStore(t)
+		arbiter := toolregistry.New()
+		registry := mcp.NewRegistry(store.Queries(), mcp.WithToolNamespaceArbiter(arbiter))
+
+		// Server A: name "taken", tool "tool-a" — owns "taken.tool-a".
+		serverA := insertTestMCPServer(t, store, "taken", "http://localhost:9999")
+		insertTestMCPTool(t, store, serverA, "tool-a")
+		if err := arbiter.Reserve(toolregistry.DotName("taken", "tool-a"), mcpSrc("taken")); err != nil {
+			t.Fatalf("seed server A reservation: %v", err)
+		}
+
+		// Server B: name "old", same tool "tool-a" — owns "old.tool-a".
+		serverB := insertTestMCPServer(t, store, "old", "http://localhost:8888")
+		insertTestMCPTool(t, store, serverB, "tool-a")
+		if err := arbiter.Reserve(toolregistry.DotName("old", "tool-a"), mcpSrc("old")); err != nil {
+			t.Fatalf("seed server B reservation: %v", err)
+		}
+
+		srv := httptest.NewServer(newMCPRouterWithArbiter(store, registry, arbiter))
+		t.Cleanup(srv.Close)
+
+		resp := updateMCPServer(t, srv.URL, serverB, "taken", "http://localhost:8888")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("status = %d, want 409", resp.StatusCode)
+		}
+
+		// Server A's reservation must survive untouched.
+		snap := arbiter.Snapshot()
+		if owner, ok := snap[toolregistry.DotName("taken", "tool-a")]; !ok || owner != mcpSrc("taken") {
+			t.Errorf("server A reservation corrupted by rejected rename (got %v, ok=%v)", owner, ok)
+		}
+		// Server B keeps its old-name reservation (rename did not commit).
+		if owner, ok := snap[toolregistry.DotName("old", "tool-a")]; !ok || owner != mcpSrc("old") {
+			t.Errorf("server B old-name reservation lost after rejected rename (got %v, ok=%v)", owner, ok)
+		}
+		// Server B's DB name must be unchanged.
+		row, err := store.GetMCPServer(context.Background(), serverB)
+		if err != nil {
+			t.Fatalf("GetMCPServer: %v", err)
+		}
+		if row.Name != "old" {
+			t.Errorf("server B name = %q after rejected rename, want old", row.Name)
+		}
+	})
+
+	t.Run("no-op when name is unchanged", func(t *testing.T) {
+		store := testutil.NewTestStore(t)
+		arbiter := toolregistry.New()
+		registry := mcp.NewRegistry(store.Queries(), mcp.WithToolNamespaceArbiter(arbiter))
+
+		serverID := insertTestMCPServer(t, store, "stable-name", "http://localhost:9999")
+		insertTestMCPTool(t, store, serverID, "tool-a")
+		if err := arbiter.Reserve(toolregistry.DotName("stable-name", "tool-a"), mcpSrc("stable-name")); err != nil {
+			t.Fatalf("seed arbiter: %v", err)
+		}
+		before := arbiter.Snapshot()
+
+		srv := httptest.NewServer(newMCPRouterWithArbiter(store, registry, arbiter))
+		t.Cleanup(srv.Close)
+
+		// Same name, different URL.
+		resp := updateMCPServer(t, srv.URL, serverID, "stable-name", "http://localhost:8888")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		after := arbiter.Snapshot()
+		if len(after) != len(before) {
+			t.Fatalf("arbiter size changed on no-op rename: before=%d after=%d", len(before), len(after))
+		}
+		for dn, owner := range before {
+			if after[dn] != owner {
+				t.Errorf("arbiter reservation %q changed on no-op rename: %v -> %v", dn, owner, after[dn])
+			}
+		}
+	})
+}


### PR DESCRIPTION
Closes #578

## Summary

`MCPHandler.Update` updated an MCP server's name/url but never refreshed the cross-source tool-namespace arbiter (`internal/toolregistry`). Tool dot-names are prefixed with the server name (`<name>.<tool>`), so a rename stranded every reservation under the **old** name — a later server reusing that name could hit a false namespace conflict. The inline `#194 follow-up` TODO orphaned this tail after #194 shipped and closed.

The fix, on rename:
1. **DB-name pre-check** — reject renaming to a name already held by a *different* server (409) before touching the arbiter.
2. **Reserve-new-before-DB** — re-reserve the server's currently-known tools under the new name. `ReserveBulk` rolls back its own partial claims on conflict, so a colliding new name fails clean with **409** and **no partial apply**; the old reservations stay intact.
3. **DB write**, then **release old-name slots** only after the write commits. On DB failure, the just-claimed new-name slots are released and the old name remains correct.

No change when the name is unchanged or when no arbiter is configured. The plugin-side analog is #574; this is the MCP side.

## Tests (table-driven, `internal/http/api/mcp_handler_test.go`)

- rename releases old reservations and re-reserves new
- rename colliding with an existing reservation → 409, no leaked/partial state
- rename to a name held by another MCP server (same tool names) → 409 without corrupting that server's slots (regression for the DB-failure-rollback corruption path)
- no-op when the name is unchanged

## Verification

`gofmt -l -s .` clean · `go build ./...` · `go vet ./...` · `go test -race` on `internal/http/api`, `internal/toolregistry`, `internal/mcp` — all green.

<details>
<summary>Architecture plan</summary>

The arbiter (`internal/toolregistry`) is a neutral leaf imported by both `internal/mcp` and `internal/plugin/tools`; the fix stays entirely in the MCP HTTP handler and does not touch the arbiter API or that boundary. `Update` now loads the existing row first (needs the old name to detect a rename and to release old slots). Ordering is chosen so the arbiter never diverges from persisted DB state:

- reserve-new → DB-write → release-old (success) / release-new (DB failure).

A pure per-name `Release` rollback can't distinguish a freshly-claimed slot from an idempotent same-owner hit, so renaming to a same-named MCP server with identical tool names would let the DB-unique-constraint rollback (`ReleaseAllFor(newSrc)`) delete the *other* server's slots. The DB-name pre-check eliminates that path before any reservation happens; the residual TOCTOU window is negligible for admin-only single-operator semantics (issue severity: low).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)