### PR TITLE
feat: Slack missing_scope errors name the specific required scope (#653)

### DIFF
--- a/plugins/slack/service.go
+++ b/plugins/slack/service.go
@@ -218,7 +218,7 @@ func (s *ToolService) Call(ctx context.Context, req *toolv1.CallRequest) (*toolv
 		if hint != healthNone {
 			s.setHealth(hostCtx, hint)
 		}
-		return errorResponse(code, humanizeSlackErr(callErr)), nil
+		return errorResponse(code, humanizeSlackErrForTool(callErr, toolName)), nil
 	}
 
 	return &toolv1.CallResponse{OutputJson: string(outputJSON)}, nil

--- a/plugins/slack/tools.go
+++ b/plugins/slack/tools.go
@@ -223,6 +223,50 @@ func humanizeSlackErr(err error) string {
 	return raw
 }
 
+// toolRequiredScopes maps each tool name to the OAuth scope(s) it needs.
+// Multi-value entries mean the tool needs ONE of the listed scopes depending
+// on the target channel type (public channel, private channel, DM, or MPDM).
+// Single-value entries need exactly that one scope.
+//
+// slack-go v0.26.0 discards Slack's top-level needed/provided fields from the
+// API response, so this static table is the authoritative source of truth for
+// surfacing actionable scope hints to operators.
+var toolRequiredScopes = map[string][]string{
+	"post_message":   {"chat:write"},                                                             // chat.postMessage
+	"update_message": {"chat:write"},                                                             // chat.update
+	"delete_message": {"chat:write"},                                                             // chat.delete
+	"react":          {"reactions:write"},                                                        // reactions.add
+	"lookup_user":    {"users:read"},                                                             // users.info
+	"list_channels":  {"channels:read", "groups:read"},                                          // conversations.list (public/private)
+	"set_topic":      {"channels:manage", "groups:write", "im:write", "mpim:write"},             // conversations.setTopic
+	"read_history":   {"channels:history", "groups:history", "im:history", "mpim:history"},      // conversations.history
+	"read_thread":    {"channels:history", "groups:history", "im:history", "mpim:history"},      // conversations.replies
+}
+
+// humanizeSlackErrForTool enriches a missing_scope error with the specific
+// OAuth scope(s) required by toolName. For any other error code, or when
+// toolName is not in toolRequiredScopes, it delegates to humanizeSlackErr so
+// every caller gets a useful message regardless of context.
+func humanizeSlackErrForTool(err error, toolName string) string {
+	if err == nil {
+		return ""
+	}
+	if strings.Contains(err.Error(), "missing_scope") {
+		if scopes, ok := toolRequiredScopes[toolName]; ok {
+			raw := err.Error()
+			if len(scopes) == 1 {
+				return raw + fmt.Sprintf(" — the %q tool needs the %q OAuth scope; add it in the Slack app's OAuth & Permissions page, reinstall the app, and re-authorize", toolName, scopes[0])
+			}
+			quoted := make([]string, len(scopes))
+			for i, s := range scopes {
+				quoted[i] = fmt.Sprintf("%q", s)
+			}
+			return raw + fmt.Sprintf(" — the %q tool needs one of these OAuth scopes (depending on the channel type): %s; add the appropriate one in the Slack app's OAuth & Permissions page, reinstall the app, and re-authorize", toolName, strings.Join(quoted, ", "))
+		}
+	}
+	return humanizeSlackErr(err)
+}
+
 // ── Rate-limit retry helper ───────────────────────────────────────────────────
 
 // callWithRetry wraps a Slack call with a single retry on RateLimitedError

--- a/plugins/slack/tools.go
+++ b/plugins/slack/tools.go
@@ -232,15 +232,15 @@ func humanizeSlackErr(err error) string {
 // API response, so this static table is the authoritative source of truth for
 // surfacing actionable scope hints to operators.
 var toolRequiredScopes = map[string][]string{
-	"post_message":   {"chat:write"},                                                             // chat.postMessage
-	"update_message": {"chat:write"},                                                             // chat.update
-	"delete_message": {"chat:write"},                                                             // chat.delete
-	"react":          {"reactions:write"},                                                        // reactions.add
-	"lookup_user":    {"users:read"},                                                             // users.info
-	"list_channels":  {"channels:read", "groups:read"},                                          // conversations.list (public/private)
-	"set_topic":      {"channels:manage", "groups:write", "im:write", "mpim:write"},             // conversations.setTopic
-	"read_history":   {"channels:history", "groups:history", "im:history", "mpim:history"},      // conversations.history
-	"read_thread":    {"channels:history", "groups:history", "im:history", "mpim:history"},      // conversations.replies
+	"post_message":   {"chat:write"},                                                       // chat.postMessage
+	"update_message": {"chat:write"},                                                       // chat.update
+	"delete_message": {"chat:write"},                                                       // chat.delete
+	"react":          {"reactions:write"},                                                  // reactions.add
+	"lookup_user":    {"users:read"},                                                       // users.info
+	"list_channels":  {"channels:read", "groups:read"},                                     // conversations.list (public/private)
+	"set_topic":      {"channels:manage", "groups:write", "im:write", "mpim:write"},        // conversations.setTopic
+	"read_history":   {"channels:history", "groups:history", "im:history", "mpim:history"}, // conversations.history
+	"read_thread":    {"channels:history", "groups:history", "im:history", "mpim:history"}, // conversations.replies
 }
 
 // humanizeSlackErrForTool enriches a missing_scope error with the specific

--- a/plugins/slack/tools_test.go
+++ b/plugins/slack/tools_test.go
@@ -1084,6 +1084,118 @@ func TestMapErr(t *testing.T) {
 	}
 }
 
+// TestHumanizeSlackErrForTool verifies that humanizeSlackErrForTool enriches
+// missing_scope errors with tool-specific scope guidance, falls back to the
+// generic message for unknown tools, and delegates non-missing_scope errors to
+// humanizeSlackErr unchanged.
+func TestHumanizeSlackErrForTool(t *testing.T) {
+	cases := []struct {
+		name         string
+		err          error
+		toolName     string
+		wantContains []string    // all substrings must appear
+		wantAbsent   []string    // none of these substrings may appear
+	}{
+		// Single-scope tools: message must include the specific scope and the raw code.
+		{
+			name:         "post_message missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "post_message",
+			wantContains: []string{"missing_scope", "chat:write"},
+		},
+		{
+			name:         "update_message missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "update_message",
+			wantContains: []string{"missing_scope", "chat:write"},
+		},
+		{
+			name:         "delete_message missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "delete_message",
+			wantContains: []string{"missing_scope", "chat:write"},
+		},
+		{
+			name:         "react missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "react",
+			wantContains: []string{"missing_scope", "reactions:write"},
+		},
+		{
+			name:         "lookup_user missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "lookup_user",
+			wantContains: []string{"missing_scope", "users:read"},
+		},
+		// Multi-scope tools: message must include the primary scope and the raw code.
+		{
+			name:         "list_channels missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "list_channels",
+			wantContains: []string{"missing_scope", "channels:read"},
+		},
+		{
+			name:         "set_topic missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "set_topic",
+			wantContains: []string{"missing_scope", "channels:manage"},
+		},
+		{
+			name:         "read_history missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "read_history",
+			wantContains: []string{"missing_scope", "channels:history"},
+		},
+		{
+			name:         "read_thread missing_scope",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "read_thread",
+			wantContains: []string{"missing_scope", "channels:history"},
+		},
+		// Unknown tool + missing_scope → generic humanizeSlackErr fallback.
+		{
+			name:         "unknown tool missing_scope falls back to generic",
+			err:          slackAPIError("missing_scope"),
+			toolName:     "not_a_tool",
+			wantContains: []string{"missing_scope", "the bot's OAuth scopes do not include"},
+			wantAbsent:   []string{"reactions:write"},
+		},
+		// Known tool + non-missing_scope → humanizeSlackErr hint, not a scope hint.
+		{
+			name:         "react not_in_channel delegates to humanizeSlackErr",
+			err:          slackAPIError("not_in_channel"),
+			toolName:     "react",
+			wantContains: []string{"not_in_channel", "not a member of this channel"},
+		},
+		// nil error → empty string.
+		{
+			name:     "nil error",
+			err:      nil,
+			toolName: "react",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := humanizeSlackErrForTool(tc.err, tc.toolName)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("humanizeSlackErrForTool(%q, %q) = %q; want it to contain %q", tc.err, tc.toolName, got, want)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("humanizeSlackErrForTool(%q, %q) = %q; want it NOT to contain %q", tc.err, tc.toolName, got, absent)
+				}
+			}
+			if tc.err == nil && got != "" {
+				t.Errorf("humanizeSlackErrForTool(nil, %q) = %q; want empty string", tc.toolName, got)
+			}
+		})
+	}
+}
+
 // slackAPIError constructs a slack.SlackErrorResponse with the given Slack
 // API error code string. mapErr uses errors.As to match this type, so we
 // must use the real type from the slack-go library.

--- a/plugins/slack/tools_test.go
+++ b/plugins/slack/tools_test.go
@@ -1093,8 +1093,8 @@ func TestHumanizeSlackErrForTool(t *testing.T) {
 		name         string
 		err          error
 		toolName     string
-		wantContains []string    // all substrings must appear
-		wantAbsent   []string    // none of these substrings may appear
+		wantContains []string // all substrings must appear
+		wantAbsent   []string // none of these substrings may appear
 	}{
 		// Single-scope tools: message must include the specific scope and the raw code.
 		{


### PR DESCRIPTION
Closes #653

## Summary
A Slack `missing_scope` tool failure now tells the operator **which OAuth scope to add**, turning a scavenger hunt into a one-step fix.

- New static `toolRequiredScopes` table maps each of the 9 Slack tools to its required bot scope(s).
- New `humanizeSlackErrForTool(err, toolName)` wrapper decorates the error at the single tool-call site (`service.go:221`), keyed by the dispatch tool name already in scope. Single-scope tools name the exact scope (`react` → `reactions:write`); multi-scope tools (`set_topic`, `read_history`/`read_thread`, `list_channels`) list the variants with "one of, depending on channel type" wording.
- The bare `missing_scope` code is always retained as the message prefix (grep-ability preserved). Unknown tools and non-`missing_scope` errors fall back to the existing `humanizeSlackErr` text.

## Deviation from the issue (important)
The issue suggests parsing Slack's `needed`/`provided` fields off the response. **This is not possible with the pinned slack-go v0.26.0**: `SlackErrorResponse` exposes only `Err string`, an unrelated `Errors []SlackResponseErrors`, and `ResponseMetadata{Cursor, Messages, Warnings}` — no `needed`/`provided`. The high-level client methods the plugin calls discard Slack's top-level `needed`/`provided`. A static per-tool table is therefore the feasible **and more reliable** source of truth (works even when Slack omits the field, and is self-documenting).

## Tests
`TestHumanizeSlackErrForTool` (table-driven, 12 cases): all 9 tools → expected scope substring + bare `missing_scope` present; unknown tool → generic fallback, no scope token leaks; known tool + `not_in_channel` → unchanged passthrough; `nil` → `""`. `go test ./plugins/slack/...` green.

## Composition with #647
`humanizeSlackErr` and `classifySlackErrCode` are untouched, so this composes cleanly with PR #662 (#647) — no shared hunks.

Review cycles: 1 (APPROVE). Brainstorming: not triggered. CLAUDE.md: no updates needed.

🤖 Generated by the agentic dev loop.
