### PR TITLE
feat: emit feedback_response_late as a plugin_audit_events row

### DIFF
--- a/internal/execution/run/runs_handler.go
+++ b/internal/execution/run/runs_handler.go
@@ -20,6 +20,8 @@ import (
 	"github.com/felag-engineering/gleipnir/internal/model"
 )
 
+const eventTypeFeedbackResponseLate = "feedback_response_late"
+
 // PaginatedRunsResponse is the JSON envelope returned by List.
 type PaginatedRunsResponse struct {
 	Runs  []RunSummary `json:"runs"`
@@ -642,8 +644,35 @@ func (h *RunsHandler) SubmitFeedback(w http.ResponseWriter, r *http.Request) {
 				"request_id", pendingID,
 				"run_id", runID,
 				"body_len", len(req.Response))
-			// TODO(#579): also emit a feedback_response_late row into
-			// plugin_audit_events (ADR-046) in addition to this slog line.
+
+			// Best-effort: write an audit row per ADR-046. Never include the response body.
+			auditPayload, marshalErr := json.Marshal(map[string]string{
+				"request_id": pendingID,
+				"run_id":     runID,
+				"substrate":  "in_app",
+				"reason":     "late",
+			})
+			if marshalErr != nil {
+				slog.Warn("feedback_response_late: audit payload marshal failed",
+					"request_id", pendingID,
+					"run_id", runID,
+					"err", marshalErr)
+			} else {
+				if _, insertErr := h.store.InsertPluginAuditEvent(ctx, db.InsertPluginAuditEventParams{
+					PluginInstanceID: nil,
+					EventType:        eventTypeFeedbackResponseLate,
+					Severity:         "warning",
+					ActorUserID:      nil,
+					PayloadJson:      string(auditPayload),
+					CreatedAt:        time.Now().UTC().Format(time.RFC3339Nano),
+				}); insertErr != nil {
+					slog.Warn("feedback_response_late: audit event insert failed",
+						"request_id", pendingID,
+						"run_id", runID,
+						"err", insertErr)
+				}
+			}
+
 			httputil.WriteError(w, http.StatusGone, "feedback request expired or already answered", "")
 			return
 		default:

--- a/internal/execution/run/runs_handler_test.go
+++ b/internal/execution/run/runs_handler_test.go
@@ -1669,5 +1669,41 @@ func TestRunsHandler_SubmitFeedback_LateCallback(t *testing.T) {
 		t.Errorf("error = %q, want %q", body.Error, "feedback request expired or already answered")
 	}
 
+	// Verify that a feedback_response_late audit row was written.
+	ctx := req.Context()
+	auditRows, err := store.ListPluginAuditEventsByType(ctx, db.ListPluginAuditEventsByTypeParams{
+		EventType: "feedback_response_late",
+		Limit:     int64(10),
+		Offset:    int64(0),
+	})
+	if err != nil {
+		t.Fatalf("ListPluginAuditEventsByType: %v", err)
+	}
+	if len(auditRows) != 1 {
+		t.Fatalf("got %d feedback_response_late audit rows, want 1", len(auditRows))
+	}
+	row := auditRows[0]
+	if row.Severity != "warning" {
+		t.Errorf("audit row severity = %q, want %q", row.Severity, "warning")
+	}
+	if row.PluginInstanceID != nil {
+		t.Errorf("audit row plugin_instance_id = %v, want nil", row.PluginInstanceID)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(row.PayloadJson), &payload); err != nil {
+		t.Fatalf("unmarshal audit payload: %v", err)
+	}
+	if payload["request_id"] != "fr-late-cb-1" {
+		t.Errorf("payload request_id = %q, want %q", payload["request_id"], "fr-late-cb-1")
+	}
+	if payload["run_id"] != "r-late-cb" {
+		t.Errorf("payload run_id = %q, want %q", payload["run_id"], "r-late-cb")
+	}
+	const lateResponseBody = "late response"
+	if strings.Contains(row.PayloadJson, lateResponseBody) {
+		t.Errorf("audit payload must not contain response body, got: %s", row.PayloadJson)
+	}
+
 	manager.Deregister("r-late-cb")
 }


### PR DESCRIPTION
Closes #579

## Summary

When a plugin posts a feedback response for an expired/already-answered request, `SubmitFeedback` returned HTTP 410 and only logged `feedback_response_late` via `slog.Warn`. Per ADR-046, a late/rejected callback is an operational/security-relevant event that belongs in `plugin_audit_events`.

This adds a best-effort `plugin_audit_events` row on that path, in addition to the existing log line.

## Changes

- `internal/execution/run/runs_handler.go` — in the `ErrUnknownRequestID` (late callback) branch, write a `feedback_response_late` row via the existing `h.store.InsertPluginAuditEvent` query. Payload carries `request_id`, `run_id`, `substrate: "in_app"`, `reason: "late"` — **never the response body** (ADR-046). `PluginInstanceID` is `nil` (the native/in-app feedback path has no plugin-instance association; the column is nullable). Severity `warning` and the event-type string match the existing hostsvc plugin-RPC late path so both substrates produce uniform rows (distinguished by the `substrate` payload key). The write is **best-effort** — a marshal or insert failure logs and still returns 410. Removes the stale TODO referencing the now-closed #180 / pre-ADR-046 split.
- `internal/execution/run/runs_handler_test.go` — extends `TestRunsHandler_SubmitFeedback_LateCallback`: asserts 410 still returned, exactly one `feedback_response_late` row, severity `warning`, nil `plugin_instance_id`, payload contains request_id/run_id, and the response-body text is absent.

No schema/query change (`InsertPluginAuditEvent` already exists); no hostsvc import added (package boundary preserved).

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**APPROVE**) → implement → code review (**APPROVE**, 0 cycles).
- CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)