### PR TITLE
feat: clearer subscribed-trigger binding form; channel exact-ID; drop dead text_regex (#651, #646, #654)

### DIFF
--- a/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.module.css
+++ b/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.module.css
@@ -139,3 +139,21 @@
   color: var(--text-muted);
   line-height: 1.5;
 }
+
+.caption {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.explainer {
+  font-size: var(--text-xs);
+  color: var(--text-second);
+  line-height: 1.5;
+  margin: 0 0 var(--space-2) 0;
+}
+
+.explainer a {
+  color: var(--color-blue);
+}

--- a/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.stories.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import { http, HttpResponse } from 'msw';
 import '@/tokens.css';
 import { SubscribedBindingConfig } from './SubscribedBindingConfig';
@@ -29,15 +30,29 @@ const SLACK_INSTANCE: ApiPluginInstanceForAudience = {
       binding_schema: {
         type: 'object',
         properties: {
-          channel: { type: 'string', description: 'Channel name (exact match)' },
-          pattern: { type: 'string', format: 'regex', description: 'Text pattern (RE2)' },
-          mention_only: { type: 'boolean', description: 'Only fire when mentioned' },
+          channel_id: {
+            type: 'string',
+            title: 'Channel',
+            description: 'Exact match on the Slack channel. Pick a channel from the searchable list; matches the message\'s stable channel ID (e.g. C012AB3CD).',
+            'x-gleipnir-options': { source: 'channels' },
+          },
+          text: {
+            type: 'string',
+            format: 'contains',
+            title: 'Text contains',
+            description: 'Case-sensitive substring; matches anywhere in the message body (not anchored to the start).',
+          },
+          mention_only: {
+            type: 'boolean',
+            title: 'Mention-only',
+            description: 'Fire only when the bot is explicitly @-mentioned.',
+          },
         },
       },
       examples: [
-        { name: 'incident-alert', payload: { channel: '#incidents', text: 'P1 fire', mentioned: false } },
-        { name: 'mentions-bot', payload: { channel: '#general', text: 'hey @bot', mentioned: true } },
-        { name: 'no-match', payload: { channel: '#random', text: 'hello' } },
+        { name: 'incident-alert', payload: { channel_id: 'C09INCIDENT', text: 'P1 fire', mentioned: false } },
+        { name: 'mentions-bot', payload: { channel_id: 'C012ABCDEF', text: 'hey @bot', mentioned: true } },
+        { name: 'no-match', payload: { channel_id: 'CRANDOM123', text: 'hello' } },
       ],
     },
   ],
@@ -58,6 +73,7 @@ const SLACK_NO_EXAMPLES: ApiPluginInstanceForAudience = {
 };
 
 const TEST_ENDPOINT = '/api/v1/admin/plugin-instances/inst-slack/event-kinds/channel_message/test-binding';
+const OPTIONS_ENDPOINT = '/api/v1/admin/plugins/plugin-slack/instances/inst-slack/options/channels';
 
 // --- Meta ---
 
@@ -66,11 +82,13 @@ const meta: Meta<typeof SubscribedBindingConfig> = {
   component: SubscribedBindingConfig,
   decorators: [
     (Story) => (
-      <QueryClientProvider client={makeQueryClient()}>
-        <div className={decoratorStyles.decorator}>
-          <Story />
-        </div>
-      </QueryClientProvider>
+      <MemoryRouter>
+        <QueryClientProvider client={makeQueryClient()}>
+          <div className={decoratorStyles.decorator}>
+            <Story />
+          </div>
+        </QueryClientProvider>
+      </MemoryRouter>
     ),
   ],
 };
@@ -96,13 +114,24 @@ export const Default: Story = {
             },
           }),
         ),
+        http.get(OPTIONS_ENDPOINT, () =>
+          HttpResponse.json({
+            data: {
+              options: [
+                { value: 'C09INCIDENT', label: '#incidents' },
+                { value: 'C012ABCDEF', label: '#general' },
+              ],
+              next_cursor: '',
+            },
+          }),
+        ),
       ],
     },
   },
   args: {
     source: 'slack-prod',
     eventKind: 'channel_message',
-    binding: { channel: '#incidents' },
+    binding: { channel_id: 'C09INCIDENT' },
     onChange: fn(),
     pluginInstances: [SLACK_INSTANCE],
   },
@@ -124,6 +153,17 @@ export const AllMatch: Story = {
             },
           }),
         ),
+        http.get(OPTIONS_ENDPOINT, () =>
+          HttpResponse.json({
+            data: {
+              options: [
+                { value: 'C09INCIDENT', label: '#incidents' },
+                { value: 'C012ABCDEF', label: '#general' },
+              ],
+              next_cursor: '',
+            },
+          }),
+        ),
       ],
     },
   },
@@ -139,12 +179,20 @@ export const AllMatch: Story = {
 // NoExamples: button is disabled, tooltip visible.
 export const NoExamples: Story = {
   parameters: {
-    msw: { handlers: [] },
+    msw: {
+      handlers: [
+        http.get(OPTIONS_ENDPOINT, () =>
+          HttpResponse.json({
+            data: { options: [], next_cursor: '' },
+          }),
+        ),
+      ],
+    },
   },
   args: {
     source: 'slack-no-examples',
     eventKind: 'channel_message',
-    binding: { channel: '#incidents' },
+    binding: { channel_id: 'C09INCIDENT' },
     onChange: fn(),
     pluginInstances: [SLACK_NO_EXAMPLES],
   },
@@ -157,9 +205,14 @@ export const CompileError: Story = {
       handlers: [
         http.post(TEST_ENDPOINT, () =>
           HttpResponse.json(
-            { error: 'binding compile error', detail: 'binding: invalid regular expression (Go RE2 required): field "pattern": error parsing regexp' },
+            { error: 'binding compile error', detail: 'binding: invalid regular expression (Go RE2 required): field "text": error parsing regexp' },
             { status: 400 },
           ),
+        ),
+        http.get(OPTIONS_ENDPOINT, () =>
+          HttpResponse.json({
+            data: { options: [], next_cursor: '' },
+          }),
         ),
       ],
     },
@@ -167,7 +220,7 @@ export const CompileError: Story = {
   args: {
     source: 'slack-prod',
     eventKind: 'channel_message',
-    binding: { pattern: '[invalid(' },
+    binding: { text: '[invalid(' },
     onChange: fn(),
     pluginInstances: [SLACK_INSTANCE],
   },
@@ -182,13 +235,21 @@ export const LoadingResults: Story = {
           await new Promise((r) => setTimeout(r, 60_000));
           return HttpResponse.json({ data: { results: [] } });
         }),
+        http.get(OPTIONS_ENDPOINT, () =>
+          HttpResponse.json({
+            data: {
+              options: [{ value: 'C012ABCDEF', label: '#incidents' }],
+              next_cursor: '',
+            },
+          }),
+        ),
       ],
     },
   },
   args: {
     source: 'slack-prod',
     eventKind: 'channel_message',
-    binding: { channel: '#incidents' },
+    binding: { channel_id: 'C09INCIDENT' },
     onChange: fn(),
     pluginInstances: [SLACK_INSTANCE],
   },

--- a/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.test.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import type { ApiPluginInstanceForAudience } from '@/api/types'
 import { SubscribedBindingConfig } from './SubscribedBindingConfig'
 
@@ -8,8 +9,18 @@ import { SubscribedBindingConfig } from './SubscribedBindingConfig'
 vi.mock('@/hooks/mutations/bindingTest')
 import { useTestBindingAgainstSamples } from '@/hooks/mutations/bindingTest'
 
+// Mock usePluginOptions so OptionsBindingField (AsyncCombobox) never fires
+// real requests. Tests that assert combobox rendering don't need real data.
+vi.mock('@/hooks/usePluginOptions', () => ({
+  usePluginOptions: vi.fn().mockReturnValue({ data: undefined, isLoading: false }),
+}))
+
 // --- Fixtures ---
 
+// SLACK_INSTANCE has:
+//   - a plain text field (`text`) to keep the role="textbox" assertion valid
+//   - a channel_id field with x-gleipnir-options so it renders role="combobox"
+//   - title/description on both fields
 const SLACK_INSTANCE: ApiPluginInstanceForAudience = {
   id: 'inst-slack',
   plugin_id: 'plugin-slack',
@@ -26,13 +37,24 @@ const SLACK_INSTANCE: ApiPluginInstanceForAudience = {
       binding_schema: {
         type: 'object',
         properties: {
-          channel: { type: 'string' },
-          mention_only: { type: 'boolean' },
+          channel_id: {
+            type: 'string',
+            title: 'Channel',
+            description: 'Exact match on the Slack channel. Pick from the searchable list.',
+            'x-gleipnir-options': { source: 'channels' },
+          },
+          text: {
+            type: 'string',
+            format: 'contains',
+            title: 'Text contains',
+            description: 'Case-sensitive substring anywhere in the message body.',
+          },
+          mention_only: { type: 'boolean', title: 'Mention-only', description: 'Fire only when the bot is @-mentioned.' },
         },
       },
       examples: [
-        { name: 'incident-channel', payload: { channel: '#incidents', text: 'alert' } },
-        { name: 'general-channel', payload: { channel: '#general', text: 'hello' } },
+        { name: 'incident-channel', payload: { channel_id: 'C09INCIDENT', text: 'alert' } },
+        { name: 'general-channel', payload: { channel_id: 'C012ABCDEF', text: 'hello' } },
       ],
     },
   ],
@@ -55,7 +77,11 @@ const NO_EXAMPLES_INSTANCE: ApiPluginInstanceForAudience = {
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    return (
+      <MemoryRouter>
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      </MemoryRouter>
+    )
   }
   return Wrapper
 }
@@ -76,7 +102,7 @@ beforeEach(() => {
 })
 
 describe('SubscribedBindingConfig — rendering', () => {
-  it('renders binding field inputs from the schema', () => {
+  it('renders the text field as a textbox and channel_id as a combobox', () => {
     render(
       <SubscribedBindingConfig
         source="slack-prod"
@@ -88,8 +114,81 @@ describe('SubscribedBindingConfig — rendering', () => {
       { wrapper: makeWrapper() },
     )
 
+    // The plain `text` field renders a text input.
     expect(screen.getByRole('textbox')).toBeInTheDocument()
-    expect(screen.getByLabelText(/channel/i)).toBeInTheDocument()
+    // The `channel_id` field with x-gleipnir-options renders a combobox.
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+
+  it('renders prop.title as the label (not the raw key)', () => {
+    render(
+      <SubscribedBindingConfig
+        source="slack-prod"
+        eventKind="channel_message"
+        binding={{}}
+        onChange={vi.fn()}
+        pluginInstances={[SLACK_INSTANCE]}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    // The `text` field has title "Text contains" — should appear, not "text".
+    expect(screen.getByText('Text contains')).toBeInTheDocument()
+    // The `channel_id` field has title "Channel" — should appear.
+    expect(screen.getAllByText('Channel').length).toBeGreaterThan(0)
+  })
+
+  it('renders prop.description as a caption below the field', () => {
+    render(
+      <SubscribedBindingConfig
+        source="slack-prod"
+        eventKind="channel_message"
+        binding={{}}
+        onChange={vi.fn()}
+        pluginInstances={[SLACK_INSTANCE]}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    expect(
+      screen.getByText('Case-sensitive substring anywhere in the message body.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Exact match on the Slack channel. Pick from the searchable list.'),
+    ).toBeInTheDocument()
+  })
+
+  it('does not render the (contains) or (regex) format suffix', () => {
+    render(
+      <SubscribedBindingConfig
+        source="slack-prod"
+        eventKind="channel_message"
+        binding={{}}
+        onChange={vi.fn()}
+        pluginInstances={[SLACK_INSTANCE]}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    expect(screen.queryByText(/\(contains\)/)).toBeNull()
+    expect(screen.queryByText(/\(regex\)/)).toBeNull()
+  })
+
+  it('renders the scope↔binding explainer with a link to the plugin instance page', () => {
+    render(
+      <SubscribedBindingConfig
+        source="slack-prod"
+        eventKind="channel_message"
+        binding={{}}
+        onChange={vi.fn()}
+        pluginInstances={[SLACK_INSTANCE]}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    const link = screen.getByRole('link', { name: /subscription scope/i })
+    expect(link).toBeInTheDocument()
+    expect(link.getAttribute('href')).toContain('/admin/plugins/plugin-slack/instances/inst-slack')
   })
 
   it('renders example names in the results area after a test', () => {
@@ -105,7 +204,7 @@ describe('SubscribedBindingConfig — rendering', () => {
       <SubscribedBindingConfig
         source="slack-prod"
         eventKind="channel_message"
-        binding={{ channel: '#incidents' }}
+        binding={{ channel_id: 'C09INCIDENT' }}
         onChange={vi.fn()}
         pluginInstances={[SLACK_INSTANCE]}
       />,
@@ -163,7 +262,7 @@ describe('SubscribedBindingConfig — click sends all payloads', () => {
       data: undefined,
     } as unknown as ReturnType<typeof useTestBindingAgainstSamples>)
 
-    const binding = { channel: '#incidents' }
+    const binding = { channel_id: 'C09INCIDENT' }
     render(
       <SubscribedBindingConfig
         source="slack-prod"
@@ -181,8 +280,8 @@ describe('SubscribedBindingConfig — click sends all payloads', () => {
       expect(mutate).toHaveBeenCalledWith({
         binding,
         payloads: [
-          { channel: '#incidents', text: 'alert' },
-          { channel: '#general', text: 'hello' },
+          { channel_id: 'C09INCIDENT', text: 'alert' },
+          { channel_id: 'C012ABCDEF', text: 'hello' },
         ],
       })
     })
@@ -210,7 +309,7 @@ describe('SubscribedBindingConfig — 400 compile error surfacing', () => {
       <SubscribedBindingConfig
         source="slack-prod"
         eventKind="channel_message"
-        binding={{ pattern: '[bad(' }}
+        binding={{ text: '[bad(' }}
         onChange={vi.fn()}
         pluginInstances={[SLACK_INSTANCE]}
       />,

--- a/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.tsx
+++ b/frontend/src/components/AgentEditor/FormMode/triggers/SubscribedBindingConfig.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import styles from './SubscribedBindingConfig.module.css';
 import type { ApiPluginInstanceForAudience } from '@/api/types';
 import { AsyncCombobox } from '@/components/form/AsyncCombobox';
 import { usePluginOptions } from '@/hooks/usePluginOptions';
 import { useTestBindingAgainstSamples } from '@/hooks/mutations/bindingTest';
+import { humanize } from '@/components/form/SchemaForm/SchemaForm';
 
 export interface SubscribedBindingConfigProps {
   source: string;       // instance_name — used to find the matching plugin instance
@@ -18,6 +20,7 @@ export interface SubscribedBindingConfigProps {
 interface SchemaProperty {
   type?: string;
   format?: string;
+  title?: string;
   description?: string;
   // x-gleipnir-options: present when the field has a dynamic options provider.
   'x-gleipnir-options'?: { source: string; multi?: boolean };
@@ -60,6 +63,8 @@ function resolveExamples(
 // hooks are called at the top level of a component (Rules of Hooks).
 function OptionsBindingField({
   name,
+  title,
+  description,
   source,
   pluginId,
   instanceId,
@@ -67,6 +72,8 @@ function OptionsBindingField({
   onChange,
 }: {
   name: string;
+  title?: string;
+  description?: string;
   source: string;
   pluginId: string;
   instanceId: string;
@@ -98,7 +105,7 @@ function OptionsBindingField({
   return (
     <div className={styles.row}>
       <label htmlFor={inputId} className={styles.label}>
-        {name}
+        {title ?? humanize(name)}
       </label>
       <AsyncCombobox
         id={inputId}
@@ -108,6 +115,7 @@ function OptionsBindingField({
         degraded={degraded}
         placeholder="Search…"
       />
+      {description && <p className={styles.caption}>{description}</p>}
     </div>
   );
 }
@@ -130,10 +138,10 @@ function BindingField({
   pluginId?: string;
   instanceId?: string;
 }) {
-  const isMentionOnly = name === 'mention_only' && prop.type === 'boolean';
   const isBool = prop.type === 'boolean';
+  const label = prop.title ?? humanize(name);
 
-  if (isMentionOnly || isBool) {
+  if (isBool) {
     return (
       <div className={styles.row}>
         <label className={styles.checkbox}>
@@ -142,11 +150,9 @@ function BindingField({
             checked={!!value}
             onChange={(e) => onChange(e.target.checked)}
           />
-          {name}
-          {isMentionOnly && (
-            <span className={styles.testTooltip}>(mention-only: only fire when @mentioned)</span>
-          )}
+          {label}
         </label>
+        {prop.description && <p className={styles.caption}>{prop.description}</p>}
       </div>
     );
   }
@@ -156,6 +162,8 @@ function BindingField({
     return (
       <OptionsBindingField
         name={name}
+        title={prop.title}
+        description={prop.description}
         source={optionsAnnotation.source}
         pluginId={pluginId}
         instanceId={instanceId}
@@ -169,10 +177,7 @@ function BindingField({
   return (
     <div className={styles.row}>
       <label htmlFor={inputId} className={styles.label}>
-        {name}
-        {prop.format && prop.format !== '' && (
-          <span className={styles.testTooltip}> ({prop.format})</span>
-        )}
+        {label}
       </label>
       <input
         id={inputId}
@@ -182,6 +187,7 @@ function BindingField({
         placeholder={prop.format === 'regex' ? 'RE2 regex…' : prop.format === 'contains' ? 'substring…' : 'exact value…'}
         onChange={(e) => onChange(e.target.value)}
       />
+      {prop.description && <p className={styles.caption}>{prop.description}</p>}
     </div>
   );
 }
@@ -232,6 +238,14 @@ export function SubscribedBindingConfig({
 
   return (
     <div className={styles.container}>
+      {pluginId && instanceId && (
+        <p className={styles.explainer}>
+          This filters events the instance is already watching. The instance's{' '}
+          <Link to={`/admin/plugins/${pluginId}/instances/${instanceId}`}>subscription scope</Link>{' '}
+          controls which channels and DMs are delivered.
+        </p>
+      )}
+
       {fieldNames.length > 0 && (
         <div className={styles.fields}>
           {fieldNames.map((name) => (

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -10,7 +10,7 @@ reference).
 
 - **ToolService v1** — `post_message` (with Block Kit), `list_channels`, `react`, `set_topic`, `read_thread`, `read_history`, `update_message`, `delete_message`, `lookup_user` (implemented by #233, #626)
 - **TriggerService v1** — five event kinds via Slack Socket Mode (#234, #621, #623):
-  - `channel_message` — any human message in a watched channel; `mention_only: true` binding selects mentions. Note: subscription-scope channel filtering matches by **channel ID** only (e.g. `C012ABCDEF`); name-based filtering (e.g. `#incidents`) silently does not match because Socket Mode events carry only IDs. Resolving names is future work.
+  - `channel_message` — any human message in a watched channel; `mention_only: true` binding selects mentions. Use `channel_id` (exact channel ID, e.g. `C012ABCDEF`) in the binding to restrict to a specific channel — the searchable channel picker in the policy editor shows available IDs. Name-based filtering is not supported because Socket Mode events carry only IDs.
   - `direct_message` — a 1:1 DM sent directly to the bot. Enable via `direct_messages: true` in the instance subscription scope.
   - `slash_command` — a workspace slash command (e.g. `/gleipnir deploy staging`). Enable via `slash_commands: true` in the instance subscription scope.
   - `message_shortcut` — a message shortcut invoked on a specific message (carries message text, ts, channel). Enable via `shortcuts: true` in the instance subscription scope.
@@ -73,28 +73,25 @@ shortcuts are explicit user intent from any surface.
 Policies that use the `channel_message` trigger can filter events using the
 following binding fields (all optional; fields are ANDed together):
 
-| Field         | Match          | Notes |
-|---------------|----------------|-------|
-| `channel`     | contains       | Substring of the channel display name or ID (e.g. `incidents`) |
-| `channel_type`| equals         | Slack channel kind: `channel` (public), `group` (private), `mpim` (multi-party DM). Empty matches any kind. Note: 1:1 DMs (`im`) now route to `direct_message`, not `channel_message`. |
-| `text`        | contains       | Substring anywhere in the message text |
-| `text_regex`  | regex (RE2)    | Go RE2 expression matched against the message text. Use `^(?i)recipe:` for anchored, case-insensitive command routing — fires on `Recipe: find dinner` but NOT on `got a great Recipe: idea`. RE2 only: no lookbehind or backreferences. |
-| `mention_only`| flag           | Only fire when the bot is @-mentioned (detected via text-scan for both `message` and `app_mention` events). Never fires for DMs. |
-| `user`        | equals         | Exact Slack user ID (e.g. `U012AB3CD`) |
+| Field          | Match  | Notes |
+|----------------|--------|-------|
+| `channel_id`   | equals | Exact Slack channel ID (e.g. `C012ABCDEF`). Pick from the searchable channel list in the policy editor. Matches the message's stable channel ID — never the display name. |
+| `channel_type` | equals | Slack channel kind: `channel` (public), `group` (private), `mpim` (multi-party DM). Empty matches any kind. Note: 1:1 DMs (`im`) now route to `direct_message`, not `channel_message`. |
+| `text`         | contains | Substring anywhere in the message text |
+| `mention_only` | flag   | Only fire when the bot is @-mentioned (detected via text-scan for both `message` and `app_mention` events). Never fires for DMs. |
+| `user`         | equals | Exact Slack user ID (e.g. `U012AB3CD`). Pick from the searchable user list in the policy editor. |
 
-`text` and `text_regex` are independent siblings: most policies set one or the
-other. See [§"Triggering runs from Slack messages"](#triggering-runs-from-slack-messages)
+See [§"Triggering runs from Slack messages"](#triggering-runs-from-slack-messages)
 for worked examples and routing behaviour.
 
 ## Trigger binding (`direct_message`)
 
 Policies that use the `direct_message` trigger can filter events using:
 
-| Field       | Match       | Notes |
-|-------------|-------------|-------|
-| `text`      | contains    | Substring anywhere in the DM text |
-| `text_regex`| regex (RE2) | Same RE2 semantics as `channel_message` |
-| `user`      | equals      | Exact Slack user ID of the sender |
+| Field  | Match    | Notes |
+|--------|----------|-------|
+| `text` | contains | Substring anywhere in the DM text |
+| `user` | equals   | Exact Slack user ID of the sender. Pick from the searchable user list in the policy editor. |
 
 `channel`, `channel_type`, and `mention_only` are absent: they have no meaning
 in a 1:1 DM conversation.
@@ -103,11 +100,10 @@ in a 1:1 DM conversation.
 
 Policies that use the `slash_command` trigger can filter events using:
 
-| Field        | Match       | Notes |
-|--------------|-------------|-------|
-| `command`    | equals      | Exact slash command name, e.g. `/gleipnir`. Leave empty to match any command. |
-| `text`       | contains    | Substring anywhere in the command arguments |
-| `text_regex` | regex (RE2) | Go RE2 expression matched against the command arguments |
+| Field     | Match    | Notes |
+|-----------|----------|-------|
+| `command` | equals   | Exact slash command name, e.g. `/gleipnir`. Leave empty to match any command. |
+| `text`    | contains | Substring anywhere in the command arguments |
 
 Example — route `/gleipnir deploy …` to a deployment policy:
 
@@ -119,7 +115,7 @@ trigger:
   event_kind: slash_command
   binding:
     command: "/gleipnir"
-    text_regex: "^deploy "
+    text: "deploy"
 capabilities:
   tools:
     - tool: slack-prod.post_message
@@ -209,7 +205,7 @@ trigger:
   source: slack-prod          # the plugin INSTANCE NAME (not a ULID)
   event_kind: channel_message
   binding:                    # optional; all fields ANDed; omit to match every message
-    text_regex: "^(?i)recipe:"
+    text: "recipe:"
 capabilities:
   tools:
     - tool: slack-prod.post_message
@@ -232,11 +228,11 @@ fires its own independent run. There is no "route to exactly one policy", no
 default/else policy, and no arbitration across policies.
 
 Two policies with overlapping bindings will both fire. Design bindings with
-mutually exclusive anchored `text_regex` prefixes so messages reach exactly the
+distinct `text` substrings or `channel_id` filters so messages reach exactly the
 policy you intend:
 
-- `"^(?i)recipe:"` — fires on `Recipe: find dinner`; does **not** fire on `"got a great Recipe: idea"` (not anchored)
-- `"^(?i)deploy:"` — a distinct non-overlapping prefix
+- `text: "recipe:"` — fires on any message containing "recipe:"
+- `text: "deploy:"` — a distinct non-overlapping substring
 
 Note: this no-arbitration statement is cross-policy. A single policy's own
 concurrency setting (`concurrency: skip` / `queue` / `parallel`) still governs
@@ -271,9 +267,9 @@ These are external Slack settings, not Gleipnir config:
 
 ### Worked examples
 
-#### Example 1 — Keyword routing via anchored regex
+#### Example 1 — Keyword routing with channel filter
 
-Fires when a message starts with `Recipe:` (case-insensitive).
+Fires when a message in a specific channel contains the word "recipe:".
 
 ```yaml
 name: recipe-finder
@@ -282,20 +278,21 @@ trigger:
   source: slack-prod          # your Slack plugin instance name
   event_kind: channel_message
   binding:
-    text_regex: "^(?i)recipe:"   # fires on "Recipe: ..."/"recipe: ..."; NOT "got a great Recipe: idea"
+    channel_id: "C012ABCDEF"  # pick from the searchable channel list in the policy editor
+    text: "recipe:"           # case-sensitive substring anywhere in the message
 capabilities:
   tools:
     - tool: slack-prod.post_message
 agent:
   task: |
     The trigger payload is a Slack channel_message. Treat everything after
-    "Recipe:" as a recipe request and reply in-thread with suggestions.
+    "recipe:" as a recipe request and reply in-thread with suggestions.
 ```
 
-Matching Slack message: `Recipe: something with chickpeas`
+Matching Slack message: `recipe: something with chickpeas`
 
-Because routing is fan-out, give any sibling policy a non-overlapping anchored
-prefix so messages reach exactly one policy.
+Because routing is fan-out, combine `channel_id` and/or `text` filters to
+keep policies from overlapping.
 
 #### Example 2 — DM-only bot
 

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -246,18 +246,15 @@ type SlackSubscriptionScope struct {
 // channel_message event kind. Fields drive the binding_schema shown in the
 // policy trigger editor.
 type SlackChannelMessageBinding struct {
-	// Channel is a substring matched against the Slack channel name or ID.
-	// ContainsField is used here rather than GlobField: the host binding evaluator
-	// rejects format:glob (binding.go:230), but accepts format:contains.
-	Channel manifest.ContainsField `json:"channel,omitempty" jsonschema:"title=Channel,description=Case-sensitive substring matched against the channel name or ID (e.g. incidents matches #incidents or C012…). Matches anywhere — not anchored."`
+	// ChannelID is an exact match on the stable Slack channel ID (e.g. C012ABCDEF).
+	// optionsChannelField emits x-gleipnir-options: {source: channels} at the
+	// property level so the admin UI renders an async channel picker combobox.
+	// OpEquals semantics (no format key) — the annotation is a UI hint only.
+	// The json key is channel_id so the evaluator's payload[name] lookup aligns
+	// with SlackChannelMessagePayload.channel_id (always present, stable ID).
+	ChannelID optionsChannelField `json:"channel_id,omitempty" jsonschema:"title=Channel,description=Exact match on the Slack channel. Pick a channel from the searchable list; matches the message's stable channel ID (e.g. C012AB3CD)."`
 	// Text is a substring matched against the message text.
 	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Case-sensitive substring; matches anywhere in the message body (not anchored to the start)."`
-	// TextRegex matches the message text against a Go RE2 regular expression.
-	// Anchored, case-insensitive command routing is the primary use:
-	// `^(?i)recipe:` fires only on messages that start with "Recipe:"/"recipe:".
-	// RE2, not PCRE — no lookbehind/backrefs. Evaluated with implicit AND
-	// alongside Text; most policies set one or the other, not both.
-	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences."`
 	// MentionOnly restricts the policy to events where the bot was mentioned.
 	MentionOnly bool `json:"mention_only,omitempty" jsonschema:"title=Mention-only,description=Fire only when the bot is explicitly @-mentioned. Note: a DM is never a mention\\, so this excludes DMs."`
 	// User restricts the policy to messages from a specific Slack user ID.
@@ -278,8 +275,6 @@ type SlackChannelMessageBinding struct {
 type SlackDirectMessageBinding struct {
 	// Text is a substring matched against the DM text.
 	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Case-sensitive substring; matches anywhere in the message body (not anchored to the start)."`
-	// TextRegex matches the DM text against a Go RE2 regular expression.
-	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences."`
 	// User restricts the policy to DMs from a specific Slack user ID.
 	// optionsUserField emits x-gleipnir-options: {source: users} so the admin
 	// UI renders an async user picker combobox (#622).
@@ -295,8 +290,6 @@ type SlackSlashCommandBinding struct {
 	Command manifest.EqualsField `json:"command,omitempty" jsonschema:"title=Command,description=Exact match on the slash command name (e.g. /gleipnir). Leave empty to match any command."`
 	// Text is a substring matched against the command arguments.
 	Text manifest.ContainsField `json:"text,omitempty" jsonschema:"title=Text contains,description=Case-sensitive substring matched anywhere in the command arguments."`
-	// TextRegex matches the command arguments against a Go RE2 regular expression.
-	TextRegex manifest.RegexField `json:"text_regex,omitempty" jsonschema:"title=Text matches (regex),description=Go RE2 regular expression matched against the command arguments. Use ^ to anchor to the start; (?i) for case-insensitive matching."`
 }
 
 // SlackMessageShortcutBinding is the per-policy binding struct for the

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -70,11 +70,12 @@ event_kinds:
   - binding_schema:
       additionalProperties: false
       properties:
-        channel:
-          description: 'Case-sensitive substring matched against the channel name or ID (e.g. incidents matches #incidents or C012…). Matches anywhere — not anchored.'
-          format: contains
+        channel_id:
+          description: Exact match on the Slack channel. Pick a channel from the searchable list; matches the message's stable channel ID (e.g. C012AB3CD).
           title: Channel
           type: string
+          x-gleipnir-options:
+            source: channels
         channel_type:
           description: 'Exact match on the Slack channel kind: channel (public), group (private), im (DM), mpim (multi-party DM). Leave empty to match any.'
           title: Channel type
@@ -87,11 +88,6 @@ event_kinds:
           description: Case-sensitive substring; matches anywhere in the message body (not anchored to the start).
           format: contains
           title: Text contains
-          type: string
-        text_regex:
-          description: Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences.
-          format: regex
-          title: Text matches (regex)
           type: string
         user:
           description: Exact match (case-sensitive) on the sender's Slack user ID (e.g. U012AB3CD). Leave empty to match all users.
@@ -197,11 +193,6 @@ event_kinds:
           format: contains
           title: Text contains
           type: string
-        text_regex:
-          description: Go RE2 regular expression matched against the message text. Case-sensitivity is controlled by the pattern (e.g. (?i) flag); use ^ to anchor to the start. RE2 syntax — no lookbehind or backreferences.
-          format: regex
-          title: Text matches (regex)
-          type: string
         user:
           description: Exact match (case-sensitive) on the sender's Slack user ID (e.g. U012AB3CD). Leave empty to match all users.
           title: User
@@ -297,11 +288,6 @@ event_kinds:
           description: Case-sensitive substring matched anywhere in the command arguments.
           format: contains
           title: Text contains
-          type: string
-        text_regex:
-          description: Go RE2 regular expression matched against the command arguments. Use ^ to anchor to the start; (?i) for case-insensitive matching.
-          format: regex
-          title: Text matches (regex)
           type: string
       type: object
     description: A workspace slash command was invoked

--- a/plugins/slack/manifest_test.go
+++ b/plugins/slack/manifest_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/felag-engineering/gleipnir/plugin-sdk/manifest"
@@ -54,29 +53,19 @@ func TestManifestYAMLIsCanonical(t *testing.T) {
 	}
 }
 
-// TestChannelMessageTextRegexBinding asserts that:
-//  1. The reflected binding_schema for channel_message declares text_regex
-//     as {type: string, format: regex} — the shape the host binding engine
-//     requires to select OpRegex (internal/plugin/binding/binding.go:327).
-//  2. A regex derived from that field behaves as documented: `^(?i)recipe:`
-//     fires only when the message text *starts* with "Recipe:" or "recipe:",
-//     not when the keyword appears mid-string.
-//
-// The slack module cannot import internal/plugin/binding (separate module,
-// internal/ boundary), so we prove the AC by:
-//   - Walking the reflected YAML schema to assert the format tag (schema
-//     shape is what the host reads at policy-save time).
-//   - Compiling and running the regex ourselves (RE2 behavior is stdlib
-//     regexp; the host uses the same engine).
-func TestChannelMessageTextRegexBinding(t *testing.T) {
-	// --- Part 1: assert the reflected schema declares text_regex correctly ---
-
+// TestChannelMessageChannelIDBinding asserts that:
+//  1. The reflected binding_schema for channel_message declares channel_id as
+//     {type: string, x-gleipnir-options: {source: "channels"}} with NO format
+//     key — the shape the host binding engine requires for OpEquals semantics
+//     (internal/plugin/binding/binding.go:238), where the annotation is a UI hint.
+//  2. The old `channel` (contains) and `text_regex` fields are absent, confirming
+//     they were removed (#646, #654).
+func TestChannelMessageChannelIDBinding(t *testing.T) {
 	node := manifest.MustReflectSchema(SlackChannelMessageBinding{})
 
 	// findMappingValue walks a YAML mapping node looking for the given key and
 	// returns its value node. Returns nil when not found.
 	findMappingValue := func(mapping *yaml.Node, key string) *yaml.Node {
-		// Mapping content is interleaved [key, value, key, value, ...].
 		for i := 0; i+1 < len(mapping.Content); i += 2 {
 			if mapping.Content[i].Value == key {
 				return mapping.Content[i+1]
@@ -85,49 +74,40 @@ func TestChannelMessageTextRegexBinding(t *testing.T) {
 		return nil
 	}
 
-	// Drill into: <root>.properties.text_regex
 	properties := findMappingValue(node, "properties")
 	if properties == nil {
 		t.Fatal("binding schema has no 'properties' key")
 	}
-	textRegex := findMappingValue(properties, "text_regex")
-	if textRegex == nil {
-		t.Fatal("binding schema has no 'text_regex' property; was manifest.go updated and manifest.yaml regenerated?")
+
+	// channel_id must be present with type:string, no format, and x-gleipnir-options.source==channels.
+	channelID := findMappingValue(properties, "channel_id")
+	if channelID == nil {
+		t.Fatal("binding schema has no 'channel_id' property; was manifest.go updated and manifest.yaml regenerated?")
 	}
 
-	typ := findMappingValue(textRegex, "type")
+	typ := findMappingValue(channelID, "type")
 	if typ == nil || typ.Value != "string" {
-		t.Errorf("text_regex: want type=string, got %v", typ)
+		t.Errorf("channel_id: want type=string, got %v", typ)
 	}
-	format := findMappingValue(textRegex, "format")
-	if format == nil || format.Value != "regex" {
-		t.Errorf("text_regex: want format=regex, got %v", format)
+	// No format key is the OpEquals discriminator.
+	format := findMappingValue(channelID, "format")
+	if format != nil {
+		t.Errorf("channel_id: want no format key (OpEquals), got format=%q", format.Value)
 	}
-
-	// --- Part 2: prove the acceptance criteria with the regex itself ---
-	//
-	// The host selects OpRegex for format:regex and calls regexp.MatchString
-	// (RE2). We reproduce that here to document the expected routing behavior
-	// without importing the host engine.
-	re := regexp.MustCompile(`^(?i)recipe:`)
-
-	should := []string{
-		"Recipe: find dinner tonight",
-		"recipe: pasta ideas",
+	// x-gleipnir-options must be present with source: channels.
+	opts := findMappingValue(channelID, "x-gleipnir-options")
+	if opts == nil {
+		t.Fatal("channel_id: missing x-gleipnir-options annotation")
 	}
-	shouldNot := []string{
-		"got a great Recipe: idea", // keyword not at start — not anchored
-		"Lunch order is in.",       // no keyword at all
+	source := findMappingValue(opts, "source")
+	if source == nil || source.Value != "channels" {
+		t.Errorf("channel_id: want x-gleipnir-options.source=channels, got %v", source)
 	}
 
-	for _, msg := range should {
-		if !re.MatchString(msg) {
-			t.Errorf("expected regex to match %q but it did not", msg)
-		}
-	}
-	for _, msg := range shouldNot {
-		if re.MatchString(msg) {
-			t.Errorf("expected regex NOT to match %q but it did", msg)
+	// The old `channel` (contains) and `text_regex` fields must be absent.
+	for _, absent := range []string{"channel", "text_regex"} {
+		if findMappingValue(properties, absent) != nil {
+			t.Errorf("channel_message binding schema should not contain removed field %q", absent)
 		}
 	}
 }
@@ -153,7 +133,7 @@ func TestDirectMessageBindingSchema(t *testing.T) {
 	}
 
 	// Fields that MUST be present in the DM binding schema.
-	for _, field := range []string{"text", "text_regex", "user"} {
+	for _, field := range []string{"text", "user"} {
 		if findMappingValue(properties, field) == nil {
 			t.Errorf("direct_message binding schema missing expected field %q", field)
 		}

--- a/plugins/slack/options.go
+++ b/plugins/slack/options.go
@@ -36,6 +36,25 @@ func (optionsUserField) JSONSchema() *jsonschema.Schema {
 	}
 }
 
+// optionsChannelField is an EqualsField variant that carries the
+// x-gleipnir-options annotation for the "channels" source. The host admin UI
+// renders an async combobox (single-select) for this field instead of a plain
+// text input. The binding evaluator uses OpEquals semantics (no format key) —
+// the annotation is purely a UI hint. Used for the channel_id binding field so
+// operators pick a stable Slack channel ID from a searchable list.
+type optionsChannelField string
+
+// JSONSchema implements jsonschema.SchemaCustomizer so that ReflectSchema emits
+// {type: string, x-gleipnir-options: {source: channels}} for this field.
+func (optionsChannelField) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "string",
+		Extras: map[string]any{
+			manifest.OptionsAnnotationKey: manifest.OptionsAnnotation{Source: "channels", Multi: false},
+		},
+	}
+}
+
 // OptionsService implements ConfigOptionsService.ListOptions for the Slack plugin.
 // It returns dynamic, searchable option lists for schema fields annotated with
 // x-gleipnir-options. Currently supports two sources:


### PR DESCRIPTION
Closes #651
Closes #646
Closes #654

Makes the Slack subscribed-trigger binding form self-explanatory and fixes two binding bugs folded in from #646 and #654.

## #651 — clarity
- The binding form now renders the manifest's `prop.title` (fallback to a humanized key) as each field label, and `prop.description` as a caption below it — matching the #627 SchemaForm convention. The cryptic `(contains)`/`(regex)` suffix is gone.
- Adds a **scope↔binding explainer** linking to the instance's *subscription scope* page, clarifying that the binding only filters events the instance is already watching.

## #654 — channel matching (exact channel-ID)
The `channel_message` `channel` filter was a case-sensitive **substring** match against the channel **display name** (so `ops` also matched `devops`, and name matching is fragile since Socket Mode events are ID-centric). It's now `channel_id` — an **exact match on the message's stable Slack channel ID**, backed by the searchable channels picker.
- New `optionsChannelField` emits `x-gleipnir-options:{source:channels}` with no `format` (→ host `OpEquals`). The picker's option value is the stable channel ID, and the binding key `channel_id` aligns with the payload's stable `channel_id` key — so it matches reliably.
- The unrelated audience `channel_config_schema` (the Notify/Request *target*) is untouched.

## #646 — dead `text_regex` removed
The `text_regex` binding silently never matched: the channel_message/direct_message/slash_command payloads carry a `text` key but **no `text_regex` key**, so the host evaluator's `payload[key]` lookup never resolved. Removed the dead field from all three bindings; `text` (contains) is unaffected. (This is the motivating case for ADR-052.)

## ⚠️ Breaking (pre-release v1.1.0)
- The channel_message `channel` binding key is renamed to **`channel_id`**; a policy using a `channel:` substring binding must re-select the channel from the picker.
- Policies using `text_regex` (which never matched) should switch to `text`.

## Deferred to follow-ups
- **ADR-052** single-field operator/matcher dropdown (#651 item 2) — documented deferral.
- Custom test payloads (#651 item 5).
- Per-event-kind "how it fires" help + dialog simplification → **sibling #655** (next PR).

## Tests
- `manifest.yaml` regenerated via `make -C plugins/slack manifest`; `TestManifestYAMLIsCanonical` enforces Go↔YAML parity. New `TestChannelMessageChannelIDBinding` (channel_id present, no format, source==channels; channel/text_regex absent); `TestDirectMessageBindingSchema` trimmed.
- Frontend: `SubscribedBindingConfig.test.tsx` asserts title labels, description captions, no `(format)` suffix, the explainer link, and both textbox/combobox field paths (mocks `usePluginOptions`, wraps in `MemoryRouter`). Stories updated with a channels MSW handler + router. `go test ./plugins/slack/...`, `npm run build`, and 10/10 component tests green.

<details><summary>Plan (architect → adversarial review → APPROVE)</summary>
Plan-reviewer verified the load-bearing #654 chain (translator sets channel_id=ev.Channel=stable ID; evaluator maps no-format→OpEquals; picker returns ch.ID), the dead-text_regex mechanism, the manifest regen path, and binding/e2e test independence. Refinements folded in: split textbox/combobox test fixtures, mock usePluginOptions, build gleipnir-plugin before regen, explicit SchemaProperty/OptionsBindingField interface updates.
</details>

Review cycles: 1 (APPROVE). CLAUDE.md: ADR-052 entry intentionally left (historical decision record).

🤖 Generated by the agentic dev loop.
