### PR TITLE
feat: add regex text matcher to Slack channel_message binding

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -39,6 +39,22 @@ slack/
   go.mod             — per-plugin module; resolved by the repo-root go.work
 ```
 
+## Trigger binding (`channel_message`)
+
+Policies that use the `channel_message` trigger can filter events using the
+following binding fields (all optional; fields are ANDed together):
+
+| Field         | Match          | Notes |
+|---------------|----------------|-------|
+| `channel`     | contains       | Substring of the channel display name or ID (e.g. `incidents`) |
+| `text`        | contains       | Substring anywhere in the message text |
+| `text_regex`  | regex (RE2)    | Go RE2 expression matched against the message text. Use `^(?i)recipe:` for anchored, case-insensitive command routing — fires on `Recipe: find dinner` but NOT on `got a great Recipe: idea`. RE2 only: no lookbehind or backreferences. |
+| `mention_only`| flag           | Only fire when the bot is mentioned |
+| `user`        | equals         | Exact Slack user ID (e.g. `U012AB3CD`) |
+
+`text` and `text_regex` are independent siblings: most policies set one or the
+other. Full trigger-binding documentation is tracked in #605.
+
 ## Channel (per-audience) config schema
 
 | Field              | Required | Description |

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -200,6 +200,12 @@ type SlackChannelMessageBinding struct {
 	Channel manifest.ContainsField `json:"channel,omitempty" jsonschema:"title=Channel,description=Substring matched against the Slack channel name or ID (e.g. #incidents)"`
 	// Text is a substring matched against the message text.
 	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Substring matched against the message text"`
+	// TextRegex matches the message text against a Go RE2 regular expression.
+	// Anchored, case-insensitive command routing is the primary use:
+	// `^(?i)recipe:` fires only on messages that start with "Recipe:"/"recipe:".
+	// RE2, not PCRE — no lookbehind/backrefs. Evaluated with implicit AND
+	// alongside Text; most policies set one or the other, not both.
+	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text (e.g. ^(?i)recipe: for anchored\\, case-insensitive routing). RE2 syntax — no lookbehind or backreferences."`
 	// MentionOnly restricts the policy to events where the bot was mentioned.
 	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Only trigger when the bot is mentioned in the message"`
 	// User restricts the policy to messages from a specific Slack user ID.

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -81,6 +81,11 @@ event_kinds:
           format: contains
           title: Text contains
           type: string
+        text_regex:
+          description: 'Go RE2 regular expression matched against the message text (e.g. ^(?i)recipe: for anchored, case-insensitive routing). RE2 syntax — no lookbehind or backreferences.'
+          format: regex
+          title: Text matches (regex)
+          type: string
         user:
           description: Slack user ID to match (e.g. U012AB3CD). Leave empty to match all users.
           title: User

--- a/plugins/slack/manifest_test.go
+++ b/plugins/slack/manifest_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
+	"gopkg.in/yaml.v3"
 )
 
 // TestManifestYAMLIsCanonical verifies that manifest.yaml on disk is the
@@ -49,5 +51,83 @@ func TestManifestYAMLIsCanonical(t *testing.T) {
 	if !bytes.Equal(diskBytes, fromGo) {
 		t.Errorf("manifest.yaml does not match pluginManifest in manifest.go:\ndisk:\n%s\nfrom Go:\n%s",
 			diskBytes, fromGo)
+	}
+}
+
+// TestChannelMessageTextRegexBinding asserts that:
+//  1. The reflected binding_schema for channel_message declares text_regex
+//     as {type: string, format: regex} — the shape the host binding engine
+//     requires to select OpRegex (internal/plugin/binding/binding.go:327).
+//  2. A regex derived from that field behaves as documented: `^(?i)recipe:`
+//     fires only when the message text *starts* with "Recipe:" or "recipe:",
+//     not when the keyword appears mid-string.
+//
+// The slack module cannot import internal/plugin/binding (separate module,
+// internal/ boundary), so we prove the AC by:
+//   - Walking the reflected YAML schema to assert the format tag (schema
+//     shape is what the host reads at policy-save time).
+//   - Compiling and running the regex ourselves (RE2 behavior is stdlib
+//     regexp; the host uses the same engine).
+func TestChannelMessageTextRegexBinding(t *testing.T) {
+	// --- Part 1: assert the reflected schema declares text_regex correctly ---
+
+	node := manifest.MustReflectSchema(SlackChannelMessageBinding{})
+
+	// findMappingValue walks a YAML mapping node looking for the given key and
+	// returns its value node. Returns nil when not found.
+	findMappingValue := func(mapping *yaml.Node, key string) *yaml.Node {
+		// Mapping content is interleaved [key, value, key, value, ...].
+		for i := 0; i+1 < len(mapping.Content); i += 2 {
+			if mapping.Content[i].Value == key {
+				return mapping.Content[i+1]
+			}
+		}
+		return nil
+	}
+
+	// Drill into: <root>.properties.text_regex
+	properties := findMappingValue(node, "properties")
+	if properties == nil {
+		t.Fatal("binding schema has no 'properties' key")
+	}
+	textRegex := findMappingValue(properties, "text_regex")
+	if textRegex == nil {
+		t.Fatal("binding schema has no 'text_regex' property; was manifest.go updated and manifest.yaml regenerated?")
+	}
+
+	typ := findMappingValue(textRegex, "type")
+	if typ == nil || typ.Value != "string" {
+		t.Errorf("text_regex: want type=string, got %v", typ)
+	}
+	format := findMappingValue(textRegex, "format")
+	if format == nil || format.Value != "regex" {
+		t.Errorf("text_regex: want format=regex, got %v", format)
+	}
+
+	// --- Part 2: prove the acceptance criteria with the regex itself ---
+	//
+	// The host selects OpRegex for format:regex and calls regexp.MatchString
+	// (RE2). We reproduce that here to document the expected routing behavior
+	// without importing the host engine.
+	re := regexp.MustCompile(`^(?i)recipe:`)
+
+	should := []string{
+		"Recipe: find dinner tonight",
+		"recipe: pasta ideas",
+	}
+	shouldNot := []string{
+		"got a great Recipe: idea", // keyword not at start — not anchored
+		"Lunch order is in.",       // no keyword at all
+	}
+
+	for _, msg := range should {
+		if !re.MatchString(msg) {
+			t.Errorf("expected regex to match %q but it did not", msg)
+		}
+	}
+	for _, msg := range shouldNot {
+		if re.MatchString(msg) {
+			t.Errorf("expected regex NOT to match %q but it did", msg)
+		}
 	}
 }


### PR DESCRIPTION
Closes #603

## Summary

Adds a sibling **`text_regex`** (Go RE2) field to the Slack plugin's `channel_message` binding, alongside the existing **`text`** (contains) field. This enables anchored, case-insensitive command routing:

```yaml
# route only messages that start with "Recipe:" / "recipe:" to a recipe agent
binding:
  text_regex: '^(?i)recipe:'
```

Previously `text` was substring-only, case-sensitive, and unanchored, so command-style routing was fragile. The host binding engine already supports `OpRegex` (RE2) — the only reason regex wasn't available was the Slack manifest pinning the field to `contains`. This is a **manifest-only** change; the host engine is untouched.

**Back-compatible:** the existing `text` (contains) field is unchanged. Approach (a) from the issue.

## What changed
- `plugins/slack/manifest.go` — `TextRegex manifest.RegexField` added to `SlackChannelMessageBinding`.
- `plugins/slack/manifest.yaml` — regenerated via `make manifest` (new `text_regex` property, `format: regex`).
- `plugins/slack/manifest_test.go` — `TestChannelMessageTextRegexBinding`: asserts the field is declared as `format: regex` and proves the AC (`^(?i)recipe:` matches `Recipe:`/`recipe:` prefixes, rejects mid-string `Recipe:` and no-keyword messages).
- `plugins/slack/README.md` — new "Trigger binding" subsection documenting the fields (full trigger docs are #605).

## Notes
- **Material manifest change** (alters `event_kinds[].binding_schema`, plugin-system-spec.md §5.4): on hot-reload it blocks pending admin re-approval; a fresh install / version bump is unaffected. No version bump made (not required; the canonical-YAML test doesn't pin it).
- **RE2, not PCRE** — no lookbehind/backreferences (documented in the field description + README).

<details>
<summary>Architecture plan</summary>

Add `text_regex` (manifest.RegexField → `{type:string, format:regex}`) to the Slack binding struct; the host engine's `OpRegex` path handles it with no change. Regenerate manifest.yaml; add a Slack-module test (can't import the root module's `internal/plugin/binding`, so it reflects the binding schema and reproduces regex matching with stdlib `regexp`). README note. Verified: regex semantics (`^` anchors to string start), no forced version bump, empty `text_regex` is a no-op via `omitempty`.
</details>

## Pipeline
- Plan review: APPROVE. Code review: APPROVE (cycle 1).
- CLAUDE.md: no updates needed (plugin-local change; documented in the plugin README).
- Part of a stacked series of Slack usability PRs; **#604 (channel_type) is stacked on this branch.**
- 🤖 Generated by the agentic dev loop.