### PR TITLE
fix: loosen TestAuditWriter_PerformanceBaseline wall-clock bound for arm64 (#680)

### DIFF
--- a/internal/execution/agent/audit_test.go
+++ b/internal/execution/agent/audit_test.go
@@ -424,8 +424,16 @@ func BenchmarkAuditWriter_SequentialEnqueue(b *testing.B) {
 }
 
 func TestAuditWriter_PerformanceBaseline(t *testing.T) {
-	// Asserts that 1000 sequential enqueues complete within 10s.
-	// Threshold is generous to avoid flaking on slow CI runners.
+	// Catastrophic-regression smoke: 1000 sequential enqueues must not take
+	// pathologically long (e.g. a per-write fsync or accidental O(n²) would push
+	// this into minutes). It is NOT a precise perf gate — an absolute wall-clock
+	// bound is inherently hardware-sensitive (CLAUDE.md: time-dependent tests),
+	// so the threshold is deliberately generous. GitHub's free ubuntu-24.04-arm
+	// runner has slow/contended disk I/O and legitimately lands around ~14s with
+	// no regression; the bound sits well above that so normal variance across
+	// amd64/arm64 runners cannot flake it while a true blow-up still trips it.
+	// See issue #680.
+	const maxElapsed = 60 * time.Second
 	s := testutil.NewTestStore(t)
 	testutil.InsertPolicy(t, s, "p1", "policy-p1", "webhook", "{}")
 	testutil.InsertRun(t, s, "r1", "p1", model.RunStatusRunning)
@@ -447,7 +455,7 @@ func TestAuditWriter_PerformanceBaseline(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	if elapsed > 10*time.Second {
-		t.Errorf("1000 sequential enqueues took %v, want < 10s", elapsed)
+	if elapsed > maxElapsed {
+		t.Errorf("1000 sequential enqueues took %v, want < %v", elapsed, maxElapsed)
 	}
 }


### PR DESCRIPTION
Closes #680.

## Problem

`TestAuditWriter_PerformanceBaseline` fails on the `backend-tests-arm64` job:

```
audit_test.go:451: 1000 sequential enqueues took 13.98s, want < 10s
```

It passes on amd64. The native arm64 job (added in #674/#676) runs on GitHub's free `ubuntu-24.04-arm` runner, whose slower/contended disk I/O legitimately takes ~14s for 1000 sequential SQLite enqueues — no regression. The test asserted an **absolute wall-clock bound**, which is inherently hardware-sensitive (CLAUDE.md flags time-dependent tests).

## Fix

Raise the threshold to a generous **60s** (named `maxElapsed`) and document why. The test stays a catastrophic-regression smoke — a per-write fsync or accidental O(n²) would push 1000 enqueues into the minutes and still trip it — while normal variance across amd64/arm64 runners can no longer flake it.

## Verification

- Passes locally (~2.4s) and reasoned to clear the slowest observed arm64 run (~14s) with wide margin.
- `go vet` + `gofmt -s` clean.

## Context

Second environment-sensitivity fix exposed by the new arm64 CI job (after #678/#679). Recommend merging before re-running #677 (Podman), whose merged arm64 job hit this.