### PR TITLE
feat: grant plugin ToolService tools from the agent editor Capabilities section

### DIFF
--- a/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.module.css
+++ b/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.module.css
@@ -73,6 +73,28 @@
   flex-shrink: 0;
 }
 
+/* Source label shown on assigned-tool rows and search results to indicate
+   whether the tool comes from an MCP server or a plugin instance.
+   e.g. "mcp:Filesystem Tools" or "plugin:slack-e2e". */
+.sourceLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  flex-shrink: 0;
+  margin-left: var(--space-1);
+}
+
+/* Badge for grants whose serverName matches neither a known MCP server nor a
+   known plugin instance. The grant is preserved (never dropped silently) but
+   flagged so the operator knows the source is missing. Composes shared amber
+   badge shape from badges.module.css. */
+.unknownBadge {
+  composes: badgeRect from '@/styles/badges.module.css';
+  composes: colorAmber from '@/styles/badges.module.css';
+  margin-left: var(--space-2);
+  flex-shrink: 0;
+}
+
 /* Approval toggle */
 
 .approvalToggle {

--- a/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.stories.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@/tokens.css';
 import { queryKeys } from '@/hooks/queryKeys';
-import type { ApiMcpServer, ApiMcpTool } from '@/api/types';
+import type { ApiMcpServer, ApiMcpTool, ApiPluginInstanceForAudience } from '@/api/types';
 import { CapabilitiesSection } from './CapabilitiesSection';
 import type { CapabilitiesFormState, AssignedTool } from './types';
 import decoratorStyles from './CapabilitiesSection.stories.module.css';
@@ -87,6 +87,25 @@ const FIXTURE_TOOLS_SRV2: ApiMcpTool[] = [
   },
 ];
 
+// Slack plugin instance fixture for WithPluginTools story.
+const FIXTURE_SLACK_INSTANCE: ApiPluginInstanceForAudience = {
+  id: 'inst-slack-1',
+  plugin_id: 'plugin-slack',
+  instance_name: 'slack-e2e',
+  plugin_name: 'Slack',
+  state: 'healthy',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: null,
+  version: 1,
+  services: ['tool', 'trigger', 'channel'],
+  tools: [
+    { name: 'send_message', description: 'Send a message to a Slack channel' },
+    { name: 'list_channels', description: 'List all accessible Slack channels' },
+    { name: 'list_users', description: 'List all users in the Slack workspace' },
+  ],
+};
+
 const FIXTURE_ASSIGNED_TOOLS: AssignedTool[] = [
   {
     toolId: 'tool-1',
@@ -94,6 +113,7 @@ const FIXTURE_ASSIGNED_TOOLS: AssignedTool[] = [
     serverName: 'Filesystem Tools',
     name: 'read_file',
     description: 'Read the contents of a file at the given path',
+    source: 'mcp',
     approvalRequired: false,
     approvalTimeout: '',
   },
@@ -103,6 +123,7 @@ const FIXTURE_ASSIGNED_TOOLS: AssignedTool[] = [
     serverName: 'Filesystem Tools',
     name: 'write_file',
     description: 'Write content to a file at the given path',
+    source: 'mcp',
     approvalRequired: true,
     approvalTimeout: '',
   },
@@ -112,16 +133,21 @@ const FIXTURE_ASSIGNED_TOOLS: AssignedTool[] = [
     serverName: 'GitHub Tools',
     name: 'create_issue',
     description: 'Create a new GitHub issue in a repository',
+    source: 'mcp',
     approvalRequired: false,
     approvalTimeout: '',
   },
 ];
 
+// makeQueryClient seeds MCP tool data AND an empty pluginInstances entry so the
+// usePluginInstancesForAudience hook doesn't background-fetch and clear cached state.
 function makeQueryClient(): QueryClient {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   qc.setQueryData(queryKeys.servers.all, FIXTURE_SERVERS);
   qc.setQueryData(queryKeys.servers.toolsAll('srv-1'), FIXTURE_TOOLS_SRV1);
   qc.setQueryData(queryKeys.servers.toolsAll('srv-2'), FIXTURE_TOOLS_SRV2);
+  // Seed empty pluginInstances to prevent background refetch from clearing state.
+  qc.setQueryData(queryKeys.admin.pluginInstances, []);
   return qc;
 }
 
@@ -169,6 +195,7 @@ export const WithApprovalTimeout: Story = {
           serverName: 'Filesystem Tools',
           name: 'write_file',
           description: 'Write content to a file at the given path',
+          source: 'mcp',
           approvalRequired: true,
           approvalTimeout: '30m',
         },
@@ -211,6 +238,8 @@ export const WithDisabledTool: Story = {
         },
       ]);
       qc.setQueryData(queryKeys.servers.toolsAll('srv-2'), FIXTURE_TOOLS_SRV2);
+      // Seed empty pluginInstances to prevent background refetch.
+      qc.setQueryData(queryKeys.admin.pluginInstances, []);
       return (
         <QueryClientProvider client={qc}>
           <div className={decoratorStyles.decorator}>
@@ -229,6 +258,7 @@ export const WithDisabledTool: Story = {
           serverName: 'Filesystem Tools',
           name: 'write_file',
           description: 'Write content to a file at the given path',
+          source: 'mcp',
           approvalRequired: false,
           approvalTimeout: '',
         },
@@ -238,8 +268,68 @@ export const WithDisabledTool: Story = {
           serverName: 'Filesystem Tools',
           name: 'read_file',
           description: 'Read the contents of a file at the given path',
+          source: 'mcp',
           approvalRequired: false,
           approvalTimeout: '',
+        },
+      ],
+      feedback: DEFAULT_FEEDBACK,
+    },
+    onChange: () => {},
+  },
+};
+
+// WithPluginTools shows a mix of MCP and plugin tools granted to a policy,
+// including a plugin tool pre-assigned from a Slack instance.
+export const WithPluginTools: Story = {
+  decorators: [
+    (Story) => {
+      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      qc.setQueryData(queryKeys.servers.all, FIXTURE_SERVERS);
+      qc.setQueryData(queryKeys.servers.toolsAll('srv-1'), FIXTURE_TOOLS_SRV1);
+      qc.setQueryData(queryKeys.servers.toolsAll('srv-2'), FIXTURE_TOOLS_SRV2);
+      qc.setQueryData(queryKeys.admin.pluginInstances, [FIXTURE_SLACK_INSTANCE]);
+      return (
+        <QueryClientProvider client={qc}>
+          <div className={decoratorStyles.decorator}>
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
+  ],
+  args: {
+    value: {
+      tools: [
+        {
+          toolId: 'tool-1',
+          serverId: 'srv-1',
+          serverName: 'Filesystem Tools',
+          name: 'read_file',
+          description: 'Read the contents of a file at the given path',
+          source: 'mcp',
+          approvalRequired: false,
+          approvalTimeout: '',
+        },
+        {
+          toolId: 'slack-e2e.send_message',
+          serverId: 'inst-slack-1',
+          serverName: 'slack-e2e',
+          name: 'send_message',
+          description: 'Send a message to a Slack channel',
+          source: 'plugin',
+          approvalRequired: false,
+          approvalTimeout: '',
+        },
+        {
+          toolId: 'slack-e2e.list_channels',
+          serverId: 'inst-slack-1',
+          serverName: 'slack-e2e',
+          name: 'list_channels',
+          description: 'List all accessible Slack channels',
+          source: 'plugin',
+          approvalRequired: true,
+          approvalTimeout: '30m',
         },
       ],
       feedback: DEFAULT_FEEDBACK,

--- a/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.test.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.test.tsx
@@ -4,9 +4,10 @@ import { useState } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { queryKeys } from '@/hooks/queryKeys'
-import type { ApiMcpServer, ApiMcpTool } from '@/api/types'
+import type { ApiMcpServer, ApiMcpTool, ApiPluginInstanceForAudience } from '@/api/types'
 import { CapabilitiesSection } from './CapabilitiesSection'
 import type { CapabilitiesFormState, AssignedTool, FeedbackFormState } from './types'
+import { formStateToYaml } from '@/components/AgentEditor/agentEditorUtils'
 
 // --- Fixtures (mirrored from CapabilitiesSection.stories.tsx) ---
 
@@ -74,6 +75,9 @@ function makeQueryClient(): QueryClient {
   qc.setQueryData(queryKeys.servers.all, FIXTURE_SERVERS)
   qc.setQueryData(queryKeys.servers.toolsAll('srv-1'), FIXTURE_TOOLS_SRV1)
   qc.setQueryData(queryKeys.servers.toolsAll('srv-2'), FIXTURE_TOOLS_SRV2)
+  // Always seed an empty pluginInstances entry so the usePluginInstancesForAudience
+  // hook doesn't fire a background fetch (which would clear cached state mid-assertion).
+  qc.setQueryData(queryKeys.admin.pluginInstances, [])
   return qc
 }
 
@@ -160,6 +164,7 @@ describe('CapabilitiesSection — tool picker remove', () => {
         serverName: 'Filesystem Tools',
         name: 'read_file',
         description: 'Read the contents of a file at the given path',
+        source: 'mcp',
         approvalRequired: false,
         approvalTimeout: '',
       },
@@ -195,6 +200,8 @@ describe('CapabilitiesSection — tool picker search filter', () => {
     qc.setQueryData(queryKeys.servers.all, FIXTURE_SERVERS)
     qc.setQueryData(queryKeys.servers.toolsAll('srv-1'), FIXTURE_TOOLS_SRV1)
     qc.setQueryData(queryKeys.servers.toolsAll('srv-2'), FIXTURE_TOOLS_SRV2)
+    // Seed empty pluginInstances to prevent background refetch.
+    qc.setQueryData(queryKeys.admin.pluginInstances, [])
     return qc
   }
 
@@ -266,6 +273,7 @@ describe('CapabilitiesSection — feedback section', () => {
         serverName: 'Filesystem Tools',
         name: 'read_file',
         description: 'Read a file',
+        source: 'mcp',
         approvalRequired: false,
         approvalTimeout: '',
       },
@@ -355,6 +363,7 @@ describe('CapabilitiesSection — approval toggle', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file at the given path',
+        source: 'mcp',
         approvalRequired: false,
         approvalTimeout: '',
       },
@@ -386,6 +395,7 @@ describe('CapabilitiesSection — approval toggle', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file at the given path',
+        source: 'mcp',
         approvalRequired: true,
         approvalTimeout: '',
       },
@@ -416,6 +426,7 @@ describe('CapabilitiesSection — approval timeout input', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file at the given path',
+        source: 'mcp',
         approvalRequired: true,
         approvalTimeout: '',
       },
@@ -432,6 +443,7 @@ describe('CapabilitiesSection — approval timeout input', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file at the given path',
+        source: 'mcp',
         approvalRequired: false,
         approvalTimeout: '',
       },
@@ -450,6 +462,7 @@ describe('CapabilitiesSection — approval timeout input', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file at the given path',
+        source: 'mcp',
         approvalRequired: true,
         approvalTimeout: '',
       },
@@ -481,6 +494,7 @@ describe('CapabilitiesSection — approval timeout input', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file at the given path',
+        source: 'mcp',
         approvalRequired: true,
         approvalTimeout: '30m',
       },
@@ -522,6 +536,8 @@ describe('CapabilitiesSection — disabled tool warning', () => {
       DISABLED_TOOL,
     ])
     qc.setQueryData(queryKeys.servers.toolsAll('srv-2'), FIXTURE_TOOLS_SRV2)
+    // Seed empty pluginInstances to prevent background refetch.
+    qc.setQueryData(queryKeys.admin.pluginInstances, [])
     return qc
   }
 
@@ -533,6 +549,7 @@ describe('CapabilitiesSection — disabled tool warning', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file',
+        source: 'mcp',
         approvalRequired: false,
         approvalTimeout: '',
       },
@@ -565,6 +582,7 @@ describe('CapabilitiesSection — disabled tool warning', () => {
         serverName: 'Filesystem Tools',
         name: 'write_file',
         description: 'Write content to a file',
+        source: 'mcp',
         approvalRequired: false,
         approvalTimeout: '',
       },
@@ -589,6 +607,7 @@ describe('CapabilitiesSection — disabled tool warning', () => {
         serverName: 'Filesystem Tools',
         name: 'read_file',
         description: 'Read the contents of a file',
+        source: 'mcp',
         approvalRequired: false,
         approvalTimeout: '',
       },
@@ -608,5 +627,169 @@ describe('CapabilitiesSection — disabled tool warning', () => {
     // The disabled badge has a distinctive title attribute; the feedback label "Disabled" is separate.
     expect(screen.queryByTitle(/Tool is disabled/)).not.toBeInTheDocument()
     expect(document.querySelector('[data-disabled="true"]')).toBeNull()
+  })
+})
+
+// --- Plugin tool tests ---
+
+const FIXTURE_SLACK_INSTANCE: ApiPluginInstanceForAudience = {
+  id: 'inst-slack-1',
+  plugin_id: 'plugin-slack',
+  instance_name: 'slack-e2e',
+  state: 'healthy',
+  implements_notify: true,
+  implements_request: true,
+  config_schema: null,
+  version: 1,
+  tools: [
+    { name: 'send_message', description: 'Send a message to a Slack channel' },
+    { name: 'list_channels', description: 'List all accessible Slack channels' },
+  ],
+}
+
+function makePluginQueryClient(): QueryClient {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  qc.setQueryData(queryKeys.servers.all, FIXTURE_SERVERS)
+  qc.setQueryData(queryKeys.servers.toolsAll('srv-1'), FIXTURE_TOOLS_SRV1)
+  qc.setQueryData(queryKeys.servers.toolsAll('srv-2'), FIXTURE_TOOLS_SRV2)
+  qc.setQueryData(queryKeys.admin.pluginInstances, [FIXTURE_SLACK_INSTANCE])
+  return qc
+}
+
+describe('CapabilitiesSection — plugin tools', () => {
+  it('(a) picker lists the plugin tool with plugin:slack-e2e label and displayName slack-e2e.send_message', async () => {
+    render(
+      <QueryClientProvider client={makePluginQueryClient()}>
+        <ControlledCapabilitiesSection />
+      </QueryClientProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add tool from registry' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('slack-e2e.send_message')).toBeInTheDocument()
+    })
+
+    // Source label for plugin tool should be present in the picker
+    expect(screen.getAllByText('plugin:slack-e2e').length).toBeGreaterThan(0)
+  })
+
+  it('(b) selecting a plugin tool stores AssignedTool with toolId === "slack-e2e.send_message" and source: "plugin"', async () => {
+    const onChange = vi.fn()
+    render(
+      <QueryClientProvider client={makePluginQueryClient()}>
+        <ControlledCapabilitiesSection onChange={onChange} />
+      </QueryClientProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add tool from registry' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('slack-e2e.send_message')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('slack-e2e.send_message'))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    const lastCall = onChange.mock.calls[0][0] as CapabilitiesFormState
+    expect(lastCall.tools).toHaveLength(1)
+    const tool = lastCall.tools[0]
+    expect(tool.toolId).toBe('slack-e2e.send_message')
+    expect(tool.source).toBe('plugin')
+    expect(tool.serverName).toBe('slack-e2e')
+    expect(tool.name).toBe('send_message')
+  })
+
+  it('(c) loading a policy with an existing slack-e2e.send_message grant shows plugin source label', async () => {
+    const assignedTools: AssignedTool[] = [
+      {
+        toolId: 'slack-e2e.send_message',
+        serverId: 'slack-e2e',
+        serverName: 'slack-e2e',
+        name: 'send_message',
+        description: 'Send a message to a Slack channel',
+        source: 'mcp', // parse-time default; reconciled at render
+        approvalRequired: false,
+        approvalTimeout: '',
+      },
+    ]
+
+    render(
+      <QueryClientProvider client={makePluginQueryClient()}>
+        <ControlledCapabilitiesSection initialTools={assignedTools} />
+      </QueryClientProvider>,
+    )
+
+    // Wait for plugin instances to be resolved and source label to appear
+    await waitFor(() => {
+      expect(screen.getByText('slack-e2e.send_message')).toBeInTheDocument()
+    })
+
+    // The plugin source label should appear on the assigned row
+    expect(screen.getByText('plugin:slack-e2e')).toBeInTheDocument()
+  })
+
+  it('(d) round-trip: plugin-sourced AssignedTool emits tool: slack-e2e.send_message unchanged', () => {
+    const pluginTool: AssignedTool = {
+      toolId: 'slack-e2e.send_message',
+      serverId: 'inst-slack-1',
+      serverName: 'slack-e2e',
+      name: 'send_message',
+      description: 'Send a message to a Slack channel',
+      source: 'plugin',
+      approvalRequired: false,
+      approvalTimeout: '',
+    }
+    // Build a minimal FormState that includes the plugin tool
+    const state = {
+      identity: { name: 'p', description: '', folder: '' },
+      trigger: { type: 'manual' as const },
+      capabilities: {
+        tools: [pluginTool],
+        feedback: { enabled: false, timeout: '', onTimeout: 'fail' },
+      },
+      audience: { name: '' },
+      task: { task: 'do things' },
+      limits: { max_tokens_per_run: 20000, max_tool_calls_per_run: 50 },
+      concurrency: { concurrency: 'skip' as const, queueDepth: 0 },
+      model: { provider: 'anthropic', model: 'claude-3-5-haiku-latest' },
+    }
+    const yaml = formStateToYaml(state)
+    expect(yaml).toContain('tool: slack-e2e.send_message')
+  })
+
+  it('(e) stale grant gone-instance.foo renders unknown badge and is NOT dropped', async () => {
+    const assignedTools: AssignedTool[] = [
+      {
+        toolId: 'gone-instance.foo',
+        serverId: 'gone-instance',
+        serverName: 'gone-instance',
+        name: 'foo',
+        description: '',
+        source: 'mcp',
+        approvalRequired: false,
+        approvalTimeout: '',
+      },
+    ]
+
+    render(
+      <QueryClientProvider client={makePluginQueryClient()}>
+        <ControlledCapabilitiesSection initialTools={assignedTools} />
+      </QueryClientProvider>,
+    )
+
+    // Row is present (grant is not dropped)
+    await waitFor(() => {
+      expect(screen.getByText('gone-instance.foo')).toBeInTheDocument()
+    })
+
+    // Unknown source badge is shown
+    expect(screen.getByTitle(/Source server or plugin instance not found/)).toBeInTheDocument()
+    expect(screen.getByText('Unknown source')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/CapabilitiesSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import { useMcpServers } from '@/hooks/queries/servers';
+import { usePluginInstancesForAudience } from '@/hooks/queries/admin';
 import { queryKeys } from '@/hooks/queryKeys';
 import { apiFetch } from '@/api/fetch';
 import type { ApiMcpTool } from '@/api/types';
@@ -15,7 +16,45 @@ export interface CapabilitiesSectionProps {
   errors?: SectionIssues;
 }
 
-type RegistryEntry = { tool: ApiMcpTool; serverName: string };
+// RegistryEntry discriminates between MCP tools and plugin tools in the picker.
+type McpRegistryEntry = { kind: 'mcp'; tool: ApiMcpTool; serverName: string };
+type PluginRegistryEntry = {
+  kind: 'plugin';
+  instanceName: string;
+  instanceId: string;
+  name: string;
+  description: string;
+};
+type RegistryEntry = McpRegistryEntry | PluginRegistryEntry;
+
+// Stable per-entry display values, computed once for filtering and rendering.
+interface EntryDisplay {
+  displayId: string;       // used for dedup: UUID for MCP, dot-name for plugin
+  displayName: string;     // e.g. "Filesystem Tools.read_file" or "slack-e2e.send_message"
+  description: string;
+  sourceLabel: string;     // e.g. "mcp:Filesystem Tools" or "plugin:slack-e2e"
+  entry: RegistryEntry;
+}
+
+function buildDisplay(e: RegistryEntry): EntryDisplay {
+  if (e.kind === 'mcp') {
+    return {
+      displayId: e.tool.id,
+      displayName: `${e.serverName}.${e.tool.name}`,
+      description: e.tool.description,
+      sourceLabel: `mcp:${e.serverName}`,
+      entry: e,
+    };
+  }
+  const dotName = `${e.instanceName}.${e.name}`;
+  return {
+    displayId: dotName,
+    displayName: dotName,
+    description: e.description,
+    sourceLabel: `plugin:${e.instanceName}`,
+    entry: e,
+  };
+}
 
 export function CapabilitiesSection({ value, onChange, errors = [] }: CapabilitiesSectionProps) {
   const capabilityRootErrors = errors.filter(e => e.field === 'capabilities').map(e => e.message);
@@ -24,6 +63,7 @@ export function CapabilitiesSection({ value, onChange, errors = [] }: Capabiliti
   const [query, setQuery] = useState('');
 
   const { data: servers } = useMcpServers();
+  const { data: pluginInstances } = usePluginInstancesForAudience();
 
   const toolQueries = useQueries({
     queries: (servers ?? []).map(s => ({
@@ -33,30 +73,66 @@ export function CapabilitiesSection({ value, onChange, errors = [] }: Capabiliti
     })),
   });
 
-  const allRegistryTools: RegistryEntry[] = (servers ?? []).flatMap((srv, i) =>
-    (toolQueries[i]?.data ?? []).map(tool => ({ tool, serverName: srv.name }))
+  // Build MCP registry entries from all discovered tools.
+  const mcpEntries: McpRegistryEntry[] = (servers ?? []).flatMap((srv, i) =>
+    (toolQueries[i]?.data ?? []).map(tool => ({ kind: 'mcp' as const, tool, serverName: srv.name }))
   );
 
-  // Build the set of identifiers for disabled tools so assigned-tool rows can
-  // show a warning badge. Each disabled tool adds two entries: the UUID (used
-  // when the tool was added through the picker in this session) and the
+  // Build plugin registry entries from every instance that declares tools.
+  // Channel/trigger-only instances contribute no rows (inst.tools is absent or empty).
+  const pluginEntries: PluginRegistryEntry[] = (pluginInstances ?? []).flatMap(inst =>
+    (inst.tools ?? []).map(t => ({
+      kind: 'plugin' as const,
+      instanceName: inst.instance_name,
+      instanceId: inst.id,
+      name: t.name,
+      description: t.description,
+    }))
+  );
+
+  // Build the set of identifiers for disabled MCP tools so assigned-tool rows
+  // can show a warning badge. Each disabled tool adds two entries: the UUID
+  // (used when the tool was added through the picker in this session) and the
   // dot-notation composite key "serverName.toolName" (used when the tool was
   // parsed from an existing policy YAML via yamlToFormState).
+  // Plugin tools have no enable/disable gate, so disabledToolIds is MCP-only.
   const disabledToolIds = new Set(
-    allRegistryTools
+    mcpEntries
       .filter(({ tool }) => !tool.enabled)
       .flatMap(({ tool, serverName }) => [tool.id, `${serverName}.${tool.name}`])
   );
 
-  const assignedIds = new Set(value.tools.map(t => t.toolId));
+  // Build the set of known plugin instance names for source reconciliation.
+  // A granted tool whose serverName matches → show plugin label at render.
+  const knownPluginInstanceNames = new Set(
+    (pluginInstances ?? []).map(inst => inst.instance_name)
+  );
+
+  // Build display entries for the full combined registry.
+  const allDisplayEntries: EntryDisplay[] = [
+    ...mcpEntries.map(buildDisplay),
+    ...pluginEntries.map(buildDisplay),
+  ];
+
+  // assignedIds tracks tools already in the list for dedup.
+  // MCP tools can be assigned via UUID (picker) OR dot-name (YAML round-trip),
+  // so we add both forms. Plugin entries dedup by dot-name only.
+  const assignedIds = new Set<string>();
+  for (const t of value.tools) {
+    assignedIds.add(t.toolId);           // dot-name for YAML-loaded; UUID for picker-added MCP
+    // Also add the dot-name form so YAML-loaded MCP grants suppress the tool from the picker.
+    assignedIds.add(`${t.serverName}.${t.name}`);
+  }
+
   const q = query.toLowerCase().trim();
-  const filteredRegistry = allRegistryTools.filter(({ tool, serverName }) => {
-    if (assignedIds.has(tool.id)) return false;
+  const filteredDisplay = allDisplayEntries.filter(d => {
+    // Exclude tools already in the assigned list (by UUID or dot-name).
+    if (assignedIds.has(d.displayId)) return false;
     if (!q) return true;
     return (
-      tool.name.toLowerCase().includes(q) ||
-      serverName.toLowerCase().includes(q) ||
-      tool.description.toLowerCase().includes(q)
+      d.displayName.toLowerCase().includes(q) ||
+      d.sourceLabel.toLowerCase().includes(q) ||
+      d.description.toLowerCase().includes(q)
     );
   });
 
@@ -86,16 +162,33 @@ export function CapabilitiesSection({ value, onChange, errors = [] }: Capabiliti
     });
   }
 
-  function handleAddTool(tool: ApiMcpTool, serverName: string) {
-    const assigned: AssignedTool = {
-      toolId: tool.id,
-      serverId: tool.server_id,
-      serverName,
-      name: tool.name,
-      description: tool.description,
-      approvalRequired: false,
-      approvalTimeout: '',
-    };
+  function handleAddEntry(d: EntryDisplay) {
+    let assigned: AssignedTool;
+    if (d.entry.kind === 'mcp') {
+      const { tool, serverName } = d.entry;
+      assigned = {
+        toolId: tool.id,
+        serverId: tool.server_id,
+        serverName,
+        name: tool.name,
+        description: tool.description,
+        source: 'mcp',
+        approvalRequired: false,
+        approvalTimeout: '',
+      };
+    } else {
+      const { instanceName, instanceId, name, description } = d.entry;
+      assigned = {
+        toolId: `${instanceName}.${name}`,
+        serverId: instanceId,
+        serverName: instanceName,
+        name,
+        description,
+        source: 'plugin',
+        approvalRequired: false,
+        approvalTimeout: '',
+      };
+    }
     onChange({ ...value, tools: [...value.tools, assigned] });
     setSearchOpen(false);
     setQuery('');
@@ -115,6 +208,31 @@ export function CapabilitiesSection({ value, onChange, errors = [] }: Capabiliti
     });
   }
 
+  // Resolve source label for a granted tool.
+  // Parse-time grants always arrive with source:'mcp' but may actually be plugin
+  // tools — reconcile by checking the live plugin instance list.
+  function resolveSourceLabel(tool: AssignedTool): string {
+    // Tools added through the plugin picker are explicitly tagged.
+    if (tool.source === 'plugin') {
+      return `plugin:${tool.serverName}`;
+    }
+    // A parse-time grant always arrives as source:'mcp', so reconcile against the
+    // live lists. Prefer the MCP label on the (runtime-impossible) name collision
+    // where an MCP server and a plugin instance share a name — toolregistry rejects
+    // such a namespace conflict, so this only governs the cosmetic label.
+    const isMcpServer = (servers ?? []).some(s => s.name === tool.serverName);
+    if (isMcpServer) {
+      return `mcp:${tool.serverName}`;
+    }
+    if (knownPluginInstanceNames.has(tool.serverName)) {
+      return `plugin:${tool.serverName}`;
+    }
+    // serverName matches neither a known MCP server nor a known plugin instance.
+    // This can happen when an MCP server was renamed after the grant was saved
+    // (name-based reconciliation limitation) or after a plugin is uninstalled.
+    return '';
+  }
+
   return (
     <div className={shared.section}>
       <div className={shared.heading}>Capabilities</div>
@@ -128,13 +246,16 @@ export function CapabilitiesSection({ value, onChange, errors = [] }: Capabiliti
         <div className={styles.toolList}>
           {value.tools.map((tool, i) => {
             const rowIssues = errors.filter(e => e.field.startsWith(`capabilities.tools[${i}].`));
+            const sourceLabel = resolveSourceLabel(tool);
+            const isDisabled = disabledToolIds.has(tool.toolId);
             return (
               <AssignedToolRow
                 key={tool.toolId}
                 tool={tool}
                 rowIndex={i}
                 rowIssues={rowIssues}
-                isDisabled={disabledToolIds.has(tool.toolId)}
+                isDisabled={isDisabled}
+                sourceLabel={sourceLabel}
                 onRemove={handleRemove}
                 onToggleApproval={handleToggleApproval}
                 onTimeoutChange={handleTimeoutChange}
@@ -148,8 +269,8 @@ export function CapabilitiesSection({ value, onChange, errors = [] }: Capabiliti
         <SearchPanel
           query={query}
           onQueryChange={setQuery}
-          results={filteredRegistry}
-          onAdd={handleAddTool}
+          results={filteredDisplay}
+          onAdd={handleAddEntry}
           onClose={() => { setSearchOpen(false); setQuery(''); }}
         />
       ) : (
@@ -205,15 +326,18 @@ interface AssignedToolRowProps {
   rowIndex: number;
   rowIssues: FormIssue[];
   isDisabled: boolean;
+  sourceLabel: string; // empty string → unknown source
   onRemove: (toolId: string) => void;
   onToggleApproval: (toolId: string) => void;
   onTimeoutChange: (toolId: string, timeout: string) => void;
 }
 
-function AssignedToolRow({ tool, rowIndex, rowIssues, isDisabled, onRemove, onToggleApproval, onTimeoutChange }: AssignedToolRowProps) {
+function AssignedToolRow({ tool, rowIndex, rowIssues, isDisabled, sourceLabel, onRemove, onToggleApproval, onTimeoutChange }: AssignedToolRowProps) {
   const displayName = `${tool.serverName}.${tool.name}`;
   const toolErrors = rowIssues.filter(e => e.field === `capabilities.tools[${rowIndex}].tool`).map(e => e.message);
   const timeoutErrors = rowIssues.filter(e => e.field === `capabilities.tools[${rowIndex}].timeout`).map(e => e.message);
+
+  const isUnknownSource = !sourceLabel;
 
   return (
     <div className={styles.toolRow} data-field={`capabilities.tools[${rowIndex}].tool`} data-disabled={isDisabled ? 'true' : undefined}>
@@ -225,6 +349,16 @@ function AssignedToolRow({ tool, rowIndex, rowIssues, isDisabled, onRemove, onTo
         >
           Disabled
         </span>
+      )}
+      {isUnknownSource ? (
+        <span
+          className={styles.unknownBadge}
+          title="Source server or plugin instance not found — this grant is preserved but cannot be resolved"
+        >
+          Unknown source
+        </span>
+      ) : (
+        <span className={styles.sourceLabel}>{sourceLabel}</span>
       )}
       <span className={styles.toolDesc}>{tool.description}</span>
       <FieldError messages={toolErrors} />
@@ -267,8 +401,8 @@ function AssignedToolRow({ tool, rowIndex, rowIssues, isDisabled, onRemove, onTo
 interface SearchPanelProps {
   query: string;
   onQueryChange: (q: string) => void;
-  results: RegistryEntry[];
-  onAdd: (tool: ApiMcpTool, serverName: string) => void;
+  results: EntryDisplay[];
+  onAdd: (d: EntryDisplay) => void;
   onClose: () => void;
 }
 
@@ -293,14 +427,15 @@ function SearchPanel({ query, onQueryChange, results, onAdd, onClose }: SearchPa
         {results.length === 0 ? (
           <div className={styles.searchEmpty}>No tools match your search.</div>
         ) : (
-          results.map(({ tool, serverName }) => (
+          results.map(d => (
             <button
-              key={tool.id}
+              key={d.displayId}
               className={styles.resultRow}
-              onClick={() => onAdd(tool, serverName)}
+              onClick={() => onAdd(d)}
             >
-              <span className={styles.toolName}>{serverName}.{tool.name}</span>
-              <span className={styles.toolDesc}>{tool.description}</span>
+              <span className={styles.toolName}>{d.displayName}</span>
+              <span className={styles.sourceLabel}>{d.sourceLabel}</span>
+              <span className={styles.toolDesc}>{d.description}</span>
             </button>
           ))
         )}

--- a/frontend/src/components/AgentEditor/FormMode/types.ts
+++ b/frontend/src/components/AgentEditor/FormMode/types.ts
@@ -1,11 +1,18 @@
 export interface AssignedTool {
   toolId: string;
   serverId: string;
+  // serverName carries the MCP server display name OR the plugin instance_name.
+  // formStateToYaml serializes as `${serverName}.${name}` so both sources
+  // emit the correct dot-notation grant with zero serializer changes.
   serverName: string;
   name: string;
   description: string;
   approvalRequired: boolean;
   approvalTimeout: string; // Go duration string (e.g. "30m"), empty string if unset
+  // source discriminates MCP tools from plugin tools at render time.
+  // 'mcp' is the default for back-compat; tools parsed from YAML get 'mcp'
+  // at parse time and are reconciled against the live plugin list at render.
+  source: 'mcp' | 'plugin';
 }
 
 export interface FeedbackFormState {

--- a/frontend/src/components/AgentEditor/agentEditorUtils.test.ts
+++ b/frontend/src/components/AgentEditor/agentEditorUtils.test.ts
@@ -756,6 +756,37 @@ describe('defaultFormState', () => {
   })
 })
 
+describe('formStateToYaml — plugin-sourced tool serialization', () => {
+  it('serializes a plugin-sourced AssignedTool as tool: <instance>.<tool> unchanged', () => {
+    // A plugin tool added via the picker has source:'plugin' and serverName=instance_name.
+    // formStateToYaml emits `${serverName}.${name}` — identical to the MCP path.
+    const state = yamlToFormState('name: p\n')!
+    const modified = {
+      ...state,
+      capabilities: {
+        ...state.capabilities,
+        tools: [
+          {
+            toolId: 'slack-e2e.send_message',
+            serverId: 'inst-slack-1',
+            serverName: 'slack-e2e',
+            name: 'send_message',
+            description: 'Send a message to a Slack channel',
+            source: 'plugin' as const,
+            approvalRequired: false,
+            approvalTimeout: '',
+          },
+        ],
+      },
+    }
+    const yaml = formStateToYaml(modified)
+    expect(yaml).toContain('tool: slack-e2e.send_message')
+    // No MCP-specific UUID or source field should appear in the output
+    expect(yaml).not.toContain('source:')
+    expect(yaml).not.toContain('inst-slack-1')
+  })
+})
+
 describe('yamlToFormState — zero limits preserved as unlimited', () => {
   it('keeps explicit 0 for max_tokens_per_run and max_tool_calls_per_run', () => {
     const yaml = `

--- a/frontend/src/components/AgentEditor/agentEditorUtils.ts
+++ b/frontend/src/components/AgentEditor/agentEditorUtils.ts
@@ -172,7 +172,9 @@ export function yamlToFormState(yaml: string): FormState | null {
           serverName: serverPart,
           name: toolPart,
           description: '',
-          role: 'tool' as const, // placeholder — CapabilitiesSection reconciles with registry
+          // Parse-time default: CapabilitiesSection reconciles plugin vs MCP at
+          // render by checking whether serverName matches a known plugin instance.
+          source: 'mcp' as const,
           approvalRequired,
           approvalTimeout,
         }]
@@ -296,7 +298,9 @@ export function formStateToYaml(state: FormState): string {
     triggerObj = { type: 'webhook', auth: trigger.auth }
   }
 
-  // Build capabilities — single tools array
+  // Build capabilities — single tools array.
+  // t.serverName carries the MCP server display name OR the plugin instance_name;
+  // both produce the correct `<source>.<tool>` dot-notation grant string.
   const tools = capabilities.tools.map(t => {
     const entry: Record<string, unknown> = { tool: `${t.serverName}.${t.name}` }
     if (t.approvalRequired) {

--- a/frontend/src/components/AgentEditor/validateFormState.test.ts
+++ b/frontend/src/components/AgentEditor/validateFormState.test.ts
@@ -19,6 +19,7 @@ function valid(): FormState {
           serverName: 'srv',
           name: 'do_thing',
           description: '',
+          source: 'mcp' as const,
           approvalRequired: false,
           approvalTimeout: '',
         },
@@ -165,8 +166,8 @@ describe('validateFormState — capabilities', () => {
   it('reports duplicate tool', () => {
     const s = valid()
     s.capabilities.tools = [
-      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: false, approvalTimeout: '' },
-      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: false, approvalTimeout: '' },
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', source: 'mcp' as const, approvalRequired: false, approvalTimeout: '' },
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', source: 'mcp' as const, approvalRequired: false, approvalTimeout: '' },
     ]
     const issues = validateFormState(s)
     expect(findIssue(issues, 'capabilities.tools[1].tool', 'duplicate')).toBe(true)
@@ -174,7 +175,7 @@ describe('validateFormState — capabilities', () => {
   it('reports invalid approval timeout', () => {
     const s = valid()
     s.capabilities.tools = [
-      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: true, approvalTimeout: 'badtime' },
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', source: 'mcp' as const, approvalRequired: true, approvalTimeout: 'badtime' },
     ]
     const issues = validateFormState(s)
     expect(findIssue(issues, 'capabilities.tools[0].timeout', 'not a valid duration')).toBe(true)
@@ -258,7 +259,7 @@ describe('validateFormState — replace + approval cross-field rule', () => {
     const s = valid()
     s.concurrency = { concurrency: 'replace', queueDepth: 0 }
     s.capabilities.tools = [
-      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: true, approvalTimeout: '' },
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', source: 'mcp' as const, approvalRequired: true, approvalTimeout: '' },
     ]
     const issues = validateFormState(s)
     expect(findIssue(issues, 'agent.concurrency', '"replace" is not valid')).toBe(true)
@@ -267,7 +268,7 @@ describe('validateFormState — replace + approval cross-field rule', () => {
     const s = valid()
     s.concurrency = { concurrency: 'replace', queueDepth: 0 }
     s.capabilities.tools = [
-      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', approvalRequired: false, approvalTimeout: '' },
+      { toolId: 'srv.t', serverId: 'srv', serverName: 'srv', name: 't', description: '', source: 'mcp' as const, approvalRequired: false, approvalTimeout: '' },
     ]
     const issues = validateFormState(s)
     expect(findIssue(issues, 'agent.concurrency', '"replace"')).toBe(false)


### PR DESCRIPTION
Closes #608

## Summary

The agent editor's **Capabilities** picker built its grantable-tool list exclusively from MCP servers, so plugin **ToolService** tools (namespaced `<instance>.<tool>`, e.g. `slack-e2e.send_message`) never appeared. With the YAML editing surface removed (ADR-019), there was **no UI path at all** to grant a plugin tool — the shipped Slack reference plugin's tools were unusable from the editor.

The picker now merges plugin-instance tools alongside MCP tools.

## Changes (frontend-only)

- `CapabilitiesSection.tsx` — pulls plugin instances via `usePluginInstancesForAudience` (the `/admin/plugin-instances` listing already returns each instance's `tools[]` for **all** instances) and merges them into the picker as `<instance>.<tool>` entries. A `mcp:<server>` / `plugin:<instance>` **source label** distinguishes them.
- `FormMode/types.ts` — `AssignedTool` gains a **UI-only** `source: 'mcp' | 'plugin'` discriminant. It is **never serialized**: `formStateToYaml` still emits `${serverName}.${name}`, so the stored grant stays a plain dot-name and **existing saved policies round-trip byte-for-byte** (ADR-002 safe). For plugin entries `serverName` carries the instance name.
- Plugin grants support policy-gated **approval** like MCP grants (ADR-008, source-agnostic). The MCP-specific enable/disable badge is scoped to MCP rows.
- A granted tool whose `serverName` resolves to neither a known MCP server nor plugin instance (e.g. a deleted instance) renders an **"Unknown source"** badge and is **never dropped**.

No backend change — the runtime/validator and the instance listing already accept `<instance>.<tool>` grants.

## Tests + stories

- `CapabilitiesSection.test.tsx` — 5 new cases: picker lists plugin tools with the source label; selecting one stores `<instance>.<tool>`; loading a policy with an existing plugin grant shows the plugin label; the grant **round-trips unchanged** through `formStateToYaml`; a stale grant is retained with the unknown badge. (Every test/story QueryClient now seeds an empty `pluginInstances` cache so the new hook doesn't background-fetch and clear state.)
- `agentEditorUtils.test.ts` — serializing a plugin-sourced `AssignedTool` emits `tool: <instance>.<tool>` with no `source` key.
- New `WithPluginTools` Storybook story.

## Review

- Generated by the agentic dev loop. Architect plan → adversarial plan review (**APPROVE**; verified the unfiltered instance listing + serializer reuse cruxes) → implement → code review (**APPROVE**). Coordinator post-fix: aligned the name-collision label preference to MCP-first per the plan.
- CLAUDE.md: no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)