### PR TITLE
feat: Slack plugin — slash commands & message shortcuts as trigger states

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -9,9 +9,12 @@ reference).
 ## What this plugin declares
 
 - **ToolService v1** — `post_message`, `list_channels`, `react`, `set_topic` (implemented by #233)
-- **TriggerService v1** — two event kinds via Slack Socket Mode (#234, #621):
+- **TriggerService v1** — five event kinds via Slack Socket Mode (#234, #621, #623):
   - `channel_message` — any human message in a watched channel; `mention_only: true` binding selects mentions. Note: subscription-scope channel filtering matches by **channel ID** only (e.g. `C012ABCDEF`); name-based filtering (e.g. `#incidents`) silently does not match because Socket Mode events carry only IDs. Resolving names is future work.
   - `direct_message` — a 1:1 DM sent directly to the bot. Enable via `direct_messages: true` in the instance subscription scope.
+  - `slash_command` — a workspace slash command (e.g. `/gleipnir deploy staging`). Enable via `slash_commands: true` in the instance subscription scope.
+  - `message_shortcut` — a message shortcut invoked on a specific message (carries message text, ts, channel). Enable via `shortcuts: true` in the instance subscription scope.
+  - `global_shortcut` — a global shortcut invoked from anywhere (no message context). Enable via `shortcuts: true` in the instance subscription scope.
 - **ChannelService v1** — `Notify` and `Request` via Slack DMs and posts (#235)
 - **Auth strategy** — `oauth2_authcode` with Slack's authorization and token endpoints
 
@@ -40,6 +43,30 @@ slack/
   .gitignore         — excludes the compiled binary and signing artifacts
   go.mod             — per-plugin module; resolved by the repo-root go.work
 ```
+
+## Subscription scope and the host trigger stream
+
+The Gleipnir host only opens the `TriggerService.Start` stream when the instance
+`subscription_scope_json` is non-empty (i.e. not `""` or `"{}"`). A fresh
+instance defaults to `"{}"`, so the stream never opens unless the operator
+configures a non-empty scope.
+
+For `channel_message` and `direct_message` this is natural — the `channels`
+list or `direct_messages: true` flag makes the JSON non-empty. For slash
+commands and shortcuts (which are not channel-scoped), use the explicit flags:
+
+| Scope flag          | When to set |
+|---------------------|-------------|
+| `slash_commands: true` | Instance is used **only** for slash commands and has no channel watch |
+| `shortcuts: true`   | Instance is used **only** for shortcuts and has no channel watch |
+
+An instance already watching channels (or with `direct_messages: true`) also
+receives slash and shortcut events without setting these flags — the host gate
+only checks that the JSON is non-empty.
+
+These flags are stream-open enablers only. Plugin-side delivery of slash/shortcut
+events bypasses the channel scope filter (`scope.matches`) — slash commands and
+shortcuts are explicit user intent from any surface.
 
 ## Trigger binding (`channel_message`)
 
@@ -71,6 +98,90 @@ Policies that use the `direct_message` trigger can filter events using:
 
 `channel`, `channel_type`, and `mention_only` are absent: they have no meaning
 in a 1:1 DM conversation.
+
+## Trigger binding (`slash_command`)
+
+Policies that use the `slash_command` trigger can filter events using:
+
+| Field        | Match       | Notes |
+|--------------|-------------|-------|
+| `command`    | equals      | Exact slash command name, e.g. `/gleipnir`. Leave empty to match any command. |
+| `text`       | contains    | Substring anywhere in the command arguments |
+| `text_regex` | regex (RE2) | Go RE2 expression matched against the command arguments |
+
+Example — route `/gleipnir deploy …` to a deployment policy:
+
+```yaml
+name: slack-deploy-command
+trigger:
+  type: subscribed
+  source: slack-prod        # your Slack plugin instance name
+  event_kind: slash_command
+  binding:
+    command: "/gleipnir"
+    text_regex: "^deploy "
+capabilities:
+  tools:
+    - tool: slack-prod.post_message
+agent:
+  task: |
+    The trigger payload is a slash command. The "text" field contains the
+    arguments after /gleipnir. Execute the requested deployment and reply
+    using post_message (response_url is in the payload for direct replies).
+```
+
+**Slack app config:** register the slash command in your Slack app settings
+(api.slack.com → your app → Slash Commands → Create New Command). Set the
+command name (e.g. `/gleipnir`); the Request URL can be left blank when Socket
+Mode is enabled — Slack delivers slash commands over the existing Socket Mode
+connection. No extra OAuth scopes are required.
+
+**Ack semantics:** the hub acks within Slack's ~3s window immediately before
+dispatching. The agent run executes asynchronously; use `post_message` or the
+`response_url` from the payload to post results back to the channel.
+
+## Trigger binding (`message_shortcut`)
+
+Policies that use the `message_shortcut` trigger can filter events using:
+
+| Field         | Match  | Notes |
+|---------------|--------|-------|
+| `callback_id` | equals | Shortcut callback_id as registered in Slack (e.g. `run_agent_on_message`). Leave empty to match any shortcut. |
+
+Example — route a "Run agent on this message" shortcut to a summarizer policy:
+
+```yaml
+name: slack-message-shortcut
+trigger:
+  type: subscribed
+  source: slack-prod
+  event_kind: message_shortcut
+  binding:
+    callback_id: "run_agent_on_message"
+capabilities:
+  tools:
+    - tool: slack-prod.post_message
+agent:
+  task: |
+    The trigger payload is a message shortcut. The "text" field contains the
+    target message text; "ts" and "channel_id" identify it. Summarize the
+    message and reply via post_message.
+```
+
+## Trigger binding (`global_shortcut`)
+
+Policies that use the `global_shortcut` trigger can filter events using:
+
+| Field         | Match  | Notes |
+|---------------|--------|-------|
+| `callback_id` | equals | Shortcut callback_id as registered in Slack. Leave empty to match any global shortcut. |
+
+**Slack app config (shortcuts):** register shortcuts in your Slack app settings
+(api.slack.com → your app → Interactivity & Shortcuts → Create New Shortcut).
+For message shortcuts, choose "On messages"; for global shortcuts, choose "Global".
+Set a unique callback_id (e.g. `run_agent_on_message`). Interactivity must be
+enabled. Both shortcut types are delivered over the existing Socket Mode
+connection — no Request URL is needed. No extra OAuth scopes are required.
 
 **Prerequisites** for `direct_message` events to arrive:
 
@@ -347,6 +458,12 @@ settings:
   socket_mode_enabled: true
   token_rotation_enabled: false
 ```
+
+After creating the app from this manifest, register slash commands and shortcuts
+separately in the Slack app settings (they cannot be declared in the app manifest
+YAML in the same step):
+- **Slash Commands** → Create New Command: set the command name (e.g. `/gleipnir`). The Request URL is not required for Socket Mode apps.
+- **Interactivity & Shortcuts** → Create New Shortcut: add a message shortcut and/or global shortcut with the callback_id values used in your policy bindings.
 
 ### App-level token (xapp-)
 

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -193,6 +193,21 @@ type SlackSubscriptionScope struct {
 	// flag is the only way to route DM events. When true, direct_message events
 	// are emitted regardless of the Channels and MentionOnly settings.
 	DirectMessages bool `json:"direct_messages,omitempty" jsonschema:"title=Direct messages,description=Watch 1:1 DMs to the bot. Channel IDs are not required (DM channel IDs are D…)."`
+
+	// SlashCommands and Shortcuts exist SOLELY to make the scope JSON non-empty
+	// so the host trigger supervisor's isEmptyScope gate passes and the
+	// TriggerService.Start stream opens. The host supervisor treats "{}" as "not
+	// configured" and never opens the stream; these flags let an instance used
+	// ONLY for slash commands or shortcuts produce a non-empty scope JSON without
+	// requiring a channel entry.
+	//
+	// They do NOT gate plugin-side delivery. The slash/shortcut handlers in
+	// service.go intentionally bypass scope.matches — slash commands and shortcuts
+	// are explicit user intent from any surface. Any other non-empty scope (e.g.
+	// a single channel in Channels, or DirectMessages=true) also satisfies the
+	// host gate without setting these flags.
+	SlashCommands bool `json:"slash_commands,omitempty" jsonschema:"title=Slash commands,description=Open the trigger stream so /slash-command invocations are delivered. Required for slash_command policies on instances that watch no channels. Slash commands are never channel-scoped."`
+	Shortcuts     bool `json:"shortcuts,omitempty" jsonschema:"title=Shortcuts,description=Open the trigger stream so message and global shortcut invocations are delivered. Required for message_shortcut / global_shortcut policies on instances that watch no channels."`
 }
 
 // SlackChannelMessageBinding is the per-policy binding struct for the
@@ -233,6 +248,89 @@ type SlackDirectMessageBinding struct {
 	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences."`
 	// User restricts the policy to DMs from a specific Slack user ID.
 	User manifest.EqualsField `json:"user,omitempty" jsonschema:"title=User,description=Exact match (case-sensitive) on the sender's Slack user ID (e.g. U012AB3CD). Leave empty to match all users."`
+}
+
+// SlackSlashCommandBinding is the per-policy binding struct for the slash_command
+// event kind. The json key MUST match the corresponding payload json key so the
+// host evaluator's payload[name] lookup aligns.
+type SlackSlashCommandBinding struct {
+	// Command matches the slash command name exactly, e.g. "/gleipnir".
+	// EqualsField → {type:string} no format → OpEquals (binding.go compileField).
+	Command manifest.EqualsField `json:"command,omitempty" jsonschema:"title=Command,description=Exact match on the slash command name (e.g. /gleipnir). Leave empty to match any command."`
+	// Text is a substring matched against the command arguments.
+	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Case-sensitive substring matched anywhere in the command arguments."`
+	// TextRegex matches the command arguments against a Go RE2 regular expression.
+	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the command arguments. Use ^ to anchor to the start; (?i) for case-insensitive matching."`
+}
+
+// SlackMessageShortcutBinding is the per-policy binding struct for the
+// message_shortcut event kind.
+type SlackMessageShortcutBinding struct {
+	// CallbackID matches the shortcut callback_id exactly.
+	// EqualsField → {type:string} no format → OpEquals.
+	CallbackID manifest.EqualsField `json:"callback_id,omitempty" jsonschema:"title=Callback ID,description=Exact match on the message shortcut callback_id registered in Slack (e.g. run_agent_on_message). Leave empty to match any shortcut."`
+}
+
+// SlackGlobalShortcutBinding is the per-policy binding struct for the
+// global_shortcut event kind.
+type SlackGlobalShortcutBinding struct {
+	// CallbackID matches the global shortcut callback_id exactly.
+	CallbackID manifest.EqualsField `json:"callback_id,omitempty" jsonschema:"title=Callback ID,description=Exact match on the global shortcut callback_id registered in Slack (e.g. start_agent). Leave empty to match any shortcut."`
+}
+
+// SlackSlashCommandPayload is the JSON payload emitted for each slash_command event.
+// yaml tags mirror json tags so manifest examples use underscore-separated keys.
+type SlackSlashCommandPayload struct {
+	// Command is the slash command name, e.g. "/gleipnir".
+	Command string `json:"command" yaml:"command" jsonschema:"title=Command,description=Slash command name (e.g. /gleipnir)"`
+	// Text contains the arguments provided after the command.
+	Text string `json:"text" yaml:"text" jsonschema:"title=Text,description=Arguments provided after the slash command"`
+	// User is the Slack user ID of the invoking user.
+	User string `json:"user,omitempty" yaml:"user,omitempty" jsonschema:"title=User,description=Slack user ID of the invoking user (e.g. U012AB3CD)"`
+	// ChannelID is the Slack channel ID where the command was typed.
+	ChannelID string `json:"channel_id,omitempty" yaml:"channel_id,omitempty" jsonschema:"title=Channel ID,description=Slack channel ID where the command was typed"`
+	// ChannelName is the channel name where the command was typed.
+	ChannelName string `json:"channel_name,omitempty" yaml:"channel_name,omitempty" jsonschema:"title=Channel name,description=Channel name where the command was typed"`
+	// TriggerID is the trigger_id that can be used to open a modal (#624).
+	TriggerID string `json:"trigger_id,omitempty" yaml:"trigger_id,omitempty" jsonschema:"title=Trigger ID,description=Trigger ID for opening a modal (valid for ~3 seconds)"`
+	// ResponseURL can be used to post a reply after the immediate ack (#624).
+	ResponseURL string `json:"response_url,omitempty" yaml:"response_url,omitempty" jsonschema:"title=Response URL,description=Webhook URL for posting a delayed response (valid for 30 minutes)"`
+	// TeamID is the Slack workspace ID.
+	TeamID string `json:"team_id,omitempty" yaml:"team_id,omitempty" jsonschema:"title=Team ID,description=Slack workspace ID"`
+}
+
+// SlackMessageShortcutPayload is the JSON payload emitted for each message_shortcut event.
+// It carries the target message context and the invoking user.
+// yaml tags mirror json tags so manifest examples use underscore-separated keys.
+type SlackMessageShortcutPayload struct {
+	// Text is the target message text.
+	Text string `json:"text,omitempty" yaml:"text,omitempty" jsonschema:"title=Text,description=Target message text"`
+	// Ts is the target message Slack timestamp.
+	Ts string `json:"ts,omitempty" yaml:"ts,omitempty" jsonschema:"title=Timestamp,description=Target message Slack timestamp (uniquely identifies the message within a channel)"`
+	// ChannelID is the Slack channel ID containing the target message.
+	ChannelID string `json:"channel_id,omitempty" yaml:"channel_id,omitempty" jsonschema:"title=Channel ID,description=Slack channel ID containing the target message"`
+	// User is the Slack user ID of the invoking user.
+	User string `json:"user,omitempty" yaml:"user,omitempty" jsonschema:"title=User,description=Slack user ID of the user who invoked the shortcut"`
+	// TriggerID is the trigger_id for modal opening (#624).
+	TriggerID string `json:"trigger_id,omitempty" yaml:"trigger_id,omitempty" jsonschema:"title=Trigger ID,description=Trigger ID for opening a modal (valid for ~3 seconds)"`
+	// CallbackID is the shortcut callback_id registered in Slack.
+	CallbackID string `json:"callback_id,omitempty" yaml:"callback_id,omitempty" jsonschema:"title=Callback ID,description=Shortcut callback_id as registered in Slack app settings"`
+	// TeamID is the Slack workspace ID.
+	TeamID string `json:"team_id,omitempty" yaml:"team_id,omitempty" jsonschema:"title=Team ID,description=Slack workspace ID"`
+}
+
+// SlackGlobalShortcutPayload is the JSON payload emitted for each global_shortcut event.
+// Global shortcuts have no message or channel context.
+// yaml tags mirror json tags so manifest examples use underscore-separated keys.
+type SlackGlobalShortcutPayload struct {
+	// User is the Slack user ID of the invoking user.
+	User string `json:"user,omitempty" yaml:"user,omitempty" jsonschema:"title=User,description=Slack user ID of the user who invoked the shortcut"`
+	// TriggerID is the trigger_id for modal opening (#624).
+	TriggerID string `json:"trigger_id,omitempty" yaml:"trigger_id,omitempty" jsonschema:"title=Trigger ID,description=Trigger ID for opening a modal (valid for ~3 seconds)"`
+	// CallbackID is the shortcut callback_id registered in Slack.
+	CallbackID string `json:"callback_id,omitempty" yaml:"callback_id,omitempty" jsonschema:"title=Callback ID,description=Shortcut callback_id as registered in Slack app settings"`
+	// TeamID is the Slack workspace ID.
+	TeamID string `json:"team_id,omitempty" yaml:"team_id,omitempty" jsonschema:"title=Team ID,description=Slack workspace ID"`
 }
 
 // SlackChannelMessagePayload is the JSON payload emitted for each channel_message
@@ -379,6 +477,71 @@ func init() {
 				TeamID:      "T03TEAM001",
 				ChannelType: "im",
 				Mentioned:   false,
+			},
+		},
+	)
+
+	// slash_command is emitted when a Slack slash command is invoked. Requires
+	// Socket Mode delivery (no Request URL needed). Ack is handled at the hub
+	// within Slack's ~3s window; results post back via post_message or response_url.
+	// New event kinds are appended after direct_message for stable canonical YAML.
+	pluginManifest.MustAddEventKindWithExamples(
+		"slash_command",
+		"A workspace slash command was invoked",
+		SlackSlashCommandBinding{},
+		manifest.MustReflectSchema(SlackSlashCommandPayload{}),
+		manifest.Example{
+			Name: "Deploy slash command",
+			Payload: SlackSlashCommandPayload{
+				Command:     "/gleipnir",
+				Text:        "deploy staging",
+				User:        "U01USER001",
+				ChannelID:   "C012ABCDEF",
+				ChannelName: "#ops",
+				TriggerID:   "trig-1.abc",
+				ResponseURL: "https://hooks.slack.com/commands/T03TEAM001/...",
+				TeamID:      "T03TEAM001",
+			},
+		},
+	)
+
+	// message_shortcut is emitted when a Slack message shortcut is invoked on a
+	// specific message. The payload carries the target message context (text, ts,
+	// channel_id) plus the invoking user and trigger_id for modal follow-up (#624).
+	pluginManifest.MustAddEventKindWithExamples(
+		"message_shortcut",
+		"A message shortcut was invoked on a message",
+		SlackMessageShortcutBinding{},
+		manifest.MustReflectSchema(SlackMessageShortcutPayload{}),
+		manifest.Example{
+			Name: "Run agent on incident message",
+			Payload: SlackMessageShortcutPayload{
+				Text:       "the database is degraded",
+				Ts:         "1700001000.000200",
+				ChannelID:  "C09INCIDENT",
+				User:       "U01USER002",
+				TriggerID:  "trig-2.def",
+				CallbackID: "run_agent_on_message",
+				TeamID:     "T03TEAM001",
+			},
+		},
+	)
+
+	// global_shortcut is emitted when a Slack global shortcut is invoked from
+	// anywhere (no message or channel context). Useful for "start a new agent run"
+	// actions accessible from any Slack surface.
+	pluginManifest.MustAddEventKindWithExamples(
+		"global_shortcut",
+		"A global shortcut was invoked",
+		SlackGlobalShortcutBinding{},
+		manifest.MustReflectSchema(SlackGlobalShortcutPayload{}),
+		manifest.Example{
+			Name: "Start agent global shortcut",
+			Payload: SlackGlobalShortcutPayload{
+				User:       "U01USER003",
+				TriggerID:  "trig-3.ghi",
+				CallbackID: "start_agent",
+				TeamID:     "T03TEAM001",
 			},
 		},
 	)

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -279,6 +279,165 @@ event_kinds:
         - channel_type
         - mentioned
       type: object
+  - binding_schema:
+      additionalProperties: false
+      properties:
+        command:
+          description: Exact match on the slash command name (e.g. /gleipnir). Leave empty to match any command.
+          title: Command
+          type: string
+        text:
+          description: Case-sensitive substring matched anywhere in the command arguments.
+          format: contains
+          title: Text contains
+          type: string
+        text_regex:
+          description: Go RE2 regular expression matched against the command arguments. Use ^ to anchor to the start; (?i) for case-insensitive matching.
+          format: regex
+          title: Text matches (regex)
+          type: string
+      type: object
+    description: A workspace slash command was invoked
+    examples:
+      - name: Deploy slash command
+        payload:
+          channel_id: C012ABCDEF
+          channel_name: '#ops'
+          command: /gleipnir
+          response_url: https://hooks.slack.com/commands/T03TEAM001/...
+          team_id: T03TEAM001
+          text: deploy staging
+          trigger_id: trig-1.abc
+          user: U01USER001
+    kind: slash_command
+    payload_schema:
+      additionalProperties: false
+      properties:
+        channel_id:
+          description: Slack channel ID where the command was typed
+          title: Channel ID
+          type: string
+        channel_name:
+          description: Channel name where the command was typed
+          title: Channel name
+          type: string
+        command:
+          description: Slash command name (e.g. /gleipnir)
+          title: Command
+          type: string
+        response_url:
+          description: Webhook URL for posting a delayed response (valid for 30 minutes)
+          title: Response URL
+          type: string
+        team_id:
+          description: Slack workspace ID
+          title: Team ID
+          type: string
+        text:
+          description: Arguments provided after the slash command
+          title: Text
+          type: string
+        trigger_id:
+          description: Trigger ID for opening a modal (valid for ~3 seconds)
+          title: Trigger ID
+          type: string
+        user:
+          description: Slack user ID of the invoking user (e.g. U012AB3CD)
+          title: User
+          type: string
+      required:
+        - command
+        - text
+      type: object
+  - binding_schema:
+      additionalProperties: false
+      properties:
+        callback_id:
+          description: Exact match on the message shortcut callback_id registered in Slack (e.g. run_agent_on_message). Leave empty to match any shortcut.
+          title: Callback ID
+          type: string
+      type: object
+    description: A message shortcut was invoked on a message
+    examples:
+      - name: Run agent on incident message
+        payload:
+          callback_id: run_agent_on_message
+          channel_id: C09INCIDENT
+          team_id: T03TEAM001
+          text: the database is degraded
+          trigger_id: trig-2.def
+          ts: "1700001000.000200"
+          user: U01USER002
+    kind: message_shortcut
+    payload_schema:
+      additionalProperties: false
+      properties:
+        callback_id:
+          description: Shortcut callback_id as registered in Slack app settings
+          title: Callback ID
+          type: string
+        channel_id:
+          description: Slack channel ID containing the target message
+          title: Channel ID
+          type: string
+        team_id:
+          description: Slack workspace ID
+          title: Team ID
+          type: string
+        text:
+          description: Target message text
+          title: Text
+          type: string
+        trigger_id:
+          description: Trigger ID for opening a modal (valid for ~3 seconds)
+          title: Trigger ID
+          type: string
+        ts:
+          description: Target message Slack timestamp (uniquely identifies the message within a channel)
+          title: Timestamp
+          type: string
+        user:
+          description: Slack user ID of the user who invoked the shortcut
+          title: User
+          type: string
+      type: object
+  - binding_schema:
+      additionalProperties: false
+      properties:
+        callback_id:
+          description: Exact match on the global shortcut callback_id registered in Slack (e.g. start_agent). Leave empty to match any shortcut.
+          title: Callback ID
+          type: string
+      type: object
+    description: A global shortcut was invoked
+    examples:
+      - name: Start agent global shortcut
+        payload:
+          callback_id: start_agent
+          team_id: T03TEAM001
+          trigger_id: trig-3.ghi
+          user: U01USER003
+    kind: global_shortcut
+    payload_schema:
+      additionalProperties: false
+      properties:
+        callback_id:
+          description: Shortcut callback_id as registered in Slack app settings
+          title: Callback ID
+          type: string
+        team_id:
+          description: Slack workspace ID
+          title: Team ID
+          type: string
+        trigger_id:
+          description: Trigger ID for opening a modal (valid for ~3 seconds)
+          title: Trigger ID
+          type: string
+        user:
+          description: Slack user ID of the user who invoked the shortcut
+          title: User
+          type: string
+      type: object
 name: slack
 schema_version: v1
 services:
@@ -302,6 +461,14 @@ subscription_schema:
     mention_only:
       description: Only emit when bot is mentioned.
       title: Mention-only
+      type: boolean
+    shortcuts:
+      description: Open the trigger stream so message and global shortcut invocations are delivered. Required for message_shortcut / global_shortcut policies on instances that watch no channels.
+      title: Shortcuts
+      type: boolean
+    slash_commands:
+      description: Open the trigger stream so /slash-command invocations are delivered. Required for slash_command policies on instances that watch no channels. Slash commands are never channel-scoped.
+      title: Slash commands
       type: boolean
   type: object
 tools:

--- a/plugins/slack/scope_test.go
+++ b/plugins/slack/scope_test.go
@@ -69,6 +69,41 @@ func TestDecodeSubscriptionScope(t *testing.T) {
 			},
 		},
 		{
+			name:  "slash_commands decoded correctly",
+			input: `{"slash_commands":true}`,
+			check: func(t *testing.T, s SlackSubscriptionScope) {
+				t.Helper()
+				if !s.SlashCommands {
+					t.Error("slash_commands: want true")
+				}
+			},
+		},
+		{
+			name:  "shortcuts decoded correctly",
+			input: `{"shortcuts":true}`,
+			check: func(t *testing.T, s SlackSubscriptionScope) {
+				t.Helper()
+				if !s.Shortcuts {
+					t.Error("shortcuts: want true")
+				}
+			},
+		},
+		{
+			// The slash_commands and shortcuts flags are stream-open enablers only
+			// and must not affect channel/DM delivery filtering. A scope with only
+			// these flags set should match all non-DM events (empty Channels +
+			// MentionOnly=false → matches everything) — the flags are not consulted
+			// in matches().
+			name:  "slash_commands=true does not affect matches() for channel events",
+			input: `{"slash_commands":true}`,
+			check: func(t *testing.T, s SlackSubscriptionScope) {
+				t.Helper()
+				if !s.matches("C01ANY", false, false) {
+					t.Error("matches: slash_commands=true scope should match all channel events (flags are stream-open only)")
+				}
+			},
+		},
+		{
 			name:    "malformed JSON returns error",
 			input:   `{not-valid`,
 			wantErr: true,

--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -495,6 +495,8 @@ func (s *TriggerService) Start(req *triggerv1.StartRequest, stream grpc.ServerSt
 	}
 
 	hub.RegisterEventsHandler(onEvent)
+	hub.RegisterSlashCommandHandler(s.onSlashCommand(hostCtx))
+	hub.RegisterTriggerInteractiveHandler(s.onShortcut(hostCtx))
 
 	// Block until the stream context is cancelled by the host (clean shutdown)
 	// or the hub's Run goroutine exits (auth failure, connection error).
@@ -553,6 +555,52 @@ func (s *TriggerService) handleNonEventsAPI(ctx context.Context, evt socketmode.
 		// will surface its own error which the post-Run classifier handles.
 		log.Printf("slack: socket mode invalid_auth event (HTTP 404 from connect)")
 		s.setTriggerHealth(ctx, healthAuthExpired)
+	}
+}
+
+// onSlashCommand returns a handler for slash command events registered on the hub.
+// The hub has already acked before this handler is called; do NOT ack here.
+// Slash commands bypass scope.matches — they are explicit user intent from any
+// surface and are not channel-scoped.
+func (s *TriggerService) onSlashCommand(ctx context.Context) func(slack.SlashCommand) {
+	return func(cmd slack.SlashCommand) {
+		eventID, payload, err := translateSlashCommand(cmd)
+		if err != nil {
+			log.Printf("slack: translateSlashCommand error: %v", err)
+			return
+		}
+		if _, err := s.host.EmitEvent(ctx, &hostv1.EmitEventRequest{
+			EventKind:   "slash_command",
+			EventId:     eventID,
+			PayloadJson: string(payload),
+		}); err != nil {
+			log.Printf("slack: EmitEvent (slash_command) failed: %v", err)
+		}
+	}
+}
+
+// onShortcut returns a handler for shortcut interactive events registered on the hub.
+// The hub has already acked and decoded the InteractionCallback; do NOT ack here.
+// Shortcuts bypass scope.matches — they are explicit user intent from any surface.
+// block_actions callbacks are dropped (translateShortcut returns emit=false) so the
+// ChannelService approval/feedback path is unaffected.
+func (s *TriggerService) onShortcut(ctx context.Context) func(slack.InteractionCallback) {
+	return func(cb slack.InteractionCallback) {
+		kind, eventID, payload, emit, err := translateShortcut(cb)
+		if err != nil {
+			log.Printf("slack: translateShortcut error: %v", err)
+			return
+		}
+		if !emit {
+			return
+		}
+		if _, err := s.host.EmitEvent(ctx, &hostv1.EmitEventRequest{
+			EventKind:   kind,
+			EventId:     eventID,
+			PayloadJson: string(payload),
+		}); err != nil {
+			log.Printf("slack: EmitEvent (%s) failed: %v", kind, err)
+		}
 	}
 }
 

--- a/plugins/slack/service_test.go
+++ b/plugins/slack/service_test.go
@@ -2374,3 +2374,267 @@ func TestChannelService_Request_HandleInteractiveTakesCorrelation(t *testing.T) 
 		t.Error("correlation entry still present after handleInteractive ran; handleInteractive must call take()")
 	}
 }
+
+// ── Slash command and shortcut trigger tests ──────────────────────────────────
+
+// slashCommandSocketEvent builds a socketmode.Event of type EventTypeSlashCommand.
+// A Request with a non-empty EnvelopeID is required so AckCount assertions work.
+func slashCommandSocketEvent(command, text, userID, channelID, triggerID string) socketmode.Event {
+	cmd := slack.SlashCommand{
+		Command:   command,
+		Text:      text,
+		UserID:    userID,
+		ChannelID: channelID,
+		TriggerID: triggerID,
+		TeamID:    "T03TEAM001",
+	}
+	return socketmode.Event{
+		Type:    socketmode.EventTypeSlashCommand,
+		Data:    cmd,
+		Request: &socketmode.Request{EnvelopeID: "env-slash-" + triggerID},
+	}
+}
+
+// messageShortcutSocketEvent builds a socketmode.Event of type EventTypeInteractive
+// carrying a message_action InteractionCallback.
+func messageShortcutSocketEvent(callbackID, triggerID, channelID, userID string) socketmode.Event {
+	cb := slack.InteractionCallback{
+		Type:       slack.InteractionTypeMessageAction,
+		TriggerID:  triggerID,
+		CallbackID: callbackID,
+		User:       slack.User{ID: userID},
+		Team:       slack.Team{ID: "T03TEAM001"},
+		Channel: slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{ID: channelID},
+			},
+		},
+		Message: slack.Message{
+			Msg: slack.Msg{
+				Text:      "the target message text",
+				Timestamp: "1700001000.000200",
+			},
+		},
+	}
+	return socketmode.Event{
+		Type:    socketmode.EventTypeInteractive,
+		Data:    cb,
+		Request: &socketmode.Request{EnvelopeID: "env-shortcut-" + triggerID},
+	}
+}
+
+// buildTriggerTestHarness is a shared helper that wires a fake socket mode runner,
+// a FakeHost with EmitEvent capture, and a TriggerService into an in-process setup.
+// Returns the TriggerServiceClient, FakeHost, emitCh, and cleanup function.
+func buildTriggerTestHarness(t *testing.T, fake *fakeSocketModeRunner) (triggerv1.TriggerServiceClient, *plugintest.FakeHost, chan plugintest.Event, func()) {
+	t.Helper()
+
+	emitCh := make(chan plugintest.Event, 10)
+	host := plugintest.NewFakeHost(
+		plugintest.WithInstanceConfigJSON(`{"app_level_token":"xapp-test-token"}`),
+		plugintest.OnEmitEvent(func(ev plugintest.Event) {
+			select {
+			case emitCh <- ev:
+			default:
+			}
+		}),
+	)
+
+	hostLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for host: %v", err)
+	}
+	hostSrv := grpc.NewServer()
+	host.Register(hostSrv)
+	go func() { _ = hostSrv.Serve(hostLis) }()
+
+	hostConn, err := grpc.NewClient(hostLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial host: %v", err)
+	}
+	hostClient := hostv1.NewHostServiceClient(hostConn)
+
+	registry := newHubRegistry(func(_ string) (socketModeRunner, error) {
+		return fake, nil
+	})
+
+	triggerLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for trigger: %v", err)
+	}
+	triggerSrv := grpc.NewServer()
+	triggerv1.RegisterTriggerServiceServer(triggerSrv,
+		newTriggerServiceWithRegistry(hostClient, registry, nil, ""))
+	go func() { _ = triggerSrv.Serve(triggerLis) }()
+
+	triggerConn, err := grpc.NewClient(triggerLis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial trigger: %v", err)
+	}
+
+	cleanup := func() {
+		triggerConn.Close()
+		triggerSrv.Stop()
+		hostConn.Close()
+		hostSrv.Stop()
+	}
+	return triggerv1.NewTriggerServiceClient(triggerConn), host, emitCh, cleanup
+}
+
+// TestTriggerStartEmitsSlashCommandEvent asserts that a slash command socket event
+// causes Start to call host.EmitEvent with kind=slash_command and that Ack fires.
+func TestTriggerStartEmitsSlashCommandEvent(t *testing.T) {
+	fake := &fakeSocketModeRunner{
+		events: []socketmode.Event{
+			slashCommandSocketEvent("/gleipnir", "deploy staging", "U01USER001", "C012ABCDEF", "trig-slash-1.abc"),
+		},
+	}
+
+	triggerClient, host, emitCh, cleanup := buildTriggerTestHarness(t, fake)
+	defer cleanup()
+
+	svcs := &services{trigger: triggerClient}
+	// Scope with slash_commands=true to open the trigger stream.
+	cancel, done := startTriggerInBackground(t, svcs, `{"slash_commands":true}`)
+
+	var ev plugintest.Event
+	select {
+	case ev = <-emitCh:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("timed out waiting for EmitEvent")
+	}
+	cancel()
+	<-done
+
+	_ = host // host is checked via emitCh above
+
+	if ev.EventKind != "slash_command" {
+		t.Errorf("event kind: want slash_command, got %q", ev.EventKind)
+	}
+	if ev.EventID == "" {
+		t.Error("event_id: want non-empty ULID string")
+	}
+
+	var p SlackSlashCommandPayload
+	if err := json.Unmarshal([]byte(ev.PayloadJSON), &p); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if p.Command != "/gleipnir" {
+		t.Errorf("command: want /gleipnir, got %q", p.Command)
+	}
+	if p.Text != "deploy staging" {
+		t.Errorf("text: want deploy staging, got %q", p.Text)
+	}
+
+	// The hub must have acked the slash command event.
+	if n := fake.AckCount(); n != 1 {
+		t.Errorf("Ack call count: want 1, got %d", n)
+	}
+}
+
+// TestTriggerStartEmitsMessageShortcutEvent asserts that a message shortcut
+// interactive event causes Start to emit a message_shortcut event and ack.
+func TestTriggerStartEmitsMessageShortcutEvent(t *testing.T) {
+	fake := &fakeSocketModeRunner{
+		events: []socketmode.Event{
+			messageShortcutSocketEvent("run_agent_on_message", "trig-shortcut-2.def", "C09INCIDENT", "U01USER002"),
+		},
+	}
+
+	triggerClient, host, emitCh, cleanup := buildTriggerTestHarness(t, fake)
+	defer cleanup()
+
+	svcs := &services{trigger: triggerClient}
+	cancel, done := startTriggerInBackground(t, svcs, `{"shortcuts":true}`)
+
+	var ev plugintest.Event
+	select {
+	case ev = <-emitCh:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("timed out waiting for EmitEvent")
+	}
+	cancel()
+	<-done
+
+	_ = host
+
+	if ev.EventKind != "message_shortcut" {
+		t.Errorf("event kind: want message_shortcut, got %q", ev.EventKind)
+	}
+	if ev.EventID == "" {
+		t.Error("event_id: want non-empty ULID string")
+	}
+
+	var p SlackMessageShortcutPayload
+	if err := json.Unmarshal([]byte(ev.PayloadJSON), &p); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if p.CallbackID != "run_agent_on_message" {
+		t.Errorf("callback_id: want run_agent_on_message, got %q", p.CallbackID)
+	}
+	if p.ChannelID != "C09INCIDENT" {
+		t.Errorf("channel_id: want C09INCIDENT, got %q", p.ChannelID)
+	}
+
+	// The hub must have acked the interactive event.
+	if n := fake.AckCount(); n != 1 {
+		t.Errorf("Ack call count: want 1, got %d", n)
+	}
+}
+
+// TestTriggerEmitsSlashCommandWithRestrictiveSubscriptionScope verifies that the
+// TriggerService emits slash_command events regardless of the subscription scope's
+// channel/mention filters. The handler intentionally bypasses scope.matches —
+// slash commands are explicit user intent from any surface.
+//
+// Note on the host gate: the HOST trigger supervisor only opens the TriggerService.Start
+// stream when subscription_scope_json is non-empty (isEmptyScope, supervisor.go:429).
+// The new slash_commands/shortcuts scope flags exist to satisfy that host gate for
+// slash/shortcut-only instances. Here we use a restrictive but non-empty scope
+// (channels limited to an unrelated channel) — the plugin-side handler deliberately
+// bypasses scope.matches, so the event is still emitted. The host gate itself is
+// exercised by existing internal/plugin/trigger supervisor tests; no new host test
+// is added here.
+func TestTriggerEmitsSlashCommandWithRestrictiveSubscriptionScope(t *testing.T) {
+	fake := &fakeSocketModeRunner{
+		events: []socketmode.Event{
+			slashCommandSocketEvent("/gleipnir", "summarize", "U01USER001", "C012ABCDEF", "trig-scope-1.abc"),
+		},
+	}
+
+	triggerClient, host, emitCh, cleanup := buildTriggerTestHarness(t, fake)
+	defer cleanup()
+
+	svcs := &services{trigger: triggerClient}
+	// Restrictive scope: channels limited to an unrelated channel; the slash
+	// command's channel is excluded by this scope. Plugin-side handler must
+	// NOT consult scope.matches for slash commands.
+	cancel, done := startTriggerInBackground(t, svcs, `{"channels":["C99OTHERUNRELATED"]}`)
+
+	var ev plugintest.Event
+	select {
+	case ev = <-emitCh:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		// If we timeout here it means scope.matches was consulted and filtered
+		// the slash command — that would be a bug.
+		if len(host.Events()) == 0 {
+			t.Fatal("timed out: slash command was not emitted despite restrictive scope — " +
+				"plugin-side handler should bypass scope.matches for slash commands")
+		}
+		t.Fatal("timed out waiting for EmitEvent")
+	}
+	cancel()
+	<-done
+
+	if ev.EventKind != "slash_command" {
+		t.Errorf("event kind: want slash_command, got %q", ev.EventKind)
+	}
+}

--- a/plugins/slack/sockethub.go
+++ b/plugins/slack/sockethub.go
@@ -27,6 +27,20 @@ type messageHandlerSlot struct {
 	fn func(socketmode.Event)
 }
 
+// slashCommandHandlerSlot wraps the slash command handler for atomic.Pointer storage.
+// The hub has already acked before dispatching; handler must NOT call Ack.
+type slashCommandHandlerSlot struct {
+	fn func(slack.SlashCommand)
+}
+
+// triggerInteractiveHandlerSlot wraps a handler that receives a pre-decoded
+// InteractionCallback for shortcut delivery. The socketmode.Event wrapper is
+// dropped (the hub has already acked and decoded the callback).
+// Handler must NOT call Ack.
+type triggerInteractiveHandlerSlot struct {
+	fn func(slack.InteractionCallback)
+}
+
 // socketHub multiplexes a single socketModeRunner between an EventsAPI handler
 // (used by TriggerService) and an interactive handler (used by ChannelService).
 // One hub per xapp-token; created and managed by hubRegistry.
@@ -37,11 +51,13 @@ type messageHandlerSlot struct {
 // (slot briefly nil). Interactive callbacks are unaffected — ChannelService
 // registers its interactive handler once at NewChannelService and never releases it.
 type socketHub struct {
-	runner             socketModeRunner
-	xappToken          string
-	eventsHandler      atomic.Pointer[eventsHandlerSlot]
-	interactiveHandler atomic.Pointer[interactiveHandlerSlot]
-	messageHandler     atomic.Pointer[messageHandlerSlot]
+	runner                   socketModeRunner
+	xappToken                string
+	eventsHandler            atomic.Pointer[eventsHandlerSlot]
+	interactiveHandler       atomic.Pointer[interactiveHandlerSlot]
+	messageHandler           atomic.Pointer[messageHandlerSlot]
+	slashCommandHandler      atomic.Pointer[slashCommandHandlerSlot]
+	triggerInteractiveHandler atomic.Pointer[triggerInteractiveHandlerSlot]
 
 	// done is closed (and doneErr written) when the hub's Run goroutine exits.
 	// Multiple goroutines may read from Done(); the channel is never sent to
@@ -95,6 +111,22 @@ func (h *socketHub) RegisterMessageHandler(fn func(socketmode.Event)) {
 	h.messageHandler.Store(&messageHandlerSlot{fn: fn})
 }
 
+// RegisterSlashCommandHandler registers the handler called for slash command events.
+// The hub acks the event before dispatching; the handler must NOT call Ack.
+// Replaces any previously registered handler atomically.
+func (h *socketHub) RegisterSlashCommandHandler(fn func(slack.SlashCommand)) {
+	h.slashCommandHandler.Store(&slashCommandHandlerSlot{fn: fn})
+}
+
+// RegisterTriggerInteractiveHandler registers a secondary handler for interactive
+// events (shortcuts) that runs after the existing interactiveHandler. The hub
+// acks before dispatching; the handler must NOT call Ack. Receives the same
+// pre-decoded InteractionCallback as the primary handler; both are isolated by
+// cb.Type (block_actions vs shortcut/message_action). Replaces atomically.
+func (h *socketHub) RegisterTriggerInteractiveHandler(fn func(slack.InteractionCallback)) {
+	h.triggerInteractiveHandler.Store(&triggerInteractiveHandlerSlot{fn: fn})
+}
+
 // Ack acknowledges a Slack Socket Mode request.
 func (h *socketHub) Ack(req socketmode.Request) {
 	h.runner.Ack(req)
@@ -105,9 +137,9 @@ func (h *socketHub) Ack(req socketmode.Request) {
 // (ADR-001; service.go:247). Blocks until ctx is cancelled or the runner exits.
 // When Run returns, h.done is closed and h.doneErr carries the error (may be nil).
 //
-// Interactive events are Acked by the hub before dispatching to the handler —
-// the handler must not call Ack. EventsAPI events are Acked by TriggerService's
-// onEvent (service.go:385-387) to avoid double-Ack.
+// Interactive events (block_actions and shortcuts) and slash commands are Acked
+// by the hub before dispatching to any handler — handlers must not call Ack.
+// EventsAPI events are Acked by TriggerService's onEvent to avoid double-Ack.
 func (h *socketHub) Run(ctx context.Context) error {
 	err := h.runner.Run(ctx, func(evt socketmode.Event) {
 		switch evt.Type {
@@ -120,6 +152,22 @@ func (h *socketHub) Run(ctx context.Context) error {
 			// must not call Ack.
 			if mslot := h.messageHandler.Load(); mslot != nil {
 				mslot.fn(evt)
+			}
+
+		case socketmode.EventTypeSlashCommand:
+			// SlashCommand is a VALUE type in evt.Data (not a pointer),
+			// per socket_mode_managed_conn.go:639-645.
+			cmd, ok := evt.Data.(slack.SlashCommand)
+			if !ok {
+				log.Printf("sockethub: slash command event has unexpected data type %T", evt.Data)
+				return
+			}
+			// Ack FIRST to satisfy Slack's ~3s budget before any handler processing.
+			if evt.Request != nil {
+				h.runner.Ack(*evt.Request)
+			}
+			if slot := h.slashCommandHandler.Load(); slot != nil {
+				slot.fn(cmd)
 			}
 
 		case socketmode.EventTypeInteractive:
@@ -135,8 +183,16 @@ func (h *socketHub) Run(ctx context.Context) error {
 			if evt.Request != nil {
 				h.runner.Ack(*evt.Request)
 			}
+			// Primary handler: ChannelService owns block_actions (approval/feedback).
 			if slot := h.interactiveHandler.Load(); slot != nil {
 				slot.fn(evt, cb)
+			}
+			// Secondary handler: TriggerService handles shortcut types.
+			// Both handlers receive the same cb and are isolated by cb.Type —
+			// interactiveHandler early-returns on non-block_actions, and
+			// translateShortcut returns emit=false on block_actions.
+			if tslot := h.triggerInteractiveHandler.Load(); tslot != nil {
+				tslot.fn(cb)
 			}
 
 		default:

--- a/plugins/slack/sockethub.go
+++ b/plugins/slack/sockethub.go
@@ -51,12 +51,12 @@ type triggerInteractiveHandlerSlot struct {
 // (slot briefly nil). Interactive callbacks are unaffected — ChannelService
 // registers its interactive handler once at NewChannelService and never releases it.
 type socketHub struct {
-	runner                   socketModeRunner
-	xappToken                string
-	eventsHandler            atomic.Pointer[eventsHandlerSlot]
-	interactiveHandler       atomic.Pointer[interactiveHandlerSlot]
-	messageHandler           atomic.Pointer[messageHandlerSlot]
-	slashCommandHandler      atomic.Pointer[slashCommandHandlerSlot]
+	runner                    socketModeRunner
+	xappToken                 string
+	eventsHandler             atomic.Pointer[eventsHandlerSlot]
+	interactiveHandler        atomic.Pointer[interactiveHandlerSlot]
+	messageHandler            atomic.Pointer[messageHandlerSlot]
+	slashCommandHandler       atomic.Pointer[slashCommandHandlerSlot]
 	triggerInteractiveHandler atomic.Pointer[triggerInteractiveHandlerSlot]
 
 	// done is closed (and doneErr written) when the hub's Run goroutine exits.

--- a/plugins/slack/translator.go
+++ b/plugins/slack/translator.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 )
 
@@ -154,6 +155,83 @@ func translate(inner slackevents.EventsAPIInnerEvent, teamID, botUserID string) 
 	default:
 		// All other inner event types (reactions, channel events, etc.) are
 		// not subscribed to by this plugin version. Drop silently.
+		return "", "", nil, false, nil
+	}
+}
+
+// translateSlashCommand converts a Slack SlashCommand into a slash_command event
+// payload. Slash commands are always delivered with explicit user intent — no
+// drop/subtype filtering; this function always returns a payload.
+//
+// eventID is derived from (channelID, triggerID): TriggerID is unique per
+// invocation and serves as the dedup key; deriveEventID's second arg (normally
+// a Slack timestamp) is reused here with the TriggerID. The ULID time component
+// falls back to now() since TriggerID is not a "sec.frac" string — harmless,
+// as dedup is driven by SHA-256("channelID:triggerID"), not the time component.
+func translateSlashCommand(cmd slack.SlashCommand) (eventID string, payload []byte, err error) {
+	p := SlackSlashCommandPayload{
+		Command:     cmd.Command,
+		Text:        cmd.Text,
+		User:        cmd.UserID, // NOTE: UserID, not cmd.User (no such field)
+		ChannelID:   cmd.ChannelID,
+		ChannelName: cmd.ChannelName,
+		TriggerID:   cmd.TriggerID,
+		ResponseURL: cmd.ResponseURL,
+		TeamID:      cmd.TeamID,
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", nil, fmt.Errorf("translateSlashCommand: marshal payload: %w", err)
+	}
+	return deriveEventID(cmd.ChannelID, cmd.TriggerID), b, nil
+}
+
+// translateShortcut converts a Slack InteractionCallback into a message_shortcut
+// or global_shortcut event. Returns emit=false for block_actions and any other
+// interaction type so the ChannelService approval/feedback path is not hijacked.
+//
+// Field notes:
+//   - cb.Message.Timestamp: promoted from the embedded slack.Msg (json tag "ts").
+//   - cb.Channel.ID: promoted via Channel→GroupConversation→Conversation.ID.
+//   - cb.User.ID: cb.User is slack.User; use .ID, not cb.UserID (no such field).
+//   - cb.Team.ID: cb.Team is slack.Team; use .ID, not cb.TeamID (no such field).
+//   - For global shortcuts cb.Channel is zero-valued (no message context), so
+//     deriveEventID is called with an empty channelID.
+func translateShortcut(cb slack.InteractionCallback) (kind, eventID string, payload []byte, emit bool, err error) {
+	switch cb.Type {
+	case slack.InteractionTypeMessageAction:
+		p := SlackMessageShortcutPayload{
+			Text:       cb.Message.Text,
+			Ts:         cb.Message.Timestamp, // promoted from embedded slack.Msg (json "ts")
+			ChannelID:  cb.Channel.ID,        // promoted via Channel→GroupConversation→Conversation.ID
+			User:       cb.User.ID,           // cb.User is slack.User; NOT cb.UserID
+			TriggerID:  cb.TriggerID,
+			CallbackID: cb.CallbackID,
+			TeamID:     cb.Team.ID, // cb.Team is slack.Team; NOT cb.TeamID
+		}
+		b, err := json.Marshal(p)
+		if err != nil {
+			return "", "", nil, false, fmt.Errorf("translateShortcut message_action: marshal payload: %w", err)
+		}
+		return "message_shortcut", deriveEventID(cb.Channel.ID, cb.TriggerID), b, true, nil
+
+	case slack.InteractionTypeShortcut:
+		p := SlackGlobalShortcutPayload{
+			User:       cb.User.ID,
+			TriggerID:  cb.TriggerID,
+			CallbackID: cb.CallbackID,
+			TeamID:     cb.Team.ID,
+		}
+		b, err := json.Marshal(p)
+		if err != nil {
+			return "", "", nil, false, fmt.Errorf("translateShortcut global: marshal payload: %w", err)
+		}
+		// Global shortcuts have no channel context — use empty channelID.
+		return "global_shortcut", deriveEventID("", cb.TriggerID), b, true, nil
+
+	default:
+		// block_actions and any other type: emit=false so the ChannelService
+		// approval/feedback path falls through untouched.
 		return "", "", nil, false, nil
 	}
 }

--- a/plugins/slack/translator_test.go
+++ b/plugins/slack/translator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 )
 
@@ -543,5 +544,205 @@ func TestTranslatePayloadChannelForMessage(t *testing.T) {
 	// Verify channel_id appears in the payload JSON.
 	if !strings.Contains(string(payload), `"CMYCHAN"`) {
 		t.Errorf("payload should contain channel ID CMYCHAN: %s", payload)
+	}
+}
+
+// TestTranslateSlashCommand verifies that translateSlashCommand maps all fields
+// correctly, including cmd.UserID (not cmd.User, which doesn't exist in slack-go).
+func TestTranslateSlashCommand(t *testing.T) {
+	cmd := slack.SlashCommand{
+		Command:     "/gleipnir",
+		Text:        "deploy staging",
+		UserID:      "U01USER001",
+		ChannelID:   "C012ABCDEF",
+		ChannelName: "#ops",
+		TriggerID:   "trig-1.abc",
+		ResponseURL: "https://hooks.slack.com/commands/T01/...",
+		TeamID:      "T03TEAM001",
+	}
+
+	eventID, payload, err := translateSlashCommand(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if eventID == "" {
+		t.Error("eventID: want non-empty ULID string")
+	}
+
+	var p SlackSlashCommandPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p.Command != "/gleipnir" {
+		t.Errorf("command: want /gleipnir, got %q", p.Command)
+	}
+	if p.Text != "deploy staging" {
+		t.Errorf("text: want %q, got %q", "deploy staging", p.Text)
+	}
+	// cmd.UserID maps to p.User — ensures we access UserID, not a non-existent User field.
+	if p.User != "U01USER001" {
+		t.Errorf("user: want U01USER001, got %q (check cmd.UserID access)", p.User)
+	}
+	if p.ChannelID != "C012ABCDEF" {
+		t.Errorf("channel_id: want C012ABCDEF, got %q", p.ChannelID)
+	}
+	if p.TriggerID != "trig-1.abc" {
+		t.Errorf("trigger_id: want trig-1.abc, got %q", p.TriggerID)
+	}
+	if p.ResponseURL != "https://hooks.slack.com/commands/T01/..." {
+		t.Errorf("response_url: want non-empty, got %q", p.ResponseURL)
+	}
+	if p.TeamID != "T03TEAM001" {
+		t.Errorf("team_id: want T03TEAM001, got %q", p.TeamID)
+	}
+}
+
+// TestTranslateSlashCommandDedup verifies that the same SlashCommand input
+// always produces the same eventID (dedup determinism).
+func TestTranslateSlashCommandDedup(t *testing.T) {
+	cmd := slack.SlashCommand{
+		Command:   "/gleipnir",
+		Text:      "deploy staging",
+		UserID:    "U01USER001",
+		ChannelID: "C012ABCDEF",
+		TriggerID: "trig-dedup-1.xyz",
+		TeamID:    "T03TEAM001",
+	}
+
+	id1, _, err1 := translateSlashCommand(cmd)
+	id2, _, err2 := translateSlashCommand(cmd)
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: %v %v", err1, err2)
+	}
+	if id1 != id2 {
+		t.Errorf("eventID not deterministic: got %q then %q", id1, id2)
+	}
+}
+
+// TestTranslateShortcut_MessageAction verifies message_shortcut translation,
+// including the promoted fields: cb.Message.Timestamp (from embedded slack.Msg)
+// and cb.Channel.ID (from Channel→GroupConversation→Conversation.ID).
+func TestTranslateShortcut_MessageAction(t *testing.T) {
+	cb := slack.InteractionCallback{
+		Type:       slack.InteractionTypeMessageAction,
+		TriggerID:  "trig-2.def",
+		CallbackID: "run_agent_on_message",
+		User:       slack.User{ID: "U01USER002"},
+		Team:       slack.Team{ID: "T03TEAM001"},
+		Channel: slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{ID: "C09INCIDENT"},
+			},
+		},
+		Message: slack.Message{
+			Msg: slack.Msg{
+				Text:      "the database is degraded",
+				Timestamp: "1700001000.000200", // cb.Message.Timestamp — promoted from embedded slack.Msg
+			},
+		},
+	}
+
+	kind, eventID, payload, emit, err := translateShortcut(cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !emit {
+		t.Fatal("emit: want true for message_action")
+	}
+	if kind != "message_shortcut" {
+		t.Errorf("kind: want message_shortcut, got %q", kind)
+	}
+	if eventID == "" {
+		t.Error("eventID: want non-empty ULID string")
+	}
+
+	var p SlackMessageShortcutPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p.Text != "the database is degraded" {
+		t.Errorf("text: want %q, got %q", "the database is degraded", p.Text)
+	}
+	// cb.Message.Timestamp is promoted from the embedded slack.Msg.
+	if p.Ts != "1700001000.000200" {
+		t.Errorf("ts: want 1700001000.000200, got %q (check cb.Message.Timestamp promoted field)", p.Ts)
+	}
+	// cb.Channel.ID is promoted via Channel→GroupConversation→Conversation.ID.
+	if p.ChannelID != "C09INCIDENT" {
+		t.Errorf("channel_id: want C09INCIDENT, got %q (check cb.Channel.ID promotion)", p.ChannelID)
+	}
+	// cb.User.ID — not cb.UserID.
+	if p.User != "U01USER002" {
+		t.Errorf("user: want U01USER002, got %q (check cb.User.ID)", p.User)
+	}
+	if p.TriggerID != "trig-2.def" {
+		t.Errorf("trigger_id: want trig-2.def, got %q", p.TriggerID)
+	}
+	if p.CallbackID != "run_agent_on_message" {
+		t.Errorf("callback_id: want run_agent_on_message, got %q", p.CallbackID)
+	}
+	// cb.Team.ID — not cb.TeamID.
+	if p.TeamID != "T03TEAM001" {
+		t.Errorf("team_id: want T03TEAM001, got %q (check cb.Team.ID)", p.TeamID)
+	}
+}
+
+// TestTranslateShortcut_Global verifies global_shortcut translation.
+// For global shortcuts, cb.Channel is zero-valued (no message context);
+// deriveEventID is called with an empty channelID.
+func TestTranslateShortcut_Global(t *testing.T) {
+	cb := slack.InteractionCallback{
+		Type:       slack.InteractionTypeShortcut,
+		TriggerID:  "trig-3.ghi",
+		CallbackID: "start_agent",
+		User:       slack.User{ID: "U01USER003"},
+		Team:       slack.Team{ID: "T03TEAM001"},
+		// Channel intentionally zero-valued — global shortcuts have no channel context.
+	}
+
+	kind, eventID, payload, emit, err := translateShortcut(cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !emit {
+		t.Fatal("emit: want true for global shortcut")
+	}
+	if kind != "global_shortcut" {
+		t.Errorf("kind: want global_shortcut, got %q", kind)
+	}
+	if eventID == "" {
+		t.Error("eventID: want non-empty ULID string")
+	}
+
+	var p SlackGlobalShortcutPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p.User != "U01USER003" {
+		t.Errorf("user: want U01USER003, got %q", p.User)
+	}
+	if p.CallbackID != "start_agent" {
+		t.Errorf("callback_id: want start_agent, got %q", p.CallbackID)
+	}
+}
+
+// TestTranslateShortcut_BlockActionsNotEmitted verifies that block_actions
+// callbacks return emit=false, preserving the ChannelService approval/feedback path.
+func TestTranslateShortcut_BlockActionsNotEmitted(t *testing.T) {
+	cb := slack.InteractionCallback{
+		Type: slack.InteractionTypeBlockActions,
+		ActionCallback: slack.ActionCallbacks{
+			BlockActions: []*slack.BlockAction{
+				{ActionID: "approve-req-123-accept", Value: "accept"},
+			},
+		},
+	}
+
+	_, _, _, emit, err := translateShortcut(cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if emit {
+		t.Error("emit: want false for block_actions (ChannelService path must not be hijacked)")
 	}
 }


### PR DESCRIPTION
Closes #623

## Summary

Slack's native, intent-carrying invocation surfaces — **slash commands** (`/gleipnir deploy staging`) and **shortcuts** (message + global) — were not handled at all (`sockethub.go` had no `EventTypeSlashCommand` case and shortcut payloads were never extracted). This adds them as new Slack-plugin trigger event kinds.

### What changed (all in `plugins/slack/`, no host change)

- **New trigger event kinds** — `slash_command` (payload: `command, text, user, channel_id, trigger_id, response_url`; binding `command` equals + optional `text`/`text_regex`), `message_shortcut` (target message `text, ts, channel_id` + invoking `user, trigger_id, callback_id`; binding `callback_id`), and `global_shortcut` (`user, trigger_id, callback_id`). Registered after `direct_message` for a stable canonical manifest.
- **Routing + ack** — a `socketmode.EventTypeSlashCommand` case acks immediately (Slack's ~3s budget) then dispatches; the existing `EventTypeInteractive` case now **dual-dispatches** the decoded `InteractionCallback` to both ChannelService (block_actions buttons) and TriggerService (shortcuts). The two paths are mutually exclusive by `cb.Type` — `handleInteractive` early-returns on non-`block_actions` and `translateShortcut` returns `emit=false` on `block_actions` — so the approval/feedback button path is untouched.
- **`trigger_id`/`response_url` capture** — persisted into the emitted payload so a later step can post back or open a modal (sets up #624).
- **Scope-gate fix** — new `slash_commands` / `shortcuts` subscription-scope flags make the scope JSON non-empty so the host `isEmptyScope` gate opens the trigger stream for a slash-only instance (an otherwise-empty `{}` scope would never open the stream). They are stream-open enablers only — they do **not** gate plugin-side delivery (slash/shortcut handlers bypass `scope.matches`).
- README documents the new kinds, the scope flags, Slack app config (register slash command + shortcuts; Socket Mode delivery, no Request URL / extra scopes), ack semantics, and worked binding examples.

No host change: `GetSubscribedActivePolicies` has no event-kind filter, the dispatcher matches generically on `EventKind`, and `EqualsField → {type:string} → OpEquals` handles `command`/`callback_id` bindings.

## Test plan

- `translator_test.go` — slash translate (field mapping incl. `cmd.UserID`) + dedup determinism; `message_shortcut` (promoted fields `cb.Message.Timestamp`/`cb.Channel.ID`/`cb.User.ID`/`cb.Team.ID`); `global_shortcut` (zero-valued channel); `block_actions → emit=false`.
- `service_test.go` — service-level emit for slash + message_shortcut asserting `AckCount()` increments and the right `EventKind`; a restrictive-scope test proving plugin-side `scope.matches` is bypassed (with a comment distinguishing it from the host gate); existing block_actions approval/feedback tests still pass.
- `scope_test.go` — decode + `matches()` bypass for the new flags.
- `manifest_test.go` — `TestManifestYAMLIsCanonical` enforces the regenerated YAML.

All `go test ./...` pass in `plugins/slack/` and at the repo root.

## Review

- Adversarial plan review: 1 REVISE cycle (caught a blocking gap — the host `isEmptyScope` gate would silently never open the stream for a slash-only instance — plus several slack-go field-access traps).
- Code review: **APPROVE** on cycle 1 (a `unusedfunc` flag on the translate functions was verified a false positive — production handlers delegate to them).
- CLAUDE.md: no updates needed (plugin-internal — no new packages, env vars, routes, or core trigger types).

<details>
<summary>Architecture plan</summary>

Two new translate functions (`translateSlashCommand`, `translateShortcut`) feeding `host.EmitEvent`; new `slashCommandHandlerSlot` + `triggerInteractiveHandlerSlot` (`func(slack.InteractionCallback)`) on the hub; ack-at-hub before dispatch; `slash_commands`/`shortcuts` scope flags to satisfy the host stream-open gate. `global_shortcut` included now (low marginal cost). All confined to `plugins/slack/`.
</details>

🤖 Generated by the agentic dev loop
