### PR TITLE
fix: evict stale dispatch conn on plugin instance deactivate/activate

### DIFF
--- a/internal/admin/instance_lifecycle.go
+++ b/internal/admin/instance_lifecycle.go
@@ -142,6 +142,7 @@ type InstanceLifecycleDeps struct {
 	ProcMgr    PluginProcessManager
 	Trigger    TriggerRestarter
 	Inflight   InflightCounter
+	Evictor    ToolConnEvictor
 	Unreg      ToolUnregistrar
 	PluginsDir string
 }
@@ -161,6 +162,7 @@ type InstanceLifecycle struct {
 	procMgr    PluginProcessManager
 	trigger    TriggerRestarter
 	inflight   InflightCounter
+	evictor    ToolConnEvictor
 	unreg      ToolUnregistrar
 	pluginsDir string
 }
@@ -180,6 +182,7 @@ func NewInstanceLifecycle(deps InstanceLifecycleDeps) *InstanceLifecycle {
 		procMgr:    deps.ProcMgr,
 		trigger:    deps.Trigger,
 		inflight:   deps.Inflight,
+		evictor:    deps.Evictor,
 		unreg:      deps.Unreg,
 		pluginsDir: deps.PluginsDir,
 	}
@@ -277,6 +280,15 @@ func (m *InstanceLifecycle) Deactivate(ctx context.Context, pluginID, instanceID
 		m.trigger.Stop(instanceID)
 	}
 
+	// Evict the cached tool-dispatch connection. procMgr.Stop closed the
+	// subprocess UDS above, so the Pool's cached *grpc.ClientConn is now dead;
+	// leaving it cached would make every tool call after reactivation fail with
+	// "grpc: the client connection is closing" (the conn is re-dialed only on a
+	// cache miss). The Pool keys by instance NAME. Best-effort, nil-safe.
+	if m.evictor != nil {
+		m.evictor.EvictInstance(inst.InstanceName)
+	}
+
 	nowStr := m.clock().UTC().Format(time.RFC3339Nano)
 	m.writeAuditEvent(ctx, auditInstanceDeactivated, "info", nowStr, map[string]any{
 		"plugin_id":     pluginID,
@@ -337,6 +349,14 @@ func (m *InstanceLifecycle) Activate(ctx context.Context, pluginID, instanceID s
 	// Best-effort trigger stream start.
 	if m.trigger != nil {
 		m.trigger.Start(ctx, instanceID)
+	}
+
+	// Defensive backstop: evict any lingering cached tool-dispatch connection so
+	// the first Call after reactivation re-dials the freshly-spawned subprocess.
+	// Deactivate already evicts, but this guards any path that respawns an
+	// instance without a preceding Deactivate. Best-effort, nil-safe.
+	if m.evictor != nil {
+		m.evictor.EvictInstance(inst.InstanceName)
 	}
 
 	nowStr := m.clock().UTC().Format(time.RFC3339Nano)

--- a/internal/admin/instance_lifecycle_test.go
+++ b/internal/admin/instance_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,6 +44,23 @@ func withPluginsDir(dir string) func(*InstanceLifecycleDeps) {
 
 func withUnreg(u ToolUnregistrar) func(*InstanceLifecycleDeps) {
 	return func(d *InstanceLifecycleDeps) { d.Unreg = u }
+}
+
+func withEvictor(e ToolConnEvictor) func(*InstanceLifecycleDeps) {
+	return func(d *InstanceLifecycleDeps) { d.Evictor = e }
+}
+
+// fakeEvictor records the instance names passed to EvictInstance so tests can
+// assert the deactivate/activate lifecycle drops the stale tool-dispatch conn.
+type fakeEvictor struct {
+	mu      sync.Mutex
+	evicted []string
+}
+
+func (f *fakeEvictor) EvictInstance(instanceName string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.evicted = append(f.evicted, instanceName)
 }
 
 // ─── Deactivate ──────────────────────────────────────────────────────────────
@@ -142,10 +160,12 @@ func TestInstanceLifecycle_Deactivate(t *testing.T) {
 
 		pm := &fakeProcessManager{}
 		restarter := &fakeTriggerRestarter{}
+		ev := &fakeEvictor{}
 		m := newTestLifecycle(q, nil,
 			withProcMgr(pm),
 			withTrigger(restarter),
 			withInflight(&fakeInflightCounter{counts: map[string]int{"prod": 0}}),
+			withEvictor(ev),
 		)
 
 		inst, err := m.Deactivate(ctx, "plugin-1", "inst-1")
@@ -161,6 +181,14 @@ func TestInstanceLifecycle_Deactivate(t *testing.T) {
 		pm.mu.Unlock()
 		if len(stopped) != 1 || stopped[0] != "inst-1" {
 			t.Errorf("Stop called with %v, want [inst-1]", stopped)
+		}
+		// The stale tool-dispatch connection must be evicted by instance NAME so a
+		// later reactivation re-dials the fresh subprocess (deactivate→activate bug).
+		ev.mu.Lock()
+		evicted := ev.evicted
+		ev.mu.Unlock()
+		if len(evicted) != 1 || evicted[0] != "prod" {
+			t.Errorf("EvictInstance called with %v, want [prod]", evicted)
 		}
 	})
 

--- a/internal/admin/plugin_handler.go
+++ b/internal/admin/plugin_handler.go
@@ -166,6 +166,16 @@ type InflightCounter interface {
 	InflightCountByInstance(instanceName string) int
 }
 
+// ToolConnEvictor closes and removes the cached tool-dispatch connection for a
+// named plugin instance. Implemented by *dispatch.Pool; kept as a narrow
+// interface here so the admin package does not import internal/plugin/dispatch
+// (mirrors InflightCounter). Called by Deactivate/Activate so a
+// stopped-then-respawned subprocess does not keep serving tool calls over the
+// dead connection cached from its prior generation. A nil evictor is a safe no-op.
+type ToolConnEvictor interface {
+	EvictInstance(instanceName string)
+}
+
 // RSSSample holds one RSS reading for a single plugin instance. Defined with
 // primitive types only so the admin package does not import
 // internal/plugin/process — the adapter in main.go converts between the two.

--- a/internal/plugin/dispatch/pool.go
+++ b/internal/plugin/dispatch/pool.go
@@ -479,6 +479,34 @@ func (p *Pool) CancelRun(runID string) {
 	}
 }
 
+// EvictInstance closes and removes the cached connection for the named instance,
+// if one exists. The next Call to that instance re-dials via ConnFactory.
+//
+// Called by the admin deactivate/activate lifecycle. Stopping a subprocess closes
+// its UDS, but the Pool caches a *grpc.ClientConn per instance and only re-dials
+// on a cache miss — so a stopped-then-respawned instance would keep serving tool
+// calls over the dead connection, failing every call with
+// "grpc: the client connection is closing". Evicting on deactivate forces a fresh
+// dial when the instance is reactivated under a new subprocess/socket.
+//
+// A no-op when nothing is cached. closeOnce guards against a concurrent CancelRun
+// goroutine that may already be force-closing the same connection.
+func (p *Pool) EvictInstance(instanceName string) {
+	p.instancesMu.Lock()
+	defer p.instancesMu.Unlock()
+	st, ok := p.instances[instanceName]
+	if !ok {
+		return
+	}
+	st.closeOnce.Do(func() {
+		if err := st.conn.Close(); err != nil {
+			slog.Warn("plugin conn.Close during evict",
+				"instance", instanceName, "err", err)
+		}
+	})
+	delete(p.instances, instanceName)
+}
+
 // Close cancels all in-flight runs (best-effort) and closes all connections.
 // Used during host shutdown.
 func (p *Pool) Close() error {

--- a/internal/plugin/dispatch/pool_test.go
+++ b/internal/plugin/dispatch/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -152,6 +153,60 @@ func TestPool_HappyPath(t *testing.T) {
 	if output != `{"echoed":"hello"}` {
 		t.Errorf("output = %q; want %q", output, `{"echoed":"hello"}`)
 	}
+}
+
+// TestPool_EvictInstance_ForcesRedial verifies that EvictInstance drops the
+// cached connection so the next Call re-dials via ConnFactory. This is the fix
+// for the deactivate→activate bug: a stopped-then-respawned subprocess must not
+// keep serving calls over the dead connection cached from its prior generation.
+func TestPool_EvictInstance_ForcesRedial(t *testing.T) {
+	srv := &fakeToolServer{
+		callHook: func(_ context.Context, _ *toolv1.CallRequest) (*toolv1.CallResponse, error) {
+			return &toolv1.CallResponse{OutputJson: `"ok"`}, nil
+		},
+	}
+	// Wrap the bufconn factory with a dial counter.
+	inner, srvCleanup := bufconnDialer(t, srv)
+	var dials atomic.Int64
+	counting := func(name string) (*grpc.ClientConn, error) {
+		dials.Add(1)
+		return inner(name)
+	}
+	pool := dispatch.New(dispatch.Config{
+		CallTimeout:          500 * time.Millisecond,
+		CancelTimeout:        150 * time.Millisecond,
+		DefaultMaxConcurrent: 10,
+		DefaultMaxQueueDepth: 10,
+		Connect:              counting,
+	})
+	defer func() {
+		pool.Close() //nolint:errcheck
+		srvCleanup()
+	}()
+
+	// First call dials once and caches the connection.
+	if _, _, err := pool.Call(context.Background(), "run-1", "pol-1", "inst", "echo", `{}`); err != nil {
+		t.Fatalf("first Call: %v", err)
+	}
+	// Second call to the same instance reuses the cached connection (no re-dial).
+	if _, _, err := pool.Call(context.Background(), "run-2", "pol-1", "inst", "echo", `{}`); err != nil {
+		t.Fatalf("second Call: %v", err)
+	}
+	if got := dials.Load(); got != 1 {
+		t.Fatalf("dials after two cached calls = %d; want 1", got)
+	}
+
+	// Evict, then the next call must re-dial.
+	pool.EvictInstance("inst")
+	if _, _, err := pool.Call(context.Background(), "run-3", "pol-1", "inst", "echo", `{}`); err != nil {
+		t.Fatalf("Call after evict: %v", err)
+	}
+	if got := dials.Load(); got != 2 {
+		t.Errorf("dials after evict+call = %d; want 2 (re-dial)", got)
+	}
+
+	// Evicting an unknown instance is a safe no-op.
+	pool.EvictInstance("does-not-exist")
 }
 
 // TestPool_ErrorEnvelope verifies that a plugin-side ErrorEnvelope is returned

--- a/main.go
+++ b/main.go
@@ -351,6 +351,7 @@ func run(cfg config.Config) error {
 		pluginProcMgr    admin.PluginProcessManager
 		pluginTrigger    admin.TriggerRestarter
 		pluginInflight   admin.InflightCounter
+		pluginEvictor    admin.ToolConnEvictor
 		pluginPluginsDir string
 		pluginInstaller  admin.PluginInstaller
 		pluginRSSAgg     admin.RSSAggregator
@@ -364,6 +365,7 @@ func run(cfg config.Config) error {
 			pluginProcMgr = mgr
 			pluginPluginsDir = cfg.PluginsDir
 			pluginInflight = rt.Pool
+			pluginEvictor = rt.Pool
 		}
 	}
 	if mgr := rt.Manager(); mgr != nil {
@@ -379,6 +381,7 @@ func run(cfg config.Config) error {
 		ProcMgr:    pluginProcMgr,
 		Trigger:    pluginTrigger,
 		Inflight:   pluginInflight,
+		Evictor:    pluginEvictor,
 		PluginsDir: pluginPluginsDir,
 		Unreg:      rt.ToolRegistrar,
 	})


### PR DESCRIPTION
## Problem

Found during the 1.1.0 release smoke test. After an admin **deactivates then reactivates** a plugin instance (#243 lifecycle), every ToolService tool call to that instance fails until the host is restarted:

- Agent-facing error: `plugin "<name>" is unavailable`
- Raw: `rpc error: code = Canceled desc = grpc: the client connection is closing`

The instance still shows **Healthy** and the trigger (Socket Mode) + channel (Request) paths reconnect fine, so the break is silent. With an **approval-gated** tool it's worse: each failed retry re-fires the approval gate, spamming the operator with duplicate approval requests.

## Root cause

`internal/plugin/dispatch/pool.go` caches a `*grpc.ClientConn` per instance in `p.instances` and only re-dials on a cache miss. It's evicted **only** on a cancel-timeout force-close or `Pool.Close()`. The `InstanceLifecycle.Deactivate`/`Activate` methods stop/spawn the subprocess and trigger stream but **never touch the Pool** — so after `Deactivate` closes the subprocess UDS, the dead conn stays cached and `Activate` reuses it.

## Fix

- Add `Pool.EvictInstance(name)` — closes the cached conn (guarded by `closeOnce`, mirroring the `CancelRun` force-disconnect path) and deletes the map entry so the next `Call` re-dials via `ConnFactory`.
- Wire it through a narrow `admin.ToolConnEvictor` interface (mirrors `InflightCounter`, keeps the `admin` → `dispatch` package boundary) to `rt.Pool` in `main.go`.
- Call it from `InstanceLifecycle.Deactivate` (primary, right after `procMgr.Stop`/`trigger.Stop`) and `Activate` (defensive backstop for any respawn path).

## Tests

- `TestPool_EvictInstance_ForcesRedial` — wraps the ConnFactory with a dial counter; asserts two cached calls dial once, and a call after `EvictInstance` re-dials (and that evicting an unknown instance is a no-op).
- Lifecycle success test asserts `Deactivate` calls the evictor with the instance **name**.
- Full `go test -race ./...` green (52 packages).

## Manual verification

Rebuilt the image, redeployed, and reproduced the exact failing sequence against a live Slack plugin instance: **deactivate → activate → `post_message`** now returns `is_error:false` with a real Slack `ts` (was `"unavailable"` before). Zero "unavailable"/"connection closing" errors post-fix.

## Follow-up (not in this PR)

Hot-reload generation rotation (`process.Manager.ReloadInstance`) is the **same bug class** — it replaces the subprocess but likely doesn't evict the Pool conn either. Worth verifying before relying on hot-reload tool continuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)