### PR TITLE
feat: explain Response buttons in the audience editor (#649)

### DIFF
--- a/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.module.css
+++ b/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.module.css
@@ -22,6 +22,50 @@
   color: var(--text-muted);
 }
 
+.description {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+}
+
+.legendItem {
+  display: flex;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+.legendTerm {
+  font-weight: var(--weight-medium);
+  color: var(--text-second);
+  flex-shrink: 0;
+  min-width: 3.5rem;
+}
+
+.legendDef {
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.legendDef::before {
+  content: '— ';
+}
+
+.legendCode {
+  font-family: var(--font-mono);
+  font-size: 0.95em;
+  color: var(--text-second);
+}
+
 .rows {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.stories.tsx
+++ b/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.stories.tsx
@@ -62,6 +62,19 @@ export const AllStyles: Story = {
   ),
 }
 
+// Explicitly shows the section description and field legend alongside populated rows.
+export const WithHelpLegend: Story = {
+  name: 'With help text / legend',
+  render: () => (
+    <Controlled
+      initial={[
+        { option_id: 'approve', label: 'Approve', value: 'approved', style: 'primary' },
+        { option_id: 'reject', label: 'Reject', value: 'rejected', style: 'danger' },
+      ]}
+    />
+  ),
+}
+
 export const Disabled: Story = {
   render: () => (
     <ResponseButtonsEditor

--- a/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.test.tsx
+++ b/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.test.tsx
@@ -103,6 +103,58 @@ describe('ResponseButtonsEditor — field editing', () => {
   })
 })
 
+describe('ResponseButtonsEditor — help text and field legend', () => {
+  it('shows the section description explaining where buttons render', () => {
+    render(<ResponseButtonsEditor value={undefined} onChange={vi.fn()} />)
+    expect(
+      screen.getByText(/interactive buttons on the routed request message/i),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the channel example (Slack Block Kit) in the description', () => {
+    render(<ResponseButtonsEditor value={undefined} onChange={vi.fn()} />)
+    expect(screen.getByText(/slack block kit/i)).toBeInTheDocument()
+  })
+
+  it('shows the ID field definition', () => {
+    render(<ResponseButtonsEditor value={undefined} onChange={vi.fn()} />)
+    // getByText with selector:'dt' targets the <dt> element directly since
+    // the jsdom version used here does not compute accessible names for <dt>.
+    expect(screen.getByText('ID', { selector: 'dt' })).toBeInTheDocument()
+    expect(screen.getByText(/stable option identifier/i)).toBeInTheDocument()
+  })
+
+  it('shows the Label field definition', () => {
+    render(<ResponseButtonsEditor value={undefined} onChange={vi.fn()} />)
+    expect(screen.getByText('Label', { selector: 'dt' })).toBeInTheDocument()
+    expect(screen.getByText(/button text the recipient sees/i)).toBeInTheDocument()
+  })
+
+  it('shows the Value field definition', () => {
+    render(<ResponseButtonsEditor value={undefined} onChange={vi.fn()} />)
+    expect(screen.getByText('Value', { selector: 'dt' })).toBeInTheDocument()
+    expect(screen.getByText(/response value recorded when clicked/i)).toBeInTheDocument()
+  })
+
+  it('shows the Style field definition', () => {
+    render(<ResponseButtonsEditor value={undefined} onChange={vi.fn()} />)
+    expect(screen.getByText('Style', { selector: 'dt' })).toBeInTheDocument()
+    expect(screen.getByText(/visual treatment/i)).toBeInTheDocument()
+  })
+
+  it('renders the legend even when no buttons are present', () => {
+    render(<ResponseButtonsEditor value={undefined} onChange={vi.fn()} />)
+    const terms = screen.getAllByRole('term')
+    expect(terms).toHaveLength(4)
+  })
+
+  it('renders the legend alongside populated rows', () => {
+    render(<ResponseButtonsEditor value={ONE_BUTTON} onChange={vi.fn()} />)
+    expect(screen.getByText(/interactive buttons on the routed request message/i)).toBeInTheDocument()
+    expect(screen.getAllByRole('term')).toHaveLength(4)
+  })
+})
+
 describe('ResponseButtonsEditor — disabled state', () => {
   it('disables all inputs and buttons when disabled=true', () => {
     render(<ResponseButtonsEditor value={ONE_BUTTON} onChange={vi.fn()} disabled />)

--- a/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.tsx
+++ b/frontend/src/components/admin/AudienceEditor/ResponseButtonsEditor.tsx
@@ -61,6 +61,36 @@ export function ResponseButtonsEditor({ value, onChange, disabled = false, idPre
         <span className={styles.hint}>Defaults to Approve / Reject if omitted.</span>
       </div>
 
+      <p className={styles.description}>
+        These become interactive buttons on the routed Request message in the channel
+        (e.g. Slack Block Kit). The recipient&apos;s click is recorded as the response and
+        flows back to the agent and audit trail.
+      </p>
+
+      <dl className={styles.legend}>
+        <div className={styles.legendItem}>
+          <dt className={styles.legendTerm}>ID</dt>
+          <dd className={styles.legendDef}>
+            Stable option identifier (<code className={styles.legendCode}>option_id</code>) sent
+            back when the button is clicked.
+          </dd>
+        </div>
+        <div className={styles.legendItem}>
+          <dt className={styles.legendTerm}>Label</dt>
+          <dd className={styles.legendDef}>Button text the recipient sees.</dd>
+        </div>
+        <div className={styles.legendItem}>
+          <dt className={styles.legendTerm}>Value</dt>
+          <dd className={styles.legendDef}>
+            Response value recorded when clicked — what the agent and audit trail see.
+          </dd>
+        </div>
+        <div className={styles.legendItem}>
+          <dt className={styles.legendTerm}>Style</dt>
+          <dd className={styles.legendDef}>Visual treatment: default, primary, or danger.</dd>
+        </div>
+      </dl>
+
       {buttons.length > 0 && (
         <div className={styles.rows}>
           {buttons.map((btn, index) => {


### PR DESCRIPTION
Closes #649

## Summary
The **Response buttons** editor in the audience editor was opaque on first encounter — rows of `ID` / `Label` / `Value` / `Style` with no explanation. This adds inline help (pure UX, no behavior change):

- **Section description** under the heading: these become interactive buttons on the routed Request (approval/feedback) message in the channel (e.g. Slack Block Kit); a recipient's click is recorded as the response and flows back to the agent and the audit trail (close-the-loop, #642).
- **One-time field legend** (`<dl>`, shown always — even before the first row is added) defining each column:
  - **ID** — the stable option identifier (`option_id`) sent back when the button is clicked.
  - **Label** — the button text the recipient sees.
  - **Value** — the response value recorded on click (what the agent/audit sees).
  - **Style** — visual treatment (default / primary / danger).
- Keeps the existing "Defaults to Approve / Reject if omitted." hint.

All copy was verified accurate against the `ResponseButton { option_id, label, value, style }` data model. `handleAdd`/`handleRemove`/`handleFieldChange` are byte-for-byte unchanged.

## Tests / stories
- 8 new assertions in `ResponseButtonsEditor.test.tsx` (section description + all four field definitions + Slack mention + empty/populated states). 19/19 green.
- New `WithHelpLegend` Storybook story.
- CSS Modules + design tokens only (no inline styles); 4px spacing scale.

Review cycles: 1 (APPROVE). Scope-gate skip (architect not needed — localized, well-specified). CLAUDE.md: no updates needed.

🤖 Generated by the agentic dev loop.
