### PR TITLE
feat: Slack missing_scope is per-tool, no longer marks instance unhealthy (#647)

### DIFF
--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -279,8 +279,6 @@ func (s *ToolService) setHealth(ctx context.Context, h healthHint) {
 		detail = "auth_expired"
 	case healthAuthMissing:
 		detail = "auth_missing"
-	case healthMissingScope:
-		detail = "missing_scope"
 	default:
 		return
 	}
@@ -650,8 +648,6 @@ func (s *TriggerService) setTriggerHealth(ctx context.Context, h healthHint) {
 		detail = "auth_expired"
 	case healthConfigMissing:
 		detail = "config_missing"
-	case healthMissingScope:
-		detail = "missing_scope"
 	default:
 		return
 	}
@@ -1357,8 +1353,6 @@ func (s *ChannelService) setChannelHealth(ctx context.Context, h healthHint) {
 		detail = "auth_expired"
 	case healthAuthMissing:
 		detail = "auth_missing"
-	case healthMissingScope:
-		detail = "missing_scope"
 	default:
 		return
 	}

--- a/plugins/slack/tools.go
+++ b/plugins/slack/tools.go
@@ -123,7 +123,6 @@ const (
 	healthAuthExpired                     // persistent auth failure — set UNHEALTHY
 	healthAuthMissing                     // no credentials configured — set UNHEALTHY
 	healthConfigMissing                   // required instance config field missing — set UNHEALTHY
-	healthMissingScope                    // bot OAuth scope grant insufficient — set UNHEALTHY
 )
 
 // mapErr maps a Slack API error to an ErrorCode and optional health hint.
@@ -168,9 +167,11 @@ func mapErr(err error) (commonv1.ErrorCode, healthHint) {
 }
 
 // classifySlackErrCode maps a Slack API error-code string to an ErrorCode and
-// health hint. Auth-class errors are split so the operator sees an actionable
-// distinction in the admin UI: "auth_expired" (re-authorize) vs "missing_scope"
-// (fix the Slack app scope grants).
+// health hint. Auth-class errors are classified by scope of impact: instance-wide
+// failures (invalid_auth, auth_expired, connection loss) drive a health-state update
+// so the admin UI surfaces an actionable badge; per-tool failures (missing_scope)
+// surface only in the tool's error response, which humanizeSlackErr decorates with
+// actionable remediation text, leaving instance health unchanged.
 func classifySlackErrCode(code string) (commonv1.ErrorCode, healthHint) {
 	switch code {
 	case "channel_not_found", "not_in_channel", "user_not_found", "message_not_found", "thread_not_found":
@@ -180,12 +181,14 @@ func classifySlackErrCode(code string) (commonv1.ErrorCode, healthHint) {
 		return commonv1.ErrorCode_ERROR_CODE_INVALID_ARG, healthNone
 
 	case "missing_scope":
-		// Distinct from the auth_expired bucket: re-authorizing with the same
-		// Slack app will NOT help — the operator must add the missing scope in
-		// the Slack app's OAuth & Permissions page, reinstall the app, then
-		// re-authorize. Surfacing this as "auth_expired" misled operators into
-		// clicking Re-authorize forever.
-		return commonv1.ErrorCode_ERROR_CODE_PERMISSION, healthMissingScope
+		// A scope gap is per-tool, not an instance-wide auth or connection failure.
+		// Other tools, the trigger stream, and channel ops keep working — downgrading
+		// the whole instance to UNHEALTHY is misleading and breaks the #622
+		// ConfigOptionsService dropdowns. Surface as a per-tool PERMISSION error;
+		// humanizeSlackErr already appends the actionable "add scope + reinstall"
+		// hint to the error message. Health downgrade is reserved for
+		// invalid_auth / auth_expired / connection loss.
+		return commonv1.ErrorCode_ERROR_CODE_PERMISSION, healthNone
 
 	case "invalid_auth", "account_inactive", "token_revoked", "not_authed":
 		// Persistent auth failures. The operator UI shows UNHEALTHY + "auth_expired"

--- a/plugins/slack/tools_test.go
+++ b/plugins/slack/tools_test.go
@@ -1017,14 +1017,14 @@ func TestMapErr(t *testing.T) {
 			wantHealth: healthAuthExpired,
 		},
 		{
-			// missing_scope is split out of the auth-expired bucket because
-			// re-authorizing the plugin with the same Slack app cannot fix it —
-			// the operator must add the missing scope in the Slack app's OAuth
-			// & Permissions page first.
+			// missing_scope is a per-tool error — other tools, the trigger stream,
+			// and channel ops keep working. No instance health downgrade; the
+			// actionable "add scope + reinstall" hint is carried in the error
+			// message by humanizeSlackErr instead.
 			name:       "missing_scope",
 			err:        slackAPIError("missing_scope"),
 			wantCode:   commonv1.ErrorCode_ERROR_CODE_PERMISSION,
-			wantHealth: healthMissingScope,
+			wantHealth: healthNone,
 		},
 		{
 			name:       "token_revoked",


### PR DESCRIPTION
Closes #647

## Summary
A single Slack tool call failing with `missing_scope` no longer drives the **entire instance** to `health_state=unhealthy`. A scope gap is per-tool, not an instance-wide auth/connection failure.

- `classifySlackErrCode("missing_scope")` now returns `(ERROR_CODE_PERMISSION, healthNone)` instead of the `healthMissingScope` hint. The agent still gets a `PERMISSION` error, and `humanizeSlackErr` still decorates it with the actionable "add the missing scope, reinstall, re-authorize" remediation text — only the instance-wide health downgrade is removed.
- The `healthMissingScope` enum value and its three now-dead `setHealth`/`setTriggerHealth`/`setChannelHealth` switch cases are removed. Health downgrade is now reserved for instance-wide failures (`invalid_auth`/`auth_expired`/connection loss).
- **Side-effect fixed:** the host gates #622 `ConfigOptionsService` option-dropdown degradation purely on `health_state` (`internal/admin/plugin_options.go`). Because a scope gap no longer flips the instance to unhealthy, the channel/user pickers stop falsely degrading to free-text.

## Tests
- `plugins/slack/tools_test.go` `TestMapErr`: `missing_scope` row now asserts `healthNone`; `invalid_auth`/`token_revoked` rows unchanged (guard against over-broadening).
- `go test ./plugins/slack/...` passes.

## Architecture plan
<details>
<summary>Plan (architect → adversarial review → APPROVE)</summary>

Option A (per the issue's recommendation): classify `missing_scope` as a per-tool `PERMISSION` error with no health downgrade. Option B (a new host-side `degraded` state) was explicitly rejected as cross-cutting/disproportionate. Plan-reviewer verified all 6 `healthMissingScope` references, the iota-tail safety of the enum deletion, the independence of `humanizeSlackErr`'s error text, and that the host dropdown gate is purely `health_state`-based.
</details>

Review cycles: 2 (cycle 1 flagged a stale doc comment on `classifySlackErrCode`, fixed in cycle 2). Brainstorming: not triggered (well-specified). CLAUDE.md: no updates needed.

🤖 Generated by the agentic dev loop.
