### PR TITLE
fix: Database Size counts WAL/SHM sidecars in WAL mode (#614)

### DIFF
--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -659,15 +659,26 @@ func formatUptime(d time.Duration) string {
 	return fmt.Sprintf("%dm", minutes)
 }
 
+// statSize returns the size in bytes of the file at path, or 0 if it does
+// not exist or cannot be stat'd.
+func statSize(path string) int64 {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
 func formatDBSize(path string) string {
 	if path == "" {
 		return "unknown"
 	}
-	fi, err := os.Stat(path)
-	if err != nil {
+	if _, err := os.Stat(path); err != nil {
 		return "unknown"
 	}
-	size := fi.Size()
+	// SQLite runs in WAL mode (ADR-003): committed data can live in the
+	// -wal sidecar until checkpoint, so the main file alone under-reports.
+	size := statSize(path) + statSize(path+"-wal") + statSize(path+"-shm")
 	switch {
 	case size >= 1<<30:
 		return fmt.Sprintf("%.1f GB", float64(size)/float64(1<<30))

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1063,5 +1065,72 @@ func TestFormatUptime(t *testing.T) {
 				t.Errorf("formatUptime(%dm) = %q, want %q", tt.minutes, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFormatDBSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		mainBytes int // -1 means don't create the main .db file
+		walBytes  int // -1 means don't create the -wal file
+		shmBytes  int // -1 means don't create the -shm file
+		expected  string
+	}{
+		{
+			name:      "main plus wal plus shm summed",
+			mainBytes: 1024,
+			walBytes:  1024 * 1023, // total 1024*1024 = 1 MB
+			shmBytes:  0,
+			expected:  "1.0 MB",
+		},
+		{
+			name:      "only main file present",
+			mainBytes: 512,
+			walBytes:  -1,
+			shmBytes:  -1,
+			expected:  "512 B",
+		},
+		{
+			name:      "missing sidecars treated as zero",
+			mainBytes: 2048,
+			walBytes:  -1,
+			shmBytes:  -1,
+			expected:  "2.0 KB",
+		},
+		{
+			name:      "main file missing reports unknown",
+			mainBytes: -1,
+			walBytes:  1024,
+			shmBytes:  -1,
+			expected:  "unknown",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "gleipnir.db")
+
+			if tt.mainBytes >= 0 {
+				writeSizedFile(t, path, tt.mainBytes)
+			}
+			if tt.walBytes >= 0 {
+				writeSizedFile(t, path+"-wal", tt.walBytes)
+			}
+			if tt.shmBytes >= 0 {
+				writeSizedFile(t, path+"-shm", tt.shmBytes)
+			}
+
+			got := formatDBSize(path)
+			if got != tt.expected {
+				t.Errorf("formatDBSize() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func writeSizedFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.WriteFile(path, make([]byte, size), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
Closes #614

## Summary
`formatDBSize` (Admin → System → System Information → "Database Size") stat'd only the main `.db` file. Gleipnir runs SQLite in **WAL mode** (ADR-003), where the main file can stay tiny (e.g. 4 KB) while committed data lives in the `-wal` sidecar until a checkpoint — so the reported size drastically under-reported (~4 KB shown for a ~1.6 MB database).

The fix sums the main `.db` file plus its `-wal` and `-shm` sidecars, treating a missing/unstattable sidecar as 0 bytes. The existing `"unknown"` not-found contract is preserved: if the **main** file itself can't be stat'd, `formatDBSize` still returns `"unknown"` (explicit `os.Stat` guard before summing). Formatting/unit thresholds are unchanged.

## Changes
- `internal/admin/handler.go` — add `statSize(path) int64` helper (0 on stat error); `formatDBSize` sums `.db` + `-wal` + `-shm`.
- `internal/admin/handler_test.go` — table-driven `TestFormatDBSize`: all-three-present, only-main, missing-sidecars, main-missing.

<details>
<summary>Plan</summary>

Scope-gate skip (well-specified, single localized function, no architect pass). Sum main + `-wal` + `-shm`; missing sidecar = 0; preserve `"unknown"` contract; add table-driven test.
</details>

## Verification
- `go build ./...` and `go vet ./...` clean (all packages + test files compile).
- `internal/admin` tests pass uncached (8.4s), including the 4 new `TestFormatDBSize` cases.
- `make lint` shows only **pre-existing** repo-wide staticcheck debt (in `mcp/`, `plugin/`, `policy/`, `trigger/`, and unrelated `handler.go:581`) — this change adds **zero** new findings.

Review cycles: 0 (approved first pass). Docs: current. Security surface: not touched (display-formatting helper only).

🤖 Generated by the agentic dev-loop — **must be merged by a human.**