### PR TITLE
feat: plugin instance onboarding — steps-to-healthy checklist, tab badges, humanized health_detail (#658)

### DIFF
--- a/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.module.css
+++ b/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.module.css
@@ -1,0 +1,128 @@
+/* "Steps to healthy" onboarding checklist (#658). Card framing matches the
+   page's banner tints; amber-neutral so it reads as guidance, not error. */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: color-mix(in srgb, var(--color-blue) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-blue) 22%, transparent);
+  border-radius: 4px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.countBadge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-second);
+}
+
+.detail {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-second);
+  line-height: 1.5;
+}
+
+.detailCta {
+  margin-left: var(--space-2);
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-blue);
+}
+
+.detailCta:hover {
+  color: var(--accent-hover);
+}
+
+.stepList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stepRow {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.iconDone {
+  display: flex;
+  align-items: center;
+  color: var(--color-green);
+}
+
+.iconPending {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+}
+
+.label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.labelDone {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-second);
+}
+
+.nextPill {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-blue);
+  background: color-mix(in srgb, var(--color-blue) 14%, transparent);
+  padding: 0 var(--space-2);
+  border-radius: 4px;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-blue);
+  white-space: nowrap;
+}
+
+.cta:hover {
+  color: var(--accent-hover);
+}

--- a/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.stories.tsx
+++ b/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { action } from 'storybook/actions'
+import '@/tokens.css'
+import { InstanceSetupSteps } from './InstanceSetupSteps'
+import { deriveSetupSteps, humanizeHealthDetail } from '@/utils/instanceSetup'
+
+const meta: Meta<typeof InstanceSetupSteps> = {
+  title: 'Admin/InstanceSetupSteps',
+  component: InstanceSetupSteps,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 640, padding: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof InstanceSetupSteps>
+
+// A Slack-shaped instance: OAuth credentials, one required config field
+// (app-level token), and a subscription scope.
+const fullInput = {
+  authStrategy: 'oauth2_authcode',
+  configSchema: { required: ['app_level_token'] },
+  hasSubscriptionSchema: true,
+}
+
+export const AllIncomplete: Story = {
+  args: {
+    steps: deriveSetupSteps({
+      ...fullInput,
+      credentials: undefined,
+      config: {},
+      subscriptionScope: {},
+    }),
+    healthDetail: humanizeHealthDetail('config_missing'),
+    onNavigate: action('navigate'),
+  },
+}
+
+export const CredentialsDone: Story = {
+  args: {
+    steps: deriveSetupSteps({
+      ...fullInput,
+      credentials: { strategy: 'oauth2_authcode', has_token: true },
+      config: {},
+      subscriptionScope: {},
+    }),
+    healthDetail: humanizeHealthDetail('credentials_missing'),
+    onNavigate: action('navigate'),
+  },
+}
+
+export const ConfigDoneScopeLeft: Story = {
+  args: {
+    steps: deriveSetupSteps({
+      ...fullInput,
+      credentials: { strategy: 'oauth2_authcode', has_token: true },
+      config: { app_level_token: '***' },
+      subscriptionScope: {},
+    }),
+    healthDetail: null,
+    onNavigate: action('navigate'),
+  },
+}
+
+export const AllDone: Story = {
+  args: {
+    steps: deriveSetupSteps({
+      ...fullInput,
+      credentials: { strategy: 'oauth2_authcode', has_token: true },
+      config: { app_level_token: '***' },
+      subscriptionScope: { channels: ['C123'] },
+    }),
+    healthDetail: null,
+    onNavigate: action('navigate'),
+  },
+}
+
+// A "none"-strategy, config-only plugin: just the required config step.
+export const ConfigOnly: Story = {
+  args: {
+    steps: deriveSetupSteps({
+      authStrategy: 'none',
+      configSchema: { required: ['endpoint_url'] },
+      config: {},
+      hasSubscriptionSchema: false,
+    }),
+    healthDetail: humanizeHealthDetail('config_missing'),
+    onNavigate: action('navigate'),
+  },
+}

--- a/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.test.tsx
+++ b/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { InstanceSetupSteps } from './InstanceSetupSteps'
+import { deriveSetupSteps, humanizeHealthDetail } from '@/utils/instanceSetup'
+
+const fullInput = {
+  authStrategy: 'oauth2_authcode',
+  configSchema: { required: ['app_level_token'] },
+  hasSubscriptionSchema: true,
+}
+
+describe('InstanceSetupSteps', () => {
+  it('renders nothing when there are no steps', () => {
+    const { container } = render(<InstanceSetupSteps steps={[]} onNavigate={() => {}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows progress count and a row per step (all incomplete)', () => {
+    const steps = deriveSetupSteps({ ...fullInput, credentials: undefined, config: {}, subscriptionScope: {} })
+    render(<InstanceSetupSteps steps={steps} onNavigate={() => {}} />)
+
+    expect(screen.getByText('0/3')).toBeInTheDocument()
+    expect(screen.getByText('Add credentials')).toBeInTheDocument()
+    expect(screen.getByText(/Fill required config/)).toBeInTheDocument()
+    expect(screen.getByText('Set subscription scope')).toBeInTheDocument()
+    // every step incomplete → three "not done" icons
+    expect(screen.getAllByLabelText('not done')).toHaveLength(3)
+  })
+
+  it('marks the first incomplete blocking step as Next', () => {
+    const steps = deriveSetupSteps({
+      ...fullInput,
+      credentials: { strategy: 'oauth2_authcode', has_token: true },
+      config: {},
+      subscriptionScope: {},
+    })
+    render(<InstanceSetupSteps steps={steps} onNavigate={() => {}} />)
+    // credentials done → config is Next
+    const next = screen.getByText('Next')
+    expect(next).toBeInTheDocument()
+    expect(screen.getByText('1/3')).toBeInTheDocument()
+    expect(screen.getByLabelText('done')).toBeInTheDocument()
+  })
+
+  it('renders the humanized health detail with a deep-link CTA', async () => {
+    const user = userEvent.setup()
+    const onNavigate = vi.fn()
+    const steps = deriveSetupSteps({ ...fullInput, credentials: undefined, config: {}, subscriptionScope: {} })
+    render(
+      <InstanceSetupSteps
+        steps={steps}
+        healthDetail={humanizeHealthDetail('config_missing')}
+        onNavigate={onNavigate}
+      />,
+    )
+    expect(screen.getByText(/Add the required configuration/)).toBeInTheDocument()
+    // Both the detail CTA and the config step CTA read "Go to Config" and both
+    // deep-link to the config tab — click the first and assert the navigation.
+    await user.click(screen.getAllByRole('button', { name: 'Go to Config' })[0])
+    expect(onNavigate).toHaveBeenCalledWith('config')
+  })
+
+  it('navigates to the step tab when a CTA is clicked', async () => {
+    const user = userEvent.setup()
+    const onNavigate = vi.fn()
+    const steps = deriveSetupSteps({ ...fullInput, credentials: undefined, config: {}, subscriptionScope: {} })
+    render(<InstanceSetupSteps steps={steps} onNavigate={onNavigate} />)
+
+    await user.click(screen.getByRole('button', { name: /Go to Credentials/ }))
+    expect(onNavigate).toHaveBeenCalledWith('credentials')
+  })
+
+  it('shows all steps done with no CTAs when complete', () => {
+    const steps = deriveSetupSteps({
+      ...fullInput,
+      credentials: { strategy: 'oauth2_authcode', has_token: true },
+      config: { app_level_token: '***' },
+      subscriptionScope: { channels: ['C1'] },
+    })
+    render(<InstanceSetupSteps steps={steps} onNavigate={() => {}} />)
+    expect(screen.getByText('3/3')).toBeInTheDocument()
+    expect(screen.getAllByLabelText('done')).toHaveLength(3)
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.queryByText('Next')).toBeNull()
+  })
+})

--- a/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.tsx
+++ b/frontend/src/components/admin/InstanceSetupSteps/InstanceSetupSteps.tsx
@@ -1,0 +1,88 @@
+import { CircleCheckBig, Circle, ArrowRight } from 'lucide-react'
+import type { SetupStep, SetupTab, HealthDetailCopy } from '@/utils/instanceSetup'
+import { firstIncompleteBlockingStep } from '@/utils/instanceSetup'
+import styles from './InstanceSetupSteps.module.css'
+
+export interface InstanceSetupStepsProps {
+  // Ordered onboarding steps (see deriveSetupSteps). When empty, nothing renders.
+  steps: SetupStep[]
+  // Humanized health_detail copy shown as a subtitle (optional).
+  healthDetail?: HealthDetailCopy | null
+  // Navigate to one of the settings tabs. The page owns tab state, so CTAs call
+  // this rather than routing.
+  onNavigate: (tab: SetupTab) => void
+}
+
+const STEP_CTA_LABEL: Record<SetupTab, string> = {
+  credentials: 'Go to Credentials',
+  config: 'Go to Config',
+  subscriptions: 'Go to Subscriptions',
+}
+
+// InstanceSetupSteps renders the "Steps to healthy" onboarding checklist for a
+// plugin instance (#658): a progress count, an optional humanized health_detail
+// line, and one row per step with a check/circle icon and a deep-link CTA for
+// incomplete steps. The first incomplete blocking step is marked "Next".
+export function InstanceSetupSteps({ steps, healthDetail, onNavigate }: InstanceSetupStepsProps) {
+  if (steps.length === 0) return null
+
+  const doneCount = steps.filter((s) => s.done).length
+  const nextStep = firstIncompleteBlockingStep(steps)
+
+  return (
+    <section className={styles.section} aria-label="Steps to healthy">
+      <div className={styles.header}>
+        <h2 className={styles.title}>Steps to healthy</h2>
+        <span className={styles.countBadge}>
+          {doneCount}/{steps.length}
+        </span>
+      </div>
+
+      {healthDetail && (
+        <p className={styles.detail}>
+          {healthDetail.message}
+          {healthDetail.tab && healthDetail.cta && (
+            <button
+              type="button"
+              className={styles.detailCta}
+              onClick={() => onNavigate(healthDetail.tab!)}
+            >
+              {healthDetail.cta}
+            </button>
+          )}
+        </p>
+      )}
+
+      <ol className={styles.stepList}>
+        {steps.map((step) => {
+          const isNext = nextStep?.key === step.key
+          return (
+            <li key={step.key} className={styles.stepRow}>
+              <span className={step.done ? styles.iconDone : styles.iconPending}>
+                {step.done ? (
+                  <CircleCheckBig size={16} aria-label="done" />
+                ) : (
+                  <Circle size={16} aria-label="not done" />
+                )}
+              </span>
+              <span className={step.done ? styles.labelDone : styles.label}>
+                {step.label}
+                {isNext && <span className={styles.nextPill}>Next</span>}
+              </span>
+              {!step.done && (
+                <button
+                  type="button"
+                  className={styles.cta}
+                  onClick={() => onNavigate(step.tab)}
+                >
+                  {STEP_CTA_LABEL[step.tab]}
+                  <ArrowRight size={13} strokeWidth={2} aria-hidden />
+                </button>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </section>
+  )
+}

--- a/frontend/src/pages/AdminPluginInstancePage.module.css
+++ b/frontend/src/pages/AdminPluginInstancePage.module.css
@@ -57,6 +57,9 @@
 }
 
 .tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
   padding: var(--space-2) var(--space-4);
   font-size: var(--text-sm);
   font-weight: var(--weight-medium);
@@ -68,6 +71,16 @@
   margin-bottom: -1px;
   transition: color var(--duration-fast) var(--ease-out),
               border-color var(--duration-fast) var(--ease-out);
+}
+
+/* Information-scent dot: signals a tab still has an incomplete required step
+   without the operator opening it (#658). */
+.tabBadge {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-amber);
+  flex-shrink: 0;
 }
 
 .tab:hover {

--- a/frontend/src/pages/AdminPluginInstancePage.tsx
+++ b/frontend/src/pages/AdminPluginInstancePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
@@ -9,10 +9,13 @@ import type { SchemaShape, SchemaProperty } from '@/components/form/SchemaForm'
 import { useOptionsContext } from '@/hooks/useOptionsContext'
 import { ReauthorizeButton } from '@/components/admin/ReauthorizeButton/ReauthorizeButton'
 import { CredentialsTab } from '@/components/admin/CredentialsTab/CredentialsTab'
+import { InstanceSetupSteps } from '@/components/admin/InstanceSetupSteps/InstanceSetupSteps'
 import { DeletePluginInstanceModal } from '@/components/admin/DeletePluginInstanceModal'
 import { AcceptManifestModal } from '@/components/admin/AcceptManifestModal'
 import { usePluginInstancesForAudience, usePluginInstanceDetail } from '@/hooks/queries/admin'
+import { usePluginInstanceCredentials } from '@/hooks/queries/plugins'
 import { useCurrentUser } from '@/hooks/queries/users'
+import { deriveSetupSteps, firstIncompleteBlockingStep, humanizeHealthDetail } from '@/utils/instanceSetup'
 import {
   useSetInstanceSubscriptionScope,
   useDeletePluginInstance,
@@ -31,6 +34,13 @@ import styles from './AdminPluginInstancePage.module.css'
 // ── tab type ─────────────────────────────────────────────────────────────────
 
 type Tab = 'subscriptions' | 'config' | 'credentials'
+
+// SETUP_RELEVANT_STATES are the health states where the "Steps to healthy"
+// onboarding checklist is meaningful — i.e. the instance still needs operator
+// setup. Healthy/inactive/terminal-error states get their own treatment and are
+// not nagged with a setup checklist (#658). pending_reauthorize already has a
+// dedicated Re-authorize banner.
+const SETUP_RELEVANT_STATES = new Set(['unhealthy', 'pending_config_migration'])
 
 // ── SubscriptionsTab ──────────────────────────────────────────────────────────
 
@@ -422,13 +432,80 @@ export default function AdminPluginInstancePage() {
 
   const hasSubscriptionSchema = !!instance?.subscription_schema
 
-  // If the plugin has no subscription_schema, default to the config tab.
-  // The Subscriptions tab is only rendered when subscription_schema is present.
+  // ── Onboarding-step derivation (#658) ────────────────────────────────────────
+  //
+  // The instance detail (config schema + redacted config values) and the
+  // redacted credentials power the "Steps to healthy" checklist, the tab badges,
+  // and the blocking-tab default. All three endpoints are admin-only, so the
+  // onboarding surface is gated on canManage; the underlying queries share their
+  // cache keys with the Config/Credentials tabs (no extra network round-trips).
+  const { data: detail, status: detailStatus } = usePluginInstanceDetail(
+    canManage ? pluginId : undefined,
+    canManage ? instanceId : undefined,
+  )
+  const { data: creds, status: credsStatus } = usePluginInstanceCredentials(
+    canManage ? pluginId : undefined,
+    canManage ? instanceId : undefined,
+  )
+
+  const configSchema = (detail?.config_schema ?? null) as SchemaShape | null
+  const instanceConfig = useMemo<Record<string, unknown>>(() => {
+    if (!detail?.config_json) return {}
+    try {
+      return JSON.parse(detail.config_json) as Record<string, unknown>
+    } catch {
+      return {}
+    }
+  }, [detail?.config_json])
+
+  const setupSteps = useMemo(() => {
+    if (!instance) return []
+    return deriveSetupSteps({
+      authStrategy: instance.auth_strategy,
+      credentials: creds,
+      configSchema,
+      config: instanceConfig,
+      hasSubscriptionSchema,
+      subscriptionScope: instance.subscription_scope,
+    })
+  }, [instance, creds, configSchema, instanceConfig, hasSubscriptionSchema])
+
+  // Tabs that still have an incomplete BLOCKING step get an information-scent dot.
+  const incompleteTabs = useMemo(
+    () => new Set(setupSteps.filter((s) => s.blocking && !s.done).map((s) => s.tab)),
+    [setupSteps],
+  )
+
+  const healthDetailCopy = humanizeHealthDetail(instance?.health_detail)
+
+  const showSetupSteps =
+    canManage &&
+    !!instance &&
+    SETUP_RELEVANT_STATES.has(instance.state) &&
+    setupSteps.length > 0
+
+  // One-time default tab. When the instance is mid-setup, open the first
+  // incomplete blocking step's tab (so the operator lands where the work is)
+  // instead of always defaulting to Subscriptions. Falls back to the old rule:
+  // Config when there is no subscription schema, else Subscriptions. Runs once,
+  // after the data needed to compute the blocker has settled, and never fights a
+  // manual tab click thereafter.
+  const didDefaultTab = useRef(false)
   useEffect(() => {
-    if (status === 'success' && !hasSubscriptionSchema && activeTab === 'subscriptions') {
+    if (didDefaultTab.current) return
+    if (status !== 'success' || !instance) return
+    // Wait for the admin-only detail/credentials queries to settle so the
+    // derived blocker is accurate before we commit to a default tab.
+    if (canManage && (detailStatus === 'pending' || credsStatus === 'pending')) return
+    didDefaultTab.current = true
+
+    const blocker = canManage ? firstIncompleteBlockingStep(setupSteps) : null
+    if (blocker) {
+      setActiveTab(blocker.tab)
+    } else if (!hasSubscriptionSchema) {
       setActiveTab('config')
     }
-  }, [status, hasSubscriptionSchema, activeTab])
+  }, [status, instance, canManage, detailStatus, credsStatus, setupSteps, hasSubscriptionSchema])
 
   // After a successful OAuth authcode round-trip the callback handler redirects
   // the browser back here with ?oauth_ok=1. Invalidate the instance list and
@@ -589,6 +666,14 @@ export default function AdminPluginInstancePage() {
         <div className={alertStyles.alertError} role="alert">{activateError}</div>
       )}
 
+      {showSetupSteps && (
+        <InstanceSetupSteps
+          steps={setupSteps}
+          healthDetail={healthDetailCopy}
+          onNavigate={setActiveTab}
+        />
+      )}
+
       <nav className={styles.tabs} aria-label="Instance settings">
         {hasSubscriptionSchema && (
           <button
@@ -605,6 +690,13 @@ export default function AdminPluginInstancePage() {
           onClick={() => setActiveTab('config')}
         >
           Config
+          {incompleteTabs.has('config') && (
+            <span
+              className={styles.tabBadge}
+              aria-label="required setup incomplete"
+              title="Required configuration is missing"
+            />
+          )}
         </button>
         <button
           type="button"
@@ -612,6 +704,13 @@ export default function AdminPluginInstancePage() {
           onClick={() => setActiveTab('credentials')}
         >
           Credentials
+          {incompleteTabs.has('credentials') && (
+            <span
+              className={styles.tabBadge}
+              aria-label="required setup incomplete"
+              title="Credentials are missing"
+            />
+          )}
         </button>
       </nav>
 

--- a/frontend/src/utils/instanceSetup.test.ts
+++ b/frontend/src/utils/instanceSetup.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import {
+  authStrategyNeedsCredentials,
+  credentialsConfigured,
+  missingRequiredConfigFields,
+  scopeConfigured,
+  deriveSetupSteps,
+  firstIncompleteBlockingStep,
+  humanizeHealthDetail,
+} from './instanceSetup'
+import type { SchemaShape } from '@/components/form/SchemaForm'
+import type { ApiRedactedCredentials } from '@/api/types'
+
+describe('authStrategyNeedsCredentials', () => {
+  it.each([
+    [undefined, false],
+    ['', false],
+    ['none', false],
+    ['static_api_key', true],
+    ['oauth2_authcode', true],
+  ])('strategy %s → %s', (strategy, expected) => {
+    expect(authStrategyNeedsCredentials(strategy)).toBe(expected)
+  })
+})
+
+describe('credentialsConfigured', () => {
+  it('returns true for strategies that need no credentials', () => {
+    expect(credentialsConfigured('none', undefined)).toBe(true)
+    expect(credentialsConfigured('', undefined)).toBe(true)
+  })
+
+  it('returns false when creds are still loading / inaccessible', () => {
+    expect(credentialsConfigured('static_api_key', undefined)).toBe(false)
+  })
+
+  it('reads the right presence flag per strategy', () => {
+    expect(credentialsConfigured('static_api_key', { strategy: 'static_api_key', has_api_key: true })).toBe(true)
+    expect(credentialsConfigured('static_api_key', { strategy: 'static_api_key', has_api_key: false })).toBe(false)
+
+    expect(credentialsConfigured('header_set', { strategy: 'header_set', header_names: ['X-Api'] })).toBe(true)
+    expect(credentialsConfigured('header_set', { strategy: 'header_set', header_names: [] })).toBe(false)
+
+    expect(credentialsConfigured('basic_auth', { strategy: 'basic_auth', has_password: true })).toBe(true)
+    // username alone is not enough
+    expect(credentialsConfigured('basic_auth', { strategy: 'basic_auth', username: 'bob' })).toBe(false)
+
+    expect(credentialsConfigured('oauth2_authcode', { strategy: 'oauth2_authcode', has_token: true })).toBe(true)
+    // client creds present but no token yet → not usable
+    expect(credentialsConfigured('oauth2_authcode', { strategy: 'oauth2_authcode', has_client_secret: true })).toBe(false)
+  })
+
+  it('is forward-compatible: unknown strategy treats any presence flag as set', () => {
+    const creds: ApiRedactedCredentials = { strategy: 'future', has_token: true }
+    expect(credentialsConfigured('future_strategy', creds)).toBe(true)
+    expect(credentialsConfigured('future_strategy', { strategy: 'future' })).toBe(false)
+  })
+})
+
+describe('missingRequiredConfigFields', () => {
+  const schema: SchemaShape = {
+    properties: { app_token: {}, channel: {}, enabled: {} },
+    required: ['app_token', 'channel'],
+  }
+
+  it('returns [] for a null schema', () => {
+    expect(missingRequiredConfigFields(null, {})).toEqual([])
+  })
+
+  it('returns [] when nothing is required', () => {
+    expect(missingRequiredConfigFields({ properties: { a: {} } }, {})).toEqual([])
+  })
+
+  it('flags missing and empty values', () => {
+    expect(missingRequiredConfigFields(schema, {})).toEqual(['app_token', 'channel'])
+    expect(missingRequiredConfigFields(schema, { app_token: '', channel: null })).toEqual([
+      'app_token',
+      'channel',
+    ])
+  })
+
+  it('treats a redacted secret ("***") as SET, not missing', () => {
+    expect(missingRequiredConfigFields(schema, { app_token: '***', channel: 'C123' })).toEqual([])
+  })
+
+  it('treats falsey-but-valid values (false, 0) as set', () => {
+    const s: SchemaShape = { required: ['flag', 'count'] }
+    expect(missingRequiredConfigFields(s, { flag: false, count: 0 })).toEqual([])
+  })
+
+  it('treats an empty array as missing', () => {
+    const s: SchemaShape = { required: ['channels'] }
+    expect(missingRequiredConfigFields(s, { channels: [] })).toEqual(['channels'])
+  })
+})
+
+describe('scopeConfigured', () => {
+  it('false for undefined / empty', () => {
+    expect(scopeConfigured(undefined)).toBe(false)
+    expect(scopeConfigured({})).toBe(false)
+    expect(scopeConfigured({ channels: [] })).toBe(false)
+  })
+  it('true when any field is filled', () => {
+    expect(scopeConfigured({ channels: ['C1'] })).toBe(true)
+    expect(scopeConfigured({ all: true })).toBe(true)
+  })
+})
+
+describe('deriveSetupSteps', () => {
+  it('omits the credentials step for a "none" plugin', () => {
+    const steps = deriveSetupSteps({
+      authStrategy: 'none',
+      configSchema: null,
+      config: {},
+      hasSubscriptionSchema: false,
+    })
+    expect(steps).toEqual([])
+  })
+
+  it('builds the full ordered list and marks done correctly (all incomplete)', () => {
+    const steps = deriveSetupSteps({
+      authStrategy: 'oauth2_authcode',
+      credentials: undefined,
+      configSchema: { required: ['app_token'] },
+      config: {},
+      hasSubscriptionSchema: true,
+      subscriptionScope: {},
+    })
+    expect(steps.map((s) => s.key)).toEqual(['credentials', 'config', 'subscriptions'])
+    expect(steps.every((s) => !s.done)).toBe(true)
+    expect(steps.find((s) => s.key === 'config')?.label).toContain('1 left')
+  })
+
+  it('marks steps done when data is present', () => {
+    const steps = deriveSetupSteps({
+      authStrategy: 'oauth2_authcode',
+      credentials: { strategy: 'oauth2_authcode', has_token: true },
+      configSchema: { required: ['app_token'] },
+      config: { app_token: '***' },
+      hasSubscriptionSchema: true,
+      subscriptionScope: { channels: ['C1'] },
+    })
+    expect(steps.every((s) => s.done)).toBe(true)
+  })
+
+  it('subscription step is non-blocking; credentials + config are blocking', () => {
+    const steps = deriveSetupSteps({
+      authStrategy: 'static_api_key',
+      configSchema: { required: ['x'] },
+      config: {},
+      hasSubscriptionSchema: true,
+      subscriptionScope: {},
+    })
+    expect(steps.find((s) => s.key === 'credentials')?.blocking).toBe(true)
+    expect(steps.find((s) => s.key === 'config')?.blocking).toBe(true)
+    expect(steps.find((s) => s.key === 'subscriptions')?.blocking).toBe(false)
+  })
+})
+
+describe('firstIncompleteBlockingStep', () => {
+  it('returns the first incomplete blocking step', () => {
+    const steps = deriveSetupSteps({
+      authStrategy: 'static_api_key',
+      credentials: { strategy: 'static_api_key', has_api_key: true },
+      configSchema: { required: ['x'] },
+      config: {},
+      hasSubscriptionSchema: false,
+    })
+    // credentials done, config not → config is the blocker
+    expect(firstIncompleteBlockingStep(steps)?.key).toBe('config')
+  })
+
+  it('returns null when all blocking steps are done', () => {
+    const steps = deriveSetupSteps({
+      authStrategy: 'none',
+      configSchema: { required: ['x'] },
+      config: { x: 'set' },
+      hasSubscriptionSchema: true,
+      subscriptionScope: {},
+    })
+    expect(firstIncompleteBlockingStep(steps)).toBeNull()
+  })
+})
+
+describe('humanizeHealthDetail', () => {
+  it('returns null for empty / oauth-refresh details', () => {
+    expect(humanizeHealthDetail(undefined)).toBeNull()
+    expect(humanizeHealthDetail('')).toBeNull()
+    expect(humanizeHealthDetail('oauth refresh failed: token expired')).toBeNull()
+  })
+
+  it('maps config_missing and credentials_missing to actionable copy + tab', () => {
+    expect(humanizeHealthDetail('config_missing')).toMatchObject({ tab: 'config', cta: expect.any(String) })
+    expect(humanizeHealthDetail('credentials_missing')).toMatchObject({ tab: 'credentials' })
+  })
+
+  it('maps config_schema_unparseable without a tab link', () => {
+    const c = humanizeHealthDetail('config_schema_unparseable')
+    expect(c?.tab).toBeUndefined()
+    expect(c?.message).toContain('config schema')
+  })
+
+  it('falls back to the raw detail for unknown strings', () => {
+    expect(humanizeHealthDetail('something_new')).toEqual({ message: 'something_new' })
+  })
+})

--- a/frontend/src/utils/instanceSetup.ts
+++ b/frontend/src/utils/instanceSetup.ts
@@ -1,0 +1,220 @@
+// Onboarding-step derivation for a plugin instance (#658).
+//
+// Getting a plugin instance to `healthy` is a multi-step setup: credentials →
+// required config → subscription scope. This module derives an ordered list of
+// those steps from the data the instance page already has (manifest auth
+// strategy, redacted credentials, config schema + redacted config values, and
+// the subscription scope), plus a humanizer that turns internal `health_detail`
+// strings into actionable copy with a deep link to the relevant tab.
+//
+// Everything here is PURE so it can be unit-tested without rendering. The page
+// owns data fetching and passes plain values in.
+
+import { REDACTION_SENTINEL } from '@/components/form/SchemaForm'
+import type { SchemaShape } from '@/components/form/SchemaForm'
+import type { ApiRedactedCredentials } from '@/api/types'
+
+// The three settings tabs an onboarding step can point at. Matches the page's
+// internal Tab union (kept local so this module stays page-agnostic).
+export type SetupTab = 'subscriptions' | 'config' | 'credentials'
+
+export interface SetupStep {
+  // Stable identity for keys / tab badges.
+  key: 'credentials' | 'config' | 'subscriptions'
+  label: string
+  done: boolean
+  // Which tab the step's CTA navigates to.
+  tab: SetupTab
+  // blocking: an incomplete blocking step prevents the instance reaching
+  // `healthy`. Credentials and required config are blocking; subscription scope
+  // is a recommended (non-blocking) step.
+  blocking: boolean
+}
+
+// authStrategyNeedsCredentials reports whether a manifest auth strategy actually
+// consumes operator-supplied credentials. "none" (and the unset/empty default)
+// are config-only, mirroring the backend's computeInstanceReadinessDetail.
+export function authStrategyNeedsCredentials(strategy: string | undefined): boolean {
+  const s = strategy ?? ''
+  return s !== '' && s !== 'none'
+}
+
+// credentialsConfigured reports whether the redacted credential view shows a
+// usable credential for the given strategy. Secret values are never present in
+// the redacted view — only presence flags — so we read those flags per strategy.
+//
+// Conservative on missing data: when creds is undefined (still loading or the
+// caller lacks access) we return false rather than claiming "done".
+export function credentialsConfigured(
+  strategy: string | undefined,
+  creds: ApiRedactedCredentials | undefined,
+): boolean {
+  if (!authStrategyNeedsCredentials(strategy)) return true
+  if (!creds) return false
+  switch (strategy) {
+    case 'static_api_key':
+      return !!creds.has_api_key
+    case 'header_set':
+      return (creds.header_names?.length ?? 0) > 0
+    case 'basic_auth':
+      // A password is the secret half; username alone is not enough.
+      return !!creds.has_password
+    case 'oauth2_authcode':
+    case 'oauth2_clientcred':
+      // A stored token is what makes the instance able to authenticate; client
+      // id/secret without a token is not yet usable.
+      return !!creds.has_token
+    default:
+      // Unknown/forward-compatible strategy: treat any presence flag as set so
+      // we neither crash nor nag indefinitely.
+      return !!(
+        creds.has_api_key ||
+        creds.has_password ||
+        creds.has_token ||
+        (creds.header_names?.length ?? 0) > 0
+      )
+  }
+}
+
+// isValueSet reports whether a config/scope value counts as filled. A redacted
+// secret ("***") means the value IS set. Empty string, null, undefined, and an
+// empty array all count as missing. `false` and `0` are valid set values.
+function isValueSet(val: unknown): boolean {
+  if (val === undefined || val === null || val === '') return false
+  if (Array.isArray(val) && val.length === 0) return false
+  if (val === REDACTION_SENTINEL) return true
+  return true
+}
+
+// missingRequiredConfigFields returns the names of required config_schema fields
+// that are not yet filled in the (redacted) config values. Robust to a null
+// schema or an absent `required` array — returns [] when nothing is required.
+export function missingRequiredConfigFields(
+  schema: SchemaShape | null,
+  config: Record<string, unknown>,
+): string[] {
+  if (!schema) return []
+  const required = schema.required ?? []
+  return required.filter((name) => !isValueSet(config[name]))
+}
+
+// scopeConfigured reports whether the subscription scope has at least one filled
+// field. Empty object / undefined → false.
+export function scopeConfigured(scope: Record<string, unknown> | undefined): boolean {
+  if (!scope) return false
+  return Object.values(scope).some(isValueSet)
+}
+
+export interface DeriveStepsInput {
+  // Manifest auth strategy (instance.auth_strategy). Empty/undefined = "none".
+  authStrategy?: string
+  // Redacted credential view; undefined while loading or when inaccessible.
+  credentials?: ApiRedactedCredentials
+  // Instance-level config schema (from the detail endpoint). null when the
+  // manifest declares none.
+  configSchema: SchemaShape | null
+  // Parsed (redacted) config values.
+  config: Record<string, unknown>
+  // Whether the plugin declares a subscription_schema (the Subscriptions tab is
+  // only rendered when true).
+  hasSubscriptionSchema: boolean
+  // Current instance subscription scope.
+  subscriptionScope?: Record<string, unknown>
+}
+
+// deriveSetupSteps builds the ordered onboarding step list. Order is
+// credentials → required config → subscription scope. Steps that do not apply to
+// the instance (e.g. credentials for a "none" plugin, config when nothing is
+// required, subscriptions when no schema) are omitted.
+export function deriveSetupSteps(input: DeriveStepsInput): SetupStep[] {
+  const steps: SetupStep[] = []
+
+  if (authStrategyNeedsCredentials(input.authStrategy)) {
+    const done = credentialsConfigured(input.authStrategy, input.credentials)
+    steps.push({
+      key: 'credentials',
+      label: done ? 'Credentials set' : 'Add credentials',
+      done,
+      tab: 'credentials',
+      blocking: true,
+    })
+  }
+
+  const requiredCount = input.configSchema?.required?.length ?? 0
+  if (requiredCount > 0) {
+    const missing = missingRequiredConfigFields(input.configSchema, input.config)
+    const done = missing.length === 0
+    steps.push({
+      key: 'config',
+      label: done
+        ? 'Required config set'
+        : `Fill required config (${missing.length} left)`,
+      done,
+      tab: 'config',
+      blocking: true,
+    })
+  }
+
+  if (input.hasSubscriptionSchema) {
+    const done = scopeConfigured(input.subscriptionScope)
+    steps.push({
+      key: 'subscriptions',
+      label: done ? 'Subscription scope set' : 'Set subscription scope',
+      done,
+      tab: 'subscriptions',
+      blocking: false,
+    })
+  }
+
+  return steps
+}
+
+// firstIncompleteBlockingStep returns the first blocking step that is not done,
+// or null when none — used to pick the default tab and the "Next" emphasis.
+export function firstIncompleteBlockingStep(steps: SetupStep[]): SetupStep | null {
+  return steps.find((s) => s.blocking && !s.done) ?? null
+}
+
+export interface HealthDetailCopy {
+  // Human-readable, actionable sentence.
+  message: string
+  // Tab to deep-link to, when the detail maps to a specific setup step.
+  tab?: SetupTab
+  // CTA label for the deep link.
+  cta?: string
+}
+
+// humanizeHealthDetail maps an internal `health_detail` string to actionable
+// operator copy with an optional deep link. Returns null when there is nothing
+// actionable to say (empty detail), or when the detail is handled by a dedicated
+// banner elsewhere (OAuth refresh failure → ReauthorizeButton banner).
+//
+// Unknown details fall back to surfacing the raw string so we never hide signal.
+export function humanizeHealthDetail(detail: string | undefined): HealthDetailCopy | null {
+  if (!detail) return null
+  // OAuth refresh failures get their own dedicated "Re-authorize" banner.
+  if (detail.startsWith('oauth refresh failed')) return null
+
+  switch (detail) {
+    case 'config_missing':
+      return {
+        message: 'Add the required configuration to finish setting up this instance.',
+        tab: 'config',
+        cta: 'Go to Config',
+      }
+    case 'credentials_missing':
+      return {
+        message: 'Add credentials so this instance can authenticate.',
+        tab: 'credentials',
+        cta: 'Add credentials',
+      }
+    case 'config_schema_unparseable':
+      return {
+        message:
+          "The plugin's config schema could not be parsed. Contact your plugin administrator.",
+      }
+    default:
+      // Fall back to the raw detail rather than hiding it.
+      return { message: detail }
+  }
+}


### PR DESCRIPTION
## Summary
Turns the plugin instance page (`AdminPluginInstancePage`) into a guided onboarding flow instead of three peer tabs with no sense of order or progress.

1. **"Steps to healthy" checklist** in the page header. Ordered: Credentials → required Config → Subscription scope. Each step shows a check/circle, a progress count (`N/M`), and a deep-link CTA for incomplete steps; the first incomplete blocking step is marked **Next**.
2. **Tab scent badges** — a dot on the Config / Credentials tab whenever a *blocking* step for that tab is still incomplete, so the next step is visible without opening each tab.
3. **Humanized `health_detail`** — internal strings mapped to actionable copy with a deep link: `config_missing` → "Add the required configuration… Go to Config", `credentials_missing` → "Add credentials…", `config_schema_unparseable` → contact admin. OAuth refresh failures keep their existing dedicated banner.
4. **Blocking-tab default** — on first load of a mid-setup instance, open the first incomplete blocking step's tab instead of always opening Subscriptions (preserves the old "no subscription schema → Config" fallback).

## How the steps are derived
A pure, fully unit-tested util (`frontend/src/utils/instanceSetup.ts`):
- **Credentials**: from the manifest auth strategy + the *redacted* credentials presence flags (`has_api_key` / `header_names` / `has_password` / `has_token`); `none`/empty strategies need no credentials. OAuth requires a stored token (client creds alone aren't usable). Unknown strategies degrade gracefully.
- **Required config**: manifest `config_schema.required[]` vs the (redacted) config values. A redacted `"***"` secret counts as **SET**; `false`/`0` are valid; empty string / empty array / missing count as missing.
- **Subscription scope**: present-but-empty scope = not done (recommended, non-blocking).

The onboarding surface is gated on **admin** (the detail + credentials GET endpoints are admin-only), and its queries share cache keys with the Config/Credentials tabs — **no extra network round-trips**. Resilient to loading / absent manifest / inaccessible credentials (conservative "not done" rather than a wrong "done").

## New component
`InstanceSetupSteps` ships with `.stories.tsx` (all-incomplete, creds-done, scope-left, all-done, config-only) and `.test.tsx`. CSS Modules + design tokens + 4px spacing throughout; no inline styles.

## Tests / build
- `npm run build` — green (tsc + vite).
- `npx vitest run --project unit` — **1266 passed**, including new `instanceSetup.test.ts` (derivation/humanizer) and `InstanceSetupSteps.test.tsx` (render across states). The `storybook` browser project is skipped locally (chromium binary not installed in this env — unrelated to this change).

## Nothing deferred
All four asks landed.

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)