### PR TITLE
docs: document Slack message triggers, fan-out routing, and DM gotchas

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -54,7 +54,182 @@ following binding fields (all optional; fields are ANDed together):
 | `user`        | equals         | Exact Slack user ID (e.g. `U012AB3CD`) |
 
 `text` and `text_regex` are independent siblings: most policies set one or the
-other. Full trigger-binding documentation is tracked in #605.
+other. See [§"Triggering runs from Slack messages"](#triggering-runs-from-slack-messages)
+for worked examples and routing behaviour.
+
+## Triggering runs from Slack messages
+
+### How a policy binds
+
+A policy fires on `channel_message` events by declaring a `subscribed` trigger
+in its YAML. The policy form editor (Admin → Policies → New Policy) is the real
+authoring surface for this — per ADR-019/ADR-048 the word "subscribed" is never
+shown in the UI, and the form produces this YAML as the stored/API payload:
+
+```yaml
+name: recipe-finder
+trigger:
+  type: subscribed
+  source: slack-prod          # the plugin INSTANCE NAME (not a ULID)
+  event_kind: channel_message
+  binding:                    # optional; all fields ANDed; omit to match every message
+    text_regex: "^(?i)recipe:"
+capabilities:
+  tools:
+    - tool: slack-prod.post_message
+agent:
+  task: |
+    The trigger payload is a Slack channel_message. Treat everything after
+    "Recipe:" as a recipe request and reply in-thread with suggestions.
+```
+
+`source` must be the plugin **instance name** (e.g. `slack-prod`), not the
+plugin ID. Binding fields are ANDed — a message must satisfy every field that is
+set. For the full list of binding fields and their match semantics, see the table
+in [§"Trigger binding (`channel_message`)"](#trigger-binding-channel_message).
+
+### Routing is fan-out (no single winner)
+
+The Gleipnir dispatcher evaluates **every** active subscribed policy against the
+incoming event. Any policy whose `source`, `event_kind`, and `binding` all match
+fires its own independent run. There is no "route to exactly one policy", no
+default/else policy, and no arbitration across policies.
+
+Two policies with overlapping bindings will both fire. Design bindings with
+mutually exclusive anchored `text_regex` prefixes so messages reach exactly the
+policy you intend:
+
+- `"^(?i)recipe:"` — fires on `Recipe: find dinner`; does **not** fire on `"got a great Recipe: idea"` (not anchored)
+- `"^(?i)deploy:"` — a distinct non-overlapping prefix
+
+Note: this no-arbitration statement is cross-policy. A single policy's own
+concurrency setting (`concurrency: skip` / `queue` / `parallel`) still governs
+how many runs that policy starts for its own repeated matches.
+
+### DM gotchas
+
+DMing the bot directly works — but is silently broken by several common
+configurations. Check all of the following when a DM produces no run:
+
+**Instance-level subscription scope (`channels` field)**
+
+The instance subscription scope (Admin → Plugins → your Slack instance →
+Subscription Scope) has a `channels` allow-list. When it is non-empty, only
+channels whose IDs appear in the list are processed. DM channel IDs start with
+`D…`, but the schema only accepts IDs matching `^C[A-Z0-9]+$`. This means a
+non-empty `channels` scope silently excludes all DMs regardless of policy
+bindings. **Leave `channels` empty for a DM bot** (empty = match all channels).
+
+Distinguish this instance-level scope — a coarse pre-filter that happens before
+any policy is evaluated — from per-policy binding fields, which are evaluated
+after the scope admits the event.
+
+**`mention_only` in binding or scope**
+
+Setting `mention_only: true` in a policy binding (or in the instance subscription
+scope) excludes DMs. A DM message is never a "mention" — `@Gleipnir` has no
+meaning inside a DM conversation. This flag only fires on `app_mention` events in
+public/private channels. Ensure both the instance scope **and** the policy binding
+have `mention_only` off (or omitted) for DM routing.
+
+**Slack-side prerequisites**
+
+These are external Slack settings, not Gleipnir config:
+
+1. **`message.im` bot event** — the Slack app must subscribe to the `message.im`
+   event so Slack delivers DMs to the bot at all. The one-click app manifest in
+   [§"Slack app manifest (one-click)"](#slack-app-manifest-one-click) already
+   includes this event.
+
+2. **App Home → Messages Tab → "Allow users to send Slash commands and messages"**
+   — this toggle must be enabled in your Slack app's settings (api.slack.com/apps
+   → your app → App Home → Show Tabs → Messages Tab). Without it, users cannot
+   send DMs to the bot even if `message.im` is subscribed. This is a Slack product
+   setting with no equivalent in Gleipnir's configuration.
+
+### Worked examples
+
+#### Example 1 — Keyword routing via anchored regex
+
+Fires when a message starts with `Recipe:` (case-insensitive).
+
+```yaml
+name: recipe-finder
+trigger:
+  type: subscribed
+  source: slack-prod          # your Slack plugin instance name
+  event_kind: channel_message
+  binding:
+    text_regex: "^(?i)recipe:"   # fires on "Recipe: ..."/"recipe: ..."; NOT "got a great Recipe: idea"
+capabilities:
+  tools:
+    - tool: slack-prod.post_message
+agent:
+  task: |
+    The trigger payload is a Slack channel_message. Treat everything after
+    "Recipe:" as a recipe request and reply in-thread with suggestions.
+```
+
+Matching Slack message: `Recipe: something with chickpeas`
+
+Because routing is fan-out, give any sibling policy a non-overlapping anchored
+prefix so messages reach exactly one policy.
+
+#### Example 2 — DM-only bot
+
+Fires on any direct message to the bot. `mention_only` is off (omitted).
+
+```yaml
+name: slack-dm-assistant
+trigger:
+  type: subscribed
+  source: slack-prod
+  event_kind: channel_message
+  binding:
+    channel_type: im        # DM-only; mention_only omitted (off)
+capabilities:
+  tools:
+    - tool: slack-prod.post_message
+agent:
+  task: |
+    The trigger payload is a direct message to the bot. Help the user and
+    reply in the same DM.
+```
+
+Matching Slack message: any DM, e.g. `what's on my calendar today?`
+
+Prerequisites:
+- Instance subscription scope `channels` **must be empty** (non-empty scope
+  blocks DMs — see §"DM gotchas").
+- `mention_only` must be off in both the instance scope and this binding.
+- Slack app must subscribe to `message.im` (already in the one-click manifest)
+  and the **App Home → Messages Tab → "Allow users to send Slash commands and
+  messages"** toggle must be enabled in your Slack app settings (external Slack
+  setting).
+
+#### Example 3 — Mention-in-channel
+
+Fires only when the bot is @-mentioned in a public or private channel. DMs are
+excluded by construction — a DM is never a mention.
+
+```yaml
+name: oncall-mention-handler
+trigger:
+  type: subscribed
+  source: slack-prod
+  event_kind: channel_message
+  binding:
+    mention_only: true      # only when bot is @-mentioned (channel events only — never DMs)
+capabilities:
+  tools:
+    - tool: slack-prod.post_message
+agent:
+  task: |
+    The trigger payload is a channel message that @-mentioned the bot.
+    Answer the mention in-thread.
+```
+
+Matching Slack message (public channel): `@Gleipnir summarize the last deploy?`
 
 ## Channel (per-audience) config schema
 

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -197,25 +197,25 @@ type SlackChannelMessageBinding struct {
 	// Channel is a substring matched against the Slack channel name or ID.
 	// ContainsField is used here rather than GlobField: the host binding evaluator
 	// rejects format:glob (binding.go:230), but accepts format:contains.
-	Channel manifest.ContainsField `json:"channel,omitempty" jsonschema:"title=Channel,description=Substring matched against the Slack channel name or ID (e.g. #incidents)"`
+	Channel manifest.ContainsField `json:"channel,omitempty" jsonschema:"title=Channel,description=Case-sensitive substring matched against the channel name or ID (e.g. incidents matches #incidents or C012…). Matches anywhere — not anchored."`
 	// Text is a substring matched against the message text.
-	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Substring matched against the message text"`
+	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Case-sensitive substring; matches anywhere in the message body (not anchored to the start)."`
 	// TextRegex matches the message text against a Go RE2 regular expression.
 	// Anchored, case-insensitive command routing is the primary use:
 	// `^(?i)recipe:` fires only on messages that start with "Recipe:"/"recipe:".
 	// RE2, not PCRE — no lookbehind/backrefs. Evaluated with implicit AND
 	// alongside Text; most policies set one or the other, not both.
-	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text (e.g. ^(?i)recipe: for anchored\\, case-insensitive routing). RE2 syntax — no lookbehind or backreferences."`
+	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences."`
 	// MentionOnly restricts the policy to events where the bot was mentioned.
-	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Only trigger when the bot is mentioned in the message"`
+	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Fire only when the bot is explicitly @-mentioned. Note: a DM is never a mention\\, so this excludes DMs."`
 	// User restricts the policy to messages from a specific Slack user ID.
-	User manifest.EqualsField `json:"user,omitempty" jsonschema:"title=User,description=Slack user ID to match (e.g. U012AB3CD). Leave empty to match all users."`
+	User manifest.EqualsField `json:"user,omitempty" jsonschema:"title=User,description=Exact match (case-sensitive) on the sender's Slack user ID (e.g. U012AB3CD). Leave empty to match all users."`
 	// ChannelType restricts the policy to a single Slack channel kind.
 	// EqualsField emits {type:string} with no format key, which the host binding
 	// evaluator maps to OpEquals (internal/plugin/binding/binding.go:238).
 	// The json key must be `channel_type` so the evaluator's payload[name]
 	// lookup aligns with SlackChannelMessagePayload.channel_type (line 241).
-	ChannelType manifest.EqualsField `json:"channel_type,omitempty" jsonschema:"title=Channel type,description=Match a Slack channel kind: channel (public)\\, group (private)\\, im (DM)\\, mpim (multi-party DM). Leave empty to match any."`
+	ChannelType manifest.EqualsField `json:"channel_type,omitempty" jsonschema:"title=Channel type,description=Exact match on the Slack channel kind: channel (public)\\, group (private)\\, im (DM)\\, mpim (multi-party DM). Leave empty to match any."`
 }
 
 // SlackChannelMessagePayload is the JSON payload emitted for each channel_message

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -68,30 +68,30 @@ event_kinds:
       additionalProperties: false
       properties:
         channel:
-          description: 'Substring matched against the Slack channel name or ID (e.g. #incidents)'
+          description: 'Case-sensitive substring matched against the channel name or ID (e.g. incidents matches #incidents or C012…). Matches anywhere — not anchored.'
           format: contains
           title: Channel
           type: string
         channel_type:
-          description: 'Match a Slack channel kind: channel (public), group (private), im (DM), mpim (multi-party DM). Leave empty to match any.'
+          description: 'Exact match on the Slack channel kind: channel (public), group (private), im (DM), mpim (multi-party DM). Leave empty to match any.'
           title: Channel type
           type: string
         mention_only:
-          description: Only trigger when the bot is mentioned in the message
+          description: 'Fire only when the bot is explicitly @-mentioned. Note: a DM is never a mention, so this excludes DMs.'
           title: Mention-only
           type: boolean
         text:
-          description: Substring matched against the message text
+          description: Case-sensitive substring; matches anywhere in the message body (not anchored to the start).
           format: contains
           title: Text contains
           type: string
         text_regex:
-          description: 'Go RE2 regular expression matched against the message text (e.g. ^(?i)recipe: for anchored, case-insensitive routing). RE2 syntax — no lookbehind or backreferences.'
+          description: Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences.
           format: regex
           title: Text matches (regex)
           type: string
         user:
-          description: Slack user ID to match (e.g. U012AB3CD). Leave empty to match all users.
+          description: Exact match (case-sensitive) on the sender's Slack user ID (e.g. U012AB3CD). Leave empty to match all users.
           title: User
           type: string
       type: object


### PR DESCRIPTION
Closes #605

> **Stacked PR** — base is `agent/606-slack-binding-descriptions` (#606 / PR #618). Merge order: #616 → #617 → #618 → this. GitHub retargets automatically as each merges.

## Summary

Adds a **"Triggering runs from Slack messages"** section to the Slack plugin README. The trigger side was nearly undocumented — an operator wanting "message the bot to kick off an agent" had no worked example and would hit several silent-no-fire traps. New subsections:

- **How a policy binds** — the subscribed-trigger policy payload shape (`type: subscribed` / `source: <instance_name>` / `event_kind: channel_message` / flat `binding`), framed as the stored/form-produced payload (per ADR-019/048 the form editor is the authoring surface; "subscribed" isn't shown in the UI).
- **Routing is fan-out** — every active subscribed policy whose binding matches fires its own run; no single-winner, no default/else. Design mutually-exclusive bindings. (Cross-policy; a single policy's own concurrency still governs its repeat fires.)
- **DM gotchas** — `mention_only` and a non-empty `channels` scope both silently exclude DMs; `message.im` + the App Home Messages Tab toggle are external Slack prerequisites.
- **Three worked examples** — keyword routing (`text_regex: "^(?i)recipe:"`), DM-only bot (`channel_type: im`), mention-in-channel (`mention_only: true`).

Builds on the binding-field table and `text_regex`/`channel_type` fields from #603/#604/#606. Docs-only.

<details>
<summary>Architecture / fact-finding</summary>

The plan was a verified fact-sheet: the policy YAML shape was confirmed against `internal/policy/parser.go` + a real `parser_test.go` fixture; `source` = instance name was confirmed at `dispatcher.go:280`; fan-out confirmed in the `dispatcher.go` dispatch loop (no break/arbitration); DM gotchas confirmed against `translator.go`/`scope.go`/`binding.go`. Plan review: APPROVE, zero issues.
</details>

## Pipeline
- Plan review: **APPROVE**. Code review: **CHANGES_REQUESTED** → fixed (a truncated Slack "Messages Tab" toggle label was made consistent) → resolved. 1 effective cycle.
- CLAUDE.md: no updates needed.
- 🤖 Generated by the agentic dev loop.