### PR TITLE
feat: Podman deployment compatibility + Podman CI smoke test (#675)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,46 @@ jobs:
       - name: Build Docker image
         run: docker build -t gleipnir:ci .
 
+  # Builds and boots the image under Podman (rootless, preinstalled on the
+  # ubuntu runner) so we gate Podman compatibility per-PR and don't silently
+  # regress it. Build + run rather than `podman compose` to avoid depending on
+  # a compose provider being installed on the runner; the compose files
+  # themselves are exercised by Docker jobs and identical in shape.
+  podman-smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Podman version
+        run: podman version
+
+      - name: Build image with Podman
+        run: podman build -t localhost/gleipnir:podman-ci .
+
+      - name: Run and health-check
+        run: |
+          set -euo pipefail
+          podman run -d --name gleipnir \
+            -e GLEIPNIR_ENCRYPTION_KEY="$(openssl rand -hex 32)" \
+            -p 3000:8080 \
+            localhost/gleipnir:podman-ci
+          # Poll the public health endpoint until it responds (or time out).
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3000/api/v1/health; then
+              echo "healthy after ${i} attempt(s)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::gleipnir did not become healthy under Podman"
+          podman logs gleipnir
+          exit 1
+
+      - name: Tear down
+        if: always()
+        run: podman rm -f gleipnir || true
+
   # Publishes :dev on every merge to main. Bleeding-edge tag — do not pull
   # this in production. :latest is reserved for the release job below.
   docker-push-dev:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -15,8 +15,13 @@ services:
       context: .
       dockerfile: Dockerfile
     image: gleipnir:local
-    # host.docker.internal lets the container reach services on the host
-    # (e.g. an LMStudio server bound to 127.0.0.1:1234). Required on Linux
-    # where the alias is not added automatically; harmless on Docker Desktop.
+    # Reach services on the host (e.g. an LMStudio server bound to
+    # 127.0.0.1:1234). `host.docker.internal` is the Docker alias (required on
+    # Linux where it is not added automatically; harmless on Docker Desktop).
+    # `host.containers.internal` is the Podman-native equivalent — Podman
+    # provides it automatically, but declaring it keeps the two stacks symmetric
+    # and lets the same config reach the host under either runtime. The
+    # `host-gateway` magic string is honored by Docker and by Podman 4.7+.
     extra_hosts:
       - "host.docker.internal:host-gateway"
+      - "host.containers.internal:host-gateway"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,8 @@
 
 services:
   api:
-    image: felagengineering/gleipnir:dev
+    # Fully-qualified for Podman short-name resolution (see docker-compose.yml).
+    image: docker.io/felagengineering/gleipnir:dev
 
   mcp-test-server:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   api:
-    image: felagengineering/gleipnir:latest
+    # Fully-qualified registry path (docker.io/…) so Podman resolves it without
+    # a short-name prompt — Podman's default registries.conf does not assume
+    # docker.io the way Docker does. Docker accepts the qualified form too.
+    image: docker.io/felagengineering/gleipnir:latest
     ports:
       - "${GLEIPNIR_PORT:-3000}:8080"
     environment:

--- a/docs/user/podman.md
+++ b/docs/user/podman.md
@@ -1,0 +1,108 @@
+# Running Gleipnir under Podman
+
+Gleipnir runs under [Podman](https://podman.io/) (rootless, daemonless — the
+default container engine on Fedora, RHEL, and CoreOS) as well as Docker. The
+published images are multi-arch (`linux/amd64` + `linux/arm64`), so Podman pulls
+the variant matching your host automatically.
+
+This page covers the few differences from the Docker quickstart in
+[setup.md](setup.md). If you are on Docker, ignore this page.
+
+## Prerequisites
+
+- Podman 4.7 or newer (`podman version`)
+- A Compose provider, if you want to use the compose files:
+  - `podman compose` (Podman's built-in subcommand, shells out to
+    `docker-compose` or `podman-compose` if present), **or**
+  - `podman-compose` (the standalone Python tool: `pip install podman-compose`)
+
+`podman` itself (build/run) needs no extra packages.
+
+## Quickstart (compose)
+
+The compose files in this repo are Podman-compatible as-is. Use the same
+commands as the Docker quickstart, swapping `docker compose` for
+`podman compose`:
+
+```bash
+cp .env.example .env
+# generate and paste the encryption key (see setup.md)
+openssl rand -hex 32
+
+podman compose up -d
+podman compose ps
+```
+
+Then open `http://localhost:3000` and complete the setup wizard exactly as in
+[setup.md](setup.md#complete-the-setup-wizard).
+
+## Quickstart (no compose)
+
+If you'd rather not install a compose provider, run the image directly. Named
+volumes keep your database and installed plugins across restarts:
+
+```bash
+podman volume create gleipnir_data
+podman volume create gleipnir_plugins
+
+podman run -d --name gleipnir \
+  -p 3000:8080 \
+  -e GLEIPNIR_ENCRYPTION_KEY="$(openssl rand -hex 32)" \
+  -v gleipnir_data:/data \
+  -v gleipnir_plugins:/plugins \
+  docker.io/felagengineering/gleipnir:latest
+
+# wait for healthy, then:
+curl -fsS http://localhost:3000/api/v1/health
+```
+
+> Save the encryption key you generate above — losing it makes every stored
+> credential permanently unrecoverable. See
+> [Operations — Backing up the encryption key](operations.md#backing-up-the-encryption-key).
+
+## Podman-specific notes
+
+### Fully-qualified image names
+
+Podman's default `registries.conf` does **not** silently prepend `docker.io/`
+to short image names the way Docker does — an unqualified `felagengineering/...`
+either prompts for a registry or fails with `short-name resolution enforced`.
+The compose files therefore reference the **fully-qualified**
+`docker.io/felagengineering/gleipnir:…`. Use the same qualified path in any
+`podman run`/`podman pull` you write by hand.
+
+### SELinux and bind mounts (Fedora / RHEL)
+
+The default compose stack uses **named volumes** (`gleipnir_data`,
+`gleipnir_plugins`), which Just Work under SELinux. If you instead **bind-mount**
+a host directory — e.g. to drop plugin tarballs from a host folder — add the
+`:z` (shared) or `:Z` (private) SELinux relabel suffix, or the container gets
+`permission denied`:
+
+```yaml
+services:
+  api:
+    volumes:
+      - ./local-plugins:/plugins:z      # :z relabels for container access
+```
+
+`:z` is a harmless no-op on non-SELinux systems, so it's safe to leave in.
+
+### Rootless port mapping
+
+Rootless Podman can only bind host ports **≥ 1024**. The default
+`GLEIPNIR_PORT=3000` is fine. If you set a privileged port (< 1024) you'll need
+`sudo`, rootful Podman, or a `net.ipv4.ip_unprivileged_port_start` sysctl change.
+
+### Reaching host services
+
+To reach a service running on the host (e.g. a local LLM at
+`127.0.0.1:1234`), Podman provides the `host.containers.internal` alias
+automatically. The build overlay (`docker-compose.build.yml`) also declares
+`host.docker.internal` so the same config works under both runtimes.
+
+## CI
+
+The `podman-smoke` job in `.github/workflows/ci.yml` builds the image with
+`podman build` and boots it with `podman run` on every PR, so Podman
+compatibility is gated and won't silently regress.

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -4,8 +4,13 @@ Getting from zero to a running Gleipnir instance with its first agent.
 
 ## Prerequisites
 
-- Docker and Docker Compose v2 (`docker compose version`)
+- Docker and Docker Compose v2 (`docker compose version`) — or Podman 4.7+
+  (see [Running under Podman](podman.md))
 - `openssl` (available on macOS and most Linux distributions by default)
+
+> **Podman users:** the stack runs under Podman too. Follow this page but read
+> [podman.md](podman.md) first for the handful of differences (compose command,
+> fully-qualified image names, SELinux bind-mount labels).
 
 ## Option A: Pre-built image (no clone required)
 
@@ -133,4 +138,5 @@ If the run completes, the stack is working end to end.
 - [Policies](policies.md) — trigger types, capability grants, run states
 - [Roles](roles.md) — add more users with appropriate permissions
 - [Operations](operations.md) — database backups, key management, upgrading
+- [Running under Podman](podman.md) — Podman-specific notes (rootless, SELinux)
 - [Playbooks](../playbooks/) — worked examples for common use cases


### PR DESCRIPTION
Closes #675.

## What

Make the stack run cleanly under **rootless Podman** (the default container engine on Fedora / RHEL / CoreOS) and gate it in CI so it doesn't silently regress. The compose files were ~90% Podman-compatible already; this fixes the real Podman/Linux gotchas.

## Changes

- **Fully-qualified image name** — `docker.io/felagengineering/gleipnir:{latest,dev}` in `docker-compose.yml` / `docker-compose.dev.yml`. Podman's default `registries.conf` does **not** assume `docker.io` for short names (it prompts or errors with `short-name resolution enforced`); Docker still resolves the qualified form (verified against the registry).
- **`docker-compose.build.yml`** — declare `host.containers.internal:host-gateway` (Podman's native host alias) alongside `host.docker.internal` so the same config reaches host services under either runtime.
- **`docs/user/podman.md`** (new) — Podman quickstart (compose + plain `podman run`), short-name resolution, SELinux `:z`/`:Z` bind-mount labels, rootless port-mapping (≥1024), and host networking. Linked from `setup.md`.
- **`.github/workflows/ci.yml`** — new `podman-smoke` job: `podman build` + `podman run` + poll `/api/v1/health` on every PR. Build+run (not `podman compose`) to avoid depending on a compose provider on the runner.

## Why no `:z` edits to tracked compose files

The tracked stack uses **named volumes** (`gleipnir_data`, `gleipnir_plugins`), which work under SELinux without relabeling. `:z` only matters for **bind mounts**, which appear only in local/dev overlays — so it's documented in `podman.md` with a copy-pasteable example rather than baked into the base stack.

## Verification

- All compose files + the workflow pass YAML validation; `docker compose config` resolves the qualified image.
- `docker manifest inspect docker.io/felagengineering/gleipnir:latest` resolves — existing Docker users are unaffected.
- Podman build/run is exercised by the new CI job (Podman isn't installed on the local dev box, so the end-to-end Podman run is validated in CI).

## Relationship to #674

Independent of the ARM PR (#676). Together they let a Raspberry Pi / Graviton operator running Podman deploy Gleipnir natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)