### PR TITLE
fix: ReloadInstance cleans up to a recoverable state when Start fails mid-reload (#587)

### DIFF
--- a/internal/plugin/process/manager.go
+++ b/internal/plugin/process/manager.go
@@ -283,6 +283,25 @@ func (m *Manager) Start(ctx context.Context, plugin db.Plugin, instance db.Plugi
 				"instance_name", instance.InstanceName,
 				"err", regErr,
 			)
+			// The subprocess is already spawned and visible in the instances map at
+			// this point, and (when a controller is configured) registered with the
+			// generation controller. Returning the error without cleanup would leave
+			// a live subprocess that can never serve tool calls — a zombie. Roll the
+			// partial start back so Start is self-contained: kill the subprocess,
+			// remove it from the map, drop the generation entry, and reset the tool
+			// generation. This also keeps ReloadInstance's caller-side cleanup simple
+			// (it only has to handle the spawn-failure path). See issue #587.
+			if stopErr := m.stopWithoutUnregister(ctx, instance.ID); stopErr != nil {
+				m.logger().Warn("plugin tool registration rollback: stop failed",
+					"instance_id", instance.ID, "err", stopErr)
+			}
+			if m.cfg.GenerationController != nil {
+				m.cfg.GenerationController.UnregisterInstance(instance.ID)
+			}
+			m.removeToolGeneration(instance.ID)
+			if healthSetter := m.HealthSetter(); healthSetter != nil {
+				healthSetter(ctx, instance.ID, model.PluginHealthStateUnhealthy, "tool_registration_failed")
+			}
 			return fmt.Errorf("manager: register tools for instance %s: %w", instance.ID, regErr)
 		}
 	}
@@ -371,16 +390,28 @@ func (m *Manager) stopWithoutUnregister(ctx context.Context, instanceID string) 
 // the same instance ID. The new generation does not begin accepting Host RPCs
 // until BeginDrain returns.
 //
-// Note: if Start fails after BeginDrain and stopWithoutUnregister have already
-// succeeded, the instance is in a stopped state with a bumped generation but no
-// running subprocess. The caller is responsible for calling Stop to fully
-// unregister the instance from the generation controller before retrying.
+// Recoverability guarantee (issue #587): if any step after BeginDrain fails —
+// the subprocess stop, or the post-reload Start — ReloadInstance cleans up
+// internally so the instance is left in a CLEAN, RECOVERABLE state rather than a
+// half-present "zombie". A failed reload always ends with the instance:
+//   - absent from the manager map (no live subprocess),
+//   - unregistered from the generation controller (no advanced generation
+//     pointing at nothing, no leaked refcount entry),
+//   - tool reservations released, and
+//   - health = unhealthy with an actionable detail.
+//
+// The operator's recovery path is then unambiguous: re-activate the instance
+// (deactivate → activate) or re-install the plugin. We do NOT attempt to roll
+// back to the prior healthy generation: by the time Start can fail, the old
+// subprocess has already been torn down and its identity token revoked, so a
+// true rollback is not achievable. A clean unhealthy stop is the achievable and
+// correct end-state.
 //
 // The actual hot-reload trigger (loader watcher → fresh tarball → calling
 // ReloadInstance) is out of scope for #294; this method is the public API that
 // #295 / the loader will call.
 //
-// See issue #294.
+// See issues #294 and #587.
 func (m *Manager) ReloadInstance(ctx context.Context, plugin db.Plugin, instance db.PluginInstance, binaryPath string, graceTimeout time.Duration) error {
 	if m.cfg.GenerationController == nil {
 		return errors.New("manager: generation controller not configured; reload requires #294 wiring")
@@ -400,10 +431,21 @@ func (m *Manager) ReloadInstance(ctx context.Context, plugin db.Plugin, instance
 		)
 	}
 
+	// From here on the generation has been bumped and (after the stop below) the
+	// old subprocess is gone. Any failure must route through cleanupFailedReload
+	// so we never return with a bumped generation still registered against no
+	// running subprocess.
+
 	// Stop the subprocess without unregistering from the controller: the
 	// generation was already bumped by BeginDrain, and RegisterInstance (called
 	// inside Start below) is idempotent and will not reset it.
 	if err := m.stopWithoutUnregister(ctx, instance.ID); err != nil {
+		// The stop failed but the instance was already removed from the map and the
+		// generation is bumped. handleLaunchFailure is NOT on this path (Start never
+		// ran), so drive health to unhealthy explicitly with an actionable detail.
+		// Truncate the cause to keep the admin UI card readable (mirrors the 120-char
+		// cap in handleLaunchFailure).
+		m.cleanupFailedReload(ctx, instance, "subprocess_stop_failed: "+truncateReason(err.Error()))
 		return fmt.Errorf("manager: stop instance %s for reload: %w", instance.ID, err)
 	}
 
@@ -417,10 +459,44 @@ func (m *Manager) ReloadInstance(ctx context.Context, plugin db.Plugin, instance
 	}
 
 	if err := m.Start(ctx, plugin, instance, binaryPath); err != nil {
+		// Start already set health to unhealthy (handleLaunchFailure on a spawn
+		// failure, or the tool-registration rollback) and, on the tool-registration
+		// path, already cleaned the generation controller + tool generation. The
+		// spawn-failure path does NOT touch the controller, so cleanupFailedReload
+		// makes the end-state uniform: unregistered + tool generation dropped. Both
+		// the controller's UnregisterInstance and removeToolGeneration are
+		// idempotent, so calling them again on the tool-registration path is safe.
+		// Pass an empty detail so we do not overwrite the more specific detail Start
+		// already recorded.
+		m.cleanupFailedReload(ctx, instance, "")
 		return fmt.Errorf("manager: restart instance %s after reload: %w", instance.ID, err)
 	}
 
 	return nil
+}
+
+// cleanupFailedReload restores a consistent, recoverable end-state after a
+// reload fails partway through (issue #587). It unregisters the instance from
+// the generation controller — removing the bumped-but-orphaned generation entry
+// and waking any Acquire callers still blocked on it — and drops the tool
+// generation counter (symmetry with full Stop teardown). When detail is
+// non-empty it also drives health to unhealthy with that detail; callers pass an
+// empty detail when a more specific health detail was already recorded upstream
+// (e.g. handleLaunchFailure) so this does not clobber it.
+//
+// All operations are idempotent so callers may invoke this even when an earlier
+// failure path (e.g. Start's tool-registration rollback) already performed some
+// of the same cleanup.
+func (m *Manager) cleanupFailedReload(ctx context.Context, instance db.PluginInstance, detail string) {
+	if m.cfg.GenerationController != nil {
+		m.cfg.GenerationController.UnregisterInstance(instance.ID)
+	}
+	m.removeToolGeneration(instance.ID)
+	if detail != "" {
+		if healthSetter := m.HealthSetter(); healthSetter != nil {
+			healthSetter(ctx, instance.ID, model.PluginHealthStateUnhealthy, detail)
+		}
+	}
 }
 
 // StopAll stops all running instances concurrently. Each Stop call shares the
@@ -685,11 +761,7 @@ func (m *Manager) handleLaunchFailure(ctx context.Context, plugin db.Plugin, ins
 	if le != nil {
 		reason = le.Cause.Error()
 	}
-	const maxReasonLen = 120
-	if len(reason) > maxReasonLen {
-		reason = reason[:maxReasonLen] + "..."
-	}
-	healthDetail := "subprocess_handshake_failed: " + reason
+	healthDetail := "subprocess_handshake_failed: " + truncateReason(reason)
 
 	// Update health state to unhealthy with the actionable detail. We call the
 	// HealthSetter directly (same path the crash watchdog uses) so the state
@@ -721,6 +793,20 @@ func (m *Manager) handleLaunchFailure(ctx context.Context, plugin db.Plugin, ins
 		m.logger().Warn("handleLaunchFailure: could not write plugin_crashed audit event",
 			"instance_id", instanceID, "err", auditErr)
 	}
+}
+
+// maxReasonLen caps how many characters of an error string we embed in a
+// health_detail value so the admin UI card stays readable without wrapping.
+const maxReasonLen = 120
+
+// truncateReason clamps reason to maxReasonLen characters, appending an ellipsis
+// when truncation occurs. Used for the runtime error strings embedded in
+// health_detail values (handshake / stop failures).
+func truncateReason(reason string) string {
+	if len(reason) > maxReasonLen {
+		return reason[:maxReasonLen] + "..."
+	}
+	return reason
 }
 
 // nextToolGeneration returns the next tool-registrar generation for instanceID.

--- a/internal/plugin/process/manager_test.go
+++ b/internal/plugin/process/manager_test.go
@@ -695,6 +695,225 @@ func TestReloadInstance_WithoutControllerReturnsError(t *testing.T) {
 	}
 }
 
+// TestReloadInstance_StartFails_CleanUpToRecoverableState verifies the issue
+// #587 recoverability guarantee: when the post-reload Start fails to spawn the
+// new subprocess, ReloadInstance must NOT leave a zombie (absent from the map
+// but with a bumped generation still registered against no subprocess). Instead
+// it cleans up to a consistent, recoverable end-state:
+//   - error returned,
+//   - instance absent from the manager map,
+//   - instance unregistered from the generation controller (so a later restart
+//     re-registers fresh at generation 1, not the orphaned bumped generation),
+//   - health = unhealthy.
+func TestReloadInstance_StartFails_CleanUpToRecoverableState(t *testing.T) {
+	reg := identity.New()
+	ctrl := generation.New()
+	q := &auditCapturingQuerier{
+		fakeQuerier: fakeQuerier{
+			plugins: []db.Plugin{{ID: "p1", Status: "active"}},
+			instances: map[string][]db.PluginInstance{
+				"p1": {{ID: "i-reload-fail", PluginID: "p1", InstanceName: "inst-fail", HealthState: "healthy"}},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// The starter succeeds on the first (initial) Start and fails on the second
+	// (post-reload restart), exercising the spawn-failure cleanup path.
+	var startCount atomic.Int32
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:              q,
+		IdentityIssuer:       reg,
+		GenerationController: ctrl,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			if startCount.Add(1) == 1 {
+				fc := fixtureConfig(t, "serve-and-block", reg, nil)
+				fc.InstanceID = cfg.InstanceID
+				return process.Start(ctx, fc)
+			}
+			// Spawn fails on the reload restart. Returning a LaunchError mirrors a
+			// real handshake failure and drives handleLaunchFailure (health=unhealthy
+			// with "subprocess_handshake_failed:").
+			return nil, &process.LaunchError{Cause: errors.New("simulated reload spawn failure")}
+		},
+	})
+
+	plugin := db.Plugin{ID: "p1", Status: "active"}
+	instance := db.PluginInstance{ID: "i-reload-fail", PluginID: "p1", InstanceName: "inst-fail", HealthState: "healthy"}
+
+	if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+		t.Fatalf("initial Start: %v", err)
+	}
+
+	// Sanity: before reload the generation is 1.
+	if gen := ctrl.RegisterInstance(instance.ID); gen != 1 {
+		t.Fatalf("pre-reload generation = %d, want 1", gen)
+	}
+
+	err := mgr.ReloadInstance(ctx, plugin, instance, os.Args[0], 5*time.Second)
+	if err == nil {
+		mgr.Stop(ctx, instance.ID) //nolint:errcheck
+		t.Fatal("expected error from ReloadInstance when restart spawn fails, got nil")
+	}
+
+	// End-state 1: the instance must be absent from the manager map.
+	if inst := mgr.Lookup(instance.ID); inst != nil {
+		t.Errorf("instance still present in manager map after failed reload (zombie); want absent")
+	}
+
+	// End-state 2: the instance must be unregistered from the generation
+	// controller. The observable signal is that RegisterInstance re-creates a
+	// fresh entry at generation 1 — if the zombie entry had survived, the bumped
+	// generation (2) would be returned instead.
+	if gen := ctrl.RegisterInstance(instance.ID); gen != 1 {
+		t.Errorf("generation after failed reload = %d; want 1 (instance should have been unregistered, not left at the bumped generation)", gen)
+	}
+
+	// End-state 3: health must have been driven to unhealthy with the
+	// handshake-failure detail (handleLaunchFailure path).
+	var sawUnhealthy bool
+	for _, detail := range q.healthDetails {
+		if strings.HasPrefix(detail, "subprocess_handshake_failed:") {
+			sawUnhealthy = true
+			break
+		}
+	}
+	if !sawUnhealthy {
+		t.Errorf("no subprocess_handshake_failed health detail recorded; got: %v", q.healthDetails)
+	}
+}
+
+// TestReloadInstance_StartFails_Recoverable verifies the end-state from a failed
+// reload is actually recoverable: a fresh Start after the failed reload succeeds
+// and the instance returns to a live, registered state. This is the operator's
+// "re-activate" recovery path.
+func TestReloadInstance_StartFails_Recoverable(t *testing.T) {
+	reg := identity.New()
+	ctrl := generation.New()
+	q := &fakeQuerier{
+		plugins: []db.Plugin{{ID: "p1", Status: "active"}},
+		instances: map[string][]db.PluginInstance{
+			"p1": {{ID: "i-recover", PluginID: "p1", InstanceName: "inst-recover", HealthState: "healthy"}},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var startCount atomic.Int32
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:              q,
+		IdentityIssuer:       reg,
+		GenerationController: ctrl,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			// Fail only the second call (the reload restart). Calls 1 and 3 succeed.
+			if startCount.Add(1) == 2 {
+				return nil, &process.LaunchError{Cause: errors.New("simulated reload spawn failure")}
+			}
+			fc := fixtureConfig(t, "serve-and-block", reg, nil)
+			fc.InstanceID = cfg.InstanceID
+			return process.Start(ctx, fc)
+		},
+	})
+
+	plugin := db.Plugin{ID: "p1", Status: "active"}
+	instance := db.PluginInstance{ID: "i-recover", PluginID: "p1", InstanceName: "inst-recover", HealthState: "healthy"}
+
+	if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+		t.Fatalf("initial Start: %v", err)
+	}
+	if err := mgr.ReloadInstance(ctx, plugin, instance, os.Args[0], 5*time.Second); err == nil {
+		t.Fatal("expected error from failed reload, got nil")
+	}
+
+	// Recovery: a fresh Start must succeed and leave a live, registered instance.
+	if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+		t.Fatalf("recovery Start after failed reload: %v", err)
+	}
+	defer mgr.Stop(ctx, instance.ID) //nolint:errcheck
+
+	if inst := mgr.Lookup(instance.ID); inst == nil {
+		t.Errorf("instance not present in manager map after recovery Start; want live")
+	}
+}
+
+// TestReloadInstance_StartFails_NoLeakedRefcount runs the failed-reload path with
+// the race detector and an in-flight Acquire to confirm cleanup does not leave a
+// leaked refcount or deadlock a blocked Acquire caller. Run the package with
+// -race to exercise the concurrency guarantee.
+func TestReloadInstance_StartFails_NoLeakedRefcount(t *testing.T) {
+	reg := identity.New()
+	ctrl := generation.New()
+	q := &fakeQuerier{
+		plugins: []db.Plugin{{ID: "p1", Status: "active"}},
+		instances: map[string][]db.PluginInstance{
+			"p1": {{ID: "i-reload-race", PluginID: "p1", InstanceName: "inst-race", HealthState: "healthy"}},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var startCount atomic.Int32
+	mgr := process.NewManager(process.ManagerConfig{
+		Querier:              q,
+		IdentityIssuer:       reg,
+		GenerationController: ctrl,
+		TestProcessStarter: func(ctx context.Context, cfg process.Config) (*process.Instance, error) {
+			if startCount.Add(1) == 1 {
+				fc := fixtureConfig(t, "serve-and-block", reg, nil)
+				fc.InstanceID = cfg.InstanceID
+				return process.Start(ctx, fc)
+			}
+			return nil, &process.LaunchError{Cause: errors.New("simulated reload spawn failure")}
+		},
+	})
+
+	plugin := db.Plugin{ID: "p1", Status: "active"}
+	instance := db.PluginInstance{ID: "i-reload-race", PluginID: "p1", InstanceName: "inst-race", HealthState: "healthy"}
+
+	if err := mgr.Start(ctx, plugin, instance, os.Args[0]); err != nil {
+		t.Fatalf("initial Start: %v", err)
+	}
+
+	// Hold an in-flight refcount across the reload. BeginDrain force-cancels it
+	// after the (very short) grace window; the held ctx must observe cancellation.
+	wrappedCtx, release, _, err := ctrl.Acquire(ctx, instance.ID)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	reloadDone := make(chan error, 1)
+	go func() {
+		reloadDone <- mgr.ReloadInstance(ctx, plugin, instance, os.Args[0], 30*time.Millisecond)
+	}()
+
+	// The held call's ctx must be force-cancelled (drain grace is short).
+	select {
+	case <-wrappedCtx.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("held call ctx was not force-cancelled within 10s")
+	}
+	release() // simulate the handler observing ctx.Done()
+
+	select {
+	case err := <-reloadDone:
+		if err == nil {
+			t.Fatal("expected error from failed reload, got nil")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ReloadInstance did not return after failed restart")
+	}
+
+	// After cleanup, a fresh Acquire on the unregistered instance must return an
+	// error (not block, not panic) — proving the controller entry was removed.
+	if _, _, _, acqErr := ctrl.Acquire(ctx, instance.ID); acqErr == nil {
+		t.Errorf("Acquire succeeded after failed-reload cleanup; want error (instance should be unregistered)")
+	}
+}
+
 // ── auditCapturingQuerier ─────────────────────────────────────────────────────
 
 // auditCapturingQuerier extends fakeQuerier with audit-event capture so tests
@@ -1089,13 +1308,15 @@ func TestManager_Start_ToolConflict_DrivesUnhealthy(t *testing.T) {
 	// Start returns an error because RegisterInstanceTools encounters a conflict.
 	err := mgr.Start(startCtx, plugin, instance, os.Args[0])
 	if err == nil {
-		// Subprocess started — clean up before failing.
+		// Unexpected success — defensively stop the spawned subprocess before failing.
 		mgr.Stop(startCtx, instance.ID) //nolint:errcheck
 		t.Fatal("expected error from Manager.Start on tool conflict, got nil")
 	}
 
-	// The subprocess was stored in the map before registration ran, so Stop
-	// is safe to call to clean up the spawned goroutine.
+	// Stop is now a defensive no-op: Start's tool-registration rollback (#587)
+	// already killed the subprocess and removed it from the map on the conflict
+	// path. We still call it so the test stays correct if that rollback ever
+	// changes.
 	mgr.Stop(startCtx, instance.ID) //nolint:errcheck
 
 	// Assert health_state in DB is unhealthy.


### PR DESCRIPTION
Closes #587

## Summary

`process.Manager.ReloadInstance` drives `BeginDrain` → `stopWithoutUnregister` → `Start`. If `Start` failed after the stop, the instance was gone from the manager map but the generation had already advanced and no subprocess was running — a "zombie" still registered in `generation.Controller`, with cleanup pushed onto the caller (self-acknowledged in the doc comment) and untested.

Hot-reload is a routine operator action (drop a fresh tarball / accept a manifest), so a failed reload must leave a clean, recoverable state — not a half-present zombie requiring manual recovery.

## End-state guarantee chosen

True rollback (restore the prior healthy generation/subprocess) is **not achievable**: by the time `Start` can fail, the old subprocess has already been torn down and its identity token revoked by `stopWithoutUnregister`. So the chosen guarantee is a **clean unhealthy stop**. A failed reload always ends with the instance:

- absent from the manager map (no live subprocess),
- unregistered from the generation controller (no advanced generation pointing at nothing, no leaked refcount entry),
- tool reservations released, and
- health = `unhealthy` with an actionable detail.

Operator recovery is then unambiguous: re-activate (deactivate → activate) or re-install.

## Changes

- **`ReloadInstance`** routes both the `stopWithoutUnregister`-failure and the `Start`-failure paths through a new `cleanupFailedReload` helper (`UnregisterInstance` + `removeToolGeneration` + conditional `health=unhealthy`). The self-acknowledging doc comment now states the recoverability guarantee.
- **`Start`** now rolls back internally when `RegisterInstanceTools` fails. At that point the subprocess is already spawned, in the map, and registered with the generation controller — returning the error without cleanup left a live subprocess that could never serve tool calls. This was a latent zombie for *every* `Start` caller, not just reload. `Start` now stops the subprocess, unregisters from the controller, drops the tool generation, and sets `health=unhealthy("tool_registration_failed")`.
- Extracted `truncateReason` so handshake- and stop-failure health details share the 120-char cap.

## Architecture

<details>
<summary>Why a clean unhealthy stop, not rollback; idempotency; generation reset</summary>

- **No rollback.** `stopWithoutUnregister` revokes the identity token and tears down the subprocess before `Start` runs. The prior generation cannot be revived; the achievable correct end-state is a clean stop.
- **`cleanupFailedReload` is idempotent.** `GenerationController.UnregisterInstance` early-returns when the entry is already gone; `removeToolGeneration` is a map `delete` (no-op on a missing key). So the `Start`-failure path can call it even after `Start`'s own tool-registration rollback already performed the same cleanup. The empty-detail call on the `Start`-failure path also avoids clobbering the more specific detail `handleLaunchFailure` already recorded.
- **Generation resets to 1 after cleanup.** After `UnregisterInstance` the controller entry is removed, so a later recovery `Start` re-registers fresh at generation 1 rather than inheriting the orphaned bumped generation that never carried traffic. This is intentional and correct — the bumped generation had no subprocess associated with it.
- **No double-close / deadlock.** `BeginDrain` already rotated and closed its drain channels before returning, so by the time `Start` (and any failure cleanup) runs the instance is no longer paused. `UnregisterInstance` wakes any `Acquire` callers with an error rather than leaving them blocked.
- **Per ADR / package boundary:** `process.go`/`waitForExit` still drive health only via the injected callback; `manager.go` imports `internal/plugin/state` as before.

</details>

## Tests

`internal/plugin/process` and `internal/plugin/generation` pass with `-race`:

- failed reload leaves a consistent, recoverable end-state (absent from map, unregistered → fresh generation 1, health=unhealthy);
- the end-state is actually recoverable (a fresh `Start` after a failed reload succeeds);
- no leaked refcount / no deadlocked `Acquire` after cleanup (race test with an in-flight `Acquire` across the reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)