### PR TITLE
feat: OAuth begin 500 paths hide raw provider error body

### DIFF
--- a/internal/admin/plugin_oauth_handler.go
+++ b/internal/admin/plugin_oauth_handler.go
@@ -28,13 +28,23 @@ type OAuthPluginQuerier interface {
 	UpdatePluginInstanceHealth(ctx context.Context, arg db.UpdatePluginInstanceHealthParams) (int64, error)
 }
 
+// OAuthManager is the narrow interface of oauth.Manager consumed by PluginOAuthHandler.
+// Extracting it as an interface lets tests inject a fake that returns controlled
+// errors without constructing a full oauth.Manager.
+type OAuthManager interface {
+	BeginAuthcode(ctx context.Context, instanceID, returnURL string) (string, error)
+	BeginClientcred(ctx context.Context, instanceID string) error
+	HandleCallback(ctx context.Context, rawState, code string) (string, error)
+	DecodeStateForRedirect(rawState string) (oauth.StateEnvelope, error)
+}
+
 // PluginOAuthHandler handles the admin OAuth2 endpoints for plugin instances.
 // It owns two routes:
 //
 //	POST /api/v1/admin/plugins/{id}/instances/{iid}/oauth/begin
 //	GET  /api/v1/admin/plugins/oauth/callback  (unprotected)
 type PluginOAuthHandler struct {
-	mgr          *oauth.Manager
+	mgr          OAuthManager
 	q            OAuthPluginQuerier
 	getPublicURL func() string
 }
@@ -42,7 +52,7 @@ type PluginOAuthHandler struct {
 // NewPluginOAuthHandler constructs a PluginOAuthHandler. getPublicURL is called
 // at request time to validate return_url against the host's configured origin;
 // it mirrors the same closure passed to oauth.NewManager in main.go.
-func NewPluginOAuthHandler(q OAuthPluginQuerier, mgr *oauth.Manager, getPublicURL func() string) *PluginOAuthHandler {
+func NewPluginOAuthHandler(q OAuthPluginQuerier, mgr OAuthManager, getPublicURL func() string) *PluginOAuthHandler {
 	return &PluginOAuthHandler{mgr: mgr, q: q, getPublicURL: getPublicURL}
 }
 
@@ -130,7 +140,9 @@ func (h *PluginOAuthHandler) Begin(w http.ResponseWriter, r *http.Request) {
 				httputil.WriteError(w, http.StatusBadRequest, "oauth configuration invalid", err.Error())
 				return
 			}
-			httputil.WriteError(w, http.StatusInternalServerError, "failed to begin OAuth flow", err.Error())
+			// Log the full error server-side (may contain provider details) but return
+			// a generic message to the client — mirrors HandleCallback's approach.
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to begin OAuth authorization", "")
 			return
 		}
 		httputil.WriteJSON(w, http.StatusOK, beginAuthcodeResponse{AuthorizeURL: authorizeURL})
@@ -142,7 +154,10 @@ func (h *PluginOAuthHandler) Begin(w http.ResponseWriter, r *http.Request) {
 				httputil.WriteError(w, http.StatusBadRequest, "oauth configuration invalid", err.Error())
 				return
 			}
-			httputil.WriteError(w, http.StatusInternalServerError, "client credentials exchange failed", err.Error())
+			// Log the full error server-side (may contain the provider's HTTP response
+			// body) but return a generic message to the client — mirrors HandleCallback's
+			// approach of keeping provider error bodies out of API responses.
+			httputil.WriteError(w, http.StatusInternalServerError, "client credentials exchange failed", "")
 			return
 		}
 		httputil.WriteJSON(w, http.StatusOK, beginClientcredResponse{Status: "ok"})

--- a/internal/admin/plugin_oauth_handler_test.go
+++ b/internal/admin/plugin_oauth_handler_test.go
@@ -23,7 +23,7 @@ import (
 // It satisfies OAuthManager so it can be injected directly into
 // PluginOAuthHandler without constructing a real oauth.Manager.
 type fakeOAuthManager struct {
-	beginAuthcodeErr  error
+	beginAuthcodeErr   error
 	beginClientcredErr error
 }
 

--- a/internal/admin/plugin_oauth_handler_test.go
+++ b/internal/admin/plugin_oauth_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +15,36 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/plugin/oauth"
 	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
 )
+
+// --- fake OAuthManager ---
+
+// fakeOAuthManager is a test double for OAuthManager that returns
+// caller-controlled errors from BeginAuthcode and BeginClientcred.
+// It satisfies OAuthManager so it can be injected directly into
+// PluginOAuthHandler without constructing a real oauth.Manager.
+type fakeOAuthManager struct {
+	beginAuthcodeErr  error
+	beginClientcredErr error
+}
+
+func (f *fakeOAuthManager) BeginAuthcode(_ context.Context, _, _ string) (string, error) {
+	if f.beginAuthcodeErr != nil {
+		return "", f.beginAuthcodeErr
+	}
+	return "https://provider.example.com/authorize?client_id=cid&state=xyz", nil
+}
+
+func (f *fakeOAuthManager) BeginClientcred(_ context.Context, _ string) error {
+	return f.beginClientcredErr
+}
+
+func (f *fakeOAuthManager) HandleCallback(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeOAuthManager) DecodeStateForRedirect(_ string) (oauth.StateEnvelope, error) {
+	return oauth.StateEnvelope{}, nil
+}
 
 // --- fake OAuthPluginQuerier ---
 
@@ -409,5 +440,85 @@ func TestPluginOAuthHandler_Begin_RelativeReturnURL_Accepted(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 for relative return_url, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// buildOAuthHandlerWithFakeMgr builds a PluginOAuthHandler that uses a
+// caller-supplied OAuthManager fake. The querier is pre-seeded with one
+// instance and one plugin for the given auth strategy.
+func buildOAuthHandlerWithFakeMgr(t *testing.T, strategy string, mgr OAuthManager) (*PluginOAuthHandler, *fakeOAuthPluginQuerier) {
+	t.Helper()
+	q := newFakeOAuthPluginQuerier()
+	q.instances["inst-1"] = db.PluginInstance{
+		ID:          "inst-1",
+		PluginID:    "plugin-1",
+		HealthState: "healthy",
+	}
+	q.plugins["plugin-1"] = db.Plugin{
+		ID:               "plugin-1",
+		ManifestSnapshot: buildTestManifest(t, strategy),
+	}
+	h := NewPluginOAuthHandler(q, mgr, func() string { return "https://gleipnir.example.com" })
+	return h, q
+}
+
+// TestPluginOAuthHandler_Begin_Authcode_500_HidesProviderBody asserts that when
+// BeginAuthcode returns an unexpected server error (one that may embed a provider
+// HTTP response body), the API response does NOT echo that body as the detail
+// field. A generic message must be returned instead.
+func TestPluginOAuthHandler_Begin_Authcode_500_HidesProviderBody(t *testing.T) {
+	const providerSentinel = "oauth2: cannot fetch token: 400 Bad Request\nResponse: {\"error\":\"invalid_client\",\"error_description\":\"secret mismatch\"}"
+
+	fakeMgr := &fakeOAuthManager{
+		beginAuthcodeErr: fmt.Errorf("oauth begin: record nonce: %s", providerSentinel),
+	}
+	h, _ := buildOAuthHandlerWithFakeMgr(t, sdkmanifest.AuthStrategyOAuth2Authcode, fakeMgr)
+
+	body, _ := json.Marshal(map[string]string{"return_url": "/admin/plugins/inst-1"})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/instances/inst-1/oauth/begin", bytes.NewReader(body))
+	r = withChiParams(r, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+	w := httptest.NewRecorder()
+
+	h.Begin(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	respBody := w.Body.String()
+	if strings.Contains(respBody, providerSentinel) {
+		t.Errorf("response body must not echo provider error body, got: %s", respBody)
+	}
+	if !strings.Contains(respBody, "failed to begin OAuth authorization") {
+		t.Errorf("expected generic error message in response, got: %s", respBody)
+	}
+}
+
+// TestPluginOAuthHandler_Begin_Clientcred_500_HidesProviderBody asserts that
+// when BeginClientcred returns an error that contains the provider's HTTP
+// response body, the API response does NOT include that body in the detail.
+func TestPluginOAuthHandler_Begin_Clientcred_500_HidesProviderBody(t *testing.T) {
+	const providerSentinel = "oauth2: cannot fetch token: 401 Unauthorized\nResponse: {\"error\":\"invalid_client\",\"error_description\":\"bad credentials\"}"
+
+	fakeMgr := &fakeOAuthManager{
+		beginClientcredErr: fmt.Errorf("clientcred exchange: %s", providerSentinel),
+	}
+	h, _ := buildOAuthHandlerWithFakeMgr(t, sdkmanifest.AuthStrategyOAuth2Clientcred, fakeMgr)
+
+	body, _ := json.Marshal(map[string]string{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-1/instances/inst-1/oauth/begin", bytes.NewReader(body))
+	r = withChiParams(r, map[string]string{"id": "plugin-1", "iid": "inst-1"})
+	w := httptest.NewRecorder()
+
+	h.Begin(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	respBody := w.Body.String()
+	if strings.Contains(respBody, providerSentinel) {
+		t.Errorf("response body must not echo provider error body, got: %s", respBody)
+	}
+	if !strings.Contains(respBody, "client credentials exchange failed") {
+		t.Errorf("expected generic error message in response, got: %s", respBody)
 	}
 }


### PR DESCRIPTION
Closes #590

## Summary

The admin OAuth `begin` handler returned raw `err.Error()` as the response `detail` on its 500 paths. For the client-credentials path this could embed the provider's HTTP error-response body in the API response — an inconsistency with `HandleCallback`, which deliberately keeps `ProviderExchangeError.Raw` out of responses.

Both begin 500 branches (authcode + clientcred) now return a **generic** `detail` to the client and continue logging the **full** wrapped error server-side via `slog.ErrorContext`, mirroring `HandleCallback`'s "log raw, hide from response" discipline.

The `ErrConfigInvalid` 400 branches intentionally keep returning `err.Error()` — those are Gleipnir-internal config-guidance messages (no provider body) that operators need to see.

## Changes

- `internal/admin/plugin_oauth_handler.go` — extracted a minimal `OAuthManager` interface seam (the production `*oauth.Manager` satisfies it; no call sites broke); both begin 500 branches return generic detail.
- `internal/admin/plugin_oauth_handler_test.go` — `fakeOAuthManager` test double + two regression tests asserting the provider-body sentinel is absent from the 500 response while the generic message is present (these fail against the old code).

## Review

- Generated by the agentic dev loop. Scope-gate matched (well-specified, ≤2 files, localized) → no architect pass.
- Code review: **APPROVE**, 0 revision cycles.
- CLAUDE.md: no updates needed (no new package/route/env var/ADR).

<details>
<summary>Plan</summary>

Fix both begin 500 branches to log the wrapped error server-side and return a generic `detail`, mirroring `HandleCallback`. Add a regression test asserting the response body contains no provider error detail.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)