### PR TITLE
feat: release plugin tool-namespace reservations on instance deletion

### DIFF
--- a/internal/admin/instance_lifecycle.go
+++ b/internal/admin/instance_lifecycle.go
@@ -466,9 +466,9 @@ func (m *InstanceLifecycle) Delete(ctx context.Context, pluginID, instanceID str
 		return &lifecycleInternalError{PublicMsg: "internal error", Err: err}
 	}
 
-	// Best-effort tool-namespace release. Nil-safe: not yet wired in main.go
-	// (see ToolUnregistrar godoc and TODO at main.go). #194 follow-up will add
-	// the one-line wire-up.
+	// Best-effort tool-namespace release. Nil-safe: wired to rt.ToolRegistrar in
+	// main.go (#574). Tests leave Unreg nil to skip the call without importing
+	// internal/plugin/tools.
 	if m.unreg != nil {
 		m.unreg.UnregisterInstance(ctx, inst.InstanceName)
 	}

--- a/internal/admin/instance_lifecycle_test.go
+++ b/internal/admin/instance_lifecycle_test.go
@@ -484,6 +484,27 @@ func TestInstanceLifecycle_Delete(t *testing.T) {
 			t.Error("instance should be deleted from store despite Stop failure")
 		}
 	})
+
+	t.Run("releases tool-namespace reservation with instance name on successful delete", func(t *testing.T) {
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-1", Name: "p", ManifestSnapshot: instanceConfigManifestNoSchema})
+		q.seed(db.PluginInstance{ID: "unreg-inst", PluginID: "plugin-1", InstanceName: "unreg-target", HealthState: "healthy"})
+		seedStorePlugin(t, store, "plugin-1", "p", nil)
+		seedStoreInstance(t, store, "unreg-inst", "plugin-1", "unreg-target")
+
+		unreg := &fakeUnreg{}
+		m := newTestLifecycle(q, store, withUnreg(unreg))
+		if err := m.Delete(ctx, "plugin-1", "unreg-inst"); err != nil {
+			t.Fatalf("Delete: unexpected error: %v", err)
+		}
+		// The unregistrar must be called with the instance NAME (not the ID).
+		// This is the regression guard against a key-mismatch: if the call were
+		// keyed by instance ID instead of name, the arbiter would silently no-op.
+		if len(unreg.names) != 1 || unreg.names[0] != "unreg-target" {
+			t.Errorf("UnregisterInstance called with %v, want [unreg-target]", unreg.names)
+		}
+	})
 }
 
 // ─── Uninstall ───────────────────────────────────────────────────────────────
@@ -641,6 +662,27 @@ func TestInstanceLifecycle_Uninstall(t *testing.T) {
 		}
 		if deleteInflight.Op != inflightOpDelete {
 			t.Errorf("Delete InflightError.Op = %v, want inflightOpDelete", deleteInflight.Op)
+		}
+	})
+
+	t.Run("releases tool-namespace reservations per instance name on uninstall", func(t *testing.T) {
+		// Uninstall requires all instances to be deleted first (InstancesRemainError
+		// guards non-empty lists). When it succeeds the instance list is empty and
+		// unreg is called zero times — correct behaviour. This test verifies: no
+		// panic when Unreg is wired, and zero calls when the plugin has no instances.
+		store := newPluginTestStore(t)
+		q := newFakePluginQuerier()
+		q.seedPlugin(db.Plugin{ID: "plugin-9", Name: "no-insts", ManifestSnapshot: instanceConfigManifestNoSchema})
+		seedStorePlugin(t, store, "plugin-9", "no-insts", nil)
+
+		unreg := &fakeUnreg{}
+		m := newTestLifecycle(q, store, withUnreg(unreg), withPluginsDir(t.TempDir()))
+		if err := m.Uninstall(ctx, "plugin-9"); err != nil {
+			t.Fatalf("Uninstall: unexpected error: %v", err)
+		}
+		// Instances are pre-deleted before Uninstall; unreg is called 0 times.
+		if len(unreg.names) != 0 {
+			t.Errorf("UnregisterInstance called with %v, want no calls (all instances pre-deleted)", unreg.names)
 		}
 	})
 }

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -130,9 +130,8 @@ type PluginProcessManager interface {
 // ToolUnregistrar is the narrow interface for releasing tool-namespace
 // reservations when an instance is deleted. Implemented by *tools.Registrar;
 // kept as an interface here so the admin package does not import
-// internal/plugin/tools. The field is wired but SetToolUnregistrar is NOT
-// called in main.go for this PR — tools.Registrar is not yet in the live
-// process path (TODO at main.go). A nil unregistrar is a safe no-op.
+// internal/plugin/tools (the concrete type is supplied from package main).
+// A nil unregistrar is a safe no-op, which tests rely on to avoid the import.
 type ToolUnregistrar interface {
 	UnregisterInstance(ctx context.Context, instanceName string)
 }

--- a/internal/admin/plugin_handler_test.go
+++ b/internal/admin/plugin_handler_test.go
@@ -2314,6 +2314,17 @@ func (f *fakeProcessManager) StartByPluginID(_ context.Context, pluginID string)
 	return f.startErr
 }
 
+// fakeUnreg is a ToolUnregistrar stub that records instance names passed to
+// UnregisterInstance. Used by instance_lifecycle_test.go to assert the correct
+// name is forwarded (the regression guard for key-mismatch bugs).
+type fakeUnreg struct {
+	names []string
+}
+
+func (f *fakeUnreg) UnregisterInstance(_ context.Context, instanceName string) {
+	f.names = append(f.names, instanceName)
+}
+
 // serveDeleteInstance wires the DeleteInstance handler into a chi router.
 func serveDeleteInstance(h *PluginHandler, pluginID, instanceID string) *httptest.ResponseRecorder {
 	r := chi.NewRouter()

--- a/main.go
+++ b/main.go
@@ -386,6 +386,7 @@ func run(cfg config.Config) error {
 		Trigger:    pluginTrigger,
 		Inflight:   pluginInflight,
 		PluginsDir: pluginPluginsDir,
+		Unreg:      rt.ToolRegistrar,
 	})
 	pluginConfig := admin.NewInstanceConfig(admin.InstanceConfigDeps{
 		Q:         store.Queries(),

--- a/pluginruntime.go
+++ b/pluginruntime.go
@@ -503,3 +503,7 @@ func (rt *pluginRuntime) shutdown() {
 		}
 	}
 }
+
+// Compile-time assertion: *plugintools.Registrar must satisfy admin.ToolUnregistrar.
+// Guards against future signature drift between the interface and the concrete type.
+var _ admin.ToolUnregistrar = (*plugintools.Registrar)(nil)


### PR DESCRIPTION
Closes #574

## Summary

Deleting a plugin instance did not release the instance's `<instance>.<tool>` name reservations held by the in-memory `toolregistry` arbiter — the `ToolUnregistrar` seam existed but no real unregistrar was wired in `main.go`, leaving stale reservations until the next host restart. Sharp edge: delete + recreate an instance with the same name before a restart collides on the stale reservation.

## Fix

Wire the already-constructed `*plugin/tools.Registrar` into `InstanceLifecycleDeps.Unreg` in `main.go`. The pieces already line up exactly — `*tools.Registrar` satisfies `admin.ToolUnregistrar` directly (identical signature; reservations are made and released under the same `Source{Kind: KindPlugin, Name: instanceName}` key), so **no adapter is needed**. A compile-time assertion in package main guards against future signature drift.

- **Delete + Uninstall** release reservations (terminal operations).
- **Deactivate** is deliberately left untouched — it's reversible, and Activate re-registers tools on respawn; releasing the namespace during the inactive window could let another instance claim the name and block reactivation.

## Tests

- `internal/admin/instance_lifecycle_test.go` — new Delete sub-test seeds an instance whose **ID differs from its name** and asserts `UnregisterInstance` is called with the **name** (not the ID): the regression guard against a key-mismatch silent no-op. Plus an Uninstall sub-test documenting that uninstall releases zero reservations on its success path (it refuses with 409 while any instances remain — they must be deleted first).
- The register→unregister→name-free round-trip is already covered by the existing `TestUnregister_FreesNamesForReuse`, so no duplicate was added.

Package boundary preserved: `internal/admin` still does not import `internal/plugin/tools` (interface in admin, concrete type supplied from package main).

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**APPROVE**) → implement → code review (**APPROVE**, 0 cycles).
- CLAUDE.md: no updates needed.

<details>
<summary>Plan</summary>

One-line wiring (`Unreg: rt.ToolRegistrar`) + compile-time assertion + stale-comment cleanup + a name-asserting regression test. Verified the name-vs-ID key matches on both the reservation and release sides.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)