### PR TITLE
fix: dedup claim/rollback so transient launch failures don't suppress at-least-once redelivery (#585)

### DIFF
--- a/internal/db/plugin_event_dedup.sql.go
+++ b/internal/db/plugin_event_dedup.sql.go
@@ -9,6 +9,28 @@ import (
 	"context"
 )
 
+const deleteEventDedup = `-- name: DeleteEventDedup :exec
+DELETE FROM plugin_event_dedup
+WHERE plugin_instance_id = ?1
+  AND event_kind = ?2
+  AND event_id = ?3
+`
+
+type DeleteEventDedupParams struct {
+	PluginInstanceID string `json:"plugin_instance_id"`
+	EventKind        string `json:"event_kind"`
+	EventID          string `json:"event_id"`
+}
+
+// Rolls back a dedup claim recorded by RecordEventIfNovel. Used when a matched
+// event failed to launch transiently, so the plugin's at-least-once redelivery
+// of the same event is treated as novel again (#585). Idempotent: a DELETE that
+// affects zero rows is not an error.
+func (q *Queries) DeleteEventDedup(ctx context.Context, arg DeleteEventDedupParams) error {
+	_, err := q.db.ExecContext(ctx, deleteEventDedup, arg.PluginInstanceID, arg.EventKind, arg.EventID)
+	return err
+}
+
 const recordEventIfNovel = `-- name: RecordEventIfNovel :execrows
 INSERT INTO plugin_event_dedup (plugin_instance_id, event_kind, event_id, created_at_ms)
 VALUES (?1, ?2, ?3, ?4)

--- a/internal/db/queries/plugin_event_dedup.sql
+++ b/internal/db/queries/plugin_event_dedup.sql
@@ -5,3 +5,13 @@ ON CONFLICT (plugin_instance_id, event_kind, event_id) DO NOTHING;
 
 -- name: SweepEventDedup :execrows
 DELETE FROM plugin_event_dedup WHERE created_at_ms < :floor;
+
+-- name: DeleteEventDedup :exec
+-- Rolls back a dedup claim recorded by RecordEventIfNovel. Used when a matched
+-- event failed to launch transiently, so the plugin's at-least-once redelivery
+-- of the same event is treated as novel again (#585). Idempotent: a DELETE that
+-- affects zero rows is not an error.
+DELETE FROM plugin_event_dedup
+WHERE plugin_instance_id = :plugin_instance_id
+  AND event_kind = :event_kind
+  AND event_id = :event_id;

--- a/internal/plugin/dedup/dedup.go
+++ b/internal/plugin/dedup/dedup.go
@@ -38,9 +38,19 @@ type Key struct {
 // Callers treat errors as misses (fail-open) so a degraded store does not
 // silently drop events.
 //
+// Unsee rolls back a claim that a prior Seen call took (it returned
+// (false, nil) and committed the key). The dispatcher calls Unsee only when an
+// event was matched but its launch failed transiently for at least one policy,
+// so the plugin's at-least-once redelivery of the same event can be treated as
+// novel again rather than silently suppressed for the full dedup window (#585).
+// Unsee must be idempotent — rolling back an absent or already-evicted key is a
+// no-op, not an error. Errors from Unsee are advisory: the caller logs and
+// proceeds, since a stranded row simply ages out at the TTL.
+//
 // Implementations must be safe for concurrent use.
 type Store interface {
 	Seen(ctx context.Context, k Key) (bool, error)
+	Unsee(ctx context.Context, k Key) error
 }
 
 // Noop is a Store that never deduplicates: every Seen call returns (false, nil).
@@ -50,3 +60,6 @@ type Noop struct{}
 
 // Seen always returns (false, nil). With Noop, every event proceeds to dispatch.
 func (Noop) Seen(_ context.Context, _ Key) (bool, error) { return false, nil }
+
+// Unsee is a no-op for Noop: it never recorded anything to roll back.
+func (Noop) Unsee(_ context.Context, _ Key) error { return nil }

--- a/internal/plugin/dedup/dedup_test.go
+++ b/internal/plugin/dedup/dedup_test.go
@@ -39,6 +39,16 @@ func TestNoop_SatisfiesInterface(t *testing.T) {
 	var _ dedup.Store = dedup.Noop{}
 }
 
+// TestNoop_UnseeIsNoop verifies Noop.Unsee always returns nil (#585).
+func TestNoop_UnseeIsNoop(t *testing.T) {
+	t.Parallel()
+
+	var store dedup.Noop
+	if err := store.Unsee(context.Background(), dedup.Key{InstanceID: "i", EventKind: "k", EventID: "e"}); err != nil {
+		t.Errorf("Noop.Unsee returned %v, want nil", err)
+	}
+}
+
 // TestNoop_DifferentKeys verifies that Noop returns false for all key variants.
 func TestNoop_DifferentKeys(t *testing.T) {
 	t.Parallel()

--- a/internal/plugin/dedup/store.go
+++ b/internal/plugin/dedup/store.go
@@ -47,6 +47,7 @@ var (
 type Querier interface {
 	RecordEventIfNovel(ctx context.Context, arg db.RecordEventIfNovelParams) (int64, error)
 	SweepEventDedup(ctx context.Context, floor int64) (int64, error)
+	DeleteEventDedup(ctx context.Context, arg db.DeleteEventDedupParams) error
 }
 
 // dbStore is a SQLite-backed Store implementation.
@@ -94,6 +95,21 @@ func (s *dbStore) Seen(ctx context.Context, k Key) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// Unsee deletes the dedup row for k, rolling back a claim taken by a prior Seen
+// that returned (false, nil). It is idempotent: a DELETE affecting zero rows is
+// not an error (the row may have already aged out at the TTL, or a concurrent
+// sweep may have evicted it). See the Store.Unsee contract (#585).
+func (s *dbStore) Unsee(ctx context.Context, k Key) error {
+	if err := s.q.DeleteEventDedup(ctx, db.DeleteEventDedupParams{
+		PluginInstanceID: k.InstanceID,
+		EventKind:        k.EventKind,
+		EventID:          k.EventID,
+	}); err != nil {
+		return fmt.Errorf("dedup unsee: %w", err)
+	}
+	return nil
 }
 
 // Sweeper runs a background loop that evicts dedup rows older than ttl by

--- a/internal/plugin/dedup/store_test.go
+++ b/internal/plugin/dedup/store_test.go
@@ -170,3 +170,66 @@ func (q *errQuerier) RecordEventIfNovel(_ context.Context, _ db.RecordEventIfNov
 func (q *errQuerier) SweepEventDedup(_ context.Context, _ int64) (int64, error) {
 	return 0, q.err
 }
+
+func (q *errQuerier) DeleteEventDedup(_ context.Context, _ db.DeleteEventDedupParams) error {
+	return q.err
+}
+
+// TestDBStore_UnseeMakesKeyNovelAgain verifies the #585 rollback: after Unsee,
+// a key recorded by a prior Seen is treated as novel again on the next Seen.
+// Clock mutation: do NOT t.Parallel().
+func TestDBStore_UnseeMakesKeyNovelAgain(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	insertPluginAndInstance(t, store, "plug-unsee", "inst-unsee")
+
+	fixedTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := dedup.NewDBStore(store.Queries())
+	s.SetClockForTest(func() time.Time { return fixedTime })
+
+	ctx := context.Background()
+	k := dedup.Key{InstanceID: "inst-unsee", EventKind: "message", EventID: "evt-unsee"}
+
+	if seen, err := s.Seen(ctx, k); err != nil || seen {
+		t.Fatalf("first Seen: seen=%v err=%v, want false,nil", seen, err)
+	}
+	// Second Seen confirms the slot is held.
+	if seen, err := s.Seen(ctx, k); err != nil || !seen {
+		t.Fatalf("second Seen: seen=%v err=%v, want true,nil", seen, err)
+	}
+	// Roll the claim back.
+	if err := s.Unsee(ctx, k); err != nil {
+		t.Fatalf("Unsee: unexpected error: %v", err)
+	}
+	// The key must now be novel again (the redelivery can fire).
+	if seen, err := s.Seen(ctx, k); err != nil || seen {
+		t.Fatalf("post-Unsee Seen: seen=%v err=%v, want false,nil (novel again)", seen, err)
+	}
+}
+
+// TestDBStore_UnseeAbsentKeyIsNoop verifies that Unsee on a key that was never
+// recorded is a no-op, not an error (idempotent).
+// Clock mutation: do NOT t.Parallel().
+func TestDBStore_UnseeAbsentKeyIsNoop(t *testing.T) {
+	store := testutil.NewTestStore(t)
+	insertPluginAndInstance(t, store, "plug-absent", "inst-absent")
+
+	s := dedup.NewDBStore(store.Queries())
+	ctx := context.Background()
+	k := dedup.Key{InstanceID: "inst-absent", EventKind: "message", EventID: "never-seen"}
+
+	if err := s.Unsee(ctx, k); err != nil {
+		t.Errorf("Unsee on absent key: got error %v, want nil", err)
+	}
+}
+
+// TestDBStore_UnseeWrapsStoreError verifies Unsee wraps the underlying DB error.
+func TestDBStore_UnseeWrapsStoreError(t *testing.T) {
+	t.Parallel()
+
+	fakeErr := errors.New("db down")
+	s := dedup.NewDBStore(&errQuerier{err: fakeErr})
+	err := s.Unsee(context.Background(), dedup.Key{InstanceID: "i", EventKind: "k", EventID: "e"})
+	if !errors.Is(err, fakeErr) {
+		t.Errorf("error = %v, want to wrap %v", err, fakeErr)
+	}
+}

--- a/internal/plugin/e2e/composition_test.go
+++ b/internal/plugin/e2e/composition_test.go
@@ -325,6 +325,10 @@ func (s *stubDedup) Seen(_ context.Context, _ dedup.Key) (bool, error) {
 	return true, nil
 }
 
+// Unsee is a no-op: stubDedup always reports hits, so there is never a claim to
+// roll back (#585).
+func (s *stubDedup) Unsee(_ context.Context, _ dedup.Key) error { return nil }
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 // TestSubstrate_HappyPath_FiresMatchingPolicyOnly wires the full trigger →

--- a/internal/plugin/trigger/dispatcher.go
+++ b/internal/plugin/trigger/dispatcher.go
@@ -141,11 +141,18 @@ func NewDispatcher(cfg DispatcherConfig) *Dispatcher {
 func (d *Dispatcher) Handle(ctx context.Context, evt Event) error {
 	// 1. Dedup — fail-open: a store error is logged as Warn and dispatch
 	//    proceeds so a degraded store does not silently drop events.
-	seen, err := d.dedup.Seen(ctx, dedup.Key{
+	//
+	// The claim is atomic (INSERT ... ON CONFLICT DO NOTHING): the first of two
+	// concurrently-arriving copies of an event wins the row and dispatches; the
+	// second sees seen==true and short-circuits. This is what excludes the
+	// concurrent-duplicate double-fire across the two ingestion paths (the
+	// supervisor recvLoop and the EmitEvent host RPC) — keep the claim here.
+	key := dedup.Key{
 		InstanceID: evt.InstanceID,
 		EventKind:  evt.EventKind,
 		EventID:    evt.EventID,
-	})
+	}
+	seen, err := d.dedup.Seen(ctx, key)
 	if err != nil {
 		d.log.WarnContext(ctx, "dedup store error; proceeding with dispatch (fail-open)",
 			"instance_id", evt.InstanceID,
@@ -157,16 +164,61 @@ func (d *Dispatcher) Handle(ctx context.Context, evt Event) error {
 		return nil
 	}
 
-	// 2. Policy scan.
+	// claimed is true only when this call freshly committed the dedup row
+	// (Seen returned (false, nil)). On the fail-open path (err != nil) nothing
+	// was committed, so there is no claim to roll back.
+	claimed := err == nil
+
+	// At-least-once redelivery (#585): if we freshly claimed the dedup slot and
+	// any transient failure prevents this event from being dispatched to its
+	// matched policies, roll the claim back so the plugin's next redelivery of
+	// this event is treated as novel rather than silently suppressed for the
+	// full dedup window. "Transient failure" covers both a downstream launch
+	// error (per-policy) and a pre-loop infrastructure error (policy scan or
+	// instance fetch) — in every case nothing was launched, so suppressing the
+	// redelivery would convert at-least-once into at-most-once.
+	//
+	// The rollback runs in a defer with a detached context so it fires even when
+	// the policy loop returns early on ctx cancellation (mid-scan shutdown would
+	// otherwise strand a committed-but-unlaunched key). context.Background()
+	// mirrors RunLauncher's failure-path DB writes, which must not inherit a
+	// cancelled run context.
+	//
+	// Consequence for the multi-policy case: when one event matches N policies
+	// and any one launch fails transiently, the redelivery re-fires ALL matched
+	// policies, including ones that already launched. This is the accepted cost
+	// of at-least-once delivery — the launcher's per-policy concurrency check
+	// (skip/queue/replace) absorbs the re-fire; only a `parallel`-concurrency
+	// policy will produce a genuine duplicate run, which is exactly what that
+	// mode opts into. A possible duplicate is strictly better than the silent
+	// permanent drop of policies that never launched, which is the bug here.
+	var rollbackClaim bool
+	defer func() {
+		if !claimed || !rollbackClaim {
+			return
+		}
+		if uErr := d.dedup.Unsee(context.Background(), key); uErr != nil {
+			d.log.WarnContext(ctx, "dedup rollback failed; event may be suppressed until TTL",
+				"instance_id", evt.InstanceID,
+				"event_id", evt.EventID,
+				"err", uErr,
+			)
+		}
+	}()
+
+	// 2. Policy scan. A scan failure is transient and nothing was launched —
+	// roll the claim back so the redelivery can retry the whole pipeline.
 	policies, err := d.q.GetSubscribedActivePolicies(ctx)
 	if err != nil {
+		rollbackClaim = true
 		return err
 	}
 
 	// Resolve the instance once per event so dispatchOne can compare the
 	// human-readable instance name (trig.Source) without an extra DB round-trip
 	// per policy. Missing instance is a hard error: the event came from a valid
-	// token-authenticated subprocess, so the row must exist.
+	// token-authenticated subprocess, so the row must exist. As with the scan,
+	// nothing launched — roll the claim back so the redelivery can retry.
 	instance, err := d.q.GetPluginInstanceByID(ctx, evt.InstanceID)
 	if err != nil {
 		d.log.ErrorContext(ctx, "trigger dispatcher: failed to fetch instance; dropping event",
@@ -174,6 +226,7 @@ func (d *Dispatcher) Handle(ctx context.Context, evt Event) error {
 			"event_id", evt.EventID,
 			"err", err,
 		)
+		rollbackClaim = true
 		return err
 	}
 
@@ -182,18 +235,30 @@ func (d *Dispatcher) Handle(ctx context.Context, evt Event) error {
 	provider, modelName := d.systemDefault(ctx)
 
 	// 3–5. For each policy: match source, compile binding, evaluate, launch.
+	// The deferred rollback above consumes anyTransientFailure once the loop
+	// completes (or returns early on ctx cancellation).
 	for _, pol := range policies {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		d.dispatchOne(ctx, pol, evt, provider, modelName, instance)
+		if d.dispatchOne(ctx, pol, evt, provider, modelName, instance) {
+			rollbackClaim = true
+		}
 	}
 	return nil
 }
 
 // dispatchOne runs steps 3–5 for a single policy row. All errors are logged
 // and isolated; dispatchOne never returns an error to the recv loop.
-func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, provider, modelName string, instance db.PluginInstance) {
+//
+// It returns launchFailed=true only when this policy MATCHED the binding but its
+// launch returned a non-nil (transient) error — the signal the caller uses to
+// roll back the per-event dedup claim (#585). Every other path returns false:
+// a non-match (different instance/kind/binding), a non-launch skip (parse,
+// schema, or compile error), and a SUCCESSFUL launch of ANY outcome
+// (Launched/Queued/Skipped). A concurrency skip or successful enqueue is a
+// deliberate, successful consumption of the event and must keep the dedup slot.
+func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, provider, modelName string, instance db.PluginInstance) (launchFailed bool) {
 	// 3. Parse and match source + event kind.
 	//
 	// trig.Source stores the human-readable instance name
@@ -206,15 +271,15 @@ func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, 
 			"event_id", evt.EventID,
 			"err", err,
 		)
-		return
+		return false
 	}
 
 	trig := parsed.Trigger
 	if trig.Source != instance.InstanceName {
-		return // policy watches a different instance
+		return false // policy watches a different instance
 	}
 	if trig.EventKind != evt.EventKind {
-		return // policy watches a different event kind
+		return false // policy watches a different event kind
 	}
 
 	// 4. Compile and evaluate binding.
@@ -227,7 +292,7 @@ func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, 
 			"err", compErr,
 		)
 		d.publishNoMatch(evt, pol.ID)
-		return
+		return false
 	}
 
 	compiled, compErr := binding.Compile(trig.Binding, schema)
@@ -238,7 +303,7 @@ func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, 
 			"err", compErr,
 		)
 		d.publishNoMatch(evt, pol.ID)
-		return
+		return false
 	}
 
 	var payload map[string]any
@@ -255,7 +320,7 @@ func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, 
 	match, _ := compiled.Evaluate(payload)
 	if !match {
 		d.publishNoMatch(evt, pol.ID)
-		return
+		return false
 	}
 
 	d.publishMatch(evt, pol.ID)
@@ -287,7 +352,10 @@ func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, 
 			d.log.ErrorContext(ctx, "trigger dispatcher: failed to launch run",
 				"policy_id", pol.ID, "run_id", res.RunID, "event_id", evt.EventID, "err", err)
 		}
-		return
+		// Every launch error here is transient (queue full, concurrency-check
+		// DB error, enqueue DB error, or a raw launch failure). Signal the
+		// caller to roll back the dedup claim so a redelivery can fire.
+		return true
 	}
 
 	switch res.Outcome {
@@ -300,6 +368,9 @@ func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, 
 	case run.OutcomeLaunched:
 		// No info log on plain launch — avoids a log-volume regression.
 	}
+	// Skip/queue/launched are all successful consumption of the event — keep
+	// the dedup slot.
+	return false
 }
 
 // parsedPolicy returns a parsed policy, using a cache keyed on (id, updated_at).

--- a/internal/plugin/trigger/dispatcher_test.go
+++ b/internal/plugin/trigger/dispatcher_test.go
@@ -69,9 +69,11 @@ func (q *fakeQuerier) ListPluginInstancesByPlugin(_ context.Context, _ string) (
 // so the very first Seen call returns true, mimicking a key already present in
 // the window (e.g. after a replay from a pre-populated store).
 type fakeDedupStore struct {
-	mu      sync.Mutex
-	seenSet map[dedup.Key]bool
-	calls   int
+	mu         sync.Mutex
+	seenSet    map[dedup.Key]bool
+	calls      int
+	unseeCalls []dedup.Key // keys passed to Unsee, in call order
+	unseeErr   error       // returned by Unsee when non-nil (tests the rollback-error log path)
 }
 
 func (s *fakeDedupStore) Seen(_ context.Context, k dedup.Key) (bool, error) {
@@ -84,6 +86,25 @@ func (s *fakeDedupStore) Seen(_ context.Context, k dedup.Key) (bool, error) {
 	already := s.seenSet[k]
 	s.seenSet[k] = true // record so subsequent calls return true
 	return already, nil
+}
+
+// Unsee mirrors the production rollback: it deletes the key so a later Seen for
+// the same key is treated as novel again, and records the call for assertions.
+func (s *fakeDedupStore) Unsee(_ context.Context, k dedup.Key) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unseeCalls = append(s.unseeCalls, k)
+	if s.unseeErr != nil {
+		return s.unseeErr
+	}
+	delete(s.seenSet, k)
+	return nil
+}
+
+func (s *fakeDedupStore) unseeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.unseeCalls)
 }
 
 func (s *fakeDedupStore) markSeen(k dedup.Key) {
@@ -115,20 +136,35 @@ func (p *fakePublisher) published() []string {
 	return out
 }
 
+// launchResult pairs an outcome with an error for a single LaunchWithConcurrency call.
+type launchResult struct {
+	res run.LaunchResult
+	err error
+}
+
 // fakeLauncher satisfies plugintrigger.RunLauncher and records LaunchWithConcurrency calls.
+// By default it returns the fixed (result, err) for every call. When byPolicy is
+// non-nil, the result is selected by LaunchParams.PolicyID instead, so a single
+// event matching multiple policies can be given mixed outcomes.
 type fakeLauncher struct {
-	mu     sync.Mutex
-	calls  []run.LaunchParams
-	result run.LaunchResult // outcome to return on success
-	err    error            // e.g. run.ErrConcurrencyQueueFull
+	mu       sync.Mutex
+	calls    []run.LaunchParams
+	result   run.LaunchResult        // outcome to return on success (default path)
+	err      error                   // e.g. run.ErrConcurrencyQueueFull (default path)
+	byPolicy map[string]launchResult // per-policy override keyed on PolicyID
 }
 
 var _ plugintrigger.RunLauncher = (*fakeLauncher)(nil)
 
 func (l *fakeLauncher) LaunchWithConcurrency(_ context.Context, p run.LaunchParams) (run.LaunchResult, error) {
 	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.calls = append(l.calls, p)
-	l.mu.Unlock()
+	if l.byPolicy != nil {
+		if lr, ok := l.byPolicy[p.PolicyID]; ok {
+			return lr.res, lr.err
+		}
+	}
 	return l.result, l.err
 }
 
@@ -186,7 +222,7 @@ func policyYAML(source, eventKind string, binding map[string]any) string {
 
 // newDispatcher wires a Dispatcher with the given querier, dedup store, and
 // launcher.
-func newDispatcher(q plugintrigger.Querier, d dedup.Store, launcher *fakeLauncher, pub event.Publisher) *plugintrigger.Dispatcher {
+func newDispatcher(q plugintrigger.Querier, d dedup.Store, launcher plugintrigger.RunLauncher, pub event.Publisher) *plugintrigger.Dispatcher {
 	return plugintrigger.NewDispatcher(plugintrigger.DispatcherConfig{
 		Launcher:  launcher,
 		Querier:   q,
@@ -744,6 +780,371 @@ func TestDispatcher_RestartReplay(t *testing.T) {
 	}
 	if launcher.callCount() != 1 {
 		t.Errorf("after replay: expected 1 launch total, got %d (duplicate run fired)", launcher.callCount())
+	}
+}
+
+// ── #585: dedup claim/rollback on transient launch failure ─────────────────────
+
+// TestDispatcher_TransientLaunchFailure_RollsBackAndRedelivers verifies the core
+// #585 fix: when a matched event's launch fails transiently, the dedup claim is
+// rolled back so the plugin's at-least-once redelivery of the same event fires.
+func TestDispatcher_TransientLaunchFailure_RollsBackAndRedelivers(t *testing.T) {
+	t.Parallel()
+
+	q := newBasicQuerier(t, "my-instance", "message")
+	dedupStore := &fakeDedupStore{}
+	// First delivery hits a transient queue-full error.
+	launcher := &fakeLauncher{err: run.ErrConcurrencyQueueFull}
+	pub := &fakePublisher{}
+	d := newDispatcher(q, dedupStore, launcher, pub)
+
+	evt := plugintrigger.Event{
+		InstanceID:  "inst-1",
+		PluginID:    "plug-1",
+		EventKind:   "message",
+		EventID:     "evt-585-1",
+		PayloadJSON: []byte(`{"text":"hello"}`),
+		ObservedAt:  time.Now(),
+	}
+
+	// First delivery: launch fails transiently → dedup claim must be rolled back.
+	if err := d.Handle(context.Background(), evt); err != nil {
+		t.Fatalf("Handle (first): %v", err)
+	}
+	if launcher.callCount() != 1 {
+		t.Fatalf("after first delivery: expected 1 launch attempt, got %d", launcher.callCount())
+	}
+	if dedupStore.unseeCount() != 1 {
+		t.Fatalf("expected 1 dedup rollback after transient failure, got %d", dedupStore.unseeCount())
+	}
+
+	// Redelivery: the rollback un-recorded the key, so it must be treated as
+	// novel and the launch must be attempted again (now succeeding).
+	launcher.err = nil
+	launcher.result = run.LaunchResult{Outcome: run.OutcomeLaunched}
+	if err := d.Handle(context.Background(), evt); err != nil {
+		t.Fatalf("Handle (redelivery): %v", err)
+	}
+	if launcher.callCount() != 2 {
+		t.Errorf("after redelivery: expected 2 launch attempts total, got %d (event was suppressed)", launcher.callCount())
+	}
+}
+
+// TestDispatcher_SuccessOutcomes_ConsumeDedupSlot verifies that every successful
+// LaunchWithConcurrency outcome (launched/queued/skipped) keeps the dedup slot:
+// the slot is NOT rolled back, and a redelivery is suppressed.
+func TestDispatcher_SuccessOutcomes_ConsumeDedupSlot(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		outcome run.LaunchOutcome
+	}{
+		{"launched", run.OutcomeLaunched},
+		{"queued", run.OutcomeQueued},
+		{"skipped", run.OutcomeSkipped},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := newBasicQuerier(t, "my-instance", "message")
+			dedupStore := &fakeDedupStore{}
+			launcher := &fakeLauncher{result: run.LaunchResult{Outcome: tc.outcome}}
+			pub := &fakePublisher{}
+			d := newDispatcher(q, dedupStore, launcher, pub)
+
+			evt := plugintrigger.Event{
+				InstanceID:  "inst-1",
+				PluginID:    "plug-1",
+				EventKind:   "message",
+				EventID:     "evt-585-success",
+				PayloadJSON: []byte(`{"text":"hello"}`),
+				ObservedAt:  time.Now(),
+			}
+
+			if err := d.Handle(context.Background(), evt); err != nil {
+				t.Fatalf("Handle (first): %v", err)
+			}
+			if dedupStore.unseeCount() != 0 {
+				t.Fatalf("outcome %v: expected NO rollback, got %d", tc.outcome, dedupStore.unseeCount())
+			}
+
+			// Redelivery must be suppressed — the slot was consumed.
+			if err := d.Handle(context.Background(), evt); err != nil {
+				t.Fatalf("Handle (redelivery): %v", err)
+			}
+			if launcher.callCount() != 1 {
+				t.Errorf("outcome %v: expected 1 launch total (slot kept), got %d", tc.outcome, launcher.callCount())
+			}
+		})
+	}
+}
+
+// TestDispatcher_NoMatch_KeepsDedupSlot verifies that an event observed but
+// matching no policy binding keeps the dedup slot — there was no launch failure,
+// so a redelivery would only re-evaluate to no-match. No rollback occurs.
+func TestDispatcher_NoMatch_KeepsDedupSlot(t *testing.T) {
+	t.Parallel()
+
+	schema := buildStringSchema("channel")
+	q := &fakeQuerier{
+		policies: []db.Policy{{
+			ID:        "pol-1",
+			Yaml:      policyYAML("my-instance", "message", map[string]any{"channel": "#incidents"}),
+			UpdatedAt: "t1",
+		}},
+		instances: map[string]db.PluginInstance{
+			"inst-1": {ID: "inst-1", PluginID: "plug-1", InstanceName: "my-instance"},
+		},
+		plugins: map[string]db.Plugin{
+			"plug-1": {ID: "plug-1", ManifestSnapshot: buildManifestYAML(t, "message", schema)},
+		},
+	}
+	dedupStore := &fakeDedupStore{}
+	launcher := &fakeLauncher{}
+	pub := &fakePublisher{}
+	d := newDispatcher(q, dedupStore, launcher, pub)
+
+	evt := plugintrigger.Event{
+		InstanceID:  "inst-1",
+		EventKind:   "message",
+		EventID:     "evt-585-nomatch",
+		PayloadJSON: []byte(`{"channel":"#general"}`),
+		ObservedAt:  time.Now(),
+	}
+	if err := d.Handle(context.Background(), evt); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if launcher.callCount() != 0 {
+		t.Errorf("expected 0 launches on no-match, got %d", launcher.callCount())
+	}
+	if dedupStore.unseeCount() != 0 {
+		t.Errorf("expected NO rollback on no-match, got %d", dedupStore.unseeCount())
+	}
+}
+
+// TestDispatcher_MultiPolicy_MixedOutcomes_RollsBack verifies the documented
+// multi-policy rule: when one event matches two policies and at least one launch
+// fails transiently, the per-event dedup slot is rolled back. On redelivery BOTH
+// policies are re-dispatched — the accepted at-least-once duplicate of the policy
+// that already launched.
+func TestDispatcher_MultiPolicy_MixedOutcomes_RollsBack(t *testing.T) {
+	t.Parallel()
+
+	// Two subscribed policies on the same instance+kind.
+	q := &fakeQuerier{
+		policies: []db.Policy{
+			{ID: "pol-ok", Yaml: policyYAML("my-instance", "message", nil), UpdatedAt: "t1"},
+			{ID: "pol-fail", Yaml: policyYAML("my-instance", "message", nil), UpdatedAt: "t1"},
+		},
+		instances: map[string]db.PluginInstance{
+			"inst-1": {ID: "inst-1", PluginID: "plug-1", InstanceName: "my-instance"},
+		},
+		plugins: map[string]db.Plugin{
+			"plug-1": {ID: "plug-1", ManifestSnapshot: buildManifestYAML(t, "message", nil)},
+		},
+	}
+	dedupStore := &fakeDedupStore{}
+	launcher := &fakeLauncher{
+		byPolicy: map[string]launchResult{
+			"pol-ok":   {res: run.LaunchResult{Outcome: run.OutcomeLaunched}},
+			"pol-fail": {err: run.ErrConcurrencyQueueFull},
+		},
+	}
+	pub := &fakePublisher{}
+	d := newDispatcher(q, dedupStore, launcher, pub)
+
+	evt := plugintrigger.Event{
+		InstanceID:  "inst-1",
+		PluginID:    "plug-1",
+		EventKind:   "message",
+		EventID:     "evt-585-multi",
+		PayloadJSON: []byte(`{"text":"hello"}`),
+		ObservedAt:  time.Now(),
+	}
+
+	if err := d.Handle(context.Background(), evt); err != nil {
+		t.Fatalf("Handle (first): %v", err)
+	}
+	if launcher.callCount() != 2 {
+		t.Fatalf("first delivery: expected 2 launch attempts (both policies), got %d", launcher.callCount())
+	}
+	if dedupStore.unseeCount() != 1 {
+		t.Fatalf("expected 1 dedup rollback when any policy fails transiently, got %d", dedupStore.unseeCount())
+	}
+
+	// Redelivery: both policies dispatched again (pol-ok re-fires; that
+	// duplicate is the accepted cost of at-least-once).
+	if err := d.Handle(context.Background(), evt); err != nil {
+		t.Fatalf("Handle (redelivery): %v", err)
+	}
+	if launcher.callCount() != 4 {
+		t.Errorf("redelivery: expected 4 launch attempts total (2 policies x 2 deliveries), got %d", launcher.callCount())
+	}
+}
+
+// TestDispatcher_ScanError_RollsBackClaim verifies that a transient policy-scan
+// DB error rolls back the dedup claim (nothing was launched), so the redelivery
+// is not stranded for the full TTL.
+func TestDispatcher_ScanError_RollsBackClaim(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{polErr: errors.New("scan boom")}
+	dedupStore := &fakeDedupStore{}
+	launcher := &fakeLauncher{}
+	pub := &fakePublisher{}
+	d := newDispatcher(q, dedupStore, launcher, pub)
+
+	evt := plugintrigger.Event{
+		InstanceID:  "inst-1",
+		PluginID:    "plug-1",
+		EventKind:   "message",
+		EventID:     "evt-585-scanerr",
+		PayloadJSON: []byte(`{"text":"hello"}`),
+		ObservedAt:  time.Now(),
+	}
+	if err := d.Handle(context.Background(), evt); err == nil {
+		t.Fatal("Handle: expected scan error, got nil")
+	}
+	if dedupStore.unseeCount() != 1 {
+		t.Errorf("expected 1 rollback after scan error, got %d", dedupStore.unseeCount())
+	}
+}
+
+// TestDispatcher_InstanceFetchError_RollsBackClaim verifies that a transient
+// instance-fetch DB error rolls back the dedup claim.
+func TestDispatcher_InstanceFetchError_RollsBackClaim(t *testing.T) {
+	t.Parallel()
+
+	// Policies scan succeeds, but the instance fetch errors.
+	q := &fakeQuerier{
+		policies: []db.Policy{{ID: "pol-1", Yaml: policyYAML("my-instance", "message", nil), UpdatedAt: "t1"}},
+		instErr:  errors.New("instance boom"),
+	}
+	dedupStore := &fakeDedupStore{}
+	launcher := &fakeLauncher{}
+	pub := &fakePublisher{}
+	d := newDispatcher(q, dedupStore, launcher, pub)
+
+	evt := plugintrigger.Event{
+		InstanceID:  "inst-1",
+		PluginID:    "plug-1",
+		EventKind:   "message",
+		EventID:     "evt-585-insterr",
+		PayloadJSON: []byte(`{"text":"hello"}`),
+		ObservedAt:  time.Now(),
+	}
+	if err := d.Handle(context.Background(), evt); err == nil {
+		t.Fatal("Handle: expected instance-fetch error, got nil")
+	}
+	if dedupStore.unseeCount() != 1 {
+		t.Errorf("expected 1 rollback after instance-fetch error, got %d", dedupStore.unseeCount())
+	}
+}
+
+// TestDispatcher_RollbackErrorIsLogged verifies that an error from Unsee does
+// not crash dispatch — Handle still returns nil (rollback errors are advisory;
+// the stranded row ages out at the TTL).
+func TestDispatcher_RollbackErrorIsLogged(t *testing.T) {
+	t.Parallel()
+
+	q := newBasicQuerier(t, "my-instance", "message")
+	dedupStore := &fakeDedupStore{unseeErr: errors.New("boom")}
+	launcher := &fakeLauncher{err: run.ErrConcurrencyQueueFull}
+	pub := &fakePublisher{}
+	d := newDispatcher(q, dedupStore, launcher, pub)
+
+	evt := plugintrigger.Event{
+		InstanceID:  "inst-1",
+		PluginID:    "plug-1",
+		EventKind:   "message",
+		EventID:     "evt-585-rberr",
+		PayloadJSON: []byte(`{"text":"hello"}`),
+		ObservedAt:  time.Now(),
+	}
+	if err := d.Handle(context.Background(), evt); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if dedupStore.unseeCount() != 1 {
+		t.Errorf("expected 1 rollback attempt, got %d", dedupStore.unseeCount())
+	}
+}
+
+// cancelLauncher fails the first policy transiently and cancels the supplied
+// context synchronously inside that launch call. This deterministically trips
+// the dispatcher loop's ctx.Err() guard before the second policy is dispatched —
+// no polling, no sleeps (CLAUDE.md: signal-don't-poll).
+type cancelLauncher struct {
+	mu     sync.Mutex
+	calls  []run.LaunchParams
+	cancel context.CancelFunc
+}
+
+var _ plugintrigger.RunLauncher = (*cancelLauncher)(nil)
+
+func (l *cancelLauncher) LaunchWithConcurrency(_ context.Context, p run.LaunchParams) (run.LaunchResult, error) {
+	l.mu.Lock()
+	l.calls = append(l.calls, p)
+	l.mu.Unlock()
+	// Cancel inside the first launch so the loop returns early before policy 2.
+	l.cancel()
+	return run.LaunchResult{}, run.ErrConcurrencyQueueFull
+}
+
+func (l *cancelLauncher) callCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.calls)
+}
+
+// TestDispatcher_CtxCancelledMidLoop_RollsBack verifies that a context
+// cancellation that returns Handle early still rolls back a claimed-but-failed
+// slot via the deferred rollback, rather than stranding it until TTL.
+func TestDispatcher_CtxCancelledMidLoop_RollsBack(t *testing.T) {
+	t.Parallel()
+
+	// Two policies: the first fails transiently AND cancels the context, so the
+	// loop's ctx.Err() guard returns Handle early before policy 2. The deferred
+	// rollback must still fire.
+	q := &fakeQuerier{
+		policies: []db.Policy{
+			{ID: "pol-fail", Yaml: policyYAML("my-instance", "message", nil), UpdatedAt: "t1"},
+			{ID: "pol-2", Yaml: policyYAML("my-instance", "message", nil), UpdatedAt: "t1"},
+		},
+		instances: map[string]db.PluginInstance{
+			"inst-1": {ID: "inst-1", PluginID: "plug-1", InstanceName: "my-instance"},
+		},
+		plugins: map[string]db.Plugin{
+			"plug-1": {ID: "plug-1", ManifestSnapshot: buildManifestYAML(t, "message", nil)},
+		},
+	}
+	dedupStore := &fakeDedupStore{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	launcher := &cancelLauncher{cancel: cancel}
+	pub := &fakePublisher{}
+	d := newDispatcher(q, dedupStore, launcher, pub)
+
+	evt := plugintrigger.Event{
+		InstanceID:  "inst-1",
+		PluginID:    "plug-1",
+		EventKind:   "message",
+		EventID:     "evt-585-cancel",
+		PayloadJSON: []byte(`{"text":"hello"}`),
+		ObservedAt:  time.Now(),
+	}
+	if err := d.Handle(ctx, evt); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Handle: unexpected error %v", err)
+	}
+	// Only the first policy launched before cancellation tripped the guard.
+	if launcher.callCount() != 1 {
+		t.Fatalf("expected exactly 1 launch before ctx cancellation, got %d", launcher.callCount())
+	}
+	// The defer must have rolled back the claim despite the early ctx return.
+	if dedupStore.unseeCount() != 1 {
+		t.Errorf("expected 1 rollback after ctx cancellation, got %d", dedupStore.unseeCount())
 	}
 }
 


### PR DESCRIPTION
Closes #585

## Summary

The plugin trigger dispatcher recorded the per-event dedup key at the **top** of `Handle` (via `INSERT ... ON CONFLICT DO NOTHING`, which atomically commits the key while reporting "novel"), but the actual run launch happens far downstream, per-policy. When a matched event then **failed to launch** for a transient reason (queue full, concurrency-check DB error, enqueue error, or a raw launch error), the dedup row was already committed — so the plugin's at-least-once redelivery of the same `event_id` was silently suppressed for the full 1-hour window and the run **never fired**. At-least-once degraded to at-most-once on the unhappy path.

## Design decision: claim + rollback (shape A)

I evaluated two shapes — (A) keep the early atomic claim and roll it back on terminal failure, vs (B) a two-phase claim/confirm with a reaper. I chose **A**:

- Invariant 1 (at-most-once, including the concurrent-arrival race) is **already** satisfied by the existing atomic claim under SQLite's single-writer serialization — the first of two concurrent copies wins the row, the second short-circuits. Shape B would have to invent a pending/confirmed column + reaper and would *weaken* the concurrent-race guarantee (a pending row is ambiguous). B buys nothing here.
- Rollback is a single idempotent `DELETE` by PK on a `WITHOUT ROWID` table — trivial and composes cleanly with the fail-open contract (on a `Seen` error nothing was committed, so `claimed=false` and no rollback is attempted).

So the fix keeps the early claim and adds `Store.Unsee` (+ a new `DeleteEventDedup` sqlc query) that the dispatcher calls when an event could not be dispatched for a transient reason.

### Both invariants hold

- **At-most-once on success:** the atomic claim stays at the top of `Handle`, so a genuine duplicate (incl. concurrent arrival across the two ingestion paths — supervisor `recvLoop` and the `EmitEvent` host RPC) sees `seen==true` and never fires twice. Successful launch outcomes — `Launched`, `Queued`, **and** `Skipped` (a deliberate concurrency-skip is a legitimate consumption) — keep the slot; only a non-nil launch error rolls back.
- **Redelivery-on-failure:** a matched-but-not-launched event due to a transient failure rolls back its claim. This also covers the two **pre-loop infrastructure errors** (policy scan, instance fetch) where nothing launched, and the **ctx-cancellation mid-loop** path — the rollback runs in a `defer` with a detached `context.Background()` so it fires even on early return.

### Multi-policy rule

The dedup key is **per-event**, but one event can match N policies. If **any** matched policy's launch fails transiently, the whole per-event claim is rolled back, so the redelivery re-fires **all** matched policies including ones that already launched. This is the accepted cost of at-least-once: the launcher's per-policy concurrency check absorbs the re-fire (skip/queue/replace), and a `parallel`-mode policy is by definition opted into duplicate runs. A possible duplicate is strictly better than the silent **permanent drop** of a policy that never launched — which is the bug being fixed.

## Tests

Table-driven coverage added: concurrent-duplicate exclusion, transient launch/scan/instance-fetch failures → redelivery fires, skip/queue/launched consume the slot, multi-policy mixed outcomes roll back, ctx-cancellation mid-loop rolls back via the defer, rollback-error is logged (not fatal), and `dbStore.Unsee` round-trip + idempotency on an absent key.

`gofmt -l -s`, `go build ./...`, `go vet`, and `go test ./...` (affected packages with `-race`, including the `e2e` and `hostsvc` consumers) all green. `sqlc generate` (v1.30.0, matching the repo's pinned generator) produced a diff scoped to the new query only.

<details>
<summary>Architecture plan (architect + adversarial plan-reviewer + code-reviewer passes)</summary>

- **Architect** chose shape A, defined the per-event vs per-policy keying semantics, and the multi-policy "roll back if any failed" rule with its consequence analysis.
- **Plan-reviewer** (adversarial) verified the claim is atomic under `SetMaxOpenConns(1)`, confirmed `ConcurrencyParallel` returns nil unconditionally (so a re-fire produces a genuine duplicate — documented), and flagged the ctx-cancellation stranding + all in-tree `dedup.Store` implementers needing `Unsee`.
- **Code-reviewer** caught that the two pre-loop early `return err` paths (policy scan, instance fetch) also stranded a claimed-but-unlaunched slot for the full TTL — the same bug class — which is now fixed (`rollbackClaim = true` on both) with dedicated tests.

Files: `internal/plugin/trigger/dispatcher.go` (claim capture + deferred rollback + `dispatchOne` returns `launchFailed`), `internal/plugin/dedup/{dedup,store}.go` (`Store.Unsee` + `Noop`/`dbStore` impls + `Querier`), `internal/db/queries/plugin_event_dedup.sql` (`DeleteEventDedup`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
