### PR TITLE
fix: deterministic provider order in /api/v1/models (#612)

### DIFF
--- a/internal/http/api/models_handler.go
+++ b/internal/http/api/models_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"sort"
 
 	"github.com/felag-engineering/gleipnir/internal/http/httputil"
 	"github.com/felag-engineering/gleipnir/internal/llm"
@@ -78,6 +79,7 @@ func (h *ModelsHandler) List(w http.ResponseWriter, r *http.Request) {
 			Models:   filterModels(toModelResponses(models), prov, enabled),
 		})
 	}
+	sortByProvider(result)
 	httputil.WriteJSON(w, http.StatusOK, result)
 }
 
@@ -118,7 +120,16 @@ func (h *ModelsHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 			Models:   toModelResponses(models),
 		})
 	}
+	sortByProvider(result)
 	httputil.WriteJSON(w, http.StatusOK, result)
+}
+
+// sortByProvider sorts result in place, alphabetically by Provider, so
+// /api/v1/models returns a deterministic order every call. Go's map
+// iteration order is randomized, and both List and Refresh build result
+// from a map keyed by provider.
+func sortByProvider(result []modelsListResponse) {
+	sort.Slice(result, func(i, j int) bool { return result[i].Provider < result[j].Provider })
 }
 
 func toModelResponses(models []llm.ModelInfo) []modelResponse {

--- a/internal/http/api/models_handler_test.go
+++ b/internal/http/api/models_handler_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -452,4 +454,79 @@ func TestModelsHandler_FilterSemantics(t *testing.T) {
 			t.Errorf("expected 2 models on filter error, got %d", len(envelope.Data[0].Models))
 		}
 	})
+}
+
+// decodeProviderOrder decodes the response envelope and returns the
+// providers in the order they appear in the JSON array.
+func decodeProviderOrder(t *testing.T, body io.Reader) []string {
+	t.Helper()
+	var envelope struct {
+		Data []struct {
+			Provider string `json:"provider"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	providers := make([]string, len(envelope.Data))
+	for i, p := range envelope.Data {
+		providers[i] = p.Provider
+	}
+	return providers
+}
+
+// TestModelsHandler_DeterministicProviderOrder guards against #612: the
+// handler builds its response by ranging over a map keyed by provider, whose
+// iteration order Go randomizes per call. Repeated calls must return
+// providers in the same, alphabetically-sorted order every time.
+func TestModelsHandler_DeterministicProviderOrder(t *testing.T) {
+	lister := &stubModelLister{
+		models: map[string][]llm.ModelInfo{
+			"openai":    {{Name: "gpt-5", DisplayName: "GPT-5"}},
+			"anthropic": {{Name: "claude-sonnet-4-6", DisplayName: "claude-sonnet-4-6"}},
+			"google":    {{Name: "gemini-2.5-flash", DisplayName: "Gemini 2.5 Flash"}},
+		},
+	}
+	wantOrder := []string{"anthropic", "google", "openai"}
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "List", method: http.MethodGet, path: "/models"},
+		{name: "Refresh", method: http.MethodPost, path: "/models/refresh"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(newModelsRouter(lister))
+			t.Cleanup(srv.Close)
+
+			// Call repeatedly: a map-iteration bug would eventually surface a
+			// different order across calls even though it might pass once.
+			for i := 0; i < 10; i++ {
+				req, err := http.NewRequest(tc.method, srv.URL+tc.path, nil)
+				if err != nil {
+					t.Fatalf("build request: %v", err)
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("%s %s: %v", tc.method, tc.path, err)
+				}
+
+				if resp.StatusCode != http.StatusOK {
+					resp.Body.Close()
+					t.Fatalf("status = %d, want 200", resp.StatusCode)
+				}
+
+				gotOrder := decodeProviderOrder(t, resp.Body)
+				resp.Body.Close()
+
+				if !reflect.DeepEqual(gotOrder, wantOrder) {
+					t.Fatalf("call %d: provider order = %v, want %v", i, gotOrder, wantOrder)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Closes #612

## Summary
`/api/v1/models` returned providers in **non-deterministic** order — the agent-editor model dropdown showed providers in a different order between page loads. Both `List` and `Refresh` in `internal/http/api/models_handler.go` built the response by ranging over the `map` returned by `ListAllModels`, and Go randomizes map iteration order per range.

The fix sorts the response by provider name (`sort.Slice`, alphabetical) before serializing, at **both** map-iteration sites, via a shared `sortByProvider` helper.

Per-provider **model** order was investigated and left untouched: the built-in providers (`anthropic`/`google`/`openai`) return copies of curated, deliberately-ordered slices, and `openaicompat` already name-sorts its list — so within-provider order is already deterministic and no curated ordering is clobbered.

## Changes
- `internal/http/api/models_handler.go` — add `sortByProvider([]modelsListResponse)`; call it after building `result` in `List` and `Refresh`.
- `internal/http/api/models_handler_test.go` — table-driven `TestModelsHandler_DeterministicProviderOrder`: a fake lister returns providers in scrambled map order; each endpoint is called 10× asserting a stable, sorted provider order (fails without the fix — verified by the reviewer).

<details>
<summary>Plan</summary>

Scope-gate skip (well-specified, single localized file). Sort providers alphabetically at both `List`/`Refresh` map-range sites; verify per-provider model order is already deterministic before touching it (it is — leave untouched); add a repeated-call ordering test.
</details>

## Verification
- `go build ./...` and `go vet ./...` clean.
- `internal/http/api` tests pass uncached (55s), including the new deterministic-order test.
- `make lint`: only pre-existing repo-wide staticcheck debt; this change adds zero new findings (staticcheck clean on `models_handler` files).

Review cycles: 0 (approved first pass). Docs: current. Security surface: not touched (read-only listing endpoint).

🤖 Generated by the agentic dev-loop — **must be merged by a human.**