### PR TITLE
fix: remove flaky absolute wall-clock bounds from backend tests

### DIFF
--- a/internal/execution/run/stress_test.go
+++ b/internal/execution/run/stress_test.go
@@ -53,7 +53,13 @@ func TestListSteps_10kStress(t *testing.T) {
 	h := run.NewRunsHandler(store, run.NewRunManager(), nil)
 	router := newRunsRouter(h)
 
-	// First-page latency check: the default limit of 500 must respond in < 500ms.
+	// First-page latency check. This is a catastrophic-regression smoke (e.g. a
+	// missing index turning pagination into a full-table scan), NOT a precise
+	// perf gate — an absolute wall-clock bound is hardware-sensitive (CLAUDE.md:
+	// time-dependent tests) and this test runs under `-race` in CI, which slows
+	// execution several-fold. The threshold is deliberately generous so loaded
+	// amd64/arm64 runners cannot flake it while a true blow-up still trips it.
+	const firstPageMax = 5 * time.Second
 	firstPageStart := time.Now()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/r-stress/steps", nil)
 	w := httptest.NewRecorder()
@@ -63,8 +69,8 @@ func TestListSteps_10kStress(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("first page: status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
-	if elapsed > 500*time.Millisecond {
-		t.Errorf("first page took %s, want < 500ms", elapsed)
+	if elapsed > firstPageMax {
+		t.Errorf("first page took %s, want < %s", elapsed, firstPageMax)
 	}
 
 	// Walk every page and assert ordering + total count.
@@ -109,8 +115,12 @@ func TestListSteps_10kStress(t *testing.T) {
 		t.Errorf("total steps walked = %d, want %d", seenTotal, totalSteps)
 	}
 
+	// Generous catastrophic-regression bound (see firstPageMax above): walking
+	// 20 pages of 500 rows under `-race` on a loaded CI runner must stay well
+	// under this, while a pathological regression (O(n²) paging) would exceed it.
+	const fullWalkMax = 60 * time.Second
 	walkElapsed := time.Since(walkStart)
-	if walkElapsed > 5*time.Second {
-		t.Errorf("full walk took %s, want < 5s", walkElapsed)
+	if walkElapsed > fullWalkMax {
+		t.Errorf("full walk took %s, want < %s", walkElapsed, fullWalkMax)
 	}
 }

--- a/internal/plugin/dispatch/channel_test.go
+++ b/internal/plugin/dispatch/channel_test.go
@@ -256,9 +256,14 @@ func TestNotify_ParallelFanOut(t *testing.T) {
 	}
 	invokedMu.Unlock()
 
-	// Wall clock must be well under NotifyTimeout * 1.5 (parallel, not serial).
-	if elapsed > 750*time.Millisecond {
-		t.Errorf("Notify took %v, want < 750ms (serial execution suspected)", elapsed)
+	// Sanity ceiling that the fan-out is parallel, not serial. The bound is
+	// deliberately generous: an absolute wall-clock assertion is hardware- and
+	// load-sensitive (CLAUDE.md: time-dependent tests) and this runs under
+	// `-race` in CI. Serial execution of the blocking/slow paths would dwarf
+	// this, so the ceiling still catches a regression to serial dispatch while
+	// normal runner variance cannot flake it.
+	if elapsed > 3*time.Second {
+		t.Errorf("Notify took %v, want < 3s (serial execution suspected)", elapsed)
 	}
 }
 
@@ -323,8 +328,13 @@ func TestNotify_DeadlineUpperBound(t *testing.T) {
 		t.Fatalf("Notify returned error: %v", err)
 	}
 
-	// Notify returns nil regardless of failures.
-	slack := 100 * time.Millisecond
+	// Notify returns nil regardless of failures. We only assert that the blocking
+	// client did not make Notify hang unbounded — i.e. the deadline IS enforced.
+	// The slack is deliberately large: the precise cancellation latency is
+	// hardware/load-sensitive (CLAUDE.md: time-dependent tests) and this runs
+	// under `-race`. A generous ceiling still proves boundedness (returns vs.
+	// hangs) without flaking on a loaded runner.
+	slack := 2 * time.Second
 	if elapsed > notifyTimeout+slack {
 		t.Errorf("Notify took %v, want < %v (deadline not enforced)", elapsed, notifyTimeout+slack)
 	}


### PR DESCRIPTION
## Why

We kept having to re-run CI on transient backend-test failures. This is the output of a suite-wide flaky-test audit.

**Method:** empirical + static.
- **Empirical (the arbiter):** `go test -race -count=8 -shuffle=on ./...` across all **52 backend packages** → **52/52 clean, zero data races, zero order-dependence, zero panics**.
- **Static:** three focused agents swept for timing, concurrency/shared-state, and external-dep/non-determinism anti-patterns; every candidate was then verified against the code and the `-race` result.

**Conclusion:** the *only* genuine intermittent-failure risks are absolute wall-clock **upper-bound** assertions — the same class that already flaked twice (#680 audit baseline; and again on the slower arm64 runner). They fail on loaded/slow CI runners — especially under `-race`, which slows execution several-fold — with no real regression. CLAUDE.md explicitly warns against time-dependent assertions.

## Changes

Loosen the three remaining absolute upper bounds to generous catastrophic-regression ceilings (a true blow-up still trips them; normal amd64/arm64 + `-race` variance cannot):

| Test | File | Before | After |
|---|---|---|---|
| `TestListSteps_10kStress` (first page) | `execution/run/stress_test.go` | `< 500ms` | `< 5s` |
| `TestListSteps_10kStress` (10k walk) | ″ | `< 5s` | `< 60s` |
| `TestNotify_DeadlineUpperBound` | `plugin/dispatch/channel_test.go` | timeout + 100ms slack | timeout + 2s slack |
| `TestNotify_FanoutPartialFailures` | ″ | `< 750ms` | `< 3s` |

(The `audit_test.go` bound was already fixed in #680/#681.)

## Verified false positives (left unchanged, on purpose)

The static agents flagged many more; each was checked and is **not** a flake:
- `manager_test.go` approval-delivery `time.Sleep` "yields" — deterministic: the approval channel is **cap-1 buffered**, so `SendApproval` succeeds regardless of goroutine scheduling.
- `manager_test.go` multi-waiter `Deregister` — `WaitForDeregistration` returns `true` for late registrants (run already gone), so every interleaving passes.
- `results`-slice / cancel-map reads — happens-before-ordered by `wg.Wait()` / blocking wait; `-race` confirms no race across 8 shuffled runs.
- `supervisor_test.go` 30ms sleeps — both scheduling outcomes still satisfy the 5s exit assertion (scenario-coverage, not pass/fail).
- poll/scheduler `waitForRuns`/`waitFor` helpers — the *correct* poll-with-generous-deadline pattern.
- negative-window checks (`pool:1306`, `scheduled:680`) — fail only on a real bug (gated work can't complete early).

## Verification

- Affected packages pass `go test -race -count=3` (execution/run, plugin/dispatch).
- `go vet` + `gofmt -s` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)