### PR TITLE
fix: compare binding numeric equality without lossy float64 coercion (#586)

### DIFF
--- a/internal/plugin/binding/binding.go
+++ b/internal/plugin/binding/binding.go
@@ -50,9 +50,12 @@
 package binding
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -103,11 +106,23 @@ type CompiledField struct {
 	// distinguish BoolValue==false from "not set").
 	HasBool bool
 
-	// FloatValue is set when the binding value was a number.
+	// FloatValue is set when the binding value was a non-integral number.
 	FloatValue float64
 
-	// HasFloat is true when the binding value was a number.
+	// HasFloat is true when the binding value is a number to be compared as a
+	// float (i.e. it was fractional, or it was an integer too large to compare
+	// exactly — see IntValue for the exact-integer fast path).
 	HasFloat bool
+
+	// IntValue holds the binding value when it was an integer. Integer bindings
+	// are compared exactly as int64 rather than via float64 so that IDs above
+	// 2^53 (Slack/Snowflake-style 64-bit event/channel/user IDs, common in this
+	// substrate) do not lose precision (#586).
+	IntValue int64
+
+	// HasInt is true when the binding value was an integer (use IntValue, not
+	// FloatValue).
+	HasInt bool
 
 	// Regex is the pre-compiled regular expression for OpRegex fields.
 	Regex *regexp.Regexp
@@ -241,17 +256,33 @@ func compileField(name string, rawVal any, fieldSchema *yaml.Node) (CompiledFiel
 		cf.HasBool = true
 
 	case "number", "integer":
-		// YAML numbers unmarshal as int or float64 depending on value.
+		// YAML numbers unmarshal as int or float64 depending on value;
+		// json.Number can also appear if the binding was decoded with
+		// UseNumber. Classify each as either an exact integer (compared via
+		// IntValue/int64) or a fractional float (compared via FloatValue). We
+		// must NOT route integers through float64 here — values above 2^53 lose
+		// precision, which is exactly the #586 bug.
 		switch v := rawVal.(type) {
-		case float64:
-			cf.FloatValue = v
-			cf.HasFloat = true
 		case int:
-			cf.FloatValue = float64(v)
-			cf.HasFloat = true
+			cf.IntValue = int64(v)
+			cf.HasInt = true
 		case int64:
-			cf.FloatValue = float64(v)
-			cf.HasFloat = true
+			cf.IntValue = v
+			cf.HasInt = true
+		case float64:
+			setNumericField(&cf, v)
+		case json.Number:
+			if i, err := v.Int64(); err == nil {
+				cf.IntValue = i
+				cf.HasInt = true
+			} else {
+				fl, ferr := v.Float64()
+				if ferr != nil {
+					return cf, fmt.Errorf("binding: field %q: invalid number %q: %w", name, v.String(), ferr)
+				}
+				cf.FloatValue = fl
+				cf.HasFloat = true
+			}
 		default:
 			return cf, fmt.Errorf("binding: field %q: expected number, got %T", name, rawVal)
 		}
@@ -317,6 +348,20 @@ func evalField(f CompiledField, payload map[string]any) bool {
 	return false
 }
 
+// setNumericField stores a float64 binding value as either an exact integer
+// (when it is integral and within int64 range) or a fractional float. Routing
+// whole numbers through IntValue lets Evaluate compare them exactly against
+// integer payload values rather than via lossy float64 arithmetic (#586).
+func setNumericField(cf *CompiledField, v float64) {
+	if i, ok := floatAsExactInt(v); ok {
+		cf.IntValue = i
+		cf.HasInt = true
+		return
+	}
+	cf.FloatValue = v
+	cf.HasFloat = true
+}
+
 // valuesEqual compares a compiled field's expected value against a payload
 // value. Silent false on type mismatch.
 func valuesEqual(f CompiledField, pv any) bool {
@@ -324,20 +369,99 @@ func valuesEqual(f CompiledField, pv any) bool {
 		b, ok := pv.(bool)
 		return ok && b == f.BoolValue
 	}
+	if f.HasInt {
+		// Integer binding: compare exactly as int64 whenever the payload value
+		// is (or losslessly represents) an integer. This is the precision-safe
+		// path for 64-bit IDs above 2^53 (#586). Only fall back to float
+		// comparison when the payload value is genuinely fractional.
+		if pi, ok := payloadAsInt(pv); ok {
+			return pi == f.IntValue
+		}
+		if pf, ok := payloadAsFloat(pv); ok {
+			return pf == float64(f.IntValue)
+		}
+		return false
+	}
 	if f.HasFloat {
-		switch v := pv.(type) {
-		case float64:
-			return v == f.FloatValue
-		case int:
-			return float64(v) == f.FloatValue
-		case int64:
-			return float64(v) == f.FloatValue
+		if pf, ok := payloadAsFloat(pv); ok {
+			return pf == f.FloatValue
 		}
 		return false
 	}
 	// String equals.
 	s, ok := pv.(string)
 	return ok && s == f.StrValue
+}
+
+// payloadAsInt extracts an exact int64 from a payload value. It handles the
+// concrete number types that json.Unmarshal / json.Decoder(UseNumber) / YAML
+// can produce, plus integer strings (some plugins JSON-encode 64-bit IDs as
+// strings to dodge the JS float53 limit). Returns false for fractional or
+// out-of-range values, leaving those to the float fallback.
+func payloadAsInt(pv any) (int64, bool) {
+	switch v := pv.(type) {
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	case float64:
+		return floatAsExactInt(v)
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return i, true
+		}
+		// A json.Number that doesn't parse as int64 is fractional or out of
+		// range; let the float path handle it.
+		return 0, false
+	case string:
+		// Accept a string only when it is a clean base-10 integer.
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return i, true
+		}
+		return 0, false
+	}
+	return 0, false
+}
+
+// payloadAsFloat extracts a float64 from a payload value for fractional
+// comparison. Used only when an exact integer comparison was not possible.
+func payloadAsFloat(pv any) (float64, bool) {
+	switch v := pv.(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		if f, err := v.Float64(); err == nil {
+			return f, true
+		}
+		return 0, false
+	case string:
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f, true
+		}
+		return 0, false
+	}
+	return 0, false
+}
+
+// floatAsExactInt reports whether v is an integral value that fits exactly in
+// an int64 (no fractional part, within range, and representable without loss).
+func floatAsExactInt(v float64) (int64, bool) {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, false
+	}
+	if v != math.Trunc(v) {
+		return 0, false // has a fractional part
+	}
+	// math.MaxInt64 is not exactly representable as float64; use a strict
+	// upper bound (2^63) and inclusive lower bound (-2^63) that are.
+	if v < math.MinInt64 || v >= math.MaxInt64 {
+		return 0, false
+	}
+	return int64(v), true
 }
 
 // payloadString extracts a string field from the payload. Returns ("", false)

--- a/internal/plugin/binding/binding_test.go
+++ b/internal/plugin/binding/binding_test.go
@@ -1,6 +1,8 @@
 package binding_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -50,6 +52,31 @@ properties:
   active:
     type: boolean
 `
+
+// schemaNumeric has an integer field (channel_id) and a fractional number
+// field (ratio) for the precision tests (#586).
+const schemaNumeric = `
+type: object
+properties:
+  channel_id:
+    type: integer
+  ratio:
+    type: number
+`
+
+// decodeJSON unmarshals a JSON string into map[string]any with UseNumber, so
+// numeric values arrive as json.Number — mirroring the production dispatcher
+// decode path after the #586 fix.
+func decodeJSON(t *testing.T, src string) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader([]byte(src)))
+	dec.UseNumber()
+	var m map[string]any
+	if err := dec.Decode(&m); err != nil {
+		t.Fatalf("decodeJSON: %v", err)
+	}
+	return m
+}
 
 // schemaGlob has a field with format:glob (unsupported in v1).
 const schemaGlob = `
@@ -448,5 +475,194 @@ func TestEndToEnd_SDKToEvaluator(t *testing.T) {
 				t.Errorf("Evaluate = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestCompileEvaluate_LargeIntPrecision is the regression suite for #586:
+// integer binding equality must not lose precision through float64 coercion.
+// The binding value comes from YAML (int / int64), and the payload value is
+// exercised across every concrete type the decode paths can produce
+// (json.Number, float64, int, int64, string).
+func TestCompileEvaluate_LargeIntPrecision(t *testing.T) {
+	schema := schemaYAML(t, schemaNumeric)
+
+	// Two distinct 64-bit IDs that are EQUAL as float64 (both round to the same
+	// value above 2^53) but UNEQUAL as integers. This is the exact failure mode
+	// from the issue.
+	const idA = int64(9007199254740993) // 2^53 + 1
+	const idB = int64(9007199254740992) // 2^53 (== idA-1; equal to idA in float64)
+
+	tests := []struct {
+		name        string
+		bindingVal  any
+		payloadVal  any
+		want        bool
+		description string
+	}{
+		{
+			name:       "json.Number large id equal",
+			bindingVal: idA,
+			payloadVal: json.Number("9007199254740993"),
+			want:       true,
+		},
+		{
+			name:       "json.Number large id unequal but float-equal",
+			bindingVal: idA,
+			payloadVal: json.Number("9007199254740992"),
+			want:       false, // would be true under the old float64 coercion bug
+		},
+		{
+			name:       "int64 large id unequal but float-equal",
+			bindingVal: idA,
+			payloadVal: idB,
+			want:       false,
+		},
+		{
+			// float64(idB) is integral and within int64 range, so it is treated
+			// as the exact integer idB and compared exactly — it does NOT match
+			// the idA binding. (Note: float64(idA) would equal float64(idB) at
+			// the bit level, so if the payload were already lossily decoded the
+			// distinction is gone before we see it. This case proves we don't
+			// re-introduce float coercion for an integral float64 input.)
+			name:       "integral float64 payload compared exactly as int",
+			bindingVal: idA,
+			payloadVal: float64(idB),
+			want:       false,
+		},
+		{
+			name:       "small int still matches (int payload)",
+			bindingVal: int64(42),
+			payloadVal: 42,
+			want:       true,
+		},
+		{
+			name:       "small int no match (int payload)",
+			bindingVal: int64(42),
+			payloadVal: 7,
+			want:       false,
+		},
+		{
+			name:       "small int matches float64 payload",
+			bindingVal: int64(42),
+			payloadVal: float64(42),
+			want:       true,
+		},
+		{
+			name:       "negative large id equal (json.Number)",
+			bindingVal: int64(-9007199254740993),
+			payloadVal: json.Number("-9007199254740993"),
+			want:       true,
+		},
+		{
+			name:       "negative large id unequal but float-equal",
+			bindingVal: int64(-9007199254740993),
+			payloadVal: json.Number("-9007199254740992"),
+			want:       false,
+		},
+		{
+			name:       "string-encoded id matches integer binding",
+			bindingVal: idA,
+			payloadVal: "9007199254740993",
+			want:       true,
+		},
+		{
+			name:       "string-encoded id no match",
+			bindingVal: idA,
+			payloadVal: "9007199254740992",
+			want:       false,
+		},
+		{
+			name:       "non-numeric string is no match (not an error)",
+			bindingVal: int64(42),
+			payloadVal: "not-a-number",
+			want:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cb, err := binding.Compile(map[string]any{"channel_id": tc.bindingVal}, schema)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			got, err := cb.Evaluate(map[string]any{"channel_id": tc.payloadVal})
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Evaluate(channel_id=%v vs %v) = %v, want %v", tc.bindingVal, tc.payloadVal, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCompileEvaluate_FractionalNumber verifies that genuinely fractional
+// fields are still compared as floats and are not broken by the integer
+// fast-path (#586).
+func TestCompileEvaluate_FractionalNumber(t *testing.T) {
+	schema := schemaYAML(t, schemaNumeric)
+
+	cb, err := binding.Compile(map[string]any{"ratio": 0.5}, schema)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		payload any
+		want    bool
+	}{
+		{"float64 equal", float64(0.5), true},
+		{"json.Number equal", json.Number("0.5"), true},
+		{"string equal", "0.5", true},
+		{"float64 unequal", float64(0.25), false},
+		{"integer payload unequal", 1, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := cb.Evaluate(map[string]any{"ratio": tc.payload})
+			if got != tc.want {
+				t.Errorf("Evaluate(ratio=0.5 vs %v) = %v, want %v", tc.payload, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCompileEvaluate_WholeNumberBindingFromYAML verifies that a binding value
+// declared as a fractional number with a whole-number value (e.g. ratio: 2)
+// still compares exactly against integer payloads.
+func TestCompileEvaluate_WholeNumberBindingFromYAML(t *testing.T) {
+	schema := schemaYAML(t, schemaNumeric)
+	cb, err := binding.Compile(map[string]any{"ratio": 2}, schema)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if match, _ := cb.Evaluate(map[string]any{"ratio": json.Number("2")}); !match {
+		t.Error("expected ratio=2 to match json.Number(\"2\")")
+	}
+	if match, _ := cb.Evaluate(map[string]any{"ratio": float64(2)}); !match {
+		t.Error("expected ratio=2 to match float64(2)")
+	}
+}
+
+// TestCompileEvaluate_FullDecodePath exercises the precision fix end-to-end
+// through the same json.Decoder(UseNumber) decode the production dispatcher
+// uses, confirming a 64-bit ID survives JSON decode without precision loss.
+func TestCompileEvaluate_FullDecodePath(t *testing.T) {
+	schema := schemaYAML(t, schemaNumeric)
+	cb, err := binding.Compile(map[string]any{"channel_id": int64(9007199254740993)}, schema)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	matchPayload := decodeJSON(t, `{"channel_id": 9007199254740993}`)
+	if match, _ := cb.Evaluate(matchPayload); !match {
+		t.Error("expected match for channel_id=9007199254740993 decoded via UseNumber")
+	}
+
+	// The float-equal neighbour must NOT match after the fix.
+	noMatchPayload := decodeJSON(t, `{"channel_id": 9007199254740992}`)
+	if match, _ := cb.Evaluate(noMatchPayload); match {
+		t.Error("expected NO match for the float-equal neighbour 9007199254740992 (precision regression)")
 	}
 }

--- a/internal/plugin/trigger/dispatcher.go
+++ b/internal/plugin/trigger/dispatcher.go
@@ -8,6 +8,7 @@
 package trigger
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -243,7 +244,13 @@ func (d *Dispatcher) dispatchOne(ctx context.Context, pol db.Policy, evt Event, 
 
 	var payload map[string]any
 	if len(evt.PayloadJSON) > 0 {
-		if err := json.Unmarshal(evt.PayloadJSON, &payload); err != nil {
+		// Decode with UseNumber so 64-bit integer IDs (Slack/Snowflake-style,
+		// above 2^53) survive as json.Number rather than being coerced to a
+		// lossy float64. The binding evaluator compares such fields exactly
+		// (#586).
+		dec := json.NewDecoder(bytes.NewReader(evt.PayloadJSON))
+		dec.UseNumber()
+		if err := dec.Decode(&payload); err != nil {
 			d.log.WarnContext(ctx, "trigger dispatcher: event payload is not valid JSON; treating as empty",
 				"policy_id", pol.ID,
 				"event_id", evt.EventID,


### PR DESCRIPTION
Closes #586

## Summary

Subscribed-trigger binding equality (`internal/plugin/binding`) coerced every numeric payload value through `float64` before comparing. JSON integer IDs above 2^53 — Slack/Snowflake-style 64-bit event/channel/user IDs, which are exactly what this substrate sees — lose precision as `float64`, so `OpEquals` on a numeric binding field could match two *unequal* IDs or fail to match equal ones.

Two-part fix so equality is correct regardless of how the caller decoded the payload:

1. **Decode path** — the trigger dispatcher now decodes the event payload with `json.Decoder.UseNumber()`, so large integers arrive as `json.Number` (string-backed, lossless) instead of `float64`.
2. **Comparison path** — integer bindings are stored and compared exactly as `int64`; float comparison is used only for genuinely fractional values.

## Tests

Added table-driven coverage for: IDs above 2^53 (equal/unequal, including the "equal as float64 but unequal as int64" failure mode), negative large ints, mixed int/float, `json.Number` vs `float64` inputs, string-encoded numbers, fractional fields, and the full `UseNumber` decode path end-to-end. Existing small-int cases (42, 7) still pass. `gofmt -l -s`, `go build ./...`, `go vet`, and `go test -race` (binding + trigger) all green; full `go test ./...` green.

<details>
<summary>Architecture</summary>

- `internal/plugin/binding/binding.go`
  - `CompiledField` gains `IntValue int64` / `HasInt bool`. The `number`/`integer` compile branch classifies the binding value as an exact integer (`int`, `int64`, integral `float64`, or integral `json.Number`) or a fractional float — integers are **never** routed through `float64`.
  - `valuesEqual` compares as `int64` whenever both sides represent an integer; it falls back to `float64` only when the payload value is genuinely fractional.
  - New helpers `payloadAsInt` / `payloadAsFloat` accept `json.Number`, `float64`, `int`, `int64`, and base-10 string-encoded numbers (some plugins JSON-encode 64-bit IDs as strings to dodge the JS float53 limit). `floatAsExactInt` reports whether a `float64` is integral and exactly representable in `int64` (strict upper bound `>= 2^63`, inclusive lower bound `MinInt64`).
  - Package remains a pure leaf: only `encoding/json`, `math`, `strconv`, `strings` (all stdlib) were added — no `internal/*` imports.
- `internal/plugin/trigger/dispatcher.go` — payload JSON decoded via `json.NewDecoder(...).UseNumber()`. The decoded map is consumed only by `binding.Evaluate`; the match/no-match publishers and `TriggerPayload` use the raw JSON bytes, so nothing downstream is exposed to `json.Number`.

Per ADR-048 (subscribed trigger type) the binding evaluator is the runtime hot path for plugin-sourced events; this keeps `OpEquals` precision-safe for the 64-bit IDs that path routinely carries.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
