### PR TITLE
fix: audience Routing preview shows instance name, not raw ULID

### DIFF
--- a/frontend/src/components/AgentEditor/FormMode/AudienceSection.stories.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/AudienceSection.stories.tsx
@@ -120,6 +120,7 @@ export const NoneSelected: Story = {
         http.get('/api/v1/admin/audiences', () =>
           HttpResponse.json({ data: [] }),
         ),
+        http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
       ],
     },
   },
@@ -137,6 +138,7 @@ export const WithAudiences: Story = {
         http.get('/api/v1/admin/audiences', () =>
           HttpResponse.json({ data: ALL_AUDIENCES }),
         ),
+        http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
       ],
     },
   },
@@ -160,6 +162,7 @@ export const Selected: Story = {
           }
           return HttpResponse.json({ error: 'not found' }, { status: 404 })
         }),
+        http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
       ],
     },
   },
@@ -177,6 +180,7 @@ export const SelectedMissing: Story = {
         http.get('/api/v1/admin/audiences', () =>
           HttpResponse.json({ data: ALL_AUDIENCES }),
         ),
+        http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
       ],
     },
   },
@@ -193,6 +197,7 @@ export const Loading: Story = {
       handlers: [
         // Never resolves — keeps the query in loading state.
         http.get('/api/v1/admin/audiences', () => new Promise(() => {})),
+        http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
       ],
     },
   },
@@ -226,6 +231,7 @@ export const Interactive: Story = {
           }
           return HttpResponse.json({ error: 'not found' }, { status: 404 })
         }),
+        http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
       ],
     },
   },

--- a/frontend/src/components/AgentEditor/FormMode/AudienceSection.test.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/AudienceSection.test.tsx
@@ -140,6 +140,7 @@ describe('AudienceSection — rendering', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: [] }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: '' })
     expect(screen.getByText('Audience')).toBeInTheDocument()
@@ -150,6 +151,7 @@ describe('AudienceSection — rendering', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: [] }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: '' })
     const select = screen.getByRole('combobox', { name: /audience/i })
@@ -162,6 +164,7 @@ describe('AudienceSection — rendering', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: AUDIENCE_LIST }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: '' })
     await waitFor(() => {
@@ -175,6 +178,7 @@ describe('AudienceSection — rendering', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: [] }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: '' })
     await waitFor(() => {
@@ -189,6 +193,7 @@ describe('AudienceSection — selection callbacks', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: AUDIENCE_LIST }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     const onChange = vi.fn()
     renderSection({ name: '' }, onChange)
@@ -208,6 +213,7 @@ describe('AudienceSection — selection callbacks', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: AUDIENCE_LIST }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     const onChange = vi.fn()
     renderSection({ name: 'ops-team' }, onChange)
@@ -225,6 +231,7 @@ describe('AudienceSection — + New audience link', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: [] }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     const onNewAudienceClick = vi.fn()
     renderSection({ name: '' }, undefined, onNewAudienceClick)
@@ -239,6 +246,7 @@ describe('AudienceSection — preview area state machine', () => {
     server.use(
       // Never resolves — simulates loading state.
       http.get('/api/v1/admin/audiences', () => new Promise(() => {})),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: 'ops-team' })
     // The text appears immediately because the query starts loading.
@@ -252,6 +260,7 @@ describe('AudienceSection — preview area state machine', () => {
       http.get('/api/v1/admin/audiences', () =>
         HttpResponse.json({ data: AUDIENCE_LIST }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: 'ghost-audience' })
     await waitFor(() => {
@@ -272,6 +281,7 @@ describe('AudienceSection — preview area state machine', () => {
         }
         return HttpResponse.json({ error: 'not found' }, { status: 404 })
       }),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: 'ops-team' })
     // RoutingPreview renders these labels
@@ -288,6 +298,7 @@ describe('AudienceSection — preview area state machine', () => {
       ),
       // Detail never resolves — simulates in-flight detail fetch.
       http.get('/api/v1/admin/audiences/:id', () => new Promise(() => {})),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
     renderSection({ name: 'ops-team' })
     // After list loads, detail is still in flight — show placeholder, not warning.

--- a/frontend/src/components/AgentEditor/FormMode/AudienceSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/AudienceSection.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom'
-import { useAudiences, useAudience } from '@/hooks/queries/admin'
+import { useAudiences, useAudience, usePluginInstancesForAudience } from '@/hooks/queries/admin'
 import { RoutingPreview } from '@/components/admin/AudienceEditor/RoutingPreview'
 import { FieldError } from '@/components/form/FieldError'
 import type { AudienceFormState, SectionIssues } from './types'
@@ -18,6 +18,7 @@ export function AudienceSection({ value, onChange, onNewAudienceClick, errors = 
   const navigate = useNavigate()
   const audiencesQuery = useAudiences()
   const audiences = audiencesQuery.data ?? []
+  const pluginInstancesQuery = usePluginInstancesForAudience()
 
   // Find the audience record matching the selected name to get its id.
   const matchedAudience = value.name !== ''
@@ -75,6 +76,7 @@ export function AudienceSection({ value, onChange, onNewAudienceClick, errors = 
         <RoutingPreview
           entries={detail.entries}
           disableInAppFallback={detail.disable_in_app_fallback}
+          pluginInstances={pluginInstancesQuery.data ?? []}
         />
       </div>
     )

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
@@ -247,7 +247,7 @@ export function AudienceEditor({
       )}
 
       {/* Routing preview */}
-      <RoutingPreview entries={displayEntries} disableInAppFallback={disableInAppFallback} />
+      <RoutingPreview entries={displayEntries} disableInAppFallback={disableInAppFallback} pluginInstances={pluginInstances} />
 
       {/* Name */}
       <section className={styles.section}>

--- a/frontend/src/components/admin/AudienceEditor/RoutingPreview.stories.tsx
+++ b/frontend/src/components/admin/AudienceEditor/RoutingPreview.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import '@/tokens.css'
 import { RoutingPreview } from './RoutingPreview'
-import type { ApiAudienceEntry } from '@/api/types'
+import type { ApiAudienceEntry, ApiPluginInstanceForAudience } from '@/api/types'
 
 const meta: Meta<typeof RoutingPreview> = {
   title: 'Admin/AudienceEditor/RoutingPreview',
@@ -48,10 +48,22 @@ const autoEntry: ApiAudienceEntry = {
   auto: true,
 }
 
+const pluginInstance = (id: string, instanceName: string): ApiPluginInstanceForAudience => ({
+  id,
+  plugin_id: 'com.example.plugin',
+  instance_name: instanceName,
+  state: 'healthy',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: null,
+  version: 1,
+})
+
 export const Empty: Story = {
   args: {
     entries: [],
     disableInAppFallback: true,
+    pluginInstances: [],
   },
 }
 
@@ -59,6 +71,7 @@ export const NotifyOnly: Story = {
   args: {
     entries: [notifyEntry('e1', 'slack-primary')],
     disableInAppFallback: false,
+    pluginInstances: [pluginInstance('slack-primary', 'slack-e2e')],
   },
 }
 
@@ -66,6 +79,7 @@ export const RequestOnly: Story = {
   args: {
     entries: [requestEntry('e1', 'pagerduty-main')],
     disableInAppFallback: false,
+    pluginInstances: [pluginInstance('pagerduty-main', 'pagerduty-prod')],
   },
 }
 
@@ -77,6 +91,11 @@ export const Mixed: Story = {
       requestEntry('e3', 'pagerduty-main'),
     ],
     disableInAppFallback: false,
+    pluginInstances: [
+      pluginInstance('slack-primary', 'slack-e2e'),
+      pluginInstance('ntfy-backup', 'ntfy-ops'),
+      pluginInstance('pagerduty-main', 'pagerduty-prod'),
+    ],
   },
 }
 
@@ -84,5 +103,6 @@ export const WithAutoEntry: Story = {
   args: {
     entries: [notifyEntry('e1', 'slack-primary'), autoEntry],
     disableInAppFallback: false,
+    pluginInstances: [pluginInstance('slack-primary', 'slack-e2e')],
   },
 }

--- a/frontend/src/components/admin/AudienceEditor/RoutingPreview.test.tsx
+++ b/frontend/src/components/admin/AudienceEditor/RoutingPreview.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RoutingPreview, entryDisplayName } from './RoutingPreview'
+import type { ApiAudienceEntry, ApiPluginInstanceForAudience } from '@/api/types'
+
+// --- Fixtures ---
+
+const ULID = '01KVXVCGQNH5WGDAXSKXZRQ7KP'
+
+const PLUGIN_INSTANCES: ApiPluginInstanceForAudience[] = [
+  {
+    id: ULID,
+    plugin_id: 'com.example.slack',
+    instance_name: 'slack-e2e',
+    state: 'healthy',
+    implements_notify: true,
+    implements_request: false,
+    config_schema: null,
+    version: 1,
+  },
+]
+
+function makeNotifyEntry(pluginInstanceId: string): ApiAudienceEntry {
+  return {
+    id: 'e1',
+    plugin_instance_id: pluginInstanceId,
+    position: 0,
+    notify: true,
+    request: false,
+    config: {},
+  }
+}
+
+const AUTO_ENTRY: ApiAudienceEntry = {
+  id: '__auto__',
+  plugin_instance_id: '',
+  position: 99,
+  notify: true,
+  request: true,
+  config: {},
+  auto: true,
+}
+
+// --- entryDisplayName unit tests ---
+
+describe('entryDisplayName', () => {
+  it('returns instance_name when plugin_instance_id matches a pluginInstances entry', () => {
+    const entry = makeNotifyEntry(ULID)
+    expect(entryDisplayName(entry, PLUGIN_INSTANCES)).toBe('slack-e2e')
+  })
+
+  it('returns the raw ULID when no pluginInstances list is provided', () => {
+    const entry = makeNotifyEntry(ULID)
+    expect(entryDisplayName(entry)).toBe(ULID)
+  })
+
+  it('returns the raw ULID when no match is found in pluginInstances', () => {
+    const entry = makeNotifyEntry(ULID)
+    expect(entryDisplayName(entry, [])).toBe(ULID)
+  })
+
+  it('returns "(unset)" for an empty plugin_instance_id', () => {
+    const entry = makeNotifyEntry('')
+    expect(entryDisplayName(entry, PLUGIN_INSTANCES)).toBe('(unset)')
+  })
+
+  it('returns the built-in fallback label for auto entries', () => {
+    expect(entryDisplayName(AUTO_ENTRY, PLUGIN_INSTANCES)).toBe(
+      'gleipnir.in-app (built-in fallback)',
+    )
+  })
+})
+
+// --- RoutingPreview rendering tests ---
+
+describe('RoutingPreview — name resolution', () => {
+  it('renders instance_name when plugin_instance_id matches a pluginInstances entry', () => {
+    render(
+      <RoutingPreview
+        entries={[makeNotifyEntry(ULID)]}
+        disableInAppFallback={true}
+        pluginInstances={PLUGIN_INSTANCES}
+      />,
+    )
+    expect(screen.getByText(/slack-e2e/)).toBeInTheDocument()
+    expect(screen.queryByText(ULID)).not.toBeInTheDocument()
+  })
+
+  it('renders the raw ULID when no pluginInstances list is provided', () => {
+    render(
+      <RoutingPreview
+        entries={[makeNotifyEntry(ULID)]}
+        disableInAppFallback={true}
+      />,
+    )
+    expect(screen.getByText(new RegExp(ULID))).toBeInTheDocument()
+  })
+
+  it('renders the raw ULID when no match is found in pluginInstances', () => {
+    render(
+      <RoutingPreview
+        entries={[makeNotifyEntry(ULID)]}
+        disableInAppFallback={true}
+        pluginInstances={[]}
+      />,
+    )
+    expect(screen.getByText(new RegExp(ULID))).toBeInTheDocument()
+  })
+
+  it('renders "(unset)" for an entry with an empty plugin_instance_id', () => {
+    render(
+      <RoutingPreview
+        entries={[makeNotifyEntry('')]}
+        disableInAppFallback={true}
+        pluginInstances={PLUGIN_INSTANCES}
+      />,
+    )
+    expect(screen.getByText(/\(unset\)/)).toBeInTheDocument()
+  })
+
+  it('renders the built-in fallback label for auto entries', () => {
+    render(
+      <RoutingPreview
+        entries={[AUTO_ENTRY]}
+        disableInAppFallback={false}
+        pluginInstances={PLUGIN_INSTANCES}
+      />,
+    )
+    expect(screen.getAllByText(/gleipnir\.in-app \(built-in fallback\)/).length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/components/admin/AudienceEditor/RoutingPreview.tsx
+++ b/frontend/src/components/admin/AudienceEditor/RoutingPreview.tsx
@@ -1,25 +1,33 @@
 import { Bell, MessageSquare } from 'lucide-react'
-import type { ApiAudienceEntry } from '@/api/types'
+import type { ApiAudienceEntry, ApiPluginInstanceForAudience } from '@/api/types'
 import styles from './RoutingPreview.module.css'
 
 interface Props {
   entries: ApiAudienceEntry[]
   disableInAppFallback?: boolean
+  pluginInstances?: ApiPluginInstanceForAudience[]
 }
 
-function entryDisplayName(entry: ApiAudienceEntry): string {
+export function entryDisplayName(
+  entry: ApiAudienceEntry,
+  pluginInstances?: ApiPluginInstanceForAudience[],
+): string {
   if (entry.auto) return 'gleipnir.in-app (built-in fallback)'
-  return entry.plugin_instance_id || '(unset)'
+  if (!entry.plugin_instance_id) return '(unset)'
+  const match = pluginInstances?.find((p) => p.id === entry.plugin_instance_id)
+  if (match) return match.instance_name
+  return entry.plugin_instance_id
 }
 
-// instanceName is optional so callers without plugin instance data can still use this.
-export function RoutingPreview({ entries, disableInAppFallback }: Props) {
+export function RoutingPreview({ entries, disableInAppFallback, pluginInstances }: Props) {
+  const displayName = (e: ApiAudienceEntry) => entryDisplayName(e, pluginInstances)
+
   const notifyEntries = entries.filter((e) => e.notify)
   const requestEntry = entries.find((e) => e.request) ?? null
 
   // If in-app fallback is not disabled and not already in entries, treat it as implicitly appended.
   const hasAutoEntry = entries.some((e) => e.auto)
-  const notifyNames = notifyEntries.map((e) => entryDisplayName(e))
+  const notifyNames = notifyEntries.map((e) => displayName(e))
   const inAppLabel = 'gleipnir.in-app (built-in fallback)'
 
   // Append in-app to notify display when it would be auto-injected.
@@ -28,10 +36,10 @@ export function RoutingPreview({ entries, disableInAppFallback }: Props) {
       ? [...notifyNames, inAppLabel]
       : notifyNames.length > 0
         ? notifyNames
-        : notifyEntries.map((e) => entryDisplayName(e))
+        : notifyEntries.map((e) => displayName(e))
 
   const requestDisplay = requestEntry
-    ? entryDisplayName(requestEntry)
+    ? displayName(requestEntry)
     : !disableInAppFallback
       ? inAppLabel
       : null

--- a/frontend/src/components/admin/AudienceEditor/index.ts
+++ b/frontend/src/components/admin/AudienceEditor/index.ts
@@ -1,4 +1,4 @@
 export { AudienceEditor } from './AudienceEditor'
 export { EntryRow } from './EntryRow'
-export { RoutingPreview } from './RoutingPreview'
+export { RoutingPreview, entryDisplayName } from './RoutingPreview'
 export { SaveGuardDialog } from './SaveGuardDialog'

--- a/frontend/src/pages/AdminAudienceDetailPage.tsx
+++ b/frontend/src/pages/AdminAudienceDetailPage.tsx
@@ -5,13 +5,13 @@ import { PageHeader } from '@/components/PageHeader'
 import { QueryBoundary, SkeletonList } from '@/components/QueryBoundary'
 import { CollapsibleJSON } from '@/components/CollapsibleJSON/CollapsibleJSON'
 import { AudienceEditor } from '@/components/admin/AudienceEditor'
-import { RoutingPreview } from '@/components/admin/AudienceEditor'
+import { RoutingPreview, entryDisplayName } from '@/components/admin/AudienceEditor'
 import { useAudience, useAudienceReferences, usePluginInstancesForAudience } from '@/hooks/queries/admin'
 import { useUpdateAudience, useDeleteAudience } from '@/hooks/mutations/admin'
 import { useCurrentUser } from '@/hooks/queries/users'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { formatDate, formatTimeAgo } from '@/utils/format'
-import type { ApiAudienceEntry, AudienceUpdateRequest } from '@/api/types'
+import type { ApiAudienceEntry, ApiPluginInstanceForAudience, AudienceUpdateRequest } from '@/api/types'
 import type { ApiError } from '@/api/fetch'
 import styles from './AdminAudienceDetailPage.module.css'
 
@@ -71,7 +71,7 @@ export default function AdminAudienceDetailPage() {
               />
             ) : (
               <>
-                <RoutingPreview entries={audienceQuery.data.entries} />
+                <RoutingPreview entries={audienceQuery.data.entries} pluginInstances={pluginInstancesQuery.data ?? []} />
 
                 <section className={styles.section}>
                   <h2 className={styles.sectionTitle}>Entries</h2>
@@ -81,7 +81,7 @@ export default function AdminAudienceDetailPage() {
                   </p>
                   <ol className={styles.entryList}>
                     {audienceQuery.data.entries.map((entry) => (
-                      <EntryCard key={`${entry.id}:${entry.position}`} entry={entry} />
+                      <EntryCard key={`${entry.id}:${entry.position}`} entry={entry} pluginInstances={pluginInstancesQuery.data ?? []} />
                     ))}
                   </ol>
                 </section>
@@ -130,17 +130,12 @@ export default function AdminAudienceDetailPage() {
   )
 }
 
-function EntryCard({ entry }: { entry: ApiAudienceEntry }) {
-  function entryDisplayName(e: ApiAudienceEntry): string {
-    if (e.auto) return 'gleipnir.in-app (built-in fallback)'
-    return e.plugin_instance_id || '(unset)'
-  }
-
+function EntryCard({ entry, pluginInstances }: { entry: ApiAudienceEntry; pluginInstances?: ApiPluginInstanceForAudience[] }) {
   return (
     <li className={`${styles.entryCard} ${entry.auto ? styles.entryCardAuto : ''}`}>
       <div className={styles.entryHeader}>
         <span className={styles.entryPosition}>{entry.position + 1}</span>
-        <span className={styles.entryName}>{entryDisplayName(entry)}</span>
+        <span className={styles.entryName}>{entryDisplayName(entry, pluginInstances)}</span>
         <div className={styles.entryFlags}>
           {entry.notify && (
             <span className={`${styles.flag} ${styles.flagNotify}`}>Notify</span>


### PR DESCRIPTION
Closes #610

## Summary

The audience **"Routing preview"** panel displayed the raw plugin instance ULID (e.g. `01KVXVCGQNH5WGDAXSKXZRQ7KP`) instead of the human-readable instance name (`slack-e2e`), even though the editable entry row right below it resolved the name correctly. `RoutingPreview.entryDisplayName` simply fell back to `entry.plugin_instance_id` — no list was plumbed in to resolve it.

## Fix

`entryDisplayName` now resolves `plugin_instance_id` → `instance_name` from the already-loaded plugin-instance list, with this order: `auto` → "gleipnir.in-app (built-in fallback)"; empty id → "(unset)"; id found → instance name; **else the raw ULID** (true last-resort, so an unresolvable route is still identifiable).

The list is threaded in at **all three** render sites:
- `AudienceEditor.tsx` (already had the list as a prop)
- `AdminAudienceDetailPage.tsx` read-only view (already calls `usePluginInstancesForAudience`)
- `AgentEditor/FormMode/AudienceSection.tsx` (added the same hook — shares the query key, so it's deduped, no extra fetch)

`entryDisplayName` is exported and reused by the detail page's read-only `EntryCard`, which had the **same** ULID-fallback bug on the same page — so the resolution logic now lives in exactly one place.

Resolution is to the instance **name** only (not "name (#channel)"): no channel field exists on the audience-entry or plugin-instance types, and this matches the editable entry-row dropdown.

## Tests + stories

- New `RoutingPreview.test.tsx` (10 tests): name renders and the ULID does **not** when resolvable; ULID fallback when unresolvable / list absent; "(unset)" for empty id; built-in fallback for auto entries.
- `RoutingPreview.stories.tsx` gains `pluginInstances` fixtures so stories show resolved names.
- `AudienceSection.test.tsx` / `.stories.tsx`: added a `GET /api/v1/admin/plugin-instances` MSW handler to every block now that the section fires that query (keeps tests/stories clean).

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**REVISE** → folded in: shared resolver for EntryCard, MSW handlers, dead-branch note) → implement → code review (**APPROVE**).
- CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)