### PR TITLE
fix: manifest schema parse errors fail closed on the config-migration gate

### DIFF
--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -554,13 +554,13 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.writeAuditEvent(ctx, auditManifestAccepted, "info", nowStr, map[string]any{
-		"plugin_id":                  pluginID,
-		"name":                       plugin.Name,
-		"old_version":                pendingRow.OldVersion,
-		"new_version":                newManifest.Version,
-		"instances_unblocked":        unblocked,
-		"instances_pending_config":   pendingConfig,
-		"config_schema_unparseable":  forceMigration,
+		"plugin_id":                 pluginID,
+		"name":                      plugin.Name,
+		"old_version":               pendingRow.OldVersion,
+		"new_version":               newManifest.Version,
+		"instances_unblocked":       unblocked,
+		"instances_pending_config":  pendingConfig,
+		"config_schema_unparseable": forceMigration,
 	})
 
 	httputil.WriteJSON(w, http.StatusOK, acceptManifestResponse{

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -494,7 +494,15 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteError(w, http.StatusInternalServerError, "corrupt manifest snapshot", parseErr.Error())
 		return
 	}
-	newlyRequired := pluginmanifest.ConfigSchemaNewlyRequiredFields(&oldManifest, &newManifest)
+	newlyRequired, schemaErr := pluginmanifest.ConfigSchemaNewlyRequiredFields(&oldManifest, &newManifest)
+	// If the new manifest's config_schema is malformed we cannot safely determine
+	// whether migration is needed — fail closed by forcing pending_config_migration
+	// rather than letting the instance silently land on healthy (fail-open).
+	forceMigration := schemaErr != nil
+	if forceMigration {
+		slog.WarnContext(ctx, "accept-manifest: config schema unparseable; forcing pending_config_migration",
+			"plugin_id", pluginID, "err", schemaErr)
+	}
 
 	nowStr := h.clock().UTC().Format(time.RFC3339Nano)
 
@@ -528,7 +536,7 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	targetState := model.PluginHealthStateHealthy
-	if len(newlyRequired) > 0 {
+	if forceMigration || len(newlyRequired) > 0 {
 		targetState = model.PluginHealthStatePendingConfigMigration
 	}
 	transitioned := h.unblockInstances(
@@ -546,12 +554,13 @@ func (h *PluginHandler) AcceptManifest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.writeAuditEvent(ctx, auditManifestAccepted, "info", nowStr, map[string]any{
-		"plugin_id":                pluginID,
-		"name":                     plugin.Name,
-		"old_version":              pendingRow.OldVersion,
-		"new_version":              newManifest.Version,
-		"instances_unblocked":      unblocked,
-		"instances_pending_config": pendingConfig,
+		"plugin_id":                  pluginID,
+		"name":                       plugin.Name,
+		"old_version":                pendingRow.OldVersion,
+		"new_version":                newManifest.Version,
+		"instances_unblocked":        unblocked,
+		"instances_pending_config":   pendingConfig,
+		"config_schema_unparseable":  forceMigration,
 	})
 
 	httputil.WriteJSON(w, http.StatusOK, acceptManifestResponse{

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -1489,6 +1489,80 @@ func TestPluginHandler_AcceptManifest(t *testing.T) {
 			t.Errorf("second accept: status = %d, want 409 (row deleted after first accept)", rec2.Code)
 		}
 	})
+
+	// Verifies that a malformed config_schema "required" block (e.g. a scalar
+	// instead of an array) causes AcceptManifest to fail CLOSED: the instance
+	// moves to pending_config_migration rather than healthy, and the response is
+	// still HTTP 200 (not 500 — pending_config_migration is the correct gate state).
+	t.Run("malformed config schema fails closed to pending_config_migration", func(t *testing.T) {
+		// v2ManifestWithMalformedRequired uses "required" as a scalar string — a
+		// valid YAML value but not the array shape JSON Schema demands. This reaches
+		// requiredFieldSet at runtime because ConfigSchema is a raw *yaml.Node.
+		const v2ManifestWithMalformedRequired = "schema_version: v1\nname: test-plugin\nversion: 2.0.0\nservices:\n  tool: v2\nauth:\n  mode: instance_credentials\n  strategy: none\nconfig_schema:\n  type: object\n  properties:\n    api_key:\n      type: string\n  required: api_key\n"
+
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{
+			ID:               "plugin-malformed",
+			Name:             "test-plugin",
+			ManifestSnapshot: v1ManifestYAML,
+			PluginVersion:    "1.0.0",
+			Status:           "pending_review",
+			Version:          1,
+		})
+		q.seed(db.PluginInstance{
+			ID:          "inst-malformed",
+			PluginID:    "plugin-malformed",
+			HealthState: string(model.PluginHealthStatePendingManifestApproval),
+			Version:     0,
+		})
+		q.seedPendingManifest("plugin-malformed", []byte(v2ManifestWithMalformedRequired), "1.0.0", "2.0.0")
+
+		h := newTestPluginHandler(q, fixedClock, testPluginHandlerConfig{})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plugins/plugin-malformed/accept-manifest", bytes.NewBufferString(`{}`))
+		req = withChiParams(req, map[string]string{"id": "plugin-malformed"})
+		rec := httptest.NewRecorder()
+		h.AcceptManifest(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (fail-closed means pending_config_migration, not 500); body: %s", rec.Code, rec.Body.String())
+		}
+
+		data := parseDataResponse(t, rec)
+		var resp acceptManifestResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp.InstancesPendingConfig != 1 {
+			t.Errorf("instances_pending_config = %d, want 1 (fail closed)", resp.InstancesPendingConfig)
+		}
+		if resp.InstancesUnblocked != 0 {
+			t.Errorf("instances_unblocked = %d, want 0", resp.InstancesUnblocked)
+		}
+
+		inst := q.instances["inst-malformed"]
+		if inst.HealthState != string(model.PluginHealthStatePendingConfigMigration) {
+			t.Errorf("inst-malformed health_state = %q, want pending_config_migration", inst.HealthState)
+		}
+
+		// Audit event must record config_schema_unparseable = true.
+		var found *db.PluginAuditEvent
+		for i := range q.auditEvents {
+			if q.auditEvents[i].EventType == auditManifestAccepted {
+				found = &q.auditEvents[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("expected a plugin_manifest_accepted audit event, got none")
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(found.PayloadJson), &payload); err != nil {
+			t.Fatalf("unmarshal audit payload: %v", err)
+		}
+		if payload["config_schema_unparseable"] != true {
+			t.Errorf("audit payload config_schema_unparseable = %v, want true", payload["config_schema_unparseable"])
+		}
+	})
 }
 
 // ── PutSubscriptionScope tests ────────────────────────────────────────────────

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -644,13 +644,13 @@ func (in *Installer) handleManifestMaterialChange(ctx context.Context, existing 
 	)
 
 	if err := in.recordAuditEvent(ctx, auditManifestMaterialChange, severityHigh, nowStr, map[string]any{
-		"plugin_id":                    existing.ID,
-		"name":                         existing.Name,
-		"old_version":                  existing.PluginVersion,
-		"new_version":                  m.Version,
-		"material_fields":              pluginmanifest.MaterialFields(changes),
-		"cosmetic_fields":              pluginmanifest.CosmeticFields(changes),
-		"candidate_manifest_b64":       base64.StdEncoding.EncodeToString(candidateBytes),
+		"plugin_id":              existing.ID,
+		"name":                   existing.Name,
+		"old_version":            existing.PluginVersion,
+		"new_version":            m.Version,
+		"material_fields":        pluginmanifest.MaterialFields(changes),
+		"cosmetic_fields":        pluginmanifest.CosmeticFields(changes),
+		"candidate_manifest_b64": base64.StdEncoding.EncodeToString(candidateBytes),
 		"newly_required_config_fields": func() []string {
 			fields, err := pluginmanifest.ConfigSchemaNewlyRequiredFields(oldManifest, m)
 			if err != nil {

--- a/internal/plugin/loader/install.go
+++ b/internal/plugin/loader/install.go
@@ -651,7 +651,15 @@ func (in *Installer) handleManifestMaterialChange(ctx context.Context, existing 
 		"material_fields":              pluginmanifest.MaterialFields(changes),
 		"cosmetic_fields":              pluginmanifest.CosmeticFields(changes),
 		"candidate_manifest_b64":       base64.StdEncoding.EncodeToString(candidateBytes),
-		"newly_required_config_fields": pluginmanifest.ConfigSchemaNewlyRequiredFields(oldManifest, m),
+		"newly_required_config_fields": func() []string {
+			fields, err := pluginmanifest.ConfigSchemaNewlyRequiredFields(oldManifest, m)
+			if err != nil {
+				slog.WarnContext(ctx, "manifest material change: cannot determine newly-required config fields; schema malformed",
+					"plugin", existing.Name, "err", err)
+				return nil
+			}
+			return fields
+		}(),
 	}); err != nil {
 		return "", fmt.Errorf("record manifest_material_change audit for %q: %w", existing.Name, err)
 	}

--- a/internal/plugin/manifest/diff.go
+++ b/internal/plugin/manifest/diff.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/felag-engineering/gleipnir/internal/plugin/schemautil"
 	sdkmanifest "github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
@@ -100,9 +101,19 @@ func CosmeticFields(changes []Change) []string {
 // "Newly required" means: a property name appears in new's "required" array
 // but did not appear in old's "required" array. Plugin-wide granularity (not
 // per-instance) per the v1 design decision.
-func ConfigSchemaNewlyRequiredFields(old, new *sdkmanifest.Manifest) []string {
-	oldRequired := requiredFieldSet(old.ConfigSchema)
-	newRequired := requiredFieldSet(new.ConfigSchema)
+//
+// A nil ConfigSchema or a schema with no "required" key is not an error (not
+// all plugins declare required config). A malformed "required" key (wrong type
+// or non-string element) returns an error; callers must fail closed.
+func ConfigSchemaNewlyRequiredFields(old, new *sdkmanifest.Manifest) ([]string, error) {
+	oldRequired, err := requiredFieldSet(old.ConfigSchema)
+	if err != nil {
+		return nil, fmt.Errorf("old config schema: %w", err)
+	}
+	newRequired, err := requiredFieldSet(new.ConfigSchema)
+	if err != nil {
+		return nil, fmt.Errorf("new config schema: %w", err)
+	}
 
 	var added []string
 	for field := range newRequired {
@@ -111,39 +122,44 @@ func ConfigSchemaNewlyRequiredFields(old, new *sdkmanifest.Manifest) []string {
 		}
 	}
 	sort.Strings(added)
-	return added
+	return added, nil
 }
 
 // requiredFieldSet extracts the set of names from a JSON Schema's "required"
-// array. Returns an empty map when the node is nil or has no "required" key.
-func requiredFieldSet(node *yaml.Node) map[string]bool {
+// array. Returns (nil, nil) when the node is nil or has no "required" key —
+// that is a legitimate schema with no required fields, not an error.
+// Returns an error when "required" exists but has the wrong type or contains a
+// non-string element; callers must treat that as a malformed schema and fail closed.
+func requiredFieldSet(node *yaml.Node) (map[string]bool, error) {
 	if node == nil {
-		return nil
+		return nil, nil
 	}
 	// Decode the node into a generic map to extract "required".
 	raw, err := yaml.Marshal(node)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("marshal config schema node: %w", err)
 	}
 	var schema map[string]any
 	if err := yaml.Unmarshal(raw, &schema); err != nil {
-		return nil
+		return nil, fmt.Errorf("unmarshal config schema: %w", err)
 	}
 	req, ok := schema["required"]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	slice, ok := req.([]any)
 	if !ok {
-		return nil
+		return nil, fmt.Errorf("config schema \"required\" must be an array, got %T", req)
 	}
 	set := make(map[string]bool, len(slice))
-	for _, v := range slice {
-		if s, ok := v.(string); ok {
-			set[s] = true
+	for i, v := range slice {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("config schema \"required\"[%d] must be a string, got %T", i, v)
 		}
+		set[s] = true
 	}
-	return set
+	return set, nil
 }
 
 // diffServices emits material changes for each service version field.
@@ -188,7 +204,12 @@ func sortedJoin(ss []string) string {
 			out = append(out, s)
 		}
 	}
-	b, _ := json.Marshal(out)
+	b, err := json.Marshal(out)
+	if err != nil {
+		// json.Marshal([]string) is effectively infallible, but if it somehow
+		// fails return a deterministic comma-joined fallback over the same slice.
+		return strings.Join(out, ",")
+	}
 	return string(b)
 }
 

--- a/internal/plugin/manifest/diff_test.go
+++ b/internal/plugin/manifest/diff_test.go
@@ -1,6 +1,7 @@
 package manifest_test
 
 import (
+	"strings"
 	"testing"
 
 	pluginmanifest "github.com/felag-engineering/gleipnir/internal/plugin/manifest"
@@ -289,7 +290,10 @@ func TestDiff_ConfigSchemaNewlyRequiredFields_ReturnsAddedNames(t *testing.T) {
 	new := baseManifest()
 	new.ConfigSchema = schemaNew
 
-	added := pluginmanifest.ConfigSchemaNewlyRequiredFields(old, new)
+	added, err := pluginmanifest.ConfigSchemaNewlyRequiredFields(old, new)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(added) != 1 || added[0] != "b" {
 		t.Errorf("newly required fields = %v, want [b]", added)
 	}
@@ -302,9 +306,67 @@ func TestDiff_ConfigSchemaNewlyRequiredFields_NilOld(t *testing.T) {
 	new := baseManifest()
 	new.ConfigSchema = schemaNew
 
-	added := pluginmanifest.ConfigSchemaNewlyRequiredFields(old, new)
+	added, err := pluginmanifest.ConfigSchemaNewlyRequiredFields(old, new)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(added) != 1 || added[0] != "token" {
 		t.Errorf("newly required fields = %v, want [token]", added)
+	}
+}
+
+func TestDiff_ConfigSchemaNewlyRequiredFields_MalformedRequired(t *testing.T) {
+	cases := []struct {
+		name      string
+		oldYAML   string
+		newYAML   string
+		wantErrIn string // "old" or "new"
+	}{
+		{
+			name:      "new required is a scalar string",
+			oldYAML:   `{"type":"object"}`,
+			newYAML:   `{"type":"object","required":"api_key"}`,
+			wantErrIn: "new",
+		},
+		{
+			name:      "new required is a map",
+			oldYAML:   `{"type":"object"}`,
+			newYAML:   `{"type":"object","required":{"api_key":true}}`,
+			wantErrIn: "new",
+		},
+		{
+			name:      "new required array contains a non-string element",
+			oldYAML:   `{"type":"object"}`,
+			newYAML:   `{"type":"object","required":["api_key",42]}`,
+			wantErrIn: "new",
+		},
+		{
+			name:      "old required is a scalar string",
+			oldYAML:   `{"type":"object","required":"token"}`,
+			newYAML:   `{"type":"object","required":["token"]}`,
+			wantErrIn: "old",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			old := baseManifest()
+			old.ConfigSchema = parseNode(t, tc.oldYAML)
+
+			new := baseManifest()
+			new.ConfigSchema = parseNode(t, tc.newYAML)
+
+			_, err := pluginmanifest.ConfigSchemaNewlyRequiredFields(old, new)
+			if err == nil {
+				t.Fatal("expected error for malformed required, got nil")
+			}
+			if tc.wantErrIn != "" {
+				errStr := err.Error()
+				if !strings.Contains(errStr, tc.wantErrIn+" config schema") {
+					t.Errorf("error %q should mention %q config schema", errStr, tc.wantErrIn)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #591

## Summary

`manifest.requiredFieldSet` swallowed every error (marshal/unmarshal failure, wrong-type `required` block) and returned an empty set indistinguishable from "no required fields." That empty set flowed through `ConfigSchemaNewlyRequiredFields` into the `AcceptManifest` hot-reload gate, so a **malformed** new schema silently reported "no newly-required fields" and let a migration-needing change through as `healthy` — a fail-OPEN on a gating decision (violates CLAUDE.md "never swallow errors").

This makes the path fail **closed**.

## Changes

- `internal/plugin/manifest/diff.go` — `requiredFieldSet` and `ConfigSchemaNewlyRequiredFields` now return `(result, error)`. A nil schema or missing `required` key is still legitimately `(nil, nil)`; a wrong-type `required` (scalar/map) or a non-string array element is now an **error**. `sortedJoin` no longer drops its `json.Marshal` error (deterministic fallback). Package stays a leaf — only `strings` added.
- `internal/admin/plugin_handler.go` — `AcceptManifest` gate: a parse error sets `forceMigration` and forces `targetState = pending_config_migration` (HTTP stays 200, not 500 — operators can still act). Audit payload records `config_schema_unparseable`.
- `internal/plugin/loader/install.go` — the material-change audit site logs-and-continues on error (that path already blocks via `pending_manifest_approval`).

## Tests

- `internal/plugin/manifest/diff_test.go` — existing tests updated to the two-value return; new table-driven cases for scalar/map/non-string-element `required` asserting an error is returned.
- `internal/admin/plugin_handler_test.go` — new subtest: a malformed candidate schema yields HTTP 200, `InstancesPendingConfig == 1`, `InstancesUnblocked == 0`, instance health `pending_config_migration`, audit flag `true`. Fails against the old fail-open code.

Reachability confirmed: `ConfigSchema` is stored as a raw `*yaml.Node`, so a wrong-type `required` survives `sdkmanifest.Unmarshal` and is only caught here.

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**APPROVE**) → implement → code review (**APPROVE**, 0 cycles). One readability nit (inline substring helper → `strings.Contains`) applied post-review.
- CLAUDE.md: no updates needed.

<details>
<summary>Plan</summary>

Thread an error out of `requiredFieldSet`/`ConfigSchemaNewlyRequiredFields`; fail closed at the `AcceptManifest` gate (force `pending_config_migration`), log-and-continue at the install.go material-change audit site, deterministic fallback for `sortedJoin`. Table-driven malformed-schema tests + a gate test asserting the fail-closed outcome.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)