### PR TITLE
fix: Gemini blocks schema, approval-button trap, + Cancel-run button

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -197,6 +197,11 @@ export interface ApproveRunResponse {
   decision: string
 }
 
+// Matches execution/run/runs_handler.go → Cancel response map[string]string
+export interface CancelRunResponse {
+  run_id: string
+}
+
 // --- Feedback ---
 
 // Matches trigger/runs_handler.go → FeedbackDecisionRequest (POST /api/v1/runs/:id/feedback)

--- a/frontend/src/components/RunDetail/RunHeader.tsx
+++ b/frontend/src/components/RunDetail/RunHeader.tsx
@@ -29,9 +29,12 @@ interface Props {
   } | null
   showRetry?: boolean
   onRetry?: () => void
+  showCancel?: boolean
+  onCancel?: () => void
+  cancelPending?: boolean
 }
 
-export function RunHeader({ run, toolCallCount, tokenTotal, duration, capabilitySnapshot, showRetry, onRetry }: Props) {
+export function RunHeader({ run, toolCallCount, tokenTotal, duration, capabilitySnapshot, showRetry, onRetry, showCancel, onCancel, cancelPending }: Props) {
   const navigate = useNavigate()
   const [adminOpen, setAdminOpen] = useState(false)
   const [capExpanded, setCapExpanded] = useState(false)
@@ -69,6 +72,11 @@ export function RunHeader({ run, toolCallCount, tokenTotal, duration, capability
         {showRetry && onRetry && (
           <Button variant="secondary" size="small" onClick={onRetry}>
             Retry
+          </Button>
+        )}
+        {showCancel && onCancel && (
+          <Button variant="danger" size="small" disabled={cancelPending} onClick={onCancel}>
+            {cancelPending ? 'Cancelling…' : 'Cancel run'}
           </Button>
         )}
       </div>

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.test.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.test.tsx
@@ -496,8 +496,19 @@ describe('AudienceEditor — channel AsyncCombobox via optionsContext (B3)', () 
   })
 })
 
-describe('AudienceEditor — response_buttons escape hatch', () => {
-  it('preserves response_buttons in the save payload when set', async () => {
+describe('AudienceEditor — response_buttons removed from the UI', () => {
+  it('does not render a response-buttons editor for a Slack entry', () => {
+    renderEditor({
+      initial: AUDIENCE_WITH_SLACK,
+      pluginInstances: [PLUGIN_SLACK_WITH_SCHEMA],
+      references: REFS_EMPTY,
+    })
+    // The custom-button escape hatch was removed; Requests use Approve/Reject.
+    expect(screen.queryByRole('button', { name: /\+ add button/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/response button/i)).not.toBeInTheDocument()
+  })
+
+  it('strips response_buttons from the save payload even when the entry had them', async () => {
     const onSave = vi.fn().mockResolvedValue(AUDIENCE_WITH_RESPONSE_BUTTONS)
     renderEditor({
       initial: AUDIENCE_WITH_RESPONSE_BUTTONS,
@@ -511,9 +522,9 @@ describe('AudienceEditor — response_buttons escape hatch', () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
     const req = onSave.mock.calls[0][0]
     const configSaved = req.entries[0].config
-    expect(configSaved).toHaveProperty('response_buttons')
-    expect(configSaved.response_buttons).toHaveLength(2)
-    expect(configSaved.response_buttons[0]).toMatchObject({ option_id: 'yes', style: 'primary' })
+    expect(configSaved).not.toHaveProperty('response_buttons')
+    // Other config fields are preserved.
+    expect(configSaved).toMatchObject({ channel: '#ops' })
   })
 
   it('omits response_buttons from payload when not set (backend default Approve/Reject)', async () => {
@@ -524,30 +535,6 @@ describe('AudienceEditor — response_buttons escape hatch', () => {
       references: REFS_EMPTY,
       onSave,
     })
-
-    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
-
-    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
-    const req = onSave.mock.calls[0][0]
-    const configSaved = req.entries[0].config
-    expect(configSaved).not.toHaveProperty('response_buttons')
-  })
-
-  it('omits response_buttons after adding then removing all buttons', async () => {
-    const onSave = vi.fn().mockResolvedValue(AUDIENCE_WITH_SLACK)
-    renderEditor({
-      initial: AUDIENCE_WITH_SLACK,
-      pluginInstances: [PLUGIN_SLACK_WITH_SCHEMA],
-      references: REFS_EMPTY,
-      onSave,
-    })
-
-    // Add a button.
-    await userEvent.click(screen.getByRole('button', { name: /\+ add button/i }))
-
-    // Remove it — the only row removal should call onChange(undefined).
-    const removeBtn = await screen.findByRole('button', { name: /remove button 1/i })
-    await userEvent.click(removeBtn)
 
     await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 

--- a/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
+++ b/frontend/src/components/admin/AudienceEditor/AudienceEditor.tsx
@@ -159,12 +159,20 @@ export function AudienceEditor({
   )
 
   function buildPayload(): AudienceCreateRequest | AudienceUpdateRequest {
-    const entryInputs = entries.map((e) => ({
-      plugin_instance_id: e.plugin_instance_id,
-      notify: e.notify,
-      request: e.request,
-      config: e.config,
-    }))
+    const entryInputs = entries.map((e) => {
+      // Custom response_buttons are no longer editable in the UI — strip the key
+      // from every save so persisted ones are cleaned up and Requests fall back
+      // to the default Approve/Reject pair (an arbitrary option_id cannot resolve
+      // an approval gate). See EntryRow.tsx for the rationale.
+      const config = { ...(e.config ?? {}) } as Record<string, unknown>
+      delete config['response_buttons']
+      return {
+        plugin_instance_id: e.plugin_instance_id,
+        notify: e.notify,
+        request: e.request,
+        config,
+      }
+    })
 
     if (initial) {
       return {

--- a/frontend/src/components/admin/AudienceEditor/EntryRow.tsx
+++ b/frontend/src/components/admin/AudienceEditor/EntryRow.tsx
@@ -3,8 +3,6 @@ import { PluginHealthChip } from '@/components/admin/PluginHealthChip/PluginHeal
 import { SchemaForm } from '@/components/form/SchemaForm'
 import type { SchemaShape } from '@/components/form/SchemaForm'
 import { useOptionsContext } from '@/hooks/useOptionsContext'
-import { ResponseButtonsEditor } from './ResponseButtonsEditor'
-import type { ResponseButton } from './ResponseButtonsEditor'
 import type { ApiAudienceEntry, ApiPluginInstanceForAudience } from '@/api/types'
 import styles from './EntryRow.module.css'
 
@@ -24,17 +22,6 @@ interface Props {
   isDragging: boolean
   isDragOver: boolean
   disabled: boolean
-}
-
-// Returns true when the schema property declares an array-of-objects field,
-// which is the gate for rendering the ResponseButtonsEditor escape hatch (S4).
-function isArrayOfObjects(prop: unknown): boolean {
-  if (typeof prop !== 'object' || prop === null) return false
-  const p = prop as Record<string, unknown>
-  if (p['type'] !== 'array') return false
-  const items = p['items']
-  if (typeof items !== 'object' || items === null) return false
-  return (items as Record<string, unknown>)['type'] === 'object'
 }
 
 function EntryConfig({
@@ -65,38 +52,22 @@ function EntryConfig({
 
   const schema = rawSchema!
 
-  // Detect the response_buttons property in the schema (S4 strict check).
-  const rbProp = schema.properties?.['response_buttons']
-  const hasResponseButtons = isArrayOfObjects(rbProp)
-
-  // Build a schema for SchemaForm that omits response_buttons — it is handled
-  // by ResponseButtonsEditor. We preserve all other properties.
+  // Custom response buttons (response_buttons) are intentionally NOT editable in
+  // the UI for now — approval/feedback Requests fall back to the default
+  // Approve/Reject buttons. A custom button whose option_id is not exactly
+  // "approve"/"reject" cannot resolve an approval gate (the host maps any other
+  // option_id to "answered"), which silently wedges approval-gated runs. We
+  // strip the property from the form schema so SchemaForm never renders it, and
+  // drop any persisted value on the next save.
   const formProperties = { ...(schema.properties ?? {}) }
-  if (hasResponseButtons) {
-    delete formProperties['response_buttons']
-  }
+  delete formProperties['response_buttons']
   const formSchema: SchemaShape = { ...schema, properties: formProperties }
 
-  // Split entry.config: SchemaForm value excludes response_buttons; the
-  // escape-hatch editor owns that key separately.
-  const rb = entry.config?.['response_buttons'] as ResponseButton[] | undefined
   const schemaFormValue: Record<string, unknown> = { ...(entry.config ?? {}) }
   delete schemaFormValue['response_buttons']
 
   function handleSchemaFormChange(next: Record<string, unknown>) {
-    const merged: Record<string, unknown> = { ...next }
-    if (rb !== undefined) {
-      merged['response_buttons'] = rb
-    }
-    onChange({ ...entry, config: merged })
-  }
-
-  function handleResponseButtonsChange(nextRb: ResponseButton[] | undefined) {
-    const merged: Record<string, unknown> = { ...schemaFormValue }
-    if (nextRb !== undefined) {
-      merged['response_buttons'] = nextRb
-    }
-    onChange({ ...entry, config: merged })
+    onChange({ ...entry, config: next })
   }
 
   return (
@@ -109,16 +80,6 @@ function EntryConfig({
         idPrefix={`entry-${index}-cfg`}
         optionsContext={optionsCtx}
       />
-      {hasResponseButtons && (
-        <div className={styles.responseButtonsSection}>
-          <ResponseButtonsEditor
-            value={rb}
-            onChange={handleResponseButtonsChange}
-            disabled={isDisabled}
-            idPrefix={`entry-${index}-rb`}
-          />
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/components/admin/CredentialsTab/CredentialsTab.tsx
+++ b/frontend/src/components/admin/CredentialsTab/CredentialsTab.tsx
@@ -436,20 +436,22 @@ function OAuthClientForm({
         Paste the Client ID and Client Secret from the provider (e.g. Slack app
         Basic Information). Both values are required before you can authorize.
       </p>
-      <label className={styles.field}>
+      <label className={styles.fieldRow}>
         <span className={styles.fieldLabel}>Client ID</span>
         <input
           type="text"
+          className={styles.input}
           value={clientId}
           onChange={(e) => setClientId(e.target.value)}
           disabled={!canManage}
           autoComplete="off"
         />
       </label>
-      <label className={styles.field}>
+      <label className={styles.fieldRow}>
         <span className={styles.fieldLabel}>Client Secret</span>
         <input
           type="password"
+          className={styles.input}
           value={clientSecret}
           onChange={(e) => setClientSecret(e.target.value)}
           disabled={!canManage}

--- a/frontend/src/hooks/mutations/runs.ts
+++ b/frontend/src/hooks/mutations/runs.ts
@@ -1,7 +1,28 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@/api/fetch'
-import type { ApproveRunRequest, ApproveRunResponse, SubmitFeedbackRequest, SubmitFeedbackResponse } from '@/api/types'
+import type { ApproveRunRequest, ApproveRunResponse, CancelRunResponse, SubmitFeedbackRequest, SubmitFeedbackResponse } from '@/api/types'
 import { queryKeys } from '../queryKeys'
+
+// useCancelRun cancels an in-flight run (pending / running / waiting_for_*).
+// The backend transitions it to failed and unblocks any approval/feedback gate
+// (POST /runs/{id}/cancel, operator|admin). 409 if the run is already terminal.
+export function useCancelRun() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (runId: string) =>
+      apiFetch<CancelRunResponse>(`/runs/${encodeURIComponent(runId)}/cancel`, {
+        method: 'POST',
+      }),
+    onSuccess: (_data, runId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.runs.detail(runId) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.runs.steps(runId) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.stats.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.attention.all })
+    },
+  })
+}
 
 export function useApproveRun() {
   const queryClient = useQueryClient()

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useRun } from '@/hooks/queries/runs'
 import { useRunSteps } from '@/hooks/queries/runs'
+import { useCancelRun } from '@/hooks/mutations/runs'
 import { useRunTimeline } from '@/hooks/useRunTimeline'
 import { useScrollSentinel } from '@/hooks/useScrollSentinel'
 import { useLiveDuration } from '@/hooks/useLiveDuration'
@@ -20,6 +21,7 @@ import { CopyBlock } from '@/components/CopyBlock'
 import type { FilterKey } from '@/components/RunDetail'
 import type { CapabilitySnapshotV2, GrantedToolEntry } from '@/components/RunDetail/types'
 import { isFeedbackEntry } from '@/components/RunDetail/types'
+import { useCurrentUser } from '@/hooks/queries/users'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import NotFoundPage from '@/pages/NotFoundPage'
 import { ApiError } from '@/api/fetch'
@@ -70,6 +72,25 @@ export default function RunDetailPage() {
   )
 
   const showRetry = run?.status === 'failed' || run?.status === 'interrupted'
+
+  const { data: currentUser } = useCurrentUser()
+  const cancelRun = useCancelRun()
+  // In-flight runs can be cancelled by operators/admins. Mirrors the backend
+  // RequireRole(Operator) gate on POST /runs/{id}/cancel and the cancellable
+  // states the RunManager accepts.
+  const inFlight =
+    run?.status === 'pending' ||
+    run?.status === 'running' ||
+    run?.status === 'waiting_for_approval' ||
+    run?.status === 'waiting_for_feedback'
+  const canCancel = currentUser?.roles.some((r) => r === 'operator' || r === 'admin') ?? false
+  const showCancel = Boolean(inFlight && canCancel)
+
+  function handleCancel() {
+    if (!id) return
+    if (!window.confirm('Cancel this run? It will be marked failed and cannot be resumed.')) return
+    cancelRun.mutate(id)
+  }
 
   const retryMessage = useMemo(() => {
     if (!run?.trigger_payload) return ''
@@ -145,6 +166,9 @@ export default function RunDetailPage() {
                 capabilitySnapshot={capabilitySnapshot}
                 showRetry={showRetry}
                 onRetry={() => setRetryModalOpen(true)}
+                showCancel={showCancel}
+                onCancel={handleCancel}
+                cancelPending={cancelRun.isPending}
               />
 
               {run.status === 'waiting_for_approval' && (

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -846,6 +846,27 @@ shipped — existing installs do **not** need to re-authorize to use the new too
 The only planned scope addition (`files:write` for `upload_file`) is deferred to
 a separate PR to keep re-auth impact isolated.
 
+### Optional scope — `groups:read` (private channels in the searchable picker)
+
+The searchable channel picker (audience entries, trigger bindings, and config
+fields backed by the `channels` option provider) calls `conversations.list`
+requesting **both public and private channels**. Listing private channels
+requires the `groups:read` scope, which is intentionally **not** in
+`oauth_defaults` to avoid forcing existing installs to re-authorize.
+
+| Scope         | Used by |
+|---------------|---------|
+| `groups:read` | `channels` option provider — listing private channels in the searchable picker |
+
+Without `groups:read`, Slack rejects the **entire** `conversations.list` call
+with `missing_scope` (not just the private results), so the picker shows no
+options and the field degrades to free-text "enter an ID directly". To enable
+it: add `groups:read` to the Slack app's bot scopes under **OAuth &
+Permissions**, add it to `oauth_defaults.scopes` in `manifest.go` (so the
+authorize URL requests it), reinstall the rebuilt bundle, and **re-authorize**
+the instance. If you only use public channels, no change is needed — public
+channels are already covered by `channels:read`.
+
 ## Token refresh
 
 Slack v2 bot tokens (`xoxb-` prefix) do not expire under normal circumstances

--- a/plugins/slack/manifest.go
+++ b/plugins/slack/manifest.go
@@ -13,7 +13,7 @@ import (
 var pluginManifest = manifest.Manifest{
 	SchemaVersion: "v1",
 	Name:          "slack",
-	Version:       "0.1.1",
+	Version:       "0.1.2",
 	Description:   "Slack integration: tools (send/list channels), triggers (channel messages), and channels (notify/request via Slack DMs and posts).",
 	Services: manifest.Services{
 		Tool:    "v1",

--- a/plugins/slack/manifest.yaml
+++ b/plugins/slack/manifest.yaml
@@ -477,8 +477,10 @@ tools:
       additionalProperties: false
       properties:
         blocks:
-          description: JSON array of Slack Block Kit block objects, e.g. [{\"type\":\"section\"
+          items:
+            type: object
           title: Blocks
+          type: array
         channel:
           description: Channel ID (C…) or name (#general)
           title: Channel
@@ -612,8 +614,10 @@ tools:
       additionalProperties: false
       properties:
         blocks:
-          description: JSON array of Slack Block Kit block objects, e.g. [{\"type\":\"section\"
+          items:
+            type: object
           title: Blocks
+          type: array
         channel:
           description: Channel ID containing the message to update
           title: Channel
@@ -660,4 +664,4 @@ tools:
         - user
       type: object
     name: lookup_user
-version: 0.1.1
+version: 0.1.2

--- a/plugins/slack/tools.go
+++ b/plugins/slack/tools.go
@@ -20,11 +20,49 @@ import (
 // ListTools (wire surface, JSON string) and manifest.go (YAML node).
 // additionalProperties: false is the library's default for struct reflections.
 
+// blockKitBlocks is a JSON array of Slack Block Kit block objects. It behaves
+// exactly like json.RawMessage at runtime (raw passthrough — the agent sends a
+// JSON array which we hand straight to slack.Blocks.UnmarshalJSON) but it
+// advertises an explicit array-of-objects JSON Schema via JSONSchema().
+//
+// Why a dedicated type: a plain json.RawMessage reflects to a *typeless* schema
+// (no "type" keyword). Provider schema translators that require a concrete
+// "type" on every property — notably Gemini, see internal/llm/google/schema.go
+// — reject that with `property "blocks": schema missing required "type" field`,
+// failing the run before the first LLM call. The items object is intentionally
+// unconstrained ({type:object}) because Block Kit shapes vary widely; the host
+// translator accepts an object with no properties.
+type blockKitBlocks json.RawMessage
+
+func (b blockKitBlocks) MarshalJSON() ([]byte, error) {
+	if len(b) == 0 {
+		return []byte("null"), nil
+	}
+	return b, nil
+}
+
+func (b *blockKitBlocks) UnmarshalJSON(data []byte) error {
+	if b == nil {
+		return errors.New("blockKitBlocks: UnmarshalJSON on nil pointer")
+	}
+	*b = append((*b)[0:0], data...)
+	return nil
+}
+
+func (blockKitBlocks) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:        "array",
+		Items:       &jsonschema.Schema{Type: "object"},
+		Title:       "Blocks",
+		Description: `JSON array of Slack Block Kit block objects, e.g. [{"type":"section","text":{...}}]. Must be a JSON array, not an object. When set, takes precedence over plain text for rendering; text is used as the notification fallback.`,
+	}
+}
+
 type PostMessageParams struct {
-	Channel  string          `json:"channel"            jsonschema:"required,title=Channel,description=Channel ID (C…) or name (#general)"`
-	Text     string          `json:"text,omitempty"     jsonschema:"title=Text,description=Message text. Used as the notification / fallback text when blocks are present\\, or as the message body when blocks are absent."`
-	Blocks   json.RawMessage `json:"blocks,omitempty"   jsonschema:"title=Blocks,description=JSON array of Slack Block Kit block objects\\, e.g. [{\\\"type\\\":\\\"section\\\",\\\"text\\\":{...}}]. Must be a JSON array\\, not an object. When set\\, takes precedence over plain text for rendering; text is used as the notification fallback."`
-	ThreadTS string          `json:"thread_ts,omitempty" jsonschema:"title=Thread TS,description=Optional parent thread timestamp to reply in-thread"`
+	Channel  string         `json:"channel"            jsonschema:"required,title=Channel,description=Channel ID (C…) or name (#general)"`
+	Text     string         `json:"text,omitempty"     jsonschema:"title=Text,description=Message text. Used as the notification / fallback text when blocks are present\\, or as the message body when blocks are absent."`
+	Blocks   blockKitBlocks `json:"blocks,omitempty"`
+	ThreadTS string         `json:"thread_ts,omitempty" jsonschema:"title=Thread TS,description=Optional parent thread timestamp to reply in-thread"`
 }
 
 type ReadThreadParams struct {
@@ -42,10 +80,10 @@ type ReadHistoryParams struct {
 }
 
 type UpdateMessageParams struct {
-	Channel string          `json:"channel"          jsonschema:"required,title=Channel,description=Channel ID containing the message to update"`
-	Ts      string          `json:"ts"               jsonschema:"required,title=Message TS,description=Timestamp of the message to update"`
-	Text    string          `json:"text,omitempty"   jsonschema:"title=Text,description=Message text. Used as the notification / fallback text when blocks are present\\, or as the message body when blocks are absent."`
-	Blocks  json.RawMessage `json:"blocks,omitempty" jsonschema:"title=Blocks,description=JSON array of Slack Block Kit block objects\\, e.g. [{\\\"type\\\":\\\"section\\\",\\\"text\\\":{...}}]. Must be a JSON array\\, not an object. When set\\, takes precedence over plain text for rendering; text is used as the notification fallback."`
+	Channel string         `json:"channel"          jsonschema:"required,title=Channel,description=Channel ID containing the message to update"`
+	Ts      string         `json:"ts"               jsonschema:"required,title=Message TS,description=Timestamp of the message to update"`
+	Text    string         `json:"text,omitempty"   jsonschema:"title=Text,description=Message text. Used as the notification / fallback text when blocks are present\\, or as the message body when blocks are absent."`
+	Blocks  blockKitBlocks `json:"blocks,omitempty"`
 }
 
 type DeleteMessageParams struct {
@@ -347,7 +385,7 @@ func handlePostMessage(ctx context.Context, sc *slack.Client, inputJSON string) 
 		return nil, slack.SlackErrorResponse{Err: "invalid_arguments"}
 	}
 
-	opts, err := msgOptionsFromTextAndBlocks(p.Text, p.Blocks)
+	opts, err := msgOptionsFromTextAndBlocks(p.Text, json.RawMessage(p.Blocks))
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +610,7 @@ func handleUpdateMessage(ctx context.Context, sc *slack.Client, inputJSON string
 		return nil, slack.SlackErrorResponse{Err: "invalid_arguments"}
 	}
 
-	opts, err := msgOptionsFromTextAndBlocks(p.Text, p.Blocks)
+	opts, err := msgOptionsFromTextAndBlocks(p.Text, json.RawMessage(p.Blocks))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Bundle of fixes found while exercising the Slack plugin end-to-end on a Google-backed policy.

## Changes

### `fix(slack)` — `blocks` schema for Gemini
`post_message`/`update_message` typed `blocks` as `json.RawMessage`, which reflects to a **typeless** JSON Schema. Gemini's function-calling translator (`internal/llm/google/schema.go`) requires a `type` on every property and rejected it with `property "blocks": schema missing required "type" field`, failing the run **before the first LLM call**. Anthropic/OpenAI tolerated it, so it only surfaced on Google models.

New `blockKitBlocks` type: identical raw-passthrough runtime behaviour (Marshal/Unmarshal), but advertises `{type: array, items: {type: object}}` via a `JSONSchema()` method. Plugin bumped `0.1.1 → 0.1.2`, manifest regenerated.

### `docs(slack)` — `groups:read` for the channel picker
The searchable channel picker requests private channels (needs `groups:read`, deliberately not in `oauth_defaults`); without it Slack rejects the whole `conversations.list` with `missing_scope` and the dropdown degrades to free-text. Documented the optional scope + fix steps.

### `fix(frontend)` — drop custom audience response buttons
Custom `response_buttons` replace the default Approve/Reject pair. For a **plugin-routed approval gate**, only `option_id` `approve`/`reject` map to a decision — any other id maps to `answered` and can never resolve the approval, silently wedging the run in `waiting_for_approval` (and the in-app Approve/Deny buttons are dead because the gate was routed to the plugin). Removed the editor; Requests now always use Approve/Reject. Custom buttons were only ever valid for feedback requests.

### `feat(frontend)` — Cancel-run button
`POST /runs/{id}/cancel` (operator|admin) had no UI. Added `useCancelRun` + a confirm-gated **Cancel run** button in the run header for in-flight runs — the escape hatch for runs stuck on a plugin-routed gate.

### `fix(frontend)` — OAuth credential input background
The OAuth Client ID / Client Secret inputs had no `className`, rendering with browser-default white instead of `var(--bg-elevated)`; their wrapper referenced a nonexistent `.field` class.

## Verification
- Gemini run granting `post_message` now translates the schema and reaches the LLM (the schema error is gone); it then used a feedback tool and the **Cancel run** button cancelled it cleanly.
- Audience editor no longer renders the response-buttons editor.
- All exercised against the running stack with the rebuilt `0.1.2` plugin (OAuth preserved via accept-manifest + binary respawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)