### PR TITLE
fix: exclude administrative inactive state from WorstHealth aggregate

### DIFF
--- a/internal/plugin/state/pluginstate.go
+++ b/internal/plugin/state/pluginstate.go
@@ -64,6 +64,10 @@ type Querier interface {
 //	6 = manifest signature rejected
 //	7 = process crash
 //	8 = deliberately deactivated by admin (inactive) — deliberate total disable
+//
+// Note: inactive's rank (8) participates ONLY in the §8.1 self-mark no-op gate
+// inside SetHealthState, NOT in cross-instance aggregation. WorstHealth excludes
+// inactive explicitly so it never masks a sibling failure (#589).
 var severity = map[model.PluginHealthState]int{
 	model.PluginHealthStateHealthy:                 0,
 	model.PluginHealthStateUnsignedPermissive:      1,
@@ -270,14 +274,28 @@ func SetHealthState(ctx context.Context, q Querier, publisher event.Publisher, i
 	return nil
 }
 
-// WorstHealth returns the most severe PluginHealthState from the given slice.
-// If the slice is empty, it returns PluginHealthStateHealthy.
+// WorstHealth returns the most severe health state across the given instances.
+// The administrative inactive state is excluded from the comparison so it never
+// masks a sibling failure (e.g. crashed) in a multi-instance aggregate (#589).
+// Special cases:
+//   - empty slice → healthy (no instances is not a failure)
+//   - all entries inactive → inactive (honest aggregate; no health signal)
 func WorstHealth(states []model.PluginHealthState) model.PluginHealthState {
 	worst := model.PluginHealthStateHealthy
+	sawNonInactive := false
 	for _, s := range states {
+		if s == model.PluginHealthStateInactive {
+			continue
+		}
+		sawNonInactive = true
 		if Severity(s) > Severity(worst) {
 			worst = s
 		}
+	}
+	// If the slice was non-empty but every entry was inactive, report inactive
+	// rather than the healthy default — no health information is available.
+	if !sawNonInactive && len(states) > 0 {
+		return model.PluginHealthStateInactive
 	}
 	return worst
 }

--- a/internal/plugin/state/pluginstate_test.go
+++ b/internal/plugin/state/pluginstate_test.go
@@ -173,16 +173,17 @@ func TestPendingReauthorizeSeverity(t *testing.T) {
 }
 
 func TestInactiveSeverity(t *testing.T) {
-	// inactive must sit at rank 8, above crashed (7), because it is a deliberate
-	// and total disable — worse than any runtime failure from an availability standpoint.
+	// inactive must sit at rank 8, above crashed (7). This rank is load-bearing
+	// for the §8.1 self-mark no-op gate in SetHealthState; do not lower it.
 	got := Severity(model.PluginHealthStateInactive)
 	if got != 8 {
 		t.Errorf("Severity(inactive) = %d, want 8", got)
 	}
-	// inactive must dominate crashed in WorstHealth.
+	// WorstHealth excludes inactive from health aggregation (#589): crashed wins
+	// over inactive because inactive is administrative, not a health failure.
 	worst := WorstHealth([]model.PluginHealthState{model.PluginHealthStateCrashed, model.PluginHealthStateInactive})
-	if worst != model.PluginHealthStateInactive {
-		t.Errorf("WorstHealth([crashed, inactive]) = %q, want inactive", worst)
+	if worst != model.PluginHealthStateCrashed {
+		t.Errorf("WorstHealth([crashed, inactive]) = %q, want crashed (#589)", worst)
 	}
 }
 
@@ -435,13 +436,39 @@ func TestWorstHealth(t *testing.T) {
 			want: model.PluginHealthStateCrashed, // severity 7 > 6 > 5
 		},
 		{
-			name: "inactive dominates all other states",
+			// #589: inactive is excluded from health aggregation; crashed wins.
+			name: "inactive is excluded; crashed dominates",
 			states: []model.PluginHealthState{
 				model.PluginHealthStateCrashed,
 				model.PluginHealthStateInactive,
 				model.PluginHealthStateSignatureInvalid,
 			},
-			want: model.PluginHealthStateInactive, // severity 8 > 7 > 6
+			want: model.PluginHealthStateCrashed, // inactive excluded; severity 7 > 6
+		},
+		{
+			name:   "inactive with healthy returns healthy",
+			states: []model.PluginHealthState{model.PluginHealthStateInactive, model.PluginHealthStateHealthy},
+			want:   model.PluginHealthStateHealthy,
+		},
+		{
+			name:   "inactive with unhealthy returns unhealthy",
+			states: []model.PluginHealthState{model.PluginHealthStateInactive, model.PluginHealthStateUnhealthy},
+			want:   model.PluginHealthStateUnhealthy,
+		},
+		{
+			name:   "inactive with crashed returns crashed",
+			states: []model.PluginHealthState{model.PluginHealthStateInactive, model.PluginHealthStateCrashed},
+			want:   model.PluginHealthStateCrashed,
+		},
+		{
+			name:   "all inactive returns inactive",
+			states: []model.PluginHealthState{model.PluginHealthStateInactive, model.PluginHealthStateInactive},
+			want:   model.PluginHealthStateInactive,
+		},
+		{
+			name:   "single inactive returns inactive",
+			states: []model.PluginHealthState{model.PluginHealthStateInactive},
+			want:   model.PluginHealthStateInactive,
 		},
 	}
 


### PR DESCRIPTION
Closes #589

## Summary

The administrative `inactive` state (operator soft-deactivation) was ranked "worst" (rank 8) in the same `severity` total order that `WorstHealth` uses to aggregate multi-instance health. A future plugin-level aggregate-health chip built on `WorstHealth` would therefore report "inactive" even when a sibling instance is `crashed` — a latent semantic trap. (Currently inert: `WorstHealth` has no production caller yet.)

## Fix

Scoped to `WorstHealth` only:
- It now **skips** `inactive` entries when computing the worst *health* severity, so a deactivated instance never masks a real failure on a sibling.
- Returns `inactive` only when **every** instance is inactive (honest aggregate — no health signal). Empty input still returns `healthy`.

The `severity` map, `Severity`, and the §8.1 self-mark gate in `SetHealthState` are left **byte-for-byte unchanged**. `inactive`'s rank 8 is load-bearing there: removing it would make `Severity(inactive) == -1` and flip the self-mark no-op gate from drop→write, reviving a deactivated instance. A cross-reference comment now documents the two distinct consumers of the rank.

## Tests

- `TestInactiveSeverity` keeps the `Severity(inactive) == 8` assertion (guards the §8.1 input) and flips `WorstHealth([crashed, inactive])` from `inactive` to `crashed`.
- `TestWorstHealth` table extended: `[inactive,healthy]→healthy`, `[inactive,unhealthy]→unhealthy`, `[inactive,crashed]→crashed`, `[inactive,inactive]→inactive`, `[inactive]→inactive`. These fail against the old fail-open ordering.

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**APPROVE**) → implement → code review (**APPROVE**, 0 cycles).
- CLAUDE.md: no updates needed.

<details>
<summary>Plan</summary>

Approach A scoped to `WorstHealth`: exclude `inactive` from the aggregate; keep the `severity` map intact to preserve the §8.1 merge gate. All-inactive → inactive, empty → healthy. Table-driven tests covering the mixes.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)