### PR TITLE
fix: seed OAuth credential structure on plugin instance creation

### DIFF
--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/model"
 	"github.com/felag-engineering/gleipnir/internal/plugin/configvalidate"
 	pluginmanifest "github.com/felag-engineering/gleipnir/internal/plugin/manifest"
+	"github.com/felag-engineering/gleipnir/internal/plugin/oauth"
 	pluginstate "github.com/felag-engineering/gleipnir/internal/plugin/state"
 	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 	"github.com/felag-engineering/gleipnir/plugin-sdk/signing"
@@ -186,6 +187,17 @@ type RSSAggregator interface {
 	Aggregate() (totalBytes uint64, count int, perInstance []RSSSample)
 }
 
+// CredentialSeeder writes an initial encrypted credential blob for a freshly
+// created plugin instance. *oauth.DBStore satisfies it. The interface keeps the
+// admin package from depending on the concrete store wiring and lets tests
+// inject a recording fake.
+//
+// CreateInstance calls SaveCredentials with expectedVersion 0 because a row
+// created by CreatePluginInstance always starts at version 0 (ADR-038 CAS).
+type CredentialSeeder interface {
+	SaveCredentials(ctx context.Context, instanceID string, creds oauth.StoredCredentials, expectedVersion int64) error
+}
+
 // PluginHandlerDeps holds all constructor-injected dependencies for PluginHandler.
 // This replaces the 8 SetXxx late-bind setters (compile-checked per issue #504).
 //
@@ -202,6 +214,10 @@ type PluginHandlerDeps struct {
 	PluginsDir     string               // empty disables FS cleanup in RejectPlugin
 	Lifecycle      *InstanceLifecycle   // extracted lifecycle module
 	Config         *InstanceConfig      // extracted config module
+	// CredentialSeeder seeds the initial credential blob on instance create.
+	// nil (e.g. no encryption key configured) skips seeding — the row is still
+	// created, the operator can set credentials later via the credentials API.
+	CredentialSeeder CredentialSeeder
 }
 
 // PluginHandler handles plugin-related admin endpoints.
@@ -215,6 +231,7 @@ type PluginHandler struct {
 	rssAggregator  RSSAggregator        // may be nil in tests; GetPluginRSS returns 503
 	lifecycle      *InstanceLifecycle   // owns Deactivate/Activate/Delete/Uninstall
 	config         *InstanceConfig      // owns PutSubscriptionScope/PutConfig/PutConfigProperty
+	credSeeder     CredentialSeeder     // nil means skip credential seeding on create
 }
 
 // NewPluginHandler constructs a PluginHandler from the given deps struct.
@@ -234,6 +251,7 @@ func NewPluginHandler(deps PluginHandlerDeps) *PluginHandler {
 		rssAggregator:  deps.RSSAggregator,
 		lifecycle:      deps.Lifecycle,
 		config:         deps.Config,
+		credSeeder:     deps.CredentialSeeder,
 	}
 }
 
@@ -1193,7 +1211,8 @@ func (h *PluginHandler) CreateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := h.q.GetPluginByID(ctx, pluginID); err != nil {
+	plugin, err := h.q.GetPluginByID(ctx, pluginID)
+	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			httputil.WriteError(w, http.StatusNotFound, "plugin not found", "")
 		} else {
@@ -1240,6 +1259,22 @@ func (h *PluginHandler) CreateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Seed the credential blob with the manifest's declared strategy + endpoints
+	// (#572). This records the Strategy at creation time so any flow that reads
+	// the credential structure before the first authorize (e.g. an OAuth instance
+	// that hasn't run /oauth/begin yet) sees a well-formed blob rather than NULL.
+	// Best-effort: the row already exists; a seed failure is logged and the
+	// operator can still set credentials via the credentials API. expectedVersion
+	// is 0 — CreatePluginInstance inserts at version 0 (ADR-038 CAS).
+	//
+	// A successful seed performs a CAS write that bumps the row to version 1. We
+	// reflect that in the returned version so a caller can immediately issue a
+	// CAS-guarded follow-up write without a spurious conflict.
+	respVersion := inst.Version
+	if h.seedInstanceCredentials(ctx, instanceID, plugin.ManifestSnapshot) {
+		respVersion++
+	}
+
 	httputil.WriteCreated(w,
 		"/api/v1/admin/plugins/"+pluginID+"/instances/"+instanceID,
 		createInstanceResponse{
@@ -1248,7 +1283,7 @@ func (h *PluginHandler) CreateInstance(w http.ResponseWriter, r *http.Request) {
 			InstanceName: inst.InstanceName,
 			HealthState:  inst.HealthState,
 			HealthDetail: inst.HealthDetail,
-			Version:      inst.Version,
+			Version:      respVersion,
 			CreatedAt:    inst.CreatedAt,
 			UpdatedAt:    inst.UpdatedAt,
 		})
@@ -1265,6 +1300,46 @@ func (h *PluginHandler) CreateInstance(w http.ResponseWriter, r *http.Request) {
 			slog.WarnContext(context.Background(), "post-create spawn failed", "plugin_id", pluginID, "err", err)
 		}
 	}
+}
+
+// seedInstanceCredentials initializes the credential blob for a newly created
+// instance from the manifest's declared auth strategy + OAuth endpoint defaults
+// (#572). It is a no-op when no seeder is wired (e.g. no encryption key), when
+// the manifest snapshot cannot be parsed, or when the strategy is unrecognised
+// (BuildSeedCredentials returns ok=false for an empty/unknown strategy — a
+// manifest without an auth block is silently skipped).
+//
+// All failures are best-effort: the instance row already exists, so a seed
+// failure is logged rather than surfaced to the caller. Non-OAuth strategies
+// get a blob carrying only the Strategy; OAuth strategies additionally carry the
+// manifest endpoint defaults.
+//
+// Returns true only when a credential blob was actually written (which bumps the
+// row's CAS version); the caller uses this to report the post-seed version.
+func (h *PluginHandler) seedInstanceCredentials(ctx context.Context, instanceID, manifestSnapshot string) bool {
+	if h.credSeeder == nil {
+		return false
+	}
+
+	var m sdkmanifest.Manifest
+	if err := sdkmanifest.Unmarshal([]byte(manifestSnapshot), &m); err != nil {
+		slog.WarnContext(ctx, "credential seed: corrupt manifest snapshot; skipping",
+			"instance_id", instanceID, "err", err)
+		return false
+	}
+
+	seed, ok := oauth.BuildSeedCredentials(m.Auth, m.Auth.OAuthDefaults)
+	if !ok {
+		// Unknown/empty strategy — nothing to seed.
+		return false
+	}
+
+	if err := h.credSeeder.SaveCredentials(ctx, instanceID, seed, 0); err != nil {
+		slog.WarnContext(ctx, "credential seed: save failed; instance created without seeded credentials",
+			"instance_id", instanceID, "strategy", seed.Strategy, "err", err)
+		return false
+	}
+	return true
 }
 
 // DeleteInstance handles DELETE /api/v1/admin/plugins/{id}/instances/{iid}.

--- a/internal/admin/plugin_handler_install_test.go
+++ b/internal/admin/plugin_handler_install_test.go
@@ -14,7 +14,26 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/felag-engineering/gleipnir/internal/db"
+	"github.com/felag-engineering/gleipnir/internal/plugin/oauth"
 )
+
+// recordingCredSeeder is a test stub for CredentialSeeder. It records the last
+// SaveCredentials call and can be configured to return an error.
+type recordingCredSeeder struct {
+	called     bool
+	gotID      string
+	gotCreds   oauth.StoredCredentials
+	gotVersion int64
+	returnErr  error
+}
+
+func (s *recordingCredSeeder) SaveCredentials(_ context.Context, instanceID string, creds oauth.StoredCredentials, expectedVersion int64) error {
+	s.called = true
+	s.gotID = instanceID
+	s.gotCreds = creds
+	s.gotVersion = expectedVersion
+	return s.returnErr
+}
 
 // fakeInstaller is a test stub for PluginInstaller.
 type fakeInstaller struct {
@@ -452,6 +471,217 @@ func TestPluginHandler_CreateInstance(t *testing.T) {
 		pm.mu.Unlock()
 		if len(started) != 0 {
 			t.Errorf("startedByPlugin = %v, want empty (no spawn on validation failure)", started)
+		}
+	})
+}
+
+// TestPluginHandler_CreateInstance_SeedsCredentials verifies that the credential
+// blob is seeded from the manifest's declared strategy + endpoints at instance
+// creation (#572). OAuth strategies additionally carry the manifest endpoint
+// defaults; non-OAuth strategies record only the Strategy; a nil seeder (no
+// encryption key) leaves credentials untouched.
+func TestPluginHandler_CreateInstance_SeedsCredentials(t *testing.T) {
+	fixedClock := func() time.Time { return time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC) }
+	const pluginID = "plugin-seed"
+
+	const oauthManifest = `schema_version: "1.0"
+name: slack
+version: "0.1.0"
+services:
+  channel: "1.0.0"
+auth:
+  mode: instance_credentials
+  strategy: oauth2_authcode
+  oauth_defaults:
+    authorization_url: https://slack.com/oauth/v2/authorize
+    token_url: https://slack.com/api/oauth.v2.access
+    scopes:
+      - chat:write
+      - channels:read
+`
+
+	const noneManifest = `schema_version: "1.0"
+name: echo
+version: "0.1.0"
+services:
+  tool: "1.0.0"
+auth:
+  mode: instance_credentials
+  strategy: none
+`
+
+	const staticKeyManifest = `schema_version: "1.0"
+name: weather
+version: "0.1.0"
+services:
+  tool: "1.0.0"
+auth:
+  mode: instance_credentials
+  strategy: static_api_key
+`
+
+	// noAuthManifest has no auth block at all: Strategy is empty, so
+	// BuildSeedCredentials returns ok=false and seeding is skipped.
+	const noAuthManifest = `schema_version: "1.0"
+name: bare
+version: "0.1.0"
+services:
+  tool: "1.0.0"
+`
+
+	tests := []struct {
+		name             string
+		manifest         string
+		wantSeeded       bool
+		wantStrategy     string
+		wantAuthorizeURL string
+		wantTokenURL     string
+		wantScopes       []string
+	}{
+		{
+			name:             "oauth2_authcode: seeded with strategy + endpoints",
+			manifest:         oauthManifest,
+			wantSeeded:       true,
+			wantStrategy:     "oauth2_authcode",
+			wantAuthorizeURL: "https://slack.com/oauth/v2/authorize",
+			wantTokenURL:     "https://slack.com/api/oauth.v2.access",
+			wantScopes:       []string{"chat:write", "channels:read"},
+		},
+		{
+			name:         "none: seeded with strategy only",
+			manifest:     noneManifest,
+			wantSeeded:   true,
+			wantStrategy: "none",
+		},
+		{
+			name:         "static_api_key: seeded with strategy only",
+			manifest:     staticKeyManifest,
+			wantSeeded:   true,
+			wantStrategy: "static_api_key",
+		},
+		{
+			name:       "no auth block: not seeded (unknown strategy)",
+			manifest:   noAuthManifest,
+			wantSeeded: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := newFakePluginQuerier()
+			q.seedPlugin(db.Plugin{
+				ID:               pluginID,
+				Name:             "p",
+				PluginVersion:    "0.1.0",
+				Status:           "active",
+				ManifestSnapshot: tt.manifest,
+			})
+			seeder := &recordingCredSeeder{}
+			h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{credSeeder: seeder})
+
+			rec := serveCreateInstance(h, pluginID, []byte(`{"instance_name":"inst-1"}`))
+			if rec.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201; body: %s", rec.Code, rec.Body.String())
+			}
+
+			if seeder.called != tt.wantSeeded {
+				t.Fatalf("seeder.called = %v, want %v", seeder.called, tt.wantSeeded)
+			}
+			if !tt.wantSeeded {
+				return
+			}
+
+			if seeder.gotVersion != 0 {
+				t.Errorf("expectedVersion = %d, want 0 (freshly inserted row)", seeder.gotVersion)
+			}
+			data := parseDataResponse(t, rec)
+			var resp createInstanceResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if seeder.gotID != resp.ID {
+				t.Errorf("seeded instance ID = %q, want %q", seeder.gotID, resp.ID)
+			}
+			// A successful seed bumps the row from version 0 to 1; the response
+			// must report the post-seed version so a follow-up CAS write succeeds.
+			if resp.Version != 1 {
+				t.Errorf("response version = %d, want 1 after successful seed", resp.Version)
+			}
+			if seeder.gotCreds.Strategy != tt.wantStrategy {
+				t.Errorf("strategy = %q, want %q", seeder.gotCreds.Strategy, tt.wantStrategy)
+			}
+			if seeder.gotCreds.AuthorizationURL != tt.wantAuthorizeURL {
+				t.Errorf("authorization_url = %q, want %q", seeder.gotCreds.AuthorizationURL, tt.wantAuthorizeURL)
+			}
+			if seeder.gotCreds.TokenURL != tt.wantTokenURL {
+				t.Errorf("token_url = %q, want %q", seeder.gotCreds.TokenURL, tt.wantTokenURL)
+			}
+			if len(tt.wantScopes) > 0 {
+				if got := seeder.gotCreds.Scopes; len(got) != len(tt.wantScopes) {
+					t.Errorf("scopes = %v, want %v", got, tt.wantScopes)
+				} else {
+					for i := range tt.wantScopes {
+						if got[i] != tt.wantScopes[i] {
+							t.Errorf("scopes[%d] = %q, want %q", i, got[i], tt.wantScopes[i])
+						}
+					}
+				}
+			}
+		})
+	}
+
+	// Nil seeder (no encryption key) leaves the instance uncredentialed and the
+	// create still succeeds.
+	t.Run("nil seeder: create succeeds without seeding", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               pluginID,
+			Name:             "p",
+			PluginVersion:    "0.1.0",
+			Status:           "active",
+			ManifestSnapshot: oauthManifest,
+		})
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
+		rec := serveCreateInstance(h, pluginID, []byte(`{"instance_name":"inst-nil"}`))
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want 201; body: %s", rec.Code, rec.Body.String())
+		}
+		// No seed happened, so the response carries the freshly-inserted version 0.
+		var resp createInstanceResponse
+		if err := json.Unmarshal(parseDataResponse(t, rec), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp.Version != 0 {
+			t.Errorf("response version = %d, want 0 (no seed)", resp.Version)
+		}
+	})
+
+	// A seed error is logged but does not fail the create (best-effort).
+	t.Run("seed error: create still returns 201", func(t *testing.T) {
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               pluginID,
+			Name:             "p",
+			PluginVersion:    "0.1.0",
+			Status:           "active",
+			ManifestSnapshot: oauthManifest,
+		})
+		seeder := &recordingCredSeeder{returnErr: errors.New("encrypt failed")}
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{credSeeder: seeder})
+		rec := serveCreateInstance(h, pluginID, []byte(`{"instance_name":"inst-err"}`))
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want 201 despite seed error; body: %s", rec.Code, rec.Body.String())
+		}
+		if !seeder.called {
+			t.Error("seeder.called = false, want true")
+		}
+		// The seed failed, so no version bump: the response keeps version 0.
+		var resp createInstanceResponse
+		if err := json.Unmarshal(parseDataResponse(t, rec), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp.Version != 0 {
+			t.Errorf("response version = %d, want 0 (seed failed)", resp.Version)
 		}
 	})
 }

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -337,6 +337,7 @@ type testPluginHandlerConfig struct {
 	pluginsDir string
 	installer  PluginInstaller
 	rssAgg     RSSAggregator
+	credSeeder CredentialSeeder
 }
 
 // newTestPluginHandler builds InstanceLifecycle + InstanceConfig + PluginHandler
@@ -359,14 +360,15 @@ func newTestPluginHandler(q PluginQuerier, clock func() time.Time, cfg testPlugi
 		Clock:   clock,
 	})
 	return NewPluginHandler(PluginHandlerDeps{
-		Q:              q,
-		Clock:          clock,
-		Installer:      cfg.installer,
-		RSSAggregator:  cfg.rssAgg,
-		ProcessManager: cfg.procMgr,
-		PluginsDir:     cfg.pluginsDir,
-		Lifecycle:      lifecycle,
-		Config:         instanceConfig,
+		Q:                q,
+		Clock:            clock,
+		Installer:        cfg.installer,
+		RSSAggregator:    cfg.rssAgg,
+		ProcessManager:   cfg.procMgr,
+		PluginsDir:       cfg.pluginsDir,
+		Lifecycle:        lifecycle,
+		Config:           instanceConfig,
+		CredentialSeeder: cfg.credSeeder,
 	})
 }
 

--- a/internal/plugin/oauth/credentials.go
+++ b/internal/plugin/oauth/credentials.go
@@ -246,10 +246,10 @@ func Resolve(authDecl sdkmanifest.AuthDecl, defaults *sdkmanifest.OAuthDefaultsD
 // Returns (StoredCredentials{Strategy: s}, true) for every supported strategy.
 // Returns (StoredCredentials{}, false) only for an unrecognised strategy string.
 //
-// TODO(plugin-instance-provision): Call this from the instance creation path
-// when CreatePluginInstance lands. For #224 the helper exists but has no live
-// call site; production wiring is deferred to the instance auto-provision
-// follow-up.
+// Wired into the instance-create path via admin.PluginHandler.CreateInstance →
+// seedInstanceCredentials (#572): the credential blob is seeded with the
+// manifest's declared strategy + endpoints at creation, before any token
+// exchange.
 func BuildSeedCredentials(authDecl sdkmanifest.AuthDecl, defaults *sdkmanifest.OAuthDefaultsDecl) (StoredCredentials, bool) {
 	switch authDecl.Strategy {
 	case sdkmanifest.AuthStrategyOAuth2Authcode, sdkmanifest.AuthStrategyOAuth2Clientcred:

--- a/main.go
+++ b/main.go
@@ -392,15 +392,24 @@ func run(cfg config.Config) error {
 		Publisher: broadcaster,
 		Trigger:   pluginTrigger,
 	})
+	// Seed the credential blob on instance create (#572). rt.CredStore is nil
+	// when no encryption key is configured; we must avoid stuffing a typed-nil
+	// pointer into the CredentialSeeder interface (that would defeat the handler's
+	// nil-guard), so only set the field when the store is genuinely present.
+	var pluginCredSeeder admin.CredentialSeeder
+	if rt.CredStore != nil {
+		pluginCredSeeder = rt.CredStore
+	}
 	pluginAdmin := admin.NewPluginHandler(admin.PluginHandlerDeps{
-		Q:              store.Queries(),
-		Publisher:      broadcaster,
-		Installer:      pluginInstaller,
-		RSSAggregator:  pluginRSSAgg,
-		ProcessManager: pluginProcMgr,
-		PluginsDir:     pluginPluginsDir,
-		Lifecycle:      pluginLifecycle,
-		Config:         pluginConfig,
+		Q:                store.Queries(),
+		Publisher:        broadcaster,
+		Installer:        pluginInstaller,
+		RSSAggregator:    pluginRSSAgg,
+		ProcessManager:   pluginProcMgr,
+		PluginsDir:       pluginPluginsDir,
+		Lifecycle:        pluginLifecycle,
+		Config:           pluginConfig,
+		CredentialSeeder: pluginCredSeeder,
 	})
 
 	handlers := api.HandlerBundle{

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -85,6 +85,11 @@ type pluginRuntime struct {
 	// CredentialsHandler handles plugin credential reads. nil when encryptionKey is absent.
 	CredentialsHandler *admin.PluginCredentialsHandler
 
+	// CredStore is the OAuth/credential store. Exposed so the plugin admin handler
+	// can seed the initial credential blob on instance create (#572). nil when
+	// encryptionKey is absent (no encrypted storage available).
+	CredStore *pluginoauth.DBStore
+
 	// OnPublicURLChanged is the hook run() assigns to adminHandler.OnPublicURLChanged
 	// so that a public_url change triggers a callback-URL rescan. nil when
 	// encryptionKey is absent (rescan requires encrypted storage).
@@ -235,6 +240,7 @@ func startPluginRuntime(
 		enc := func(p string) (string, error) { return crypto.Encrypt(encryptionKey, p) }
 		dec := func(c string) (string, error) { return crypto.Decrypt(encryptionKey, c) }
 		oauthStore := pluginoauth.NewDBStore(store.Queries(), enc, dec, store.Queries(), time.Now)
+		rt.CredStore = oauthStore
 		oauthNonces := pluginoauth.NewDBNonceStore(store.Queries(), time.Now)
 		// Own the janitor goroutine under bgWG so shutdown() can join it rather
 		// than abandoning a mid-Prune DB write (#500). The janitor selects on


### PR DESCRIPTION
Closes #572

## Summary

Creating a plugin instance via `POST /api/v1/admin/plugins/{id}/instances` previously always wrote `plugin_instances.credentials_encrypted = NULL`, even for instances whose manifest declares an OAuth strategy (`oauth2_authcode` / `oauth2_clientcred`). The seed helper `oauth.BuildSeedCredentials` existed but had only test callers (it carried a `TODO(plugin-instance-provision)`). As a result a freshly-created OAuth instance had no `Strategy` recorded in its (absent) credential blob until the operator ran `/oauth/begin` or the synchronous client-cred exchange — a sharp edge for any flow that reads the strategy before the first authorize.

This wires `BuildSeedCredentials` into the create path so the credential blob is initialized with the manifest's declared strategy + OAuth endpoint defaults at creation, before any token exchange.

- Adds a `CredentialSeeder` interface to `internal/admin` (satisfied by `*oauth.DBStore`) and injects it via `PluginHandlerDeps`. `nil` (no encryption key configured → no encrypted storage) skips seeding cleanly.
- `CreateInstance` parses the plugin's manifest snapshot (reusing the plugin row already fetched for the existence check — no extra DB round-trip), builds the seed, and writes it with `expectedVersion = 0` (the row is inserted at version 0 per ADR-038 CAS).
- **Best-effort:** the row already exists, so a seed failure is logged rather than surfaced; the operator can still set credentials via the credentials API. A manifest with no auth block (empty strategy) is silently skipped via `BuildSeedCredentials`'s `ok=false` path. Non-OAuth strategies record only the `Strategy`; OAuth strategies additionally carry the endpoint defaults.
- A successful seed performs a CAS write that bumps the row 0 → 1; the create response now reports the **post-seed version** so an immediate follow-up CAS-guarded credential write does not spuriously conflict.
- Removes the now-stale `TODO(plugin-instance-provision)` comment, repointing it to the live call site (#572).
- `main.go` guards against the typed-nil-interface trap: `rt.CredStore` (`*oauth.DBStore`, nil without an encryption key) is only assigned into the interface field when non-nil, preserving the handler's `nil` guard.

Non-OAuth and no-encryption-key paths are unaffected. New table-driven tests cover: oauth strategy seeds endpoints + scopes; `none` / `static_api_key` seed strategy-only; no-auth-block skips; nil seeder skips (response version 0); seed error still returns 201 (version 0); and a successful seed reports version 1.

## Verification

`gofmt -l -s .`, `go build ./...`, `go vet ./...`, and `go test ./...` all pass; affected packages (`internal/admin`, `internal/plugin/oauth`) run green under `-race`.

<details>
<summary>Architecture plan</summary>

1. **Interface, not concrete store.** Define `CredentialSeeder { SaveCredentials(ctx, instanceID, creds, expectedVersion) error }` in `internal/admin`; `*oauth.DBStore` already satisfies it. Keeps the admin package decoupled from store wiring and enables a recording fake in tests. (`internal/admin` already imports `internal/plugin/oauth` — no new package boundary.)
2. **Wiring.** Expose the OAuth `*DBStore` on `pluginRuntime.CredStore` (set inside the `encryptionKey != nil` block in `pluginruntime.go`); pass it into `PluginHandlerDeps.CredentialSeeder` from `main.go`, guarding the typed-nil trap.
3. **Create path.** Capture the plugin row at the existence-check (already fetched), parse its manifest, call `BuildSeedCredentials(m.Auth, m.Auth.OAuthDefaults)`, and `SaveCredentials(..., expectedVersion: 0)`. Seed synchronously before `WriteCreated` so the response can report the bumped version; failures are best-effort (logged).
4. **Tests.** Table-driven over oauth/none/static/no-auth + nil-seeder + seed-error subtests, asserting seeded strategy/endpoints/scopes, `expectedVersion == 0`, and the response version (1 on seed, 0 otherwise).

Stress-tested with a plan-reviewer (confirmed manifest field shapes `m.Auth` / `m.Auth.OAuthDefaults *OAuthDefaultsDecl`, the typed-nil interface trap, version=0 invariant, and that empty-manifest snapshots unmarshal to a zero struct without error so existing tests stay green) and a code-reviewer (APPROVE; flagged the stale-version-in-response edge, now fixed).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)