### PR TITLE
fix: run view tool count excludes feedback channel, matching Agents card

### DIFF
--- a/frontend/src/components/RunDetail/CapabilitySnapshotCard.module.css
+++ b/frontend/src/components/RunDetail/CapabilitySnapshotCard.module.css
@@ -59,6 +59,33 @@
   border-top: 1px solid var(--border-subtle);
 }
 
+.feedbackRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.feedbackChip {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-feedback);
+  background: color-mix(in srgb, var(--color-feedback) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-feedback) 25%, transparent);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.feedbackLabel {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/components/RunDetail/CapabilitySnapshotCard.stories.tsx
+++ b/frontend/src/components/RunDetail/CapabilitySnapshotCard.stories.tsx
@@ -120,3 +120,37 @@ export const WithNullSystemPrompt: Story = {
     systemPrompt: null,
   },
 }
+
+// Feedback-enabled variants — ask_operator excluded from tool count, shown as separate indicator.
+
+const WITH_FEEDBACK_LEGACY: CapabilitySnapshotContent = [
+  ...MIXED_TOOLS,
+  { server_name: 'gleipnir', tool_name: 'ask_operator', approval: 'none', timeout: 0, on_timeout: '' },
+]
+
+export const LegacyWithFeedback: Story = {
+  name: 'Legacy array — with feedback (ask_operator excluded from count)',
+  args: { content: WITH_FEEDBACK_LEGACY },
+}
+
+const WITH_FEEDBACK_V2: CapabilitySnapshotContent = {
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  tools: [
+    ...MIXED_TOOLS,
+    { server_name: 'gleipnir', tool_name: 'ask_operator', approval: 'none', timeout: 0, on_timeout: '' },
+  ],
+}
+
+export const V2WithFeedback: Story = {
+  name: 'V2 — with feedback (ask_operator excluded from count)',
+  args: { content: WITH_FEEDBACK_V2 },
+}
+
+export const V2WithFeedbackAndSystemPrompt: Story = {
+  name: 'V2 — with feedback + system prompt',
+  args: {
+    content: WITH_FEEDBACK_V2,
+    systemPrompt: SAMPLE_SYSTEM_PROMPT,
+  },
+}

--- a/frontend/src/components/RunDetail/CapabilitySnapshotCard.test.tsx
+++ b/frontend/src/components/RunDetail/CapabilitySnapshotCard.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CapabilitySnapshotCard } from './CapabilitySnapshotCard'
+import type { CapabilitySnapshotContent } from './types'
+
+const TWO_REAL_TOOLS: CapabilitySnapshotContent = [
+  { server_name: 'fs', tool_name: 'read_file', approval: 'none', timeout: 30, on_timeout: 'fail' },
+  { server_name: 'fs', tool_name: 'write_file', approval: 'required', timeout: 60, on_timeout: 'fail' },
+]
+
+const WITH_FEEDBACK: CapabilitySnapshotContent = [
+  ...TWO_REAL_TOOLS,
+  { server_name: 'gleipnir', tool_name: 'ask_operator', approval: 'none', timeout: 0, on_timeout: '' },
+]
+
+const V2_WITH_FEEDBACK: CapabilitySnapshotContent = {
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  tools: [
+    { server_name: 'fs', tool_name: 'read_file', approval: 'none', timeout: 30, on_timeout: 'fail' },
+    { server_name: 'fs', tool_name: 'write_file', approval: 'required', timeout: 60, on_timeout: 'fail' },
+    { server_name: 'gleipnir', tool_name: 'ask_operator', approval: 'none', timeout: 0, on_timeout: '' },
+  ],
+}
+
+describe('CapabilitySnapshotCard — feedback filtering (legacy array shape)', () => {
+  it('shows "2 tools" when snapshot has 2 real tools + ask_operator', () => {
+    render(<CapabilitySnapshotCard content={WITH_FEEDBACK} />)
+    expect(screen.getByText(/2 tools/)).toBeInTheDocument()
+    expect(screen.queryByText(/3 tools/)).not.toBeInTheDocument()
+  })
+
+  it('shows feedback indicator when ask_operator is present', async () => {
+    render(<CapabilitySnapshotCard content={WITH_FEEDBACK} />)
+    // Expand to see the feedback indicator
+    fireEvent.click(screen.getByRole('button', { name: /capability snapshot/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Feedback')).toBeInTheDocument()
+    })
+  })
+
+  it('omits ask_operator from the tool table', async () => {
+    render(<CapabilitySnapshotCard content={WITH_FEEDBACK} />)
+    fireEvent.click(screen.getByRole('button', { name: /capability snapshot/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument()
+    })
+    expect(screen.getByText('read_file')).toBeInTheDocument()
+    expect(screen.getByText('write_file')).toBeInTheDocument()
+    expect(screen.queryByText('ask_operator')).not.toBeInTheDocument()
+    // gleipnir server name must not appear in the table
+    expect(screen.queryByText('gleipnir')).not.toBeInTheDocument()
+  })
+
+  it('shows "2 tools" for a snapshot without feedback (no regression)', () => {
+    render(<CapabilitySnapshotCard content={TWO_REAL_TOOLS} />)
+    expect(screen.getByText(/2 tools/)).toBeInTheDocument()
+    expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+  })
+
+  it('does NOT show feedback indicator when ask_operator is absent', async () => {
+    render(<CapabilitySnapshotCard content={TWO_REAL_TOOLS} />)
+    fireEvent.click(screen.getByRole('button', { name: /capability snapshot/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+  })
+})
+
+describe('CapabilitySnapshotCard — feedback filtering (V2 object shape)', () => {
+  it('shows "2 tools" for V2 snapshot with ask_operator', () => {
+    render(<CapabilitySnapshotCard content={V2_WITH_FEEDBACK} />)
+    expect(screen.getByText(/2 tools/)).toBeInTheDocument()
+    expect(screen.queryByText(/3 tools/)).not.toBeInTheDocument()
+  })
+
+  it('shows feedback indicator when expanded (V2 shape)', async () => {
+    render(<CapabilitySnapshotCard content={V2_WITH_FEEDBACK} />)
+    fireEvent.click(screen.getByRole('button', { name: /capability snapshot/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Feedback')).toBeInTheDocument()
+    })
+  })
+
+  it('omits ask_operator from table (V2 shape)', async () => {
+    render(<CapabilitySnapshotCard content={V2_WITH_FEEDBACK} />)
+    fireEvent.click(screen.getByRole('button', { name: /capability snapshot/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('ask_operator')).not.toBeInTheDocument()
+    expect(screen.queryByText('gleipnir')).not.toBeInTheDocument()
+  })
+
+  it('still shows provider and model in collapsed summary (V2 shape)', () => {
+    render(<CapabilitySnapshotCard content={V2_WITH_FEEDBACK} />)
+    const summary = screen.getByRole('button', { name: /capability snapshot/i })
+    expect(summary.textContent).toContain('Anthropic')
+    expect(summary.textContent).toContain('claude-sonnet-4-6')
+  })
+})

--- a/frontend/src/components/RunDetail/CapabilitySnapshotCard.tsx
+++ b/frontend/src/components/RunDetail/CapabilitySnapshotCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Settings, ChevronDown, ChevronUp, ChevronRight } from 'lucide-react'
 import type { CapabilitySnapshotContent, CapabilitySnapshotV2, GrantedToolEntry } from './types'
+import { isFeedbackEntry } from './types'
 import { formatProviderName } from '@/utils/format'
 import styles from './CapabilitySnapshotCard.module.css'
 
@@ -16,9 +17,11 @@ export function CapabilitySnapshotCard({ content, systemPrompt }: Props) {
   // Support both the legacy array shape (pre-ADR-023) and the V2 object shape.
   const isV2 = !Array.isArray(content) && content !== null && typeof content === 'object'
   const tools = isV2 ? (content as CapabilitySnapshotV2).tools : (content as GrantedToolEntry[])
+  const realTools = (tools ?? []).filter(t => !isFeedbackEntry(t))
+  const feedbackEnabled = (tools ?? []).some(isFeedbackEntry)
   const modelName = isV2 ? (content as CapabilitySnapshotV2).model : undefined
   const provider = isV2 ? (content as CapabilitySnapshotV2).provider : undefined
-  const count = tools?.length ?? 0
+  const count = realTools.length
 
   return (
     <div className={styles.card}>
@@ -36,6 +39,12 @@ export function CapabilitySnapshotCard({ content, systemPrompt }: Props) {
       </button>
       {expanded && (
         <div className={styles.tableWrapper}>
+          {feedbackEnabled && (
+            <div className={styles.feedbackRow}>
+              <span className={styles.feedbackChip}>Feedback</span>
+              <span className={styles.feedbackLabel}>gleipnir.ask_operator — human-in-the-loop channel</span>
+            </div>
+          )}
           <table className={styles.table}>
             <thead>
               <tr>
@@ -45,7 +54,7 @@ export function CapabilitySnapshotCard({ content, systemPrompt }: Props) {
               </tr>
             </thead>
             <tbody>
-              {tools.map((t, i) => (
+              {realTools.map((t, i) => (
                 <tr key={i}>
                   <td className={styles.mono}>{t.server_name}</td>
                   <td className={styles.mono}>{t.tool_name}</td>

--- a/frontend/src/components/RunDetail/RunHeader.module.css
+++ b/frontend/src/components/RunDetail/RunHeader.module.css
@@ -73,6 +73,12 @@
   line-height: 1;
 }
 
+.capabilityRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .capabilityBar {
   display: inline-flex;
   align-items: center;
@@ -85,6 +91,18 @@
   border: none;
   cursor: pointer;
   transition: color var(--duration-fast) var(--ease-out);
+}
+
+.feedbackChip {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-feedback);
+  background: color-mix(in srgb, var(--color-feedback) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-feedback) 25%, transparent);
+  border-radius: 4px;
 }
 
 .capabilityBar:hover {

--- a/frontend/src/components/RunDetail/RunHeader.stories.tsx
+++ b/frontend/src/components/RunDetail/RunHeader.stories.tsx
@@ -95,3 +95,40 @@ export const FailedWithRetry: Story = {
     onRetry: fn(),
   },
 }
+
+export const WithFeedbackEnabled: Story = {
+  name: 'With feedback capability (ask_operator excluded from tool count)',
+  args: {
+    run: BASE_RUN,
+    toolCallCount: 3,
+    tokenTotal: 1200,
+    duration: 90_000,
+    capabilitySnapshot: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      toolCount: 2,
+      tools: [
+        { server_name: 'fs-server', tool_name: 'read_file', approval: 'none' },
+        { server_name: 'fs-server', tool_name: 'write_file', approval: 'required' },
+      ],
+      feedbackEnabled: true,
+    },
+  },
+}
+
+export const WithFeedbackOnly: Story = {
+  name: 'With feedback only (zero granted tools)',
+  args: {
+    run: BASE_RUN,
+    toolCallCount: 0,
+    tokenTotal: 200,
+    duration: 15_000,
+    capabilitySnapshot: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      toolCount: 0,
+      tools: [],
+      feedbackEnabled: true,
+    },
+  },
+}

--- a/frontend/src/components/RunDetail/RunHeader.test.tsx
+++ b/frontend/src/components/RunDetail/RunHeader.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import React from 'react'
+import { RunHeader } from './RunHeader'
+import type { ApiRun } from '@/api/types'
+
+const BASE_RUN: ApiRun = {
+  id: 'run-1',
+  policy_id: 'pol-1',
+  policy_name: 'test-policy',
+  status: 'complete',
+  trigger_type: 'manual',
+  trigger_payload: '{}',
+  started_at: '2026-01-01T00:00:00Z',
+  completed_at: '2026-01-01T00:01:00Z',
+  token_cost: 100,
+  error: null,
+  created_at: '2026-01-01T00:00:00Z',
+  system_prompt: null,
+  model: 'claude-sonnet-4-6',
+}
+
+const TWO_REAL_TOOLS = [
+  { server_name: 'fs', tool_name: 'read_file', approval: 'none' as const },
+  { server_name: 'fs', tool_name: 'write_file', approval: 'required' as const },
+]
+
+function renderHeader(capabilitySnapshot: React.ComponentProps<typeof RunHeader>['capabilitySnapshot']) {
+  return render(
+    <MemoryRouter>
+      <RunHeader
+        run={BASE_RUN}
+        toolCallCount={0}
+        tokenTotal={0}
+        duration={60_000}
+        capabilitySnapshot={capabilitySnapshot}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('RunHeader — feedback filtering', () => {
+  it('shows "2 tools" when snapshot has 2 real tools + ask_operator entry', () => {
+    renderHeader({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      toolCount: 2,
+      tools: TWO_REAL_TOOLS,
+      feedbackEnabled: true,
+    })
+    const bar = screen.getByRole('button', { name: /2 tools/i })
+    expect(bar.textContent).toContain('2 tools')
+    expect(bar.textContent).not.toContain('3 tools')
+  })
+
+  it('shows a Feedback chip when feedbackEnabled is true', () => {
+    renderHeader({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      toolCount: 2,
+      tools: TWO_REAL_TOOLS,
+      feedbackEnabled: true,
+    })
+    expect(screen.getByText('Feedback')).toBeInTheDocument()
+  })
+
+  it('does NOT show a Feedback chip when feedbackEnabled is false', () => {
+    renderHeader({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      toolCount: 2,
+      tools: TWO_REAL_TOOLS,
+      feedbackEnabled: false,
+    })
+    expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+  })
+
+  it('does NOT show a Feedback chip when feedbackEnabled is omitted', () => {
+    renderHeader({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      toolCount: 2,
+      tools: TWO_REAL_TOOLS,
+    })
+    expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+  })
+
+  it('expanded table omits ask_operator — only shows the 2 real tools', async () => {
+    renderHeader({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      toolCount: 2,
+      tools: TWO_REAL_TOOLS,
+      feedbackEnabled: true,
+    })
+    fireEvent.click(screen.getByRole('button', { name: /2 tools/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument()
+    })
+    // Both real tools are present
+    expect(screen.getByText('read_file')).toBeInTheDocument()
+    expect(screen.getByText('write_file')).toBeInTheDocument()
+    // ask_operator must not appear in the table
+    expect(screen.queryByText('ask_operator')).not.toBeInTheDocument()
+    expect(screen.queryByText('gleipnir')).not.toBeInTheDocument()
+  })
+
+  it('shows "1 tool" when snapshot has exactly one real tool and no feedback', () => {
+    renderHeader({
+      toolCount: 1,
+      tools: [{ server_name: 'fs', tool_name: 'read_file', approval: 'none' as const }],
+      feedbackEnabled: false,
+    })
+    const bar = screen.getByRole('button', { name: /1 tool/i })
+    expect(bar.textContent).toContain('1 tool')
+    expect(bar.textContent).not.toContain('tools')
+  })
+})

--- a/frontend/src/components/RunDetail/RunHeader.tsx
+++ b/frontend/src/components/RunDetail/RunHeader.tsx
@@ -25,6 +25,7 @@ interface Props {
     model?: string
     toolCount: number
     tools: Array<CapabilityTool>
+    feedbackEnabled?: boolean
   } | null
   showRetry?: boolean
   onRetry?: () => void
@@ -83,17 +84,22 @@ export function RunHeader({ run, toolCallCount, tokenTotal, duration, capability
 
       {capabilityParts.length > 0 && (
         <div>
-          <button
-            type="button"
-            className={styles.capabilityBar}
-            onClick={() => setCapExpanded(o => !o)}
-            aria-expanded={capExpanded}
-          >
-            {capabilityParts.join(' · ')}
-            <span className={styles.capabilityChevron}>
-              {capExpanded ? <ChevronUp size={14} aria-hidden /> : <ChevronDown size={14} aria-hidden />}
-            </span>
-          </button>
+          <div className={styles.capabilityRow}>
+            <button
+              type="button"
+              className={styles.capabilityBar}
+              onClick={() => setCapExpanded(o => !o)}
+              aria-expanded={capExpanded}
+            >
+              {capabilityParts.join(' · ')}
+              <span className={styles.capabilityChevron}>
+                {capExpanded ? <ChevronUp size={14} aria-hidden /> : <ChevronDown size={14} aria-hidden />}
+              </span>
+            </button>
+            {capabilitySnapshot?.feedbackEnabled && (
+              <span className={styles.feedbackChip}>Feedback</span>
+            )}
+          </div>
           {capExpanded && capabilitySnapshot && capabilitySnapshot.tools.length > 0 && (
             <div className={styles.capabilityTableWrapper}>
               <table className={styles.capabilityTable}>

--- a/frontend/src/components/RunDetail/types.ts
+++ b/frontend/src/components/RunDetail/types.ts
@@ -50,6 +50,15 @@ export interface GrantedToolEntry {
   on_timeout: string
 }
 
+// The feedback channel is registered at runtime as gleipnir.ask_operator when
+// feedback.enabled: true. It is a capability, not a granted MCP/plugin tool,
+// so it must be excluded from the tool count and listed separately.
+export const FEEDBACK_SENTINEL = { server_name: 'gleipnir', tool_name: 'ask_operator' } as const
+
+export function isFeedbackEntry(t: GrantedToolEntry): boolean {
+  return t.server_name === 'gleipnir' && t.tool_name === 'ask_operator'
+}
+
 // CapabilitySnapshotV2 is the shape written by agent runs after ADR-023.
 // Older snapshots written before this change are plain GrantedToolEntry arrays.
 // provider is optional for backward compat: snapshots written before issue #352 have model but no provider.

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -19,6 +19,7 @@ import { ApprovalActions } from '@/components/RunDetail/ApprovalActions'
 import { CopyBlock } from '@/components/CopyBlock'
 import type { FilterKey } from '@/components/RunDetail'
 import type { CapabilitySnapshotV2, GrantedToolEntry } from '@/components/RunDetail/types'
+import { isFeedbackEntry } from '@/components/RunDetail/types'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import NotFoundPage from '@/pages/NotFoundPage'
 import { ApiError } from '@/api/fetch'
@@ -48,11 +49,14 @@ export default function RunDetailPage() {
     const content = snapshotSteps[0].content
     const isV2 = !Array.isArray(content) && content !== null && typeof content === 'object'
     const tools = isV2 ? (content as CapabilitySnapshotV2).tools : (content as GrantedToolEntry[])
+    const realTools = (tools ?? []).filter(t => !isFeedbackEntry(t))
+    const feedbackEnabled = (tools ?? []).some(isFeedbackEntry)
     return {
       provider: isV2 ? (content as CapabilitySnapshotV2).provider : undefined,
       model: isV2 ? (content as CapabilitySnapshotV2).model : undefined,
-      toolCount: tools?.length ?? 0,
-      tools: tools ?? [],
+      toolCount: realTools.length,
+      tools: realTools,
+      feedbackEnabled,
     }
   }, [snapshotSteps])
 


### PR DESCRIPTION
Closes #611

## Summary

A policy with `feedback.enabled: true` showed **"2 tools"** on the Agents card but **"3 tools"** in the run view. The card counts granted MCP/plugin tools only (`len(Capabilities.Tools)` — correct), while the run view derived its count from the `capability_snapshot.tools[]` array, which legitimately includes the synthetic feedback entry `gleipnir.ask_operator` registered at runtime.

Per the chosen fix (and the domain model — `tool` and `feedback` are two distinct capability categories), the run view now **excludes the feedback channel from the tool count** (so it matches the card) and **surfaces feedback as its own chip** instead of folding `ask_operator` into "tools".

## Changes (frontend-only)

- `types.ts` — shared `isFeedbackEntry` predicate + `FEEDBACK_SENTINEL` (matches `{server_name:'gleipnir', tool_name:'ask_operator'}`), the single source of truth.
- `RunDetailPage.tsx` — the `capabilitySnapshot` memo splits real tools from the feedback entry; exposes `feedbackEnabled`.
- `RunHeader.tsx` / `CapabilitySnapshotCard.tsx` — count and tool table now use the feedback-free list; a separate "Feedback" chip renders when enabled. `CapabilitySnapshotCard` filters independently because it reads raw step content directly.
- CSS via `color-mix(in srgb, var(--color-feedback) …%, transparent)` (codebase convention); CSS Modules only, 4px spacing.

Backend is untouched — the capability snapshot still records `ask_operator` (it really is registered at runtime); only the run-view *presentation* separates feedback.

## Tests + stories

- New `RunHeader.test.tsx` (6) and `CapabilitySnapshotCard.test.tsx` (9): assert the count is "2 tools" not "3" with `ask_operator` present, the expanded table omits it, and the feedback chip appears only when enabled. Both fail against the old code.
- Feedback-enabled variants added to both existing `.stories.tsx`.

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**APPROVE**) → implement → code review (**APPROVE**, 0 cycles). Coordinator post-fixes: removed an unused import, converted hardcoded `rgba` to `color-mix` token usage.
- CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)