### PR TITLE
feat: confirm before clearing plugin instance credentials (#659)

### DIFF
--- a/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.module.css
+++ b/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.module.css
@@ -1,0 +1,6 @@
+.body {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  line-height: 1.6;
+  margin: 0 0 var(--space-4);
+}

--- a/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.stories.tsx
+++ b/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import '@/tokens.css'
+import { ClearCredentialsModal } from './ClearCredentialsModal'
+
+const meta: Meta<typeof ClearCredentialsModal> = {
+  title: 'Admin/ClearCredentialsModal',
+  component: ClearCredentialsModal,
+}
+
+export default meta
+type Story = StoryObj<typeof ClearCredentialsModal>
+
+// Default — idle state, no error. Admin sees the consequence copy and can confirm
+// or cancel.
+export const Default: Story = {
+  args: {
+    onClose: () => {},
+    onConfirm: () => {},
+    isPending: false,
+    error: null,
+  },
+}
+
+// Pending — the clear request is in flight; the button is disabled and shows
+// loading text.
+export const Pending: Story = {
+  args: {
+    onClose: () => {},
+    onConfirm: () => {},
+    isPending: true,
+    error: null,
+  },
+}
+
+// Error — the DELETE request failed; the error detail is shown under the modal body.
+export const ErrorState: Story = {
+  args: {
+    onClose: () => {},
+    onConfirm: () => {},
+    isPending: false,
+    error: 'Clear failed. Please try again.',
+  },
+}

--- a/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.test.tsx
+++ b/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ClearCredentialsModal } from './ClearCredentialsModal'
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof ClearCredentialsModal>> = {},
+) {
+  const defaults: React.ComponentProps<typeof ClearCredentialsModal> = {
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    isPending: false,
+    error: null,
+  }
+  return render(<ClearCredentialsModal {...defaults} {...overrides} />)
+}
+
+describe('ClearCredentialsModal', () => {
+  it('states the re-authorization consequence', () => {
+    renderModal()
+    expect(screen.getByText(/you'll need to re-authorize/i)).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when Clear credentials button is clicked', async () => {
+    const onConfirm = vi.fn()
+    renderModal({ onConfirm })
+    await userEvent.click(screen.getByRole('button', { name: /clear credentials/i }))
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('disables the confirm button while pending', () => {
+    renderModal({ isPending: true })
+    expect(screen.getByRole('button', { name: /clear/i })).toBeDisabled()
+  })
+
+  it('shows error message under role=alert when error is set', () => {
+    renderModal({ error: 'Clear failed.' })
+    expect(screen.getByRole('alert')).toHaveTextContent('Clear failed.')
+  })
+
+  it('does not render alert element when error is null', () => {
+    renderModal({ error: null })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.tsx
+++ b/frontend/src/components/admin/ClearCredentialsModal/ClearCredentialsModal.tsx
@@ -1,0 +1,55 @@
+import { Modal } from '@/components/Modal'
+import { ModalFooter } from '@/components/ModalFooter'
+import alertStyles from '@/styles/alerts.module.css'
+import styles from './ClearCredentialsModal.module.css'
+
+export interface ClearCredentialsModalProps {
+  onClose: () => void
+  onConfirm: () => void
+  isPending: boolean
+  error: string | null
+}
+
+// ClearCredentialsModal asks the admin to confirm clearing an instance's stored
+// credentials. Clearing is destructive and has no undo — for an OAuth instance it
+// wipes the token and forces a full re-authorization. The neighboring
+// "Delete instance" action is already gated by a confirmation modal, so this keeps
+// the two destructive actions consistent (see issue #659).
+//
+// The caller owns the mutation state and passes isPending + error so the modal can
+// remain a presentational component that is straightforward to test — mirrors
+// DeletePluginInstanceModal.
+export function ClearCredentialsModal({
+  onClose,
+  onConfirm,
+  isPending,
+  error,
+}: ClearCredentialsModalProps) {
+  const footer = (
+    <ModalFooter
+      onCancel={onClose}
+      onSubmit={onConfirm}
+      isLoading={isPending}
+      submitLabel="Clear credentials"
+      loadingLabel="Clearing…"
+      submitDisabled={isPending}
+      variant="danger"
+    />
+  )
+
+  return (
+    <Modal title="Clear credentials" onClose={onClose} footer={footer}>
+      <p className={styles.body}>
+        This removes the stored credentials. You'll need to re-authorize before this
+        instance can call its tools/channels again.
+      </p>
+      <p className={styles.body}>This action cannot be undone.</p>
+
+      {error != null && (
+        <div className={alertStyles.alertError} role="alert">
+          {error}
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/src/components/admin/CredentialsTab/CredentialsTab.test.tsx
+++ b/frontend/src/components/admin/CredentialsTab/CredentialsTab.test.tsx
@@ -369,7 +369,7 @@ describe('clear credentials', () => {
     expect(screen.getByRole('button', { name: /clear credentials/i })).toBeInTheDocument()
   })
 
-  it('calls DELETE /credentials on clear', async () => {
+  it('opens a confirmation modal without mutating on first click', async () => {
     let called = false
     server.use(
       http.delete(BASE_URL, () => {
@@ -382,7 +382,48 @@ describe('clear credentials', () => {
       strategy: 'static_api_key',
     })
     await userEvent.click(screen.getByRole('button', { name: /clear credentials/i }))
+    // The confirmation modal explains the re-auth consequence and no DELETE fires.
+    expect(screen.getByText(/you'll need to re-authorize/i)).toBeInTheDocument()
+    expect(called).toBe(false)
+  })
+
+  it('calls DELETE /credentials only after confirming in the modal', async () => {
+    let called = false
+    server.use(
+      http.delete(BASE_URL, () => {
+        called = true
+        return HttpResponse.json({ data: {} })
+      }),
+    )
+    renderTab({
+      creds: { strategy: 'static_api_key', has_api_key: true },
+      strategy: 'static_api_key',
+    })
+    await userEvent.click(screen.getByRole('button', { name: /clear credentials/i }))
+    // Confirm button lives in the modal footer (second "Clear credentials" button).
+    const confirmButtons = screen.getAllByRole('button', { name: /clear credentials/i })
+    await userEvent.click(confirmButtons[confirmButtons.length - 1])
     await waitFor(() => expect(called).toBe(true))
+  })
+
+  it('cancel closes the modal without mutating', async () => {
+    let called = false
+    server.use(
+      http.delete(BASE_URL, () => {
+        called = true
+        return HttpResponse.json({ data: {} })
+      }),
+    )
+    renderTab({
+      creds: { strategy: 'static_api_key', has_api_key: true },
+      strategy: 'static_api_key',
+    })
+    await userEvent.click(screen.getByRole('button', { name: /clear credentials/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await waitFor(() =>
+      expect(screen.queryByText(/you'll need to re-authorize/i)).not.toBeInTheDocument(),
+    )
+    expect(called).toBe(false)
   })
 
   it('auditor: Clear button is hidden', () => {

--- a/frontend/src/components/admin/CredentialsTab/CredentialsTab.tsx
+++ b/frontend/src/components/admin/CredentialsTab/CredentialsTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Button } from '@/components/Button'
+import { ClearCredentialsModal } from '@/components/admin/ClearCredentialsModal/ClearCredentialsModal'
 import { ReauthorizeButton } from '@/components/admin/ReauthorizeButton/ReauthorizeButton'
 import { usePluginInstanceCredentials } from '@/hooks/queries/plugins'
 import {
@@ -13,7 +14,6 @@ import {
 import { isOAuthRefreshFailure } from '@/utils/pluginHealth'
 import { formatTimestamp } from '@/utils/format'
 import { errMessage } from '@/api/fetch'
-import type { ApiError } from '@/api/fetch'
 import type { PluginAuthStrategy } from '@/api/types'
 import styles from './CredentialsTab.module.css'
 
@@ -602,12 +602,29 @@ export function CredentialsTab({
   const { data: creds, status } = usePluginInstanceCredentials(pluginId, instanceId)
   const clearMutation = useClearPluginCredentials()
   const [clearError, setClearError] = useState<string | null>(null)
+  const [showClearModal, setShowClearModal] = useState(false)
 
-  function handleClear() {
+  function openClearModal() {
+    setClearError(null)
+    setShowClearModal(true)
+  }
+
+  function closeClearModal() {
+    setShowClearModal(false)
+  }
+
+  // Clearing credentials is destructive with no undo (for OAuth it forces a full
+  // re-auth), so it is gated behind a confirmation modal — mirroring the
+  // already-confirmed "Delete instance" action (issue #659). The modal stays open
+  // on error so the operator sees the failure in context; it closes on success.
+  function handleConfirmClear() {
     setClearError(null)
     clearMutation.mutate(
       { pluginId, instanceId },
       {
+        onSuccess: () => {
+          setShowClearModal(false)
+        },
         onError: (err) => {
           setClearError(errMessage(err, 'Clear failed.'))
         },
@@ -702,13 +719,26 @@ export function CredentialsTab({
             type="button"
             variant="ghost"
             size="small"
-            onClick={handleClear}
+            onClick={openClearModal}
             disabled={clearMutation.isPending}
           >
-            {clearMutation.isPending ? 'Clearing…' : 'Clear credentials'}
+            Clear credentials
           </Button>
-          {clearError && <p className={styles.errorMsg} role="alert">{clearError}</p>}
+          {/* Error from a failed clear is shown inside the modal while it is open;
+              surface it here too once the modal closes so it is not lost. */}
+          {clearError && !showClearModal && (
+            <p className={styles.errorMsg} role="alert">{clearError}</p>
+          )}
         </div>
+      )}
+
+      {showClearModal && (
+        <ClearCredentialsModal
+          onClose={closeClearModal}
+          onConfirm={handleConfirmClear}
+          isPending={clearMutation.isPending}
+          error={clearError}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

The **Clear credentials** action on the plugin instance Credentials tab fired immediately on click with **no confirmation**. This is destructive with no undo — for an `oauth2_authcode` instance it wipes the stored token and forces a full re-authorization. The neighboring **Delete instance** action already uses a confirmation modal (`DeletePluginInstanceModal`), so the two destructive actions were inconsistent.

## Changes

- New `ClearCredentialsModal` component, mirroring the `DeletePluginInstanceModal` pattern exactly: presentational, built on `Modal` + `ModalFooter`, `danger` variant, caller owns mutation state (`isPending` + `error`). Ships with a `.module.css` (design tokens, 4px scale — CSS Modules only), a `.stories.tsx` (Default / Pending / ErrorState), and a `.test.tsx`.
- `CredentialsTab`: the **Clear credentials** button now opens the modal instead of mutating directly. The modal's confirm action runs the clear mutation; the modal stays open on error (so the failure shows in context) and closes on success.
- Consequence copy per the issue: "This removes the stored credentials. You'll need to re-authorize before this instance can call its tools/channels again."

## Tests

- `ClearCredentialsModal.test.tsx`: confirm calls `onConfirm`, cancel calls `onClose`, error surfaces under `role=alert`, pending disables the button.
- `CredentialsTab.test.tsx`: clicking Clear opens the modal **without** firing the DELETE; confirming fires DELETE; cancel closes without mutating.
- `npm run build` (tsc + vite) green; `npx vitest run` on both components green (39 tests). The Playwright teardown error in the vitest output is a pre-existing environment issue (browser-mode project, chromium not installed) unrelated to this change.

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)