### PR TITLE
docs: clarify Slack channel_message binding-field matcher semantics

### DIFF
--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -197,25 +197,25 @@ type SlackChannelMessageBinding struct {
 	// Channel is a substring matched against the Slack channel name or ID.
 	// ContainsField is used here rather than GlobField: the host binding evaluator
 	// rejects format:glob (binding.go:230), but accepts format:contains.
-	Channel manifest.ContainsField `json:"channel,omitempty" jsonschema:"title=Channel,description=Substring matched against the Slack channel name or ID (e.g. #incidents)"`
+	Channel manifest.ContainsField `json:"channel,omitempty" jsonschema:"title=Channel,description=Case-sensitive substring matched against the channel name or ID (e.g. incidents matches #incidents or C012…). Matches anywhere — not anchored."`
 	// Text is a substring matched against the message text.
-	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Substring matched against the message text"`
+	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Case-sensitive substring; matches anywhere in the message body (not anchored to the start)."`
 	// TextRegex matches the message text against a Go RE2 regular expression.
 	// Anchored, case-insensitive command routing is the primary use:
 	// `^(?i)recipe:` fires only on messages that start with "Recipe:"/"recipe:".
 	// RE2, not PCRE — no lookbehind/backrefs. Evaluated with implicit AND
 	// alongside Text; most policies set one or the other, not both.
-	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text (e.g. ^(?i)recipe: for anchored\\, case-insensitive routing). RE2 syntax — no lookbehind or backreferences."`
+	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences."`
 	// MentionOnly restricts the policy to events where the bot was mentioned.
-	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Only trigger when the bot is mentioned in the message"`
+	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Fire only when the bot is explicitly @-mentioned. Note: a DM is never a mention\\, so this excludes DMs."`
 	// User restricts the policy to messages from a specific Slack user ID.
-	User manifest.EqualsField `json:"user,omitempty" jsonschema:"title=User,description=Slack user ID to match (e.g. U012AB3CD). Leave empty to match all users."`
+	User manifest.EqualsField `json:"user,omitempty" jsonschema:"title=User,description=Exact match (case-sensitive) on the sender's Slack user ID (e.g. U012AB3CD). Leave empty to match all users."`
 	// ChannelType restricts the policy to a single Slack channel kind.
 	// EqualsField emits {type:string} with no format key, which the host binding
 	// evaluator maps to OpEquals (internal/plugin/binding/binding.go:238).
 	// The json key must be `channel_type` so the evaluator's payload[name]
 	// lookup aligns with SlackChannelMessagePayload.channel_type (line 241).
-	ChannelType manifest.EqualsField `json:"channel_type,omitempty" jsonschema:"title=Channel type,description=Match a Slack channel kind: channel (public)\\, group (private)\\, im (DM)\\, mpim (multi-party DM). Leave empty to match any."`
+	ChannelType manifest.EqualsField `json:"channel_type,omitempty" jsonschema:"title=Channel type,description=Exact match on the Slack channel kind: channel (public)\\, group (private)\\, im (DM)\\, mpim (multi-party DM). Leave empty to match any."`
 }
 
 // SlackChannelMessagePayload is the JSON payload emitted for each channel_message

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -68,30 +68,30 @@ event_kinds:
       additionalProperties: false
       properties:
         channel:
-          description: 'Substring matched against the Slack channel name or ID (e.g. #incidents)'
+          description: 'Case-sensitive substring matched against the channel name or ID (e.g. incidents matches #incidents or C012…). Matches anywhere — not anchored.'
           format: contains
           title: Channel
           type: string
         channel_type:
-          description: 'Match a Slack channel kind: channel (public), group (private), im (DM), mpim (multi-party DM). Leave empty to match any.'
+          description: 'Exact match on the Slack channel kind: channel (public), group (private), im (DM), mpim (multi-party DM). Leave empty to match any.'
           title: Channel type
           type: string
         mention_only:
-          description: Only trigger when the bot is mentioned in the message
+          description: 'Fire only when the bot is explicitly @-mentioned. Note: a DM is never a mention, so this excludes DMs.'
           title: Mention-only
           type: boolean
         text:
-          description: Substring matched against the message text
+          description: Case-sensitive substring; matches anywhere in the message body (not anchored to the start).
           format: contains
           title: Text contains
           type: string
         text_regex:
-          description: 'Go RE2 regular expression matched against the message text (e.g. ^(?i)recipe: for anchored, case-insensitive routing). RE2 syntax — no lookbehind or backreferences.'
+          description: Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences.
           format: regex
           title: Text matches (regex)
           type: string
         user:
-          description: Slack user ID to match (e.g. U012AB3CD). Leave empty to match all users.
+          description: Exact match (case-sensitive) on the sender's Slack user ID (e.g. U012AB3CD). Leave empty to match all users.
           title: User
           type: string
       type: object


### PR DESCRIPTION
Closes #606

> **Stacked PR** — base is `agent/604-slack-channel-type-binding` (#604 / PR #617). Merge #616 → #617 → this in order; GitHub retargets automatically as each merges.

## Summary

Tightens the `description=` text on all six `SlackChannelMessageBinding` fields so the policy-editor trigger form states the **real matcher semantics**. Previously "Substring matched against the message text" didn't tell an operator the match is case-sensitive and unanchored — exactly the surprises behind fragile keyword routing.

Updated descriptions (all verified accurate against the host binding engine):
- `channel` / `text` — case-sensitive substring, matches anywhere, not anchored
- `text_regex` — case-sensitivity via the pattern (`(?i)`), `^` anchors; RE2, no lookbehind
- `mention_only` — only when the bot is @-mentioned; **a DM is never a mention, so this excludes DMs**
- `user` / `channel_type` — exact (case-sensitive) match

**Description-only** — cosmetic per plugin-system-spec.md §5.4; no field, type, or matcher-behavior changes. `manifest.yaml` regenerated.

## Pipeline
- Scope-gate skip (well-specified, ≤2 files, localized) — no architect/plan-review.
- Code review: **APPROVE** (cycle 1) — descriptions verified factually accurate against the engine + translator.
- CLAUDE.md: no updates needed.
- 🤖 Generated by the agentic dev loop.