### PR TITLE
feat: multi-arch (arm64) container images + ARM CI build/test (#674)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,32 @@ jobs:
           path: coverage.out
           retention-days: 30
 
+  # Native arm64 build + test. Runs on GitHub's free arm64 runner so we gate
+  # ARM correctness per-PR rather than discovering breakage at image-publish
+  # time. The build is CGO-free + pure-Go SQLite, so this is a real native run,
+  # not emulation. Mirrors backend-tests but without the coverage upload (that
+  # job remains the canonical coverage source on amd64).
+  backend-tests-arm64:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build
+        run: go build ./...
+        env:
+          GOWORK: off
+
+      - name: Test
+        run: go test -race ./...
+        env:
+          GOWORK: off
+
   frontend-tests:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -259,8 +285,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker image
-        run: docker build -t gleipnir:ci .
+      # QEMU is needed only for the tiny final runtime stage, whose `apk add`
+      # RUN executes as arm64. The heavy Go + frontend builder stages are pinned
+      # to BUILDPLATFORM and cross-compile, so they stay native (no emulation).
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      # Build both target platforms (no push) so a cross-compile regression in
+      # the Dockerfile fails the PR here rather than at publish time.
+      - name: Build Docker image (amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: gleipnir:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Publishes :dev on every merge to main. Bleeding-edge tag — do not pull
   # this in production. :latest is reserved for the release job below.
@@ -270,6 +311,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # QEMU emulates the arm64 runtime stage's `apk add`; the cross-compiled
+      # Go build itself runs natively (see Dockerfile BUILDPLATFORM pins).
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -280,6 +324,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             felagengineering/gleipnir:dev
@@ -297,6 +342,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # QEMU emulates the arm64 runtime stage's `apk add`; the cross-compiled
+      # Go build itself runs natively (see Dockerfile BUILDPLATFORM pins).
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -307,6 +355,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             felagengineering/gleipnir:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Stage 1: Build the React frontend
-FROM node:20-alpine AS frontend-builder
+# Pinned to BUILDPLATFORM so the npm build runs natively on the build host
+# (an amd64 CI runner) rather than under QEMU — its output (frontend/dist) is
+# static JS/CSS and architecture-neutral, so there is nothing to gain from
+# running it on the target arch.
+FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
@@ -7,7 +11,14 @@ COPY frontend/ .
 RUN npm run build
 
 # Stage 2: Build the Go binary
-FROM golang:1.25-alpine AS builder
+# Pinned to BUILDPLATFORM so the Go toolchain itself runs natively on the build
+# host and CROSS-COMPILES to the target arch via GOOS/GOARCH. This is the fast
+# path enabled by CGO_ENABLED=0 + pure-Go SQLite (modernc.org/sqlite): no cgo
+# C-toolchain and no QEMU are needed to produce an arm64 binary on an amd64
+# runner. TARGETOS/TARGETARCH are injected automatically by buildx.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /app
 # plugin-sdk is a sub-module pulled in via a `replace` directive in the root
 # go.mod; its go.mod/go.sum must exist on disk before `go mod download` can
@@ -18,10 +29,12 @@ RUN go mod download
 COPY . .
 # Overwrite frontend/dist with the freshly built assets so go:embed picks them up.
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
-RUN CGO_ENABLED=0 go build -o /gleipnir . && \
-    CGO_ENABLED=0 go build -o /gleipnirctl ./cmd/gleipnirctl
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /gleipnir . && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /gleipnirctl ./cmd/gleipnirctl
 
 # Stage 3: Minimal runtime image
+# NOT pinned to BUILDPLATFORM — this stage resolves to TARGETPLATFORM, so the
+# runtime base matches the target arch and receives the cross-built binary.
 FROM alpine:3.20
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /gleipnir /usr/local/bin/gleipnir

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -19,6 +19,28 @@ docker compose up        # run full stack (Go binary with embedded frontend)
 
 The `Makefile` wraps the common targets: `make build` (`go build ./...`), `make test` (`go test -race ./...`), `make lint` (gofmt check + plugin import boundary + staticcheck), and `make proto` (regenerate gRPC stubs). `make help` lists them all.
 
+### Cross-compiling for arm64
+
+The backend is CGO-free (`CGO_ENABLED=0`) and uses pure-Go SQLite
+(`modernc.org/sqlite`), so there is no C cross-toolchain to set up — building
+for another architecture is just a matter of setting `GOARCH`:
+
+```bash
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o gleipnir-arm64 .
+```
+
+The multi-arch container image is produced the same way: the `Dockerfile`'s
+builder stages are pinned to `--platform=$BUILDPLATFORM` and cross-compile to
+`$TARGETARCH`, so `docker buildx build --platform linux/amd64,linux/arm64`
+builds both variants without emulating the Go toolchain. CI publishes both
+(`docker-push-dev` / `docker-push-release` in `.github/workflows/ci.yml`), and
+the `backend-tests-arm64` job runs the suite natively on an arm64 runner.
+
+**Plugins** are separate compiled Go binaries the host spawns as subprocesses,
+so a plugin's `GOARCH` must match the **host** it will run on. The Slack plugin
+Makefile takes the same `GOARCH` override: `make build GOARCH=arm64` (or the
+`build-arm64` convenience target).
+
 ## Frontend
 
 Run from `frontend/`:

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -7,6 +7,11 @@ Getting from zero to a running Gleipnir instance with its first agent.
 - Docker and Docker Compose v2 (`docker compose version`)
 - `openssl` (available on macOS and most Linux distributions by default)
 
+> **Architectures.** Published images are multi-arch — both `linux/amd64`
+> (Intel/AMD) and `linux/arm64` (Raspberry Pi 4/5, Apple silicon, Ampere/AWS
+> Graviton). Docker and Podman automatically pull the variant matching your
+> host; the commands below are identical on either architecture.
+
 ## Option A: Pre-built image (no clone required)
 
 Create a working directory and add two files:

--- a/plugins/slack/Makefile
+++ b/plugins/slack/Makefile
@@ -1,8 +1,21 @@
-.PHONY: build test manifest validate clean
+.PHONY: build build-arm64 test manifest validate clean
 
-# build compiles the plugin binary.
+# Plugins are compiled Go binaries the host spawns as subprocesses, so the
+# binary's GOARCH must match the HOST arch, not the build machine. Like the
+# main server the plugin is CGO-free, so cross-compiling is a matter of setting
+# GOARCH. Override GOOS/GOARCH to target a different host:
+#   make build GOARCH=arm64        # build for an arm64 host
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+# build compiles the plugin binary for the current (or overridden) GOOS/GOARCH.
 build:
-	go build -o slack .
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o slack .
+
+# build-arm64 is a convenience target for the common cross-build case
+# (e.g. packaging a bundle for a Raspberry Pi / Graviton host from an amd64 box).
+build-arm64:
+	$(MAKE) build GOARCH=arm64
 
 # test runs the unit test suite.
 test:


### PR DESCRIPTION
Closes #674.

## What

Publish **`linux/amd64` + `linux/arm64`** images so homelab operators on Raspberry Pi 4/5, Apple silicon, Ampere, and AWS Graviton can run Gleipnir natively. The build was already arch-portable (`CGO_ENABLED=0` + pure-Go `modernc.org/sqlite`), so this is a CI + Dockerfile-args change — not a port.

## Changes

- **`Dockerfile`** — pin the frontend + Go builder stages to `--platform=$BUILDPLATFORM` and cross-compile via `GOOS`/`GOARCH` from buildx's `TARGETOS`/`TARGETARCH`. The Go toolchain runs natively (no QEMU); only the small runtime stage resolves to `TARGETPLATFORM`.
- **`.github/workflows/ci.yml`**:
  - `platforms: linux/amd64,linux/arm64` added to `docker-push-dev`, `docker-push-release`, and the PR `docker-build` smoke job.
  - `docker/setup-qemu-action` added to those buildx jobs (emulates only the arm64 runtime `apk add`).
  - New `backend-tests-arm64` job on the free `ubuntu-24.04-arm` runner — gates arm64 correctness per-PR, natively.
- **`plugins/slack/Makefile`** — `GOARCH`-aware `build` + a `build-arm64` target. Plugin binaries are spawned as subprocesses, so they must match the **host** arch.
- **Docs** — arm64 note in `docs/user/setup.md`; cross-compile guide in `docs/developer/building.md`.

## Verification (local)

- Cross-compiled `gleipnir`, `gleipnirctl`, and the Slack plugin to ARM aarch64 (statically linked).
- Built a real `docker buildx --platform linux/arm64` image end-to-end (cross-compile + arm64 `apk` under QEMU).
- Booted that arm64 image under QEMU → `/api/v1/health` returns `{"data":{"status":"ok"}}`; image arch confirmed `arm64`.

## Notes

- Multi-arch publish requires the existing `DOCKERHUB_*` secrets (unchanged).
- Per-arch plugin **bundle distribution/signing** is left as a follow-up if it grows; this PR makes the plugin *buildable* per-arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)