### PR TITLE
fix: Agents list card shows friendly trigger label, never raw "subscribed"

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -11,6 +11,8 @@ export interface ApiPolicyListItem {
   id: string
   name: string
   trigger_type: string
+  trigger_source?: string
+  trigger_event_kind?: string
   folder: string
   model: string
   tool_count: number

--- a/frontend/src/components/AgentList/PolicyCard.stories.tsx
+++ b/frontend/src/components/AgentList/PolicyCard.stories.tsx
@@ -135,3 +135,32 @@ export const NoLatestRun: Story = {
     },
   },
 }
+
+export const Subscribed: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={makeQueryClient('pol-sub')}>
+        <MemoryRouter>
+          <Story />
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+  ],
+  args: {
+    policy: {
+      ...BASE_POLICY,
+      id: 'pol-sub',
+      name: 'Slack Channel Monitor',
+      trigger_type: 'subscribed',
+      trigger_source: 'slack-e2e',
+      trigger_event_kind: 'channel_message',
+      latest_run: {
+        id: 'run-sub',
+        status: 'complete',
+        started_at: new Date(Date.now() - 10 * 60_000).toISOString(),
+        token_cost: 850,
+      },
+      next_fire_at: null,
+    },
+  },
+}

--- a/frontend/src/components/AgentList/PolicyCard.test.tsx
+++ b/frontend/src/components/AgentList/PolicyCard.test.tsx
@@ -102,7 +102,7 @@ describe('PolicyCard', () => {
       </MemoryRouter>,
     )
     expect(screen.getByText('system-health-check')).toBeInTheDocument()
-    expect(screen.getByText('webhook')).toBeInTheDocument()
+    expect(screen.getByText('Webhook')).toBeInTheDocument()
     expect(screen.getByText('gemini-2.5-flash')).toBeInTheDocument()
     expect(screen.getByText('5 tools')).toBeInTheDocument()
   })
@@ -195,6 +195,36 @@ describe('PolicyCard', () => {
     )
     screen.getByRole('button', { name: /run system-health-check/i }).click()
     expect(onTrigger).toHaveBeenCalledWith('p1', 'system-health-check')
+  })
+
+  it('renders friendly label for subscribed trigger with source and event_kind', () => {
+    const subscribedPolicy: ApiPolicyListItem = {
+      ...POLICY,
+      trigger_type: 'subscribed',
+      trigger_source: 'slack-e2e',
+      trigger_event_kind: 'channel_message',
+    }
+    render(
+      <MemoryRouter>
+        <PolicyCard policy={subscribedPolicy} onTrigger={() => {}} />
+      </MemoryRouter>,
+    )
+    expect(screen.queryByText('subscribed')).toBeNull()
+    expect(screen.getByText('channel_message (slack-e2e)')).toBeInTheDocument()
+  })
+
+  it('renders "Plugin event" fallback for subscribed trigger with no source or event_kind', () => {
+    const subscribedPolicy: ApiPolicyListItem = {
+      ...POLICY,
+      trigger_type: 'subscribed',
+    }
+    render(
+      <MemoryRouter>
+        <PolicyCard policy={subscribedPolicy} onTrigger={() => {}} />
+      </MemoryRouter>,
+    )
+    expect(screen.queryByText('subscribed')).toBeNull()
+    expect(screen.getByText('Plugin event')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/AgentList/PolicyCard.tsx
+++ b/frontend/src/components/AgentList/PolicyCard.tsx
@@ -7,6 +7,7 @@ import { isRunStatus } from '@/constants/status'
 import type { RunStatus } from '@/constants/status'
 import { formatTimeAgo, formatTimestamp } from '@/utils/format'
 import { PolicyCardExpanded } from './PolicyCardExpanded'
+import { triggerPillLabel } from './triggerLabel'
 import styles from './PolicyCard.module.css'
 
 // formatNextFire returns a relative "in Xm" / "in Xh" string for a future ISO
@@ -68,7 +69,7 @@ export function PolicyCard({ policy, onTrigger }: Props) {
         <div className={styles.leftZone}>
           <div className={`${styles.statusDot} ${statusDotClass(run?.status)}`} />
           <span className={styles.policyName}>{policy.name}</span>
-          <span className={styles.triggerPill}>{policy.trigger_type}</span>
+          <span className={styles.triggerPill}>{triggerPillLabel(policy)}</span>
           {isPaused && <span className={styles.pausedPill}>Paused</span>}
           {policy.model && <span className={styles.modelPill}>{policy.model}</span>}
           {policy.tool_count > 0 && (

--- a/frontend/src/components/AgentList/triggerLabel.test.ts
+++ b/frontend/src/components/AgentList/triggerLabel.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { triggerPillLabel, BUILTIN_TRIGGER_LABELS } from './triggerLabel'
+
+describe('BUILTIN_TRIGGER_LABELS', () => {
+  it('maps all five built-in trigger types to title-case labels', () => {
+    expect(BUILTIN_TRIGGER_LABELS['webhook']).toBe('Webhook')
+    expect(BUILTIN_TRIGGER_LABELS['manual']).toBe('Manual')
+    expect(BUILTIN_TRIGGER_LABELS['scheduled']).toBe('Scheduled')
+    expect(BUILTIN_TRIGGER_LABELS['poll']).toBe('Poll')
+    expect(BUILTIN_TRIGGER_LABELS['cron']).toBe('Cron')
+  })
+})
+
+describe('triggerPillLabel', () => {
+  const cases: Array<{
+    name: string
+    input: { trigger_type: string; trigger_source?: string; trigger_event_kind?: string }
+    expected: string
+  }> = [
+    { name: 'webhook → Webhook', input: { trigger_type: 'webhook' }, expected: 'Webhook' },
+    { name: 'manual → Manual', input: { trigger_type: 'manual' }, expected: 'Manual' },
+    { name: 'scheduled → Scheduled', input: { trigger_type: 'scheduled' }, expected: 'Scheduled' },
+    { name: 'poll → Poll', input: { trigger_type: 'poll' }, expected: 'Poll' },
+    { name: 'cron → Cron', input: { trigger_type: 'cron' }, expected: 'Cron' },
+    {
+      name: 'unknown type → returned verbatim',
+      input: { trigger_type: 'some_future_type' },
+      expected: 'some_future_type',
+    },
+    {
+      name: 'subscribed with both source and event_kind',
+      input: { trigger_type: 'subscribed', trigger_source: 'slack-e2e', trigger_event_kind: 'channel_message' },
+      expected: 'channel_message (slack-e2e)',
+    },
+    {
+      name: 'subscribed with event_kind only (no source)',
+      input: { trigger_type: 'subscribed', trigger_event_kind: 'channel_message' },
+      expected: 'channel_message',
+    },
+    {
+      name: 'subscribed with neither source nor event_kind → Plugin event fallback',
+      input: { trigger_type: 'subscribed' },
+      expected: 'Plugin event',
+    },
+  ]
+
+  for (const { name, input, expected } of cases) {
+    it(name, () => {
+      expect(triggerPillLabel(input)).toBe(expected)
+    })
+  }
+
+  it('never returns "subscribed" for a subscribed trigger with both fields', () => {
+    const label = triggerPillLabel({
+      trigger_type: 'subscribed',
+      trigger_source: 'slack-e2e',
+      trigger_event_kind: 'channel_message',
+    })
+    expect(label).not.toBe('subscribed')
+    expect(label).not.toContain('subscribed')
+  })
+
+  it('never returns "subscribed" for a subscribed trigger with event_kind only', () => {
+    const label = triggerPillLabel({
+      trigger_type: 'subscribed',
+      trigger_event_kind: 'channel_message',
+    })
+    expect(label).not.toBe('subscribed')
+  })
+
+  it('never returns "subscribed" for a subscribed trigger with no fields', () => {
+    const label = triggerPillLabel({ trigger_type: 'subscribed' })
+    expect(label).not.toBe('subscribed')
+  })
+})

--- a/frontend/src/components/AgentList/triggerLabel.ts
+++ b/frontend/src/components/AgentList/triggerLabel.ts
@@ -1,0 +1,28 @@
+import type { ApiPolicyListItem } from '@/api/types'
+
+export const BUILTIN_TRIGGER_LABELS: Record<string, string> = {
+  webhook: 'Webhook',
+  manual: 'Manual',
+  scheduled: 'Scheduled',
+  poll: 'Poll',
+  cron: 'Cron',
+}
+
+/**
+ * Returns a human-readable pill label for the given policy's trigger type.
+ * For subscribed policies, surfaces the event kind and source so the literal
+ * word "subscribed" is never shown to operators (ADR-048).
+ */
+export function triggerPillLabel(
+  policy: Pick<ApiPolicyListItem, 'trigger_type' | 'trigger_source' | 'trigger_event_kind'>,
+): string {
+  if (policy.trigger_type === 'subscribed') {
+    if (policy.trigger_event_kind) {
+      return policy.trigger_source
+        ? `${policy.trigger_event_kind} (${policy.trigger_source})`
+        : policy.trigger_event_kind
+    }
+    return 'Plugin event'
+  }
+  return BUILTIN_TRIGGER_LABELS[policy.trigger_type] ?? policy.trigger_type
+}

--- a/internal/http/api/policy_handler.go
+++ b/internal/http/api/policy_handler.go
@@ -66,20 +66,22 @@ type runSummary struct {
 }
 
 type policyListItem struct {
-	ID           string      `json:"id"`
-	Name         string      `json:"name"`
-	TriggerType  string      `json:"trigger_type"`
-	Folder       string      `json:"folder"`
-	Model        string      `json:"model"`
-	ToolCount    int         `json:"tool_count"`
-	ToolRefs     []string    `json:"tool_refs"`
-	AvgTokenCost int64       `json:"avg_token_cost"`
-	RunCount     int64       `json:"run_count"`
-	CreatedAt    string      `json:"created_at"`
-	UpdatedAt    string      `json:"updated_at"`
-	PausedAt     *string     `json:"paused_at"`
-	LatestRun    *runSummary `json:"latest_run"`
-	NextFireAt   *string     `json:"next_fire_at"`
+	ID               string      `json:"id"`
+	Name             string      `json:"name"`
+	TriggerType      string      `json:"trigger_type"`
+	TriggerSource    string      `json:"trigger_source,omitempty"`
+	TriggerEventKind string      `json:"trigger_event_kind,omitempty"`
+	Folder           string      `json:"folder"`
+	Model            string      `json:"model"`
+	ToolCount        int         `json:"tool_count"`
+	ToolRefs         []string    `json:"tool_refs"`
+	AvgTokenCost     int64       `json:"avg_token_cost"`
+	RunCount         int64       `json:"run_count"`
+	CreatedAt        string      `json:"created_at"`
+	UpdatedAt        string      `json:"updated_at"`
+	PausedAt         *string     `json:"paused_at"`
+	LatestRun        *runSummary `json:"latest_run"`
+	NextFireAt       *string     `json:"next_fire_at"`
 }
 
 type policyDetail struct {
@@ -132,6 +134,11 @@ func (h *PolicyHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 
 		item.NextFireAt = computeNextFireAt(row.TriggerType, summary, item.LatestRun, row.PausedAt)
+
+		if row.TriggerType == string(model.TriggerTypeSubscribed) {
+			item.TriggerSource = summary.Trigger.Source
+			item.TriggerEventKind = summary.Trigger.EventKind
+		}
 
 		items = append(items, item)
 	}
@@ -193,8 +200,10 @@ type policyYAMLSummary struct {
 		Tools []policyToolEntry `yaml:"tools"`
 	} `yaml:"capabilities"`
 	Trigger struct {
-		FireAt   []string `yaml:"fire_at"`  // scheduled only, RFC3339 timestamps
-		Interval string   `yaml:"interval"` // poll only, Go duration string e.g. "5m"
+		FireAt    []string `yaml:"fire_at"`    // scheduled only, RFC3339 timestamps
+		Interval  string   `yaml:"interval"`   // poll only, Go duration string e.g. "5m"
+		Source    string   `yaml:"source"`     // subscribed only
+		EventKind string   `yaml:"event_kind"` // subscribed only
 	} `yaml:"trigger"`
 }
 

--- a/internal/http/api/policy_handler_test.go
+++ b/internal/http/api/policy_handler_test.go
@@ -1876,6 +1876,96 @@ agent:
 	})
 }
 
+// TestPolicyListSubscribedTriggerFields verifies that the List handler populates
+// trigger_source and trigger_event_kind only for subscribed policies and omits
+// them (omitempty) for all other trigger types.
+func TestPolicyListSubscribedTriggerFields(t *testing.T) {
+	t.Run("subscribed policy includes trigger_source and trigger_event_kind", func(t *testing.T) {
+		store := newPolicyHandlerStore(t)
+		subscribedYAML := `
+name: slack-monitor
+trigger:
+  type: subscribed
+  source: slack-e2e
+  event_kind: channel_message
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+capabilities:
+  tools:
+    - tool: slack-e2e.send_message
+agent:
+  task: Handle Slack messages
+`
+		testutil.InsertPolicy(t, store, "pol-sub", "slack-monitor", "subscribed", subscribedYAML)
+
+		srv := httptest.NewServer(newPolicyRouter(store))
+		t.Cleanup(srv.Close)
+
+		resp, err := http.Get(srv.URL + "/policies")
+		if err != nil {
+			t.Fatalf("GET /policies: %v", err)
+		}
+		defer resp.Body.Close()
+
+		var envelope struct {
+			Data []struct {
+				ID               string `json:"id"`
+				TriggerType      string `json:"trigger_type"`
+				TriggerSource    string `json:"trigger_source"`
+				TriggerEventKind string `json:"trigger_event_kind"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(envelope.Data) != 1 {
+			t.Fatalf("got %d items, want 1", len(envelope.Data))
+		}
+		item := envelope.Data[0]
+		if item.TriggerType != "subscribed" {
+			t.Errorf("trigger_type = %q, want subscribed", item.TriggerType)
+		}
+		if item.TriggerSource != "slack-e2e" {
+			t.Errorf("trigger_source = %q, want slack-e2e", item.TriggerSource)
+		}
+		if item.TriggerEventKind != "channel_message" {
+			t.Errorf("trigger_event_kind = %q, want channel_message", item.TriggerEventKind)
+		}
+	})
+
+	t.Run("non-subscribed policy omits trigger_source and trigger_event_kind", func(t *testing.T) {
+		store := newPolicyHandlerStore(t)
+		testutil.InsertPolicy(t, store, "pol-wh", "my-webhook", "webhook", "trigger: webhook\n")
+
+		srv := httptest.NewServer(newPolicyRouter(store))
+		t.Cleanup(srv.Close)
+
+		resp, err := http.Get(srv.URL + "/policies")
+		if err != nil {
+			t.Fatalf("GET /policies: %v", err)
+		}
+		defer resp.Body.Close()
+
+		var rawEnvelope struct {
+			Data []json.RawMessage `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&rawEnvelope); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(rawEnvelope.Data) != 1 {
+			t.Fatalf("got %d items, want 1", len(rawEnvelope.Data))
+		}
+		raw := string(rawEnvelope.Data[0])
+		if strings.Contains(raw, `"trigger_source"`) {
+			t.Errorf("webhook policy must not include trigger_source, got: %s", raw)
+		}
+		if strings.Contains(raw, `"trigger_event_kind"`) {
+			t.Errorf("webhook policy must not include trigger_event_kind, got: %s", raw)
+		}
+	})
+}
+
 func TestComputeNextFireAt(t *testing.T) {
 	const interval = "5m"
 	pollSummary := api.PolicyYAMLSummary{}


### PR DESCRIPTION
Closes #609

## Summary

The `/agents` `PolicyCard` rendered `policy.trigger_type` verbatim, so a plugin-sourced policy showed the literal **`subscribed`** pill — an **ADR-048** violation (that internal word must never reach the UI). The editor's TriggerPicker already renders a friendly label; the list card now does too.

## Changes

- **Frontend** — new `triggerPillLabel` util (`AgentList/triggerLabel.ts`): built-in types render title-case (`Webhook`, `Manual`, `Scheduled`, `Poll`, `Cron`) consistent with the editor's `TriggerPicker`; `subscribed` renders `"<event_kind> (<source>)"` (or just `"<event_kind>"`, or a `"Plugin event"` fallback). **No code path ever returns `"subscribed"`.** `PolicyCard` uses it at the single render site.
- **Backend** — the policy-list DTO only carried `trigger_type`, so the `List` handler now projects `trigger_source` / `trigger_event_kind` from the policy YAML it already parses, populated **only** for subscribed policies (`omitempty`). Per **ADR-002**, no new DB columns or model fields — just a read-only projection of the YAML blob.

A reduced label (vs the editor's full manifest-description form) is intentional: the list is a dense, all-roles view and the handler doesn't load plugin manifests; `"<event_kind> (<source>)"` is unambiguous and satisfies ADR-048 without an extra admin fetch.

## Tests + stories

- `triggerLabel.test.ts` — exhaustive table over all built-ins, unknown types, and all three subscribed data shapes, including explicit "never returns `subscribed`" assertions.
- `PolicyCard.test.tsx` — subscribed card asserts `subscribed` is absent and the friendly label present, plus the `Plugin event` fallback (existing webhook assertion updated to `Webhook`).
- `policy_handler_test.go` — `TestPolicyListSubscribedTriggerFields`: subscribed response includes the fields; non-subscribed omits them (asserted against raw JSON for `omitempty`).
- New `Subscribed` Storybook variant on `PolicyCard`.

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**APPROVE**) → implement → code review (**APPROVE**, 0 cycles).
- CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)