### PR TITLE
feat: setup checklist tools step satisfied by an MCP server OR a tool plugin (#650)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -258,7 +258,7 @@ Organized by feature area:
 
 ~29 custom hooks. Data-fetching hooks follow the pattern: `use{Resource}` wraps a TanStack `useQuery`, `use{Action}` wraps a `useMutation`. All query keys go through `queryKeys.ts`.
 
-`useSetupReadiness` — composes `useModels`, `useMcpServers`, and `usePolicies` to derive system readiness state (`hasModel`, `hasServer`, `hasAgent`, `nextStep`). Used by the dashboard and agents page empty states.
+`useSetupReadiness` — composes `useModels`, `useMcpServers`, `usePolicies`, and `usePluginInstancesForAudience` to derive system readiness state (`hasModel`, `hasToolSource`, `hasAgent`, `nextStep`). The tools step (`hasToolSource`) is satisfied by an MCP server OR a tool-providing plugin instance (one whose `services` includes `tool`); the plugin read degrades to `false` on error and is intentionally excluded from `isError` so a 403 (e.g. the `approver` role) never breaks the checklist. Used by the dashboard and agents page empty states.
 
 `useOptionsContext` — builds the `optionsContext` (`{search, degraded}`) passed to SchemaForm for plugin dynamic-option dropdowns; calls `/admin/plugins/{id}/instances/{iid}/options/{source}` via `apiFetch` (not TanStack Query) and tracks the `degraded` fallback flag. Shared by the plugin instance config tab and the audience editor (#622/#627).
 

--- a/frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.tsx
+++ b/frontend/src/components/dashboard/RecentRunsFeed/RecentRunsFeed.tsx
@@ -21,9 +21,9 @@ const EMPTY_STATE_BY_STEP = {
     ctaLabel: 'Go to Models',
     ctaTo: '/admin/models',
   },
-  server: {
-    headline: 'Add an MCP server to give agents tools',
-    subtext: 'MCP servers expose the tools your agents can call.',
+  tools: {
+    headline: 'Add an MCP server or tool plugin to give agents tools',
+    subtext: 'MCP servers and tool-providing plugins both expose tools your agents can call.',
     ctaLabel: 'Go to Tools',
     ctaTo: '/tools',
   },

--- a/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.stories.tsx
+++ b/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.stories.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof SetupChecklist>
 export const AllIncomplete: Story = {
   args: {
     hasModel: false,
-    hasServer: false,
+    hasToolSource: false,
     hasAgent: false,
     hasFirstRun: false,
     isLoading: false,
@@ -37,17 +37,28 @@ export const AllIncomplete: Story = {
 export const ModelDone: Story = {
   args: {
     hasModel: true,
-    hasServer: false,
+    hasToolSource: false,
     hasAgent: false,
     hasFirstRun: false,
     isLoading: false,
   },
 }
 
-export const ServerDone: Story = {
+export const ToolSourceDone: Story = {
   args: {
     hasModel: true,
-    hasServer: true,
+    hasToolSource: true,
+    hasAgent: false,
+    hasFirstRun: false,
+    isLoading: false,
+  },
+}
+
+// Demonstrates that a tool-providing plugin (no MCP server) satisfies the tools step.
+export const ToolPluginDone: Story = {
+  args: {
+    hasModel: true,
+    hasToolSource: true,
     hasAgent: false,
     hasFirstRun: false,
     isLoading: false,
@@ -57,7 +68,7 @@ export const ServerDone: Story = {
 export const AgentDone: Story = {
   args: {
     hasModel: true,
-    hasServer: true,
+    hasToolSource: true,
     hasAgent: true,
     hasFirstRun: false,
     isLoading: false,
@@ -67,7 +78,7 @@ export const AgentDone: Story = {
 export const Loading: Story = {
   args: {
     hasModel: false,
-    hasServer: false,
+    hasToolSource: false,
     hasAgent: false,
     hasFirstRun: false,
     isLoading: true,

--- a/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.test.tsx
+++ b/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.test.tsx
@@ -6,7 +6,7 @@ import { SetupChecklist } from './SetupChecklist'
 
 function renderChecklist(props: {
   hasModel?: boolean
-  hasServer?: boolean
+  hasToolSource?: boolean
   hasAgent?: boolean
   hasFirstRun?: boolean
   isLoading?: boolean
@@ -15,7 +15,7 @@ function renderChecklist(props: {
     <MemoryRouter>
       <SetupChecklist
         hasModel={props.hasModel ?? false}
-        hasServer={props.hasServer ?? false}
+        hasToolSource={props.hasToolSource ?? false}
         hasAgent={props.hasAgent ?? false}
         hasFirstRun={props.hasFirstRun ?? false}
         isLoading={props.isLoading ?? false}
@@ -33,7 +33,7 @@ describe('SetupChecklist', () => {
     renderChecklist({})
 
     expect(screen.getByText('Add a model API key')).toBeInTheDocument()
-    expect(screen.getByText('Register an MCP server')).toBeInTheDocument()
+    expect(screen.getByText('Add an MCP server or tool plugin')).toBeInTheDocument()
     expect(screen.getByText('Create an agent')).toBeInTheDocument()
     expect(screen.getByText('Trigger your first run')).toBeInTheDocument()
   })
@@ -58,7 +58,7 @@ describe('SetupChecklist', () => {
   })
 
   it('does not show a CTA for completed steps', () => {
-    renderChecklist({ hasModel: true, hasServer: true })
+    renderChecklist({ hasModel: true, hasToolSource: true })
 
     expect(screen.queryByRole('link', { name: 'Go to Models' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Go to Tools' })).not.toBeInTheDocument()
@@ -69,7 +69,7 @@ describe('SetupChecklist', () => {
   it('returns null when every step is done and not loading', () => {
     const { container } = renderChecklist({
       hasModel: true,
-      hasServer: true,
+      hasToolSource: true,
       hasAgent: true,
       hasFirstRun: true,
       isLoading: false,
@@ -81,7 +81,7 @@ describe('SetupChecklist', () => {
   it('does not return null when loading even if all steps would be done', () => {
     renderChecklist({
       hasModel: true,
-      hasServer: true,
+      hasToolSource: true,
       hasAgent: true,
       hasFirstRun: true,
       isLoading: true,

--- a/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.tsx
+++ b/frontend/src/components/dashboard/SetupChecklist/SetupChecklist.tsx
@@ -7,7 +7,7 @@ const COLLAPSED_STORAGE_KEY = 'gleipnir-setup-collapsed'
 
 export interface SetupChecklistProps {
   hasModel: boolean
-  hasServer: boolean
+  hasToolSource: boolean
   hasAgent: boolean
   hasFirstRun: boolean
   isLoading: boolean
@@ -20,16 +20,16 @@ interface Step {
   cta: string
 }
 
-export function SetupChecklist({ hasModel, hasServer, hasAgent, hasFirstRun, isLoading }: SetupChecklistProps) {
+export function SetupChecklist({ hasModel, hasToolSource, hasAgent, hasFirstRun, isLoading }: SetupChecklistProps) {
   const [collapsed, setCollapsed] = useLocalStorage(COLLAPSED_STORAGE_KEY, false)
 
-  const allDone = hasModel && hasServer && hasAgent && hasFirstRun
+  const allDone = hasModel && hasToolSource && hasAgent && hasFirstRun
 
   if (allDone && !isLoading) return null
 
   const steps: Step[] = [
     { label: 'Add a model API key', done: hasModel, href: '/admin/models', cta: 'Go to Models' },
-    { label: 'Register an MCP server', done: hasServer, href: '/tools', cta: 'Go to Tools' },
+    { label: 'Add an MCP server or tool plugin', done: hasToolSource, href: '/tools', cta: 'Go to Tools' },
     { label: 'Create an agent', done: hasAgent, href: '/agents/new', cta: 'New Agent' },
     { label: 'Trigger your first run', done: hasFirstRun, href: '/agents', cta: 'Go to Agents' },
   ]

--- a/frontend/src/hooks/useSetupReadiness.test.ts
+++ b/frontend/src/hooks/useSetupReadiness.test.ts
@@ -16,6 +16,8 @@ function setupHandlers(opts: {
   models?: { provider: string; models: { name: string; display_name: string }[] }[]
   servers?: { id: string; name: string }[]
   policies?: { id: string; name: string }[]
+  plugins?: { id: string; instance_name: string; services?: string[] }[]
+  pluginsStatus?: number
 }) {
   server.use(
     http.get('/api/v1/models', () =>
@@ -27,6 +29,12 @@ function setupHandlers(opts: {
     http.get('/api/v1/policies', () =>
       HttpResponse.json({ data: opts.policies ?? [] }),
     ),
+    http.get('/api/v1/admin/plugin-instances', () => {
+      if (opts.pluginsStatus && opts.pluginsStatus !== 200) {
+        return HttpResponse.json({ error: 'forbidden' }, { status: opts.pluginsStatus })
+      }
+      return HttpResponse.json({ data: opts.plugins ?? [] })
+    }),
   )
 }
 
@@ -39,7 +47,7 @@ describe('useSetupReadiness', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.hasModel).toBe(false)
-    expect(result.current.hasServer).toBe(false)
+    expect(result.current.hasToolSource).toBe(false)
     expect(result.current.hasAgent).toBe(false)
     expect(result.current.nextStep).toBe('model')
   })
@@ -55,7 +63,7 @@ describe('useSetupReadiness', () => {
     expect(result.current.nextStep).toBe('model')
   })
 
-  it('returns nextStep server when models are present but no servers', async () => {
+  it('returns nextStep tools when models are present but no servers or tool plugins', async () => {
     setupHandlers({
       models: [{ provider: 'anthropic', models: [{ name: 'claude-3', display_name: 'Claude 3' }] }],
     })
@@ -65,11 +73,11 @@ describe('useSetupReadiness', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.hasModel).toBe(true)
-    expect(result.current.hasServer).toBe(false)
-    expect(result.current.nextStep).toBe('server')
+    expect(result.current.hasToolSource).toBe(false)
+    expect(result.current.nextStep).toBe('tools')
   })
 
-  it('returns nextStep agent when models and servers are present but no agents', async () => {
+  it('returns nextStep agent when models and an MCP server are present but no agents', async () => {
     setupHandlers({
       models: [{ provider: 'anthropic', models: [{ name: 'claude-3', display_name: 'Claude 3' }] }],
       servers: [{ id: 's1', name: 'my-server' }],
@@ -80,7 +88,23 @@ describe('useSetupReadiness', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.hasModel).toBe(true)
-    expect(result.current.hasServer).toBe(true)
+    expect(result.current.hasToolSource).toBe(true)
+    expect(result.current.hasAgent).toBe(false)
+    expect(result.current.nextStep).toBe('agent')
+  })
+
+  it('returns nextStep agent when models and a tool plugin are present but no servers and no agents', async () => {
+    setupHandlers({
+      models: [{ provider: 'anthropic', models: [{ name: 'claude-3', display_name: 'Claude 3' }] }],
+      plugins: [{ id: 'pi1', instance_name: 'slack-main', services: ['tool', 'channel'] }],
+    })
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.hasModel).toBe(true)
+    expect(result.current.hasToolSource).toBe(true)
     expect(result.current.hasAgent).toBe(false)
     expect(result.current.nextStep).toBe('agent')
   })
@@ -97,7 +121,7 @@ describe('useSetupReadiness', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.hasModel).toBe(true)
-    expect(result.current.hasServer).toBe(true)
+    expect(result.current.hasToolSource).toBe(true)
     expect(result.current.hasAgent).toBe(true)
     expect(result.current.nextStep).toBe('ready')
   })
@@ -110,11 +134,12 @@ describe('useSetupReadiness', () => {
     expect(result.current.isLoading).toBe(true)
   })
 
-  it('reports isError true when a query fails', async () => {
+  it('reports isError true when a query fails (models 500), plugin 403 does not contribute', async () => {
     server.use(
       http.get('/api/v1/models', () => HttpResponse.json({ error: 'server error' }, { status: 500 })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
       http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json({ data: [] })),
     )
 
     const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
@@ -122,5 +147,26 @@ describe('useSetupReadiness', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.isError).toBe(true)
+  })
+
+  it('degrades gracefully when plugin-instances returns 403 — isError stays false, hasToolSource stays false', async () => {
+    server.use(
+      http.get('/api/v1/models', () =>
+        HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'claude-3', display_name: 'Claude 3' }] }] }),
+      ),
+      http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () =>
+        HttpResponse.json({ error: 'forbidden' }, { status: 403 }),
+      ),
+    )
+
+    const { result } = renderHook(() => useSetupReadiness(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.isError).toBe(false)
+    expect(result.current.hasToolSource).toBe(false)
+    expect(result.current.nextStep).toBe('tools')
   })
 })

--- a/frontend/src/hooks/useSetupReadiness.ts
+++ b/frontend/src/hooks/useSetupReadiness.ts
@@ -1,22 +1,28 @@
 import { useModels } from '@/hooks/queries/users'
 import { useMcpServers } from '@/hooks/queries/servers'
 import { usePolicies } from '@/hooks/queries/policies'
+import { usePluginInstancesForAudience } from '@/hooks/queries/admin'
 
 export interface SetupReadiness {
   hasModel: boolean
-  hasServer: boolean
+  hasToolSource: boolean
   hasAgent: boolean
   isLoading: boolean
   isError: boolean
-  nextStep: 'model' | 'server' | 'agent' | 'ready'
+  nextStep: 'model' | 'tools' | 'agent' | 'ready'
 }
 
 export function useSetupReadiness(): SetupReadiness {
   const models = useModels()
   const servers = useMcpServers()
   const policies = usePolicies()
+  // Plugin instances enrich the tools step: a tool-providing plugin satisfies
+  // the same step as an MCP server. Errors here degrade to hasToolPlugin=false
+  // rather than propagating to isError — a 403 from non-admin roles must not
+  // break the checklist for the whole dashboard.
+  const plugins = usePluginInstancesForAudience()
 
-  const isLoading = models.isLoading || servers.isLoading || policies.isLoading
+  const isLoading = models.isLoading || servers.isLoading || policies.isLoading || plugins.isLoading
   const isError = models.isError || servers.isError || policies.isError
 
   // The API can return [{provider: 'anthropic', models: []}] when no API key
@@ -24,18 +30,20 @@ export function useSetupReadiness(): SetupReadiness {
   // length check on the outer array would give a false positive.
   const hasModel = models.data?.some(g => g.models.length > 0) ?? false
   const hasServer = (servers.data?.length ?? 0) > 0
+  const hasToolPlugin = (plugins.data ?? []).some(i => i.services?.includes('tool') ?? false)
+  const hasToolSource = hasServer || hasToolPlugin
   const hasAgent = (policies.data?.length ?? 0) > 0
 
   let nextStep: SetupReadiness['nextStep']
   if (!hasModel) {
     nextStep = 'model'
-  } else if (!hasServer) {
-    nextStep = 'server'
+  } else if (!hasToolSource) {
+    nextStep = 'tools'
   } else if (!hasAgent) {
     nextStep = 'agent'
   } else {
     nextStep = 'ready'
   }
 
-  return { hasModel, hasServer, hasAgent, isLoading, isError, nextStep }
+  return { hasModel, hasToolSource, hasAgent, isLoading, isError, nextStep }
 }

--- a/frontend/src/pages/AgentsPage.test.tsx
+++ b/frontend/src/pages/AgentsPage.test.tsx
@@ -30,6 +30,7 @@ const POLICIES: ApiPolicyListItem[] = [
 
 const STUB_MODEL_RESPONSE = [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }]
 const STUB_SERVER_RESPONSE = [{ id: 's1', name: 'my-server', url: 'http://localhost:9000', tool_count: 1 }]
+const EMPTY_PLUGINS = { data: [] }
 
 function makeClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -54,6 +55,7 @@ describe('AgentsPage', () => {
       }),
       http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()
@@ -72,6 +74,7 @@ describe('AgentsPage', () => {
       http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
       http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()
@@ -96,6 +99,7 @@ describe('AgentsPage', () => {
         HttpResponse.json({ data: [{ provider: 'anthropic', models: [] }] }),
       ),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()
@@ -107,18 +111,19 @@ describe('AgentsPage', () => {
     expect(screen.getByRole('link', { name: 'Go to Models' })).toHaveAttribute('href', '/admin/models')
   })
 
-  it('shows "Add an MCP server" empty state when model is set but no server', async () => {
+  it('shows "Add an MCP server or tool plugin" empty state when model is set but no tool source', async () => {
     server.use(
       http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
       http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()
     renderPage(qc)
 
     await waitFor(() => {
-      expect(screen.getByText('Add an MCP server to give agents tools')).toBeInTheDocument()
+      expect(screen.getByText('Add an MCP server or tool plugin to give agents tools')).toBeInTheDocument()
     })
     expect(screen.getByRole('link', { name: 'Go to Tools' })).toHaveAttribute('href', '/tools')
   })
@@ -128,6 +133,7 @@ describe('AgentsPage', () => {
       http.get('/api/v1/policies', () => HttpResponse.json({ data: POLICIES })),
       http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()
@@ -144,6 +150,7 @@ describe('AgentsPage', () => {
       http.get('/api/v1/policies', () => HttpResponse.json({ data: POLICIES })),
       http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()
@@ -163,6 +170,7 @@ describe('AgentsPage', () => {
       }),
       http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()
@@ -187,6 +195,7 @@ describe('AgentsPage', () => {
       }),
       http.get('/api/v1/models', () => HttpResponse.json({ data: STUB_MODEL_RESPONSE })),
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: STUB_SERVER_RESPONSE })),
+      http.get('/api/v1/admin/plugin-instances', () => HttpResponse.json(EMPTY_PLUGINS)),
     )
 
     const qc = makeClient()

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -28,10 +28,10 @@ export default function AgentsPage() {
         ctaLabel="Go to Models"
         ctaTo="/admin/models"
       />
-    : readiness.nextStep === 'server'
+    : readiness.nextStep === 'tools'
     ? <EmptyState
-        headline="Add an MCP server to give agents tools"
-        subtext="Agents use MCP tools to do their work. Register a server first."
+        headline="Add an MCP server or tool plugin to give agents tools"
+        subtext="Agents use tools to do their work. Register an MCP server or install a tool-providing plugin first."
         ctaLabel="Go to Tools"
         ctaTo="/tools"
       />

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -100,6 +100,9 @@ function setupDefaultHandlers() {
     http.get('/api/v1/policies', () =>
       HttpResponse.json({ data: [STUB_POLICY] }),
     ),
+    http.get('/api/v1/admin/plugin-instances', () =>
+      HttpResponse.json({ data: [] }),
+    ),
   )
 }
 
@@ -196,6 +199,9 @@ describe('DashboardPage', () => {
       http.get('/api/v1/policies', () =>
         HttpResponse.json({ data: [STUB_POLICY] }),
       ),
+      http.get('/api/v1/admin/plugin-instances', () =>
+        HttpResponse.json({ data: [] }),
+      ),
     )
 
     renderDashboard(makeClient())
@@ -216,6 +222,9 @@ describe('DashboardPage', () => {
         HttpResponse.json({ data: [{ provider: 'anthropic', models: [] }] }),
       ),
       http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () =>
+        HttpResponse.json({ data: [] }),
+      ),
     )
 
     renderDashboard(makeClient())
@@ -229,7 +238,7 @@ describe('DashboardPage', () => {
     expect(modelsLinks.every(l => l.getAttribute('href') === '/admin/models')).toBe(true)
   })
 
-  it('RecentRunsFeed empty state shows "Add an MCP server" when model is set but no server', async () => {
+  it('RecentRunsFeed empty state shows "Add an MCP server or tool plugin" when model is set but no tool source', async () => {
     server.use(
       http.get('/api/v1/stats', () => HttpResponse.json({ data: STATS })),
       http.get('/api/v1/stats/timeseries', () => HttpResponse.json({ data: TIMESERIES })),
@@ -240,12 +249,15 @@ describe('DashboardPage', () => {
         HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }] }),
       ),
       http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () =>
+        HttpResponse.json({ data: [] }),
+      ),
     )
 
     renderDashboard(makeClient())
 
     await waitFor(() => {
-      expect(screen.getByText('Add an MCP server to give agents tools')).toBeInTheDocument()
+      expect(screen.getByText('Add an MCP server or tool plugin to give agents tools')).toBeInTheDocument()
     })
     const toolsLinks = screen.getAllByRole('link', { name: 'Go to Tools' })
     expect(toolsLinks.every(l => l.getAttribute('href') === '/tools')).toBe(true)
@@ -264,6 +276,9 @@ describe('DashboardPage', () => {
         HttpResponse.json({ data: [{ provider: 'anthropic', models: [{ name: 'm1', display_name: 'Claude' }] }] }),
       ),
       http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () =>
+        HttpResponse.json({ data: [] }),
+      ),
     )
 
     renderDashboard(makeClient())
@@ -295,6 +310,9 @@ describe('DashboardPage', () => {
       http.get('/api/v1/mcp/servers', () => HttpResponse.json({ data: [] })),
       http.get('/api/v1/models', () => HttpResponse.json({ data: [] })),
       http.get('/api/v1/policies', () => HttpResponse.json({ data: [] })),
+      http.get('/api/v1/admin/plugin-instances', () =>
+        HttpResponse.json({ data: [] }),
+      ),
     )
 
     renderDashboard(makeClient())
@@ -320,6 +338,9 @@ describe('DashboardPage', () => {
       ),
       http.get('/api/v1/policies', () =>
         HttpResponse.json({ data: [STUB_POLICY] }),
+      ),
+      http.get('/api/v1/admin/plugin-instances', () =>
+        HttpResponse.json({ data: [] }),
       ),
     )
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -26,7 +26,7 @@ export default function DashboardPage() {
       <PageHeader title="Control Center" />
       <SetupChecklist
         hasModel={readiness.hasModel}
-        hasServer={readiness.hasServer}
+        hasToolSource={readiness.hasToolSource}
         hasAgent={readiness.hasAgent}
         hasFirstRun={hasFirstRun}
         isLoading={readiness.isLoading || recentRuns.isLoading}


### PR DESCRIPTION
Closes #650

## Summary
The onboarding setup checklist treated "tools" as MCP-server-only. Now that plugins ship with a `ToolService`, a user who installs a tool-providing plugin (e.g. the Slack plugin's 9 tools) and has no MCP server was still nagged to "Register an MCP server" and the step never completed. The **tools step is now satisfied by an MCP server OR a tool-providing plugin instance**.

- `useSetupReadiness` derives `hasToolSource = hasServer || hasToolPlugin`, where `hasToolPlugin` is true when any `/admin/plugin-instances` entry declares a `ToolService` (its `services` array includes `"tool"`). Renamed the field `hasServer → hasToolSource` and the `nextStep` member `'server' → 'tools'`; all consumers updated (`SetupChecklist`, `DashboardPage`, `AgentsPage`, `RecentRunsFeed`).
- **Error isolation (load-bearing):** the admin-only `/admin/plugin-instances` read is **excluded from `isError`**, so a 403 (e.g. the `approver` role, which can't read it) degrades `hasToolPlugin` to `false` instead of breaking the whole checklist. Covered by a dedicated 403 test.
- Step copy → **"Add an MCP server or tool plugin"**; the dashboard/agents empty states name both paths; single CTA to `/tools` (ADR-030 protocol-agnostic tools surface).

## Tests / stories
- `useSetupReadiness.test.ts`: plugin-only-satisfies-tools (`services:['tool']` → `hasToolSource`, `nextStep:'agent'`) + 403 error-isolation (`isError:false`, `hasToolSource:false`) + MSW handler wired into all cases.
- Updated `SetupChecklist`/`DashboardPage`/`AgentsPage` tests for the new copy + handler; 35 tests green; `tsc --noEmit` + `npm run build` clean.
- Stories: `ServerDone → ToolSourceDone`, new `ToolPluginDone`.
- `frontend/CLAUDE.md` `useSetupReadiness` description updated.

<details><summary>Architecture plan (architect → adversarial review → APPROVE)</summary>
Signal `services.includes('tool')` verified against backend `plugin_instance_handler.go` (`append(services, "tool")`). Plan-reviewer caught a missed consumer (`DashboardPage.test.tsx` asserted the old empty-state headline + needed the MSW handler) and an inaccurate "servers not role-gated" claim — both folded in. Implementer also found `AgentsPage.test.tsx` via grep.
</details>

Review cycles: 1 (APPROVE). Brainstorming: not triggered. CLAUDE.md: frontend/CLAUDE.md updated.

🤖 Generated by the agentic dev loop.
