### PR TITLE
fix: audience drag-to-reorder highlight cleanup (no stuck/sticky indicator)

### DIFF
--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.test.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.test.tsx
@@ -179,6 +179,71 @@ describe('AudienceEditor — drag-reorder', () => {
     // Just verify no errors thrown and re-render happens
     expect(screen.getAllByRole('button', { name: /move up/i }).length).toBeGreaterThan(0)
   })
+
+  // jsdom does not implement DataTransfer; onDragStart writes effectAllowed, so
+  // every dragStart needs a minimal stub passed through the fireEvent init.
+  function fakeDataTransfer() {
+    return { effectAllowed: '', dropEffect: '', setData: vi.fn(), getData: vi.fn() }
+  }
+
+  it('shows the drop indicator on the hovered row but never on the dragged row itself', () => {
+    renderEditor()
+    const rows = screen.getAllByRole('listitem')
+    // rows = [e1 (slack-1), e2 (pd-1), auto in-app]
+    fireEvent.dragStart(rows[0], { dataTransfer: fakeDataTransfer() })
+
+    // Dragging over the OTHER row marks it as the drop target.
+    fireEvent.dragOver(rows[1], { dataTransfer: fakeDataTransfer() })
+    expect(rows[1].className).toMatch(/dragOver/)
+    expect(rows[0].className).toMatch(/dragging/)
+
+    // Dragging back over the dragged row never marks the source as a drop target.
+    fireEvent.dragOver(rows[0], { dataTransfer: fakeDataTransfer() })
+    expect(rows[0].className).not.toMatch(/dragOver/)
+    expect(rows[0].className).toMatch(/dragging/)
+  })
+
+  it('never shows the drop indicator on the auto gleipnir.in-app row', () => {
+    renderEditor()
+    const rows = screen.getAllByRole('listitem')
+    const autoRow = rows[2]
+    fireEvent.dragStart(rows[0], { dataTransfer: fakeDataTransfer() })
+    fireEvent.dragOver(autoRow, { dataTransfer: fakeDataTransfer() })
+    expect(autoRow.className).not.toMatch(/dragOver/)
+  })
+
+  it('clears all drag highlighting on dragEnd, even without a drop (aborted drag)', () => {
+    renderEditor()
+    const rows = screen.getAllByRole('listitem')
+    fireEvent.dragStart(rows[0], { dataTransfer: fakeDataTransfer() })
+    fireEvent.dragOver(rows[1], { dataTransfer: fakeDataTransfer() })
+    expect(rows[0].className).toMatch(/dragging/)
+    expect(rows[1].className).toMatch(/dragOver/)
+
+    // Released outside any row: no drop event fires, only dragEnd on the source.
+    fireEvent.dragEnd(rows[0], { dataTransfer: fakeDataTransfer() })
+
+    const after = screen.getAllByRole('listitem')
+    expect(after[0].className).not.toMatch(/dragging/)
+    expect(after[1].className).not.toMatch(/dragOver/)
+  })
+
+  it('reorders entries on a real drop', () => {
+    renderEditor()
+    const rows = screen.getAllByRole('listitem')
+    // Before: entry 1 = slack-1, entry 2 = pd-1
+    const before = screen.getAllByRole('combobox') as HTMLSelectElement[]
+    expect(before[0].value).toBe('slack-1')
+
+    fireEvent.dragStart(rows[0], { dataTransfer: fakeDataTransfer() })
+    fireEvent.dragOver(rows[1], { dataTransfer: fakeDataTransfer() })
+    fireEvent.drop(rows[1], { dataTransfer: fakeDataTransfer() })
+
+    // After: slack-1 moved past pd-1 → first select is now pd-1.
+    const after = screen.getAllByRole('combobox') as HTMLSelectElement[]
+    expect(after[0].value).toBe('pd-1')
+    expect(after[1].value).toBe('slack-1')
+  })
 })
 
 describe('AudienceEditor — SaveGuardDialog opens conditionally', () => {

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
@@ -123,10 +123,19 @@ export function AudienceEditor({
   const handleDragOver = useCallback(
     (e: React.DragEvent, index: number) => {
       e.preventDefault()
+      // No drop target for the row being dragged itself — dropping onto it is a no-op.
+      if (dragIndex === null || index === dragIndex) return
       if (dragOverIndex !== index) setDragOverIndex(index)
     },
-    [dragOverIndex],
+    [dragIndex, dragOverIndex],
   )
+
+  // dragEnd fires on the source row whether the drag was dropped or aborted
+  // (released outside any row), so it is the guaranteed cleanup for both paths.
+  const handleDragEnd = useCallback(() => {
+    setDragIndex(null)
+    setDragOverIndex(null)
+  }, [])
 
   const handleDrop = useCallback(
     (e: React.DragEvent, dropIndex: number) => {
@@ -298,6 +307,7 @@ export function AudienceEditor({
               }}
               onDragOver={(e) => handleDragOver(e, index)}
               onDrop={(e) => handleDrop(e, index)}
+              onDragEnd={handleDragEnd}
               isDragging={dragIndex === index}
               isDragOver={dragOverIndex === index && dragIndex !== index}
               disabled={!canManage}
@@ -325,6 +335,7 @@ export function AudienceEditor({
               onDragStart={() => {}}
               onDragOver={() => {}}
               onDrop={() => {}}
+              onDragEnd={() => {}}
               isDragging={false}
               isDragOver={false}
               disabled={true}

--- a/frontend/src/components/admin/AudienceEditor/EntryRow.module.css
+++ b/frontend/src/components/admin/AudienceEditor/EntryRow.module.css
@@ -18,8 +18,12 @@
   opacity: 0.5;
 }
 
+/*
+ * Inset box-shadow rather than border-top: the indicator sits inside the row's
+ * box so it never reflows the list by 2px as the drop target moves between rows.
+ */
 .dragOver {
-  border-top: 2px solid var(--color-blue);
+  box-shadow: inset 0 2px 0 0 var(--color-blue);
 }
 
 .rowHeader {

--- a/frontend/src/components/admin/AudienceEditor/EntryRow.tsx
+++ b/frontend/src/components/admin/AudienceEditor/EntryRow.tsx
@@ -20,6 +20,7 @@ interface Props {
   onDragStart: (e: React.DragEvent) => void
   onDragOver: (e: React.DragEvent) => void
   onDrop: (e: React.DragEvent) => void
+  onDragEnd: (e: React.DragEvent) => void
   isDragging: boolean
   isDragOver: boolean
   disabled: boolean
@@ -134,6 +135,7 @@ export function EntryRow({
   onDragStart,
   onDragOver,
   onDrop,
+  onDragEnd,
   isDragging,
   isDragOver,
   disabled,
@@ -183,6 +185,7 @@ export function EntryRow({
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onDragEnd={onDragEnd}
     >
       <div className={styles.rowHeader}>
         {/* Drag handle */}


### PR DESCRIPTION
## Summary

Fixes the sticky/inconsistent drop-indicator when dragging audience entry cards to reorder (#657).

Root cause was in `AudienceEditor.tsx` + `EntryRow.{tsx,module.css}`: drag state was cleaned up only in `handleDrop`, `handleDragOver` highlighted every row (including the dragged one), and the indicator used `border-top` which reflowed layout by 2px.

### Changes
- **`AudienceEditor.tsx`** — added an `onDragEnd` handler that always resets `dragIndex`/`dragOverIndex`. `dragEnd` fires on the source row whether the drag is dropped or aborted (released outside any row), so it is the guaranteed cleanup for both paths. `handleDragOver` now early-returns for the dragged row itself (`index === dragIndex`) so the source never becomes a drop target. (The synthetic, non-draggable `gleipnir.in-app` row already passes no-op drag handlers, so it is never a target.)
- **`EntryRow.tsx`** — threaded a new `onDragEnd` prop onto the `<li>`.
- **`EntryRow.module.css`** — replaced the `.dragOver` `border-top: 2px` with `box-shadow: inset 0 2px 0 0 var(--color-blue)`. The indicator now sits inside the row's box and never reflows the list as the drop target moves between rows. Token-based, no layout shift.

Keyboard reorder (up/down arrows) is untouched.

### Tests
Extended the `AudienceEditor — drag-reorder` vitest suite:
- `dragEnd` clears all highlighting after an aborted drag (no stuck `.dragging`/`.dragOver`).
- The dragged row and the auto `gleipnir.in-app` row never show the drop indicator.
- A real `drop` reorders the entries.

### Status
- `npm run build` (tsc + vite): green
- `npx vitest run src/components/admin/AudienceEditor`: 28/28 passing

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)