### PR TITLE
fix: deterministic TestAcquire_BlocksWhilePaused_WakesOnNewGeneration (#678)

### DIFF
--- a/internal/plugin/generation/controller.go
+++ b/internal/plugin/generation/controller.go
@@ -97,6 +97,15 @@ func newGenState() *genState {
 type Controller struct {
 	mu         sync.Mutex
 	byInstance map[string]*genState
+
+	// afterPauseHook, if non-nil, is invoked by BeginDrain the moment an instance
+	// is committed to the paused state. It is a test-only synchronisation seam,
+	// always nil in production, and set exactly once before any BeginDrain via
+	// SetAfterPauseHookForTest (export_test.go) — so the go-statement that launches
+	// the drain establishes happens-before and no lock is needed. It exists because
+	// BeginDrain does not return until *after* it un-pauses, leaving a test no
+	// public signal for the mid-drain paused window (issue #678).
+	afterPauseHook func(instanceID string)
 }
 
 // New returns a Controller with no registered instances.
@@ -327,6 +336,14 @@ func (c *Controller) BeginDrain(ctx context.Context, instanceID string, grace ti
 		waitCh = ch
 	}
 	s.mu.Unlock()
+
+	// Test-only synchronisation seam (nil in production): paused is now committed,
+	// so a test can deterministically know the blocked-Acquire window is open
+	// before it issues the racing Acquire. Fired outside s.mu so the hook cannot
+	// re-enter the lock. See Controller.afterPauseHook / issue #678.
+	if c.afterPauseHook != nil {
+		c.afterPauseHook(instanceID)
+	}
 
 	// --- Step 2: wait up to grace for in-flight calls to drain ---
 	drainedNaturally := false

--- a/internal/plugin/generation/controller_test.go
+++ b/internal/plugin/generation/controller_test.go
@@ -74,44 +74,51 @@ func TestAcquire_IncrementsRefcountAndReleaseDecrements(t *testing.T) {
 // arriving during a drain pause waits until BeginDrain completes and then
 // succeeds under the new generation.
 //
-// Synchronisation: we hold a refcount slot throughout, which guarantees
-// BeginDrain cannot return until we release it. Therefore any goroutine started
-// after BeginDrain is launched and while the refcount is held will find the
-// instance paused and block in Acquire — no sleep needed.
+// Synchronisation: BeginDrain commits paused=true internally and then blocks
+// until the drain completes, so there is no public signal for the mid-drain
+// paused window. We use the afterPauseHook test seam (issue #678) to block until
+// paused is committed before issuing the racing Acquire. That makes the
+// blocked-Acquire path deterministic — the second Acquire can never observe the
+// old generation (the earlier version closed a channel BEFORE calling BeginDrain
+// and so depended on goroutine start order, which occasionally returned gen 1).
 func TestAcquire_BlocksWhilePaused_WakesOnNewGeneration(t *testing.T) {
 	c := generation.New()
 	c.RegisterInstance("inst-d")
 
 	ctx := context.Background()
 
-	// Acquire a slot that will hold BeginDrain open.
+	// Acquire a slot that holds BeginDrain open: a non-zero refcount forces
+	// BeginDrain to park in its drain wait until we release this slot.
 	_, held, _, err := c.Acquire(ctx, "inst-d")
 	if err != nil {
 		t.Fatalf("Acquire (held): %v", err)
 	}
 
-	drainStarted := make(chan struct{})
+	// paused closes the instant BeginDrain commits paused=true for inst-d. The
+	// hook is per-controller, so it is set before the drain goroutine launches
+	// (establishing happens-before) and needs no restore.
+	paused := make(chan struct{})
+	c.SetAfterPauseHookForTest(func(instanceID string) {
+		if instanceID == "inst-d" {
+			close(paused)
+		}
+	})
+
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		// Signal just before blocking on the drain channel so the test knows
-		// BeginDrain has set paused=true and is waiting for the refcount to drop.
-		close(drainStarted)
 		_, _, _ = c.BeginDrain(ctx, "inst-d", time.Second)
 	}()
 
-	// Wait until BeginDrain has started (and thus set paused=true). Because we
-	// still hold the refcount, BeginDrain cannot return — the instance is
-	// guaranteed to be in the paused state when the next Acquire goroutine runs.
+	// Block until paused is committed. After this point any Acquire is guaranteed
+	// to find the instance paused (and the generation cannot rotate to 2 without
+	// first clearing paused), so the racing Acquire below can never see gen 1.
 	select {
-	case <-drainStarted:
+	case <-paused:
 	case <-time.After(5 * time.Second):
-		t.Fatal("BeginDrain goroutine did not start")
+		t.Fatal("BeginDrain did not reach the paused state")
 	}
 
-	// A new Acquire must block while paused. The drain goroutine above holds the
-	// lock only briefly (to set paused=true) and then releases it before waiting
-	// on the drain channel, so this Acquire call will enter the select and block.
 	acquireResult := make(chan uint64, 1)
 	go func() {
 		_, rel, gen, err := c.Acquire(ctx, "inst-d")
@@ -123,8 +130,8 @@ func TestAcquire_BlocksWhilePaused_WakesOnNewGeneration(t *testing.T) {
 		acquireResult <- gen
 	}()
 
-	// Release the held slot so BeginDrain can complete and unblock the waiting
-	// Acquire goroutine.
+	// Release the held slot so BeginDrain can complete and rotate the generation,
+	// waking the blocked Acquire.
 	held()
 
 	select {

--- a/internal/plugin/generation/export_test.go
+++ b/internal/plugin/generation/export_test.go
@@ -1,0 +1,14 @@
+package generation
+
+// SetAfterPauseHookForTest installs fn as the post-pause synchronisation hook
+// invoked by BeginDrain once an instance is committed to the paused state. It is
+// the test-only seam that lets the external generation_test package observe the
+// mid-drain paused window deterministically (issue #678).
+//
+// The hook lives on the Controller (not a package global), so each test's own
+// controller is isolated — there is nothing to restore and no cross-test leak.
+// Call this before issuing any BeginDrain on the controller; the launching
+// go-statement then establishes happens-before for BeginDrain's read.
+func (c *Controller) SetAfterPauseHookForTest(fn func(instanceID string)) {
+	c.afterPauseHook = fn
+}


### PR DESCRIPTION
Closes #678.

## Problem

`TestAcquire_BlocksWhilePaused_WakesOnNewGeneration` flakes on the amd64 `backend-tests` job (`controller_test.go: blocked Acquire returned gen 1, want 2`). Observed on two unrelated PRs (#676, #677) in the same week; the identical suite passed on the `backend-tests-arm64` runner in those runs, and it passes locally — a load-sensitive scheduling flake, not a product bug.

## Root cause

The test depended on goroutine **start order**, which Go does not guarantee (a "signal-don't-poll" violation per CLAUDE.md):

```go
go func() {
    close(drainStarted)          // closed BEFORE BeginDrain runs
    c.BeginDrain(...)
}()
<-drainStarted                   // proves nothing about paused state
```

`BeginDrain` commits `paused=true` internally and then blocks until the drain completes — it never returns until *after* it un-pauses, so there is no public signal for the mid-drain paused window. The second `Acquire` could therefore run while `paused` was still `false` and acquire under the old generation.

## Fix

A minimal **per-`Controller`** test-only synchronisation seam (the export-hook pattern CLAUDE.md prescribes):

- `controller.go`: `Controller.afterPauseHook` (nil in production), invoked by `BeginDrain` the instant `paused` is committed. One nil-check on the rare hot-reload path; no production behaviour change.
- `export_test.go`: `(*Controller).SetAfterPauseHookForTest(fn)`.
- The test blocks on the hook before issuing the racing `Acquire`, so it always observes `paused=true` first → gen 1 is structurally impossible. No sleeps, no start-order assumptions.

The hook lives on the `Controller`, not a package global, so each test is isolated (an earlier package-global draft tripped `-race` because another test's `BeginDrain` goroutine read the global concurrently). Set before the drain goroutine launches, so the go-statement establishes happens-before — no lock needed.

## Verification

- `go test -race -count=500` on the target test → green.
- `go test -race -count=50` over the whole `generation` package → green (no data race).
- `go vet`, `gofmt -s`, and full-module `go build` clean.

## Why this is its own PR

The flake is pre-existing on `main` and blocks both #676 (ARM) and #677 (Podman). Merging this first lets those two go reliably green. Recommend merging this ahead of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)